### PR TITLE
Fix the grabber's missing-binary backoff, and collapse the native build into one command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,10 +461,17 @@ must exist, each must yield files, and the count is printed beside the verdict s
 number that has quietly halved is visible rather than implied. It also asserts that
 every tool in `tools/` is named in this file - see below.
 
-And the four that are not proof tools, listed because a tool nobody documented is a
-tool nobody runs:
+And the seven with no home anywhere above, listed because a tool nobody documented is
+a tool nobody runs. The arithmetic, written down because a count nobody adds up is how
+this list rotted the first time: `tools/` holds **25** files, of which **16** are
+`*-check` proof tools, **7** are the block below, and **2** — `prof-summary.mjs` and
+`render-worker.mjs` — are described further up beside the tools that drive them rather
+than here. This line said "four" over a list of six until that was counted instead of
+recalled, which is the same drift the paragraph below it warns about, happening to the
+paragraph that warns about it:
 
 ```
+node tools/build-native.mjs        # builds libfreenect2 into vendor/prefix, then the grabber
 node tools/fake-grabber.mjs        # a grabber that needs no sensor, for driving the server
 node tools/make-fixture.js         # loops one short capture into an arbitrarily long one
 node tools/sweep-all.mjs           # every mutation of every tool; needs a server and hours

--- a/README.md
+++ b/README.md
@@ -329,30 +329,30 @@ brew install libusb jpeg-turbo cmake                       # macOS
 sudo apt install libusb-1.0-0-dev libturbojpeg0-dev cmake  # Debian / Raspberry Pi OS
 ```
 
-Then, on macOS with Homebrew:
+Then build both:
 
 ```bash
-cmake -S third_party/libfreenect2 -B vendor/build \
-  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-  -DCMAKE_INSTALL_PREFIX="$PWD/vendor/prefix" \
-  -DENABLE_CXX11=ON -DENABLE_OPENCL=ON -DENABLE_OPENGL=OFF -DENABLE_CUDA=OFF \
-  -DTurboJPEG_INCLUDE_DIRS="$(brew --prefix jpeg-turbo)/include" \
-  -DTurboJPEG_LIBRARIES="$(brew --prefix jpeg-turbo)/lib/libturbojpeg.dylib"
-cmake --build vendor/build --target install -j8
-
-cmake -S native -B native/build && cmake --build native/build -j8
+npm run build:native
 ```
 
-`brew --prefix` rather than a literal `/opt/homebrew` because that path is
-Apple-Silicon-only — Intel Macs put it at `/usr/local`, and a hardcoded prefix is a
-build failure whose message does not mention the prefix.
+It picks a preset from the platform — `macos` builds depth on OpenCL, `linux`
+covers the Pi and builds it on OpenGL — resolves Homebrew's prefix rather than
+assuming one, and refuses with the `brew install` line you need when a dependency
+is missing rather than letting it surface as a cmake package it could not find.
+`--preset macos|linux` overrides the detection, `--clean` discards the vendored
+build, and `node tools/build-native.mjs --help` has the rest.
 
-On Linux and the Pi, drop both `TurboJPEG_*` flags entirely — pkg-config finds it —
-and swap `-DENABLE_OPENCL=ON -DENABLE_OPENGL=OFF` for `OFF`/`ON`. V3D has OpenGL
-and no OpenCL, and the grabber's `--pipeline` is guarded by whichever the library
-was actually compiled with rather than falling through silently. OpenGL is off on
-macOS deliberately: it only drives libfreenect2's own viewer, which we don't use,
-and it is the most deprecated path on the platform.
+Picking the wrong preset costs you a refusal rather than a silent slow path: the
+grabber's `--pipeline` is guarded by whichever backend the library was actually
+compiled with, so a build without the one you ask for says so instead of falling
+through to something else.
+
+The flags are in that script rather than here, one copy, next to the comments
+explaining why each is what it is — the OpenCL/OpenGL split, the CMake policy
+floor that v0.2.1 needs, and why the Homebrew prefix is looked up instead of
+written down. It closes by running the grabber it just built rather than checking
+that the file exists, since a stale binary and one linked against a prefix that
+has moved both exist perfectly well.
 
 `node tools/vendor-check.mjs` proves the source is upstream v0.2.1 plus exactly
 the declared edits, offline, before you trust a build of it.

--- a/README.md
+++ b/README.md
@@ -326,8 +326,15 @@ Install the dependencies first:
 
 ```bash
 brew install libusb jpeg-turbo cmake                       # macOS
-sudo apt install libusb-1.0-0-dev libturbojpeg0-dev cmake  # Debian / Raspberry Pi OS
+sudo apt install libusb-1.0-0-dev libturbojpeg0-dev cmake \
+                 libglfw3-dev libgl1-mesa-dev              # Debian / Raspberry Pi OS
 ```
+
+The two GL packages are on the Debian line and not the macOS one because the `linux`
+preset builds depth on OpenGL, and libfreenect2 treats a missing GLFW as a reason to
+build without it rather than a reason to stop — so this line lacking them produced a
+CPU-only library and a build that reported success over it. The build now refuses that
+outcome, but the refusal is a worse way to find out than installing them here.
 
 Then build both:
 

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -18,14 +18,37 @@ endif()
 set(FREENECT2_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/prefix"
     CACHE PATH "libfreenect2 install prefix")
 
+# **Moving the root has to move the library, and on its own it does not.** find_path and
+# find_library write their answers into the cache and then skip entirely on any later
+# configure that finds those entries already set, so a build directory first configured
+# with -DFREENECT2_ROOT=~/freenect2 keeps resolving to ~/freenect2 no matter what root is
+# passed afterwards. Measured rather than reasoned: configuring against a foreign prefix
+# and then re-running the build script with -DFREENECT2_ROOT=vendor/prefix moved this one
+# variable and left FREENECT2_LIBRARY and the grabber's rpath on the foreign copy, exit 0,
+# with the script reporting OK over a library it had not built. Dropping the resolved
+# paths whenever the root changes is what makes the override mean anything.
+if(NOT "${FREENECT2_ROOT}" STREQUAL "${FREENECT2_ROOT_RESOLVED}")
+  unset(FREENECT2_INCLUDE_DIR CACHE)
+  unset(FREENECT2_LIBRARY CACHE)
+endif()
+
+# NO_DEFAULT_PATH rather than HINTS, so the prefix is binding rather than preferred. With
+# hints alone a root holding no libfreenect2 falls through to the system search path and
+# links whatever is installed there - the same wrong library by a quieter route, and it
+# would make the message below false at the moment it matters most.
 find_path(FREENECT2_INCLUDE_DIR libfreenect2/libfreenect2.hpp
-          HINTS "${FREENECT2_ROOT}/include")
+          PATHS "${FREENECT2_ROOT}/include" NO_DEFAULT_PATH)
 find_library(FREENECT2_LIBRARY freenect2
-             HINTS "${FREENECT2_ROOT}/lib")
+             PATHS "${FREENECT2_ROOT}/lib" NO_DEFAULT_PATH)
 
 if(NOT FREENECT2_INCLUDE_DIR OR NOT FREENECT2_LIBRARY)
   message(FATAL_ERROR "libfreenect2 not found under ${FREENECT2_ROOT} - build it there or pass -DFREENECT2_ROOT=")
 endif()
+
+# Recorded only once the pair above resolved, so a configure that failed to find the
+# library cannot leave a marker claiming this root was searched successfully.
+set(FREENECT2_ROOT_RESOLVED "${FREENECT2_ROOT}" CACHE INTERNAL
+    "the prefix FREENECT2_INCLUDE_DIR and FREENECT2_LIBRARY were resolved under")
 
 # turbojpeg is an ordinary system package on Linux but keg-only under Homebrew,
 # so it is off the default search path on macOS and needs an explicit hint.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "start": "node server/index.js",
+    "build:native": "node tools/build-native.mjs",
     "replay": "node server/index.js --replay captures/sample.knct",
     "record": "node server/index.js --record",
     "syntax": "node tools/syntax-check.mjs",

--- a/server/index.js
+++ b/server/index.js
@@ -1957,10 +1957,30 @@ function startLive() {
     broadcastText(JSON.stringify({ camera }));
 
     if (needsRestart) {
-      console.log(`[server] colour camera ${camera.color ? 'on' : 'off'} - restarting grabber`);
-      restarting = true;
-      attempt = 0;
-      stopGrabber();
+      // **`restarting` is a claim about an exit that is coming, so it is only armed when
+      // there is a child whose exit it describes.** With none - the window between a
+      // failed spawn nulling `child` and the backoff's timer firing, which on a machine
+      // where the binary is missing is most of the time - `stopGrabber` returns on the
+      // spot, no exit is ever emitted, and the flag stays set for the life of the
+      // process. What eventually reads it is the *next* grabber's exit, after a clean
+      // handshake and however many minutes of good footage: that exit is a real failure,
+      // and the restart branch takes it, returns before `scheduleRetry`, and so leaves
+      // the sensor status reading `live` with nothing running while the backoff skips a
+      // step. One toggle at the wrong moment, one silently mishandled failure later.
+      //
+      // Nothing is lost by not arming it. The setting itself reaches the grabber through
+      // `buildArgs` on the spawn the backoff has already scheduled, which is the same
+      // door it goes through on a restart. `attempt` stays where it is for a reason of
+      // its own: with no child there is no requested restart to excuse, the pending
+      // retry is a genuine backoff step, and zeroing it would restart the table - so a
+      // sensorless editing station whose colour toggle gets touched now and then would
+      // never reach `absent`, which is the one conclusion that machine needs.
+      console.log(`[server] colour camera ${camera.color ? 'on' : 'off'} - ${child ? 'restarting grabber' : 'takes effect on the next spawn'}`);
+      if (child) {
+        restarting = true;
+        attempt = 0;
+        stopGrabber();
+      }
       return;
     }
     // Colour off means there is no exposure to set, but the flag is still worth

--- a/server/index.js
+++ b/server/index.js
@@ -1811,6 +1811,37 @@ function startLive() {
     dying.once('exit', () => clearTimeout(timer));
   };
 
+  // The backoff itself, reached from the two ways a grabber can fail to be running: it
+  // exited, or it never started. Both want the same answer - spend the short table
+  // first in case this is a sensor that is merely slow to enumerate at boot, then
+  // conclude the machine has none and look again rarely - and both used to be written
+  // out only once, in the exit handler, which is why the second way had no backoff at
+  // all. One implementation, so a change to the table cannot reach one caller and miss
+  // the other.
+  const scheduleRetry = () => {
+    // A grabber that has *never* handshaken is not the flaky USB link this backoff
+    // was written for - it is a machine with no sensor on it, which is exactly what
+    // the editing station running this same library is. Told apart, because the two
+    // want opposite answers: a sensor that worked and dropped keeps the short
+    // backoff, since that is the bus drop the design expects to ride out, while one
+    // that has never appeared is reported absent so `/record/state` stops claiming a
+    // take could start here and the record button says why. The full backoff table
+    // is spent first rather than concluding on the first exit, because a node whose
+    // sensor is slow to enumerate at boot is the same shape for the first few
+    // seconds and must not be written off as an editing machine.
+    const absent = !everLive && attempt >= RESTART_DELAYS.length;
+    setSensorState(absent ? 'absent' : 'lost');
+    const delay = absent ? ABSENT_DELAY : RESTART_DELAYS[Math.min(attempt, RESTART_DELAYS.length - 1)];
+    attempt++;
+    // Once absent, said once. The alternative is this line and libfreenect2's
+    // enumeration every few seconds for as long as the editing station is up.
+    if (!absent) console.log(`[server] restarting grabber in ${delay}ms (attempt ${attempt})`);
+    else if (attempt === RESTART_DELAYS.length + 1) {
+      console.log(`[server] no sensor found in ${attempt} attempts - looking again every ${ABSENT_DELAY / 1000}s`);
+    }
+    setTimeout(spawnGrabber, delay);
+  };
+
   const spawnGrabber = () => {
     const grabberArgs = buildArgs();
     console.log(`[server] starting grabber: ${bin} ${grabberArgs.join(' ')}`);
@@ -1819,7 +1850,8 @@ function startLive() {
     const parser = new MessageParser();
     // stdin is a pipe so settings that do not need a restart can be sent to the
     // running grabber instead of costing a multi-second device reopen.
-    child = spawn(bin, grabberArgs, { stdio: ['pipe', 'pipe', 'inherit'] });
+    const proc = spawn(bin, grabberArgs, { stdio: ['pipe', 'pipe', 'inherit'] });
+    child = proc;
     child.stdin.on('error', () => { /* the grabber can exit mid-write */ });
     // A grabber that cannot be spawned at all - not built here, or built for
     // another architecture - arrives as an `error` event rather than an exit, and
@@ -1829,8 +1861,39 @@ function startLive() {
     // condition arriving earlier, and it must not be the one shape that is fatal.
     // Surfaced by running this server on a machine with no sensor at all, which is
     // exactly what a library on an editing machine is.
+    //
+    // **And backing off is the whole of it, which this handler did not do for its
+    // first life.** It logged and returned, while every retry in this file hangs off
+    // `exit` - an event a failed spawn never emits, since there is no process to exit.
+    // So the promise `ABSENT_DELAY` is written to keep, that a sensor appearing later
+    // is picked up without anyone restarting the server, silently did not hold when
+    // what appeared later was the *binary*: one line in the log at boot and then
+    // nothing for the life of the process. Measured on a fresh worktree, where
+    // `native/build/grabber` does not exist until it is built - the server was started
+    // first, the grabber was built underneath it, and thirty-six seconds of sampling
+    // caught no spawn at all because the timer had never been armed.
+    //
+    // Routed through the same `scheduleRetry` the exit path uses rather than a second
+    // timer of its own, so a missing binary and a dropped USB link converge on one
+    // backoff, one absent conclusion and one log line.
     child.on('error', (err) => {
       console.error(`[server] grabber could not start: ${err.message}`);
+      if (shuttingDown) return;
+      // **Only when no process was ever created.** `error` is not exclusively a spawn
+      // failure - it also fires when a signal cannot be delivered to a grabber that is
+      // running perfectly well - and in that case `exit` follows and schedules the
+      // retry itself. Scheduling here as well would put two grabbers on a device that
+      // admits one, which is the failure this whole file is arranged around and which
+      // arrives as an enumeration error in the loser rather than as anything naming a
+      // double spawn. `pid` is undefined only for a process that never started, so it
+      // is the question actually being asked; `proc` rather than `child` because a
+      // later spawn may already have reassigned it by the time this runs.
+      if (proc.pid !== undefined) return;
+      // Nothing to signal and no stdin to write to, so it must not look live to the
+      // colour toggle or to `stopGrabber` - the latter would otherwise kill a pid that
+      // does not exist and then wait out its grace period for an exit that cannot come.
+      if (child === proc) child = null;
+      scheduleRetry();
     });
 
     child.stdout.on('data', (chunk) => {
@@ -1881,27 +1944,7 @@ function startLive() {
         setTimeout(spawnGrabber, delay);
         return;
       }
-      // A grabber that has *never* handshaken is not the flaky USB link this backoff
-      // was written for - it is a machine with no sensor on it, which is exactly what
-      // the editing station running this same library is. Told apart, because the two
-      // want opposite answers: a sensor that worked and dropped keeps the short
-      // backoff, since that is the bus drop the design expects to ride out, while one
-      // that has never appeared is reported absent so `/record/state` stops claiming a
-      // take could start here and the record button says why. The full backoff table
-      // is spent first rather than concluding on the first exit, because a node whose
-      // sensor is slow to enumerate at boot is the same shape for the first few
-      // seconds and must not be written off as an editing machine.
-      const absent = !everLive && attempt >= RESTART_DELAYS.length;
-      setSensorState(absent ? 'absent' : 'lost');
-      const delay = absent ? ABSENT_DELAY : RESTART_DELAYS[Math.min(attempt, RESTART_DELAYS.length - 1)];
-      attempt++;
-      // Once absent, said once. The alternative is this line and libfreenect2's
-      // enumeration every few seconds for as long as the editing station is up.
-      if (!absent) console.log(`[server] restarting grabber in ${delay}ms (attempt ${attempt})`);
-      else if (attempt === RESTART_DELAYS.length + 1) {
-        console.log(`[server] no sensor found in ${attempt} attempts - looking again every ${ABSENT_DELAY / 1000}s`);
-      }
-      setTimeout(spawnGrabber, delay);
+      scheduleRetry();
     });
   };
 

--- a/tools/build-native.mjs
+++ b/tools/build-native.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// Builds the two native artifacts the server needs: libfreenect2 out of
+// `third_party/libfreenect2` into the gitignored `vendor/prefix`, and the grabber out of
+// `native/` into `native/build`. Neither needs the network.
+//
+//   node tools/build-native.mjs [--preset macos|linux] [--jobs N] [--clean]
+//
+// This exists because the version of it that lived in README.md was thirteen lines of
+// cmake flags a reader had to retype correctly, with the platform differences described
+// in a paragraph underneath rather than applied. Two copies of a build - one in prose and
+// one in whatever people actually ran - is the drift this repo rejects everywhere else,
+// so the README now names this file and carries no flags of its own. The reasoning that
+// used to sit under that code block is here instead, beside the line it governs.
+//
+// **A build script that exits 0 without a working binary is the failure mode this whole
+// suite is about**, and "the file exists" does not rule it out - a grabber left over from
+// a previous checkout, or one linked against a prefix that is no longer there, both exist.
+// So the last thing this does is run the grabber it just built. dyld resolves the rpath
+// before `main`, so `--help` coming back clean is a statement about the library too: point
+// the rpath at nothing and it fails there rather than at the first sensor.
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { cpus } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..');
+const argv = process.argv.slice(2);
+const flag = (name) => (argv.includes(name) ? argv[argv.indexOf(name) + 1] : null);
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(`usage: node tools/build-native.mjs [--preset macos|linux] [--jobs N] [--clean]
+
+  --preset overrides the platform detection. macos builds depth on OpenCL and leaves
+           OpenGL off; linux is the other way round and covers the Raspberry Pi.
+  --jobs   parallel compile jobs. Defaults to this machine's core count, capped at 8.
+  --clean  removes vendor/build, vendor/prefix and native/build first. The vendored
+           library is a one-time build, so the ordinary run reuses it.`);
+  process.exit(0);
+}
+
+// Two presets rather than three, and the Pi rides with linux. The reason the Pi needs
+// OpenGL is that its V3D has no OpenCL at all - a fact about that GPU rather than about
+// Linux - so a desktop Linux box with a real OpenCL runtime arguably wants the macOS
+// arrangement instead. Nobody here has measured that, and the grabber's `--pipeline` is
+// guarded by whichever backend the library was actually compiled with rather than falling
+// through silently, so the wrong guess is a refusal rather than a slow build. An untested
+// third preset would still be a configuration this repo ships without having run it, so
+// the README's two are what this offers until somebody measures the third.
+const PRESETS = {
+  macos: {
+    cmake: ['-DENABLE_OPENCL=ON', '-DENABLE_OPENGL=OFF'],
+    // OpenGL is off deliberately rather than incidentally: it drives libfreenect2's own
+    // viewer, which nothing here uses, and it is the most deprecated path on the platform.
+    why: 'depth on OpenCL, OpenGL off (it only drives libfreenect2\'s own viewer)',
+  },
+  linux: {
+    cmake: ['-DENABLE_OPENCL=OFF', '-DENABLE_OPENGL=ON'],
+    why: 'depth on OpenGL, OpenCL off (the Pi\'s V3D has no OpenCL)',
+  },
+};
+
+const detect = () => {
+  if (process.platform === 'darwin') return 'macos';
+  if (process.platform === 'linux') return 'linux';
+  return null;
+};
+
+const preset = flag('--preset') ?? detect();
+if (!preset || !PRESETS[preset]) {
+  const named = flag('--preset');
+  console.error(named
+    ? `unknown preset ${named} - this ships ${Object.keys(PRESETS).join(' and ')}`
+    : `no preset for platform ${process.platform} - pass --preset ${Object.keys(PRESETS).join('|')} if one of them fits`);
+  process.exit(2);
+}
+
+const JOBS = Number(flag('--jobs')) || Math.min(cpus().length || 4, 8);
+
+// Where everything lands. `vendor` and `native/build` are both gitignored; the prefix is
+// what the grabber's rpath points at, so moving either of these means editing
+// native/CMakeLists.txt to match.
+const VENDOR_BUILD = join(REPO, 'vendor/build');
+const VENDOR_PREFIX = join(REPO, 'vendor/prefix');
+const NATIVE_BUILD = join(REPO, 'native/build');
+const GRABBER = join(NATIVE_BUILD, 'grabber');
+
+// **A missing dependency has to be named here rather than discovered in cmake's output.**
+// The one this bites on is TurboJPEG: cmake reports it as a package it could not find,
+// which reads as a problem with the source tree rather than as one `brew install` away.
+// `brew --prefix` rather than a literal `/opt/homebrew` because that path is
+// Apple-Silicon-only - Intel Macs put it at `/usr/local`, and a hardcoded prefix fails
+// with a message that never mentions the prefix.
+const brewPrefix = (formula) => {
+  const r = spawnSync('brew', ['--prefix', formula], { encoding: 'utf8' });
+  if (r.status !== 0 || !r.stdout?.trim()) return null;
+  const path = r.stdout.trim();
+  return existsSync(path) ? path : null;
+};
+
+const have = (bin, args = ['--version']) => spawnSync(bin, args, { stdio: 'ignore' }).status === 0;
+
+if (!have('cmake')) {
+  console.error(`cmake is not on PATH - ${preset === 'macos' ? 'brew install cmake' : 'sudo apt install cmake'}`);
+  process.exit(2);
+}
+
+const vendorFlags = [
+  // CMake 4 dropped compatibility with pre-3.5 policies and libfreenect2 v0.2.1 predates
+  // that floor, so without this the configure step stops before it reports anything about
+  // the tree it was given.
+  '-DCMAKE_POLICY_VERSION_MINIMUM=3.5',
+  `-DCMAKE_INSTALL_PREFIX=${VENDOR_PREFIX}`,
+  '-DENABLE_CXX11=ON',
+  '-DENABLE_CUDA=OFF',
+  ...PRESETS[preset].cmake,
+];
+
+if (preset === 'macos') {
+  const missing = ['libusb', 'jpeg-turbo'].filter((f) => !brewPrefix(f));
+  if (missing.length) {
+    console.error(`missing Homebrew packages: ${missing.join(', ')} - brew install ${missing.join(' ')}`);
+    process.exit(2);
+  }
+  // Pointed at explicitly because libfreenect2's finder does not look inside Homebrew's
+  // opt paths. On Linux both flags come off entirely and pkg-config finds it.
+  const jpeg = brewPrefix('jpeg-turbo');
+  vendorFlags.push(
+    `-DTurboJPEG_INCLUDE_DIRS=${join(jpeg, 'include')}`,
+    `-DTurboJPEG_LIBRARIES=${join(jpeg, 'lib/libturbojpeg.dylib')}`,
+  );
+}
+
+const run = (bin, args) => {
+  console.log(`[build-native] ${bin} ${args.join(' ')}`);
+  execFileSync(bin, args, { cwd: REPO, stdio: 'inherit' });
+};
+
+console.log(`[build-native] preset ${preset} - ${PRESETS[preset].why}`);
+console.log(`[build-native] ${JOBS} parallel jobs`);
+
+if (argv.includes('--clean')) {
+  for (const dir of [VENDOR_BUILD, VENDOR_PREFIX, NATIVE_BUILD]) rmSync(dir, { recursive: true, force: true });
+  console.log('[build-native] removed vendor/build, vendor/prefix and native/build');
+}
+
+try {
+  run('cmake', ['-S', 'third_party/libfreenect2', '-B', 'vendor/build', ...vendorFlags]);
+  run('cmake', ['--build', 'vendor/build', '--target', 'install', `-j${JOBS}`]);
+  run('cmake', ['-S', 'native', '-B', 'native/build']);
+  run('cmake', ['--build', 'native/build', `-j${JOBS}`]);
+} catch {
+  // execFileSync already put the compiler's own output on this terminal, so repeating the
+  // exception here would bury it. Exit 2 on the same reading the proof tools use: the
+  // build did not run to completion, which is a different answer from one that produced a
+  // binary this script then rejected.
+  console.error('[build-native] FAILED - the build did not complete; its output is above');
+  process.exit(2);
+}
+
+// Everything above can succeed and still leave nothing usable, so the claim is closed by
+// running the artifact rather than by stat-ing it. `--help` returns before any device
+// enumeration, so this stays true on a machine with no sensor - which is most of them,
+// the library and the editor being documented to run on an editing station.
+if (!existsSync(GRABBER)) {
+  console.error(`[build-native] FAILED - cmake reported success but ${GRABBER} does not exist`);
+  process.exit(1);
+}
+
+const probe = spawnSync(GRABBER, ['--help'], { encoding: 'utf8' });
+if (probe.status !== 0) {
+  console.error('[build-native] FAILED - the grabber was built but will not run:');
+  console.error((probe.stderr || probe.stdout || `exit ${probe.status}`).trim());
+  console.error('a dyld failure here means the binary is not resolving vendor/prefix');
+  process.exit(1);
+}
+
+// Read back out of the binary's own usage text rather than out of the flags passed in,
+// because those two disagreeing is the whole point of asking. The grabber prints the
+// pipelines its libfreenect2 was compiled with, so a prefix built for the other preset -
+// or an older one still sitting in vendor/ - shows up here as a backend that is missing.
+//
+// Both streams, because the grabber writes its usage to *stderr* - reading stdout alone
+// matched nothing and reported `unknown` on a perfectly good build, which is this repo's
+// own rule about a counter grepping a phrase the system never emits, reproduced inside
+// the tool written to respect it. It survived the first run because the shell that
+// checked it merged the two streams with `2>&1`.
+const offers = /this build offers ([a-z ]+)/.exec(`${probe.stderr}${probe.stdout}`)?.[1]?.trim();
+console.log(`[build-native] grabber runs and reports depth pipelines: ${offers ?? 'unknown'}`);
+console.log(`[build-native] OK - ${GRABBER}`);
+console.log('[build-native] node tools/vendor-check.mjs proves the tree is upstream v0.2.1 plus the declared edits');

--- a/tools/build-native.mjs
+++ b/tools/build-native.mjs
@@ -47,16 +47,29 @@ if (argv.includes('--help') || argv.includes('-h')) {
 // through silently, so the wrong guess is a refusal rather than a slow build. An untested
 // third preset would still be a configuration this repo ships without having run it, so
 // the README's two are what this offers until somebody measures the third.
+//
+// `backend` is the pipeline token the built grabber must report back, and it is the whole
+// reason the probe below is an assertion rather than a print. `ENABLE_OPENGL=ON` is a
+// request, not a requirement: libfreenect2's own CMakeLists answers a missing GLFW3 or
+// OpenGL with `HAVE_OpenGL no` and carries on, so the configure succeeds, the build
+// succeeds, and what installs into vendor/prefix is a CPU-only library. The Pi is where
+// that lands, because the Debian dependency line below installs libusb and turbojpeg and
+// nothing that provides GLFW - the documented path produced the roughly half-rate CPU
+// depth processor and this script said OK over it.
 const PRESETS = {
   macos: {
     cmake: ['-DENABLE_OPENCL=ON', '-DENABLE_OPENGL=OFF'],
     // OpenGL is off deliberately rather than incidentally: it drives libfreenect2's own
     // viewer, which nothing here uses, and it is the most deprecated path on the platform.
     why: 'depth on OpenCL, OpenGL off (it only drives libfreenect2\'s own viewer)',
+    backend: 'cl',
+    missing: 'OpenCL is a system framework here, so a build without it means the configure did not see it - check vendor/build/CMakeCache.txt',
   },
   linux: {
     cmake: ['-DENABLE_OPENCL=OFF', '-DENABLE_OPENGL=ON'],
     why: 'depth on OpenGL, OpenCL off (the Pi\'s V3D has no OpenCL)',
+    backend: 'gl',
+    missing: 'sudo apt install libglfw3-dev libgl1-mesa-dev, then re-run with --clean',
   },
 };
 
@@ -147,7 +160,24 @@ if (argv.includes('--clean')) {
 try {
   run('cmake', ['-S', 'third_party/libfreenect2', '-B', 'vendor/build', ...vendorFlags]);
   run('cmake', ['--build', 'vendor/build', '--target', 'install', `-j${JOBS}`]);
-  run('cmake', ['-S', 'native', '-B', 'native/build']);
+  // **`FREENECT2_ROOT` is passed rather than defaulted, because a cache entry outlives the
+  // run that set it.** native/CMakeLists.txt declares it `CACHE PATH` with vendor/prefix as
+  // its default, and a default only applies to a cache that does not already hold the key -
+  // so anybody who once configured this tree with the documented `-DFREENECT2_ROOT=` override
+  // (the Pi's ~/freenect2 is the one in the README) keeps that path on every later configure
+  // that does not name one. This command would then build the vendored library, install it,
+  // verify it, and link the grabber against the other prefix entirely - and the `--help` probe
+  // below would still pass, because the rpath points at whichever libdir was found and an
+  // external libfreenect2 0.2 runs the same. Reporting success about a library it did not
+  // build is precisely the stale-prefix failure `vendor-check --mutate stale-prefix` exists
+  // for, arriving through the build rather than through the check.
+  //
+  // Naming it here is half the fix and the smaller half: `find_library` caches its answer,
+  // so passing the root moves the hint and leaves the resolved path where it was.
+  // native/CMakeLists.txt drops the resolved pair whenever the root changes, which is what
+  // makes this argument do anything - measured, because the first version of this line was
+  // written on its own and the grabber's rpath did not move.
+  run('cmake', ['-S', 'native', '-B', 'native/build', `-DFREENECT2_ROOT=${VENDOR_PREFIX}`]);
   run('cmake', ['--build', 'native/build', `-j${JOBS}`]);
 } catch {
   // execFileSync already put the compiler's own output on this terminal, so repeating the
@@ -187,5 +217,20 @@ if (probe.status !== 0) {
 // checked it merged the two streams with `2>&1`.
 const offers = /this build offers ([a-z ]+)/.exec(`${probe.stderr}${probe.stdout}`)?.[1]?.trim();
 console.log(`[build-native] grabber runs and reports depth pipelines: ${offers ?? 'unknown'}`);
+
+// **And the answer is checked rather than printed**, which for one commit it was not - the
+// string was read out of the binary for exactly the reason that makes it worth reading,
+// then logged beside an unconditional OK. Every build offers `cpu`, so the only thing that
+// line distinguishes is a build that lost the backend the preset asked for, and that is
+// the build it reported as fine.
+//
+// `offers` unparseable fails here rather than passing as `unknown`, on the reading the
+// proof tools use throughout: a claim that could not be tested is not a claim that held.
+const { backend, missing } = PRESETS[preset];
+if (!offers || !offers.split(/\s+/).includes(backend)) {
+  console.error(`[build-native] FAILED - the ${preset} preset asks for ${backend} depth, and this build offers ${offers ? `only ${offers}` : 'a set this script could not read'}`);
+  console.error(`the library configured without it and fell back to cpu, which runs at roughly half rate: ${missing}`);
+  process.exit(1);
+}
 console.log(`[build-native] OK - ${GRABBER}`);
 console.log('[build-native] node tools/vendor-check.mjs proves the tree is upstream v0.2.1 plus the declared edits');


### PR DESCRIPTION
Two changes that came out of the same failure: a fresh worktree has no `native/build/grabber`, the server logged `ENOENT` once at boot, and it then never looked again for the rest of its life.

## The fix

`server/index.js`'s `error` handler logged and returned. Every retry in that file hangs off `exit`, which a failed spawn never emits — there is no process to exit. So the promise `ABSENT_DELAY` exists to keep, that a sensor appearing later gets picked up without anyone restarting the server, quietly did not hold when what appeared later was the *binary*.

Both failure paths now go through one `scheduleRetry`, so a missing binary and a dropped USB link converge on one backoff and one absent conclusion. It's guarded on `proc.pid`, because `error` also fires for a signal that can't be delivered to a grabber that is running fine — and there `exit` follows and schedules its own retry. Arming both would put two grabbers on a device that admits one, which surfaces as an enumeration failure in whichever loses rather than as anything naming a double spawn.

## The build

`npm run build:native` replaces thirteen lines of cmake flags in the README plus a paragraph of platform differences to apply by hand. Two presets, detected and overridable with `--preset`: `macos` (OpenCL, OpenGL off) and `linux` (the reverse, covering the Pi). The README now carries no flags — the reasoning lives in the script beside the line it governs.

It closes by *running* the grabber rather than stat-ing it, since a stale binary and one linked against a moved prefix both exist perfectly well.

## Verification

| what | result |
| --- | --- |
| ENOENT fix, binary appears under a running server | 5 attempts in 20s, 4 backoff lines, absent verdict, picked up at 27s — matching the predicted t=45s retry |
| pre-fix control (handler restored to log-and-return) | 1 line, 0 backoff, never picked up in 40s |
| `build-native --clean` from nothing | both artifacts rebuilt, exit 0 |
| `vendor-check` on the resulting prefix | 288 assertions, 0 failed |
| probe control: `vendor/prefix` hidden | grabber exits 134 at dyld; restored, exits 0 |
| `npm test` (`syntax-check` + `release-gate-check`) | 0 failed, 35 files, all 25 tools named in CLAUDE.md |

macOS 25.5.0, M2 Max, cmake 4.3.3, npm 12. The ENOENT probe points `--grabber` at a path under `/tmp`, so no USB device is reachable from the test at all.

Two instrument flaws were caught by running things rather than reading them, and both are recorded in the commits: the build script's pipeline read-back grepped stdout where the grabber writes usage to stderr, and the first ENOENT probe grepped a string that sits inside the ENOENT message's own path, so it reported success from the first second.

## Gaps

- **No proof tool covers either change.** Both falsification controls were run by hand; nothing re-runs them.
- **The `linux` preset has never executed** — there's no Linux box here, so it's a faithful transcription of the README's flags rather than a measurement. The Pi is where a wrong flag surfaces.
- **Two refusal branches are untested**: missing cmake and missing Homebrew packages.
- **`--jobs` is now a cap at core count** rather than the old literal `-j8`, so a machine with fewer than eight cores builds slower than the documented command did.
- **The desktop-Linux OpenCL question is left open** rather than encoded as an untested third preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)