### PR TITLE
Put the way out of every surface in the same corner, and pin it there

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,34 @@ it, and JSON quoting carries newlines as two literal characters. Ship it base64.
 node `pkill -f` matches the remote shell running your own command — resolve listeners by port
 through `ss`.
 
+**Never `git stash` in a worktree of this repo.** The stash is a single ref in the shared
+`.git`, so every worktree pushes onto one stack. A session here stashed to take a baseline
+measurement, a concurrent session in `ridgehead` stashed ninety seconds later, and the pop
+restored *ridgehead's* `server/index.js` into this tree while orphaning six files of this
+one's — silently, because the pop was redirected to `/dev/null` and only its exit code would
+have said so. Nothing is lost when it happens, since the stash commits survive as unreachable
+objects (`git fsck --unreachable`, then read `%s` for `On <branch>:` and take `^3` for the
+untracked file), but the recovery is long and the interference runs both ways. To take a
+baseline, copy the modified files somewhere outside the repo, `git checkout --` them, measure,
+and copy them back.
+
+**And that session was the reason four proof-tool runs failed, in two different ways.**
+`library-check` binds **fixed** ports — 8210 and 8211, plus `MAC_PORT + 2/4/5` — so two
+worktrees running it at once do not get an address-in-use error, they get each other's server:
+the arm here stat-ed `three-warning-take.knct`, a fixture belonging to the other tree, and
+reported the run as not finishing. Pass `--node-port`/`--mac-port` and take a range nothing
+else holds. The second way is quieter and worse, because it looks like a finding: under
+contention the preset-apply evaluate dies with `Resulting promise was garbage collected`, a
+sibling of the `Execution context was destroyed` the call is already wrapped against, and the
+run stops at 139 of 256 assertions. That reproduced **five times** against a change while a
+baseline taken on an idle machine passed twice, which reads as a regression with a clean
+control — and the change was innocent. What settled it was running the *unmodified* tree
+back to back in the same conditions, where it crashed identically. **Before believing a
+proof tool caught your change, re-run the baseline in the conditions the failure happened
+in, not the conditions the baseline happened in** — and check `pgrep -f "tools/.*-check.mjs"`
+first, because on this machine another agent's run is the normal state rather than the
+exception.
+
 ## Proof tools
 
 Each takes a running server and exits non-zero on failure.
@@ -358,6 +386,7 @@ node tools/library-check.mjs --mutate plant-open-take     # ... and must FAIL
 node tools/editor-check.mjs --url http://localhost:8080   # the editor's controls: that they exist, that pressing them changes something
 node tools/editor-check.mjs --mutate lanes-clear-siblings --no-render  # ... and must FAIL
 node tools/editor-check.mjs --mutate plant-unswept-control --no-render # ... and must FAIL
+node tools/editor-check.mjs --mutate nav-at-the-foot --no-render       # ... and must FAIL
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows
 node tools/monitor-check.mjs --mutate decimate-reaches-recorder  # ... and must FAIL mutated
 node tools/monitor-check.mjs --mutate bind-ignores-grid          # ... and must FAIL mutated
@@ -407,6 +436,20 @@ without it, "every control was tested" is a sentence the tool writes about itsel
 file** because each was NOT CAUGHT against a build with a fix removed: the rule they named
 had been made redundant by the two-row bar, which is worth knowing about the fix as well as
 about the check.
+
+`nav-at-the-foot` is the control for a second claim section 1 makes, that the way out of the
+editor is *reachable* rather than merely present — it was under thirteen groups of sliders at
+the end of a column that scrolls, which is being in the document and nowhere on the screen.
+**Its first probe sat in a dead zone of exactly the kind recorded above**: it scrolled the
+column to its end and asked whether the nav was inside the panel, and the end of the travel is
+precisely where a nav at the foot *is* visible — the mutation came back 683px down and
+comfortably in view, reddening only the structural half of the row. The end a foot-nav fails is
+the top, where the panel sits when you arrive, so both ends are read now and the mutated build
+answers 1958px. The probe is also the one thing in section 1 that moves the page it measures,
+and leaving the column scrolled put section 8's crop sliders under different pointer
+coordinates: the crop rows went from 0.005% apart to 0.446% and read as a rendering regression
+the change had caused. It restores the scroll position now. **Both flaws were found by running
+the mutation and reading which rows fired, not by reading the probe.**
 
 The two below need no server, and `registration-check` needs no sensor either -
 it runs on a corpus of `Registration::apply` inputs dumped by

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -104,6 +104,32 @@ const MUTATIONS = {
     ]],
   },
 
+  // The control for the placement rows in section 1, and it is the bug being put back
+  // rather than an invention: the nav spent its whole life at the foot of the panel,
+  // under every slider, on the one surface where the column is long enough to scroll.
+  // It stays a working nav that goes to the right places - the failure being restored
+  // is that you cannot see it, which is why the rows it must redden are the geometric
+  // ones and not the sweep.
+  'nav-at-the-foot': {
+    file: 'web/index.html',
+    edits: [
+      [
+        '        <nav class="surfacenav" id="navRow" aria-label="Surfaces">\n'
+        + '          <a id="toMenu" href="/">menu</a>\n'
+        + '          <a id="toLibrary" href="/gallery">gallery</a>\n'
+        + '        </nav>\n',
+        '',
+      ],
+      [
+        '    </div>\n  </div><!-- #panelBody -->',
+        '    </div>\n\n    <nav class="surfacenav" id="navRow" aria-label="Surfaces">\n'
+        + '      <a id="toMenu" href="/">menu</a>\n'
+        + '      <a id="toLibrary" href="/gallery">gallery</a>\n'
+        + '    </nav>\n  </div><!-- #panelBody -->',
+      ],
+    ],
+  },
+
   // The bug that started this file. The rebuild goes back to clearing its columns of
   // everything it does not recognise, which takes the in/out markers with it. Both
   // append sites move back too, so the mutated build is a working editor with no way
@@ -361,7 +387,8 @@ const DRIVER_RULES = [
   },
   {
     what: 'navigation out of the editor',
-    by: 'sensor-view-check and library-check follow both links',
+    by: 'sensor-view-check and library-check follow both links, and the rows below '
+      + 'assert where the nav sits and where its two anchors go',
     match: (el) => el.closest('#navRow'),
   },
 ];
@@ -525,7 +552,13 @@ try {
   // The sweep is over what the page actually contains rather than over a list kept
   // here, which is the only version of this that survives somebody adding a button.
   const sweep = await page.evaluate(`(${((rules) => {
-    const els = [...document.querySelectorAll('.tbar input, .tbar select, .tbar button, #panel input, #panel select, #panel button')];
+    // Anchors are in the list because the way out of this surface is two of them.
+    // They were buttons calling `location.href` until the nav moved into the panel
+    // head, and a selector naming only the form controls would have watched them
+    // leave the sweep rather than fail - the "passes by disappearing" shape this
+    // file's own section 1 exists to refuse.
+    const els = [...document.querySelectorAll('.tbar input, .tbar select, .tbar button, .tbar a, '
+      + '#panel input, #panel select, #panel button, #panel a')];
     return els.map((el) => ({
       id: el.id || null,
       tag: el.tagName,
@@ -567,6 +600,73 @@ try {
   check(sweep.length > 60, 'and the sweep found the panel, not an empty page', `${sweep.length} controls`);
   check(sweep.some((r) => r.id === 'tExport') && sweep.some((r) => r.id === 'tIn' || true),
     'the strip is among what was swept', `${sweep.filter((r) => r.inTbar).map((r) => r.id).filter(Boolean).slice(0, 6).join(', ')}...`);
+
+  // Being in the document is not the same as being reachable, which is the whole of
+  // what was wrong with this control before it moved. It sat under thirteen groups of
+  // sliders at the foot of a column that scrolls, so on any window the panel filled it
+  // was off screen until somebody scrolled for it - swept by this file, covered by a
+  // rule, and invisible to the person using the editor.
+  //
+  // **Measured at both ends of the travel, because one end is a dead zone.** The first
+  // version of this scrolled the column to its end and asked whether the nav was inside
+  // the panel, which is precisely where a nav at the foot of the column *is* inside the
+  // panel - `nav-at-the-foot` came back 683px down and comfortably visible, and the row
+  // only reddened on the structural half of its condition. The end a foot-nav fails is
+  // the top, where the panel sits when you arrive. So both are read.
+  const nav = await page.evaluate(`(${(() => {
+    const el = document.getElementById('navRow');
+    const panel = document.getElementById('panel');
+    const body = document.getElementById('panelBody');
+    if (!el || !panel || !body) return { present: false, hasBody: !!body };
+    const was = body.scrollTop;
+    const at = (to) => {
+      body.scrollTop = to;
+      const r = el.getBoundingClientRect();
+      const p = panel.getBoundingClientRect();
+      return {
+        scrolled: Math.round(body.scrollTop),
+        top: Math.round(r.top - p.top),
+        inside: r.top >= p.top - 0.5 && r.bottom <= p.bottom + 0.5,
+      };
+    };
+    const travel = body.scrollHeight - body.clientHeight;
+    const top = at(0);
+    const end = at(body.scrollHeight);
+    // Put the column back where it was found. Section 8 drives the crop sliders by
+    // pointer coordinate, and a panel left scrolled to its end puts every one of them
+    // somewhere else - which is what happened: the crop rows moved from 0.005% apart
+    // to 0.446% and read as a rendering regression this change had caused. This probe
+    // is the one thing in section 1 that alters the page it is measuring, so it is also
+    // the one thing that has to undo itself.
+    body.scrollTop = was;
+    return {
+      present: true,
+      hasBody: true,
+      // How far the column can travel. A nav that cannot scroll out of sight is a nav
+      // this claim was never tested on, so the number is a row of its own.
+      travel: Math.round(travel),
+      inBody: !!el.closest('#panelBody'),
+      top,
+      end,
+      // Destinations off the markup rather than off a click handler, because that is
+      // where they live now and a browser can only follow what it can read.
+      hrefs: [...el.querySelectorAll('a')].map((a) => a.getAttribute('href')),
+    };
+  }).toString()})()`);
+
+  check(nav.present, 'the panel has a head and a nav in it',
+    nav.present ? `${nav.hrefs.length} links` : `navRow/panelBody present: ${nav.hasBody}`);
+  check(nav.travel > 0, 'and the panel body genuinely scrolls, so the rows below are measuring something',
+    `${nav.travel}px of travel`);
+  check(nav.present && nav.top.inside && nav.end.inside,
+    'the way out is on screen at both ends of that travel, which is what "not at the foot" means',
+    nav.present ? `${nav.top.top}px below the panel top at rest, ${nav.end.top}px scrolled to the end` : 'absent');
+  check(nav.present && !nav.inBody,
+    'and it is outside the scrolling column rather than merely near its top',
+    `in the scrolling body: ${nav.inBody}`);
+  check(nav.present && nav.hrefs.join(' ') === '/ /gallery',
+    'and both chips carry the destination in the markup, in the order every surface uses',
+    nav.hrefs.join(' '));
 
   // =====================================================================
   console.log('\n[2] the keyboard, and the guard that has to come with it');

--- a/tools/sensor-view-check.mjs
+++ b/tools/sensor-view-check.mjs
@@ -479,7 +479,17 @@ const PROBE = `(() => {
      */
     panel() {
       const vis = (el) => !!el && el.checkVisibility({ checkVisibilityCSS: true });
-      const blocks = [...document.querySelectorAll('#panel > .group, #panel > .btnrow')].map((el) => ({
+      // The child combinator is doing real work and has to stay: a \`.btnrow\` also
+      // lives inside half the groups, and a descendant selector would list those as
+      // blocks of the panel. So when the scrolling column became \`#panelBody\` under a
+      // head that does not scroll, this had to follow it - and \`.surfacenav\` is named
+      // beside them because the nav moved into that head. Dropping it from the list
+      // would have taken it out of the closing row below, which is what asserts every
+      // block nothing else names is on both surfaces: the nav would have stopped being
+      // covered here by disappearing rather than by failing.
+      const blocks = [...document.querySelectorAll(
+        '#panelBody > .group, #panelBody > .btnrow, #panelHead .surfacenav',
+      )].map((el) => ({
         // The id where there is one, the group's own heading where there is not.
         // A heading that gets reworded fails the naming row loudly, which is the
         // right answer: this file was written the week the panel was regrouped.

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Kinect v2 · point cloud</title>
+<!-- Before the page's own rules on purpose: nav.css owns how the chips look and the
+     page owns where they sit, so a placement rule here has to win the tie. -->
+<link rel="stylesheet" href="/nav.css" />
 <style>
   :root {
     --ink: #e8ecf1;
@@ -43,14 +46,29 @@
      than a border because it must not enter the layout the letterbox just computed. */
   #stage { outline: 1px solid rgba(120, 220, 210, 0.28); }
 
+  /* Two boxes rather than one scrolling box, and the split is what makes the way out
+     of this surface reachable. The panel fills the window's height and its content is
+     thirteen groups of sliders long, so anything living at the end of that column is
+     off screen until you scroll for it - which is where `gallery` and `menu` were, and
+     they are the two controls you press when you have stopped looking at the sliders.
+     A sticky head inside the scroller was the smaller change and the wrong one: this
+     panel is translucent over the live cloud, so a sticky child would have had the
+     grade sliders visibly travelling underneath it. */
   #panel {
     position: fixed; top: 16px; left: 16px; width: 252px; max-height: calc(100vh - 32px);
-    overflow-y: auto; padding: 14px; border: 1px solid var(--line); border-radius: 10px;
+    display: flex; flex-direction: column; overflow: hidden;
+    border: 1px solid var(--line); border-radius: 10px;
     background: rgba(8, 11, 16, 0.82); backdrop-filter: blur(12px); z-index: 10;
-    scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.2) transparent;
   }
+  #panelHead { flex: none; padding: 14px 14px 0; }
+  /* `min-height: 0` because a flex item refuses to shrink below its content without it,
+     which would push the panel past the window rather than scrolling inside it. */
+  #panelBody { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 0 14px 14px;
+    scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.2) transparent; }
+  .panelbar { display: flex; align-items: center; gap: 8px; }
+  .panelbar h1 { flex: 1; min-width: 0; }
   #panel h1 { margin: 0 0 2px; font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; }
-  #status { color: var(--dim); margin-bottom: 12px; }
+  #status { color: var(--dim); }
   #status b { color: var(--accent); font-weight: 500; }
 
   .group { border-top: 1px solid var(--line); padding-top: 10px; margin-top: 10px; }
@@ -383,9 +401,25 @@
 </head>
 <body>
   <div id="panel">
-    <h1>Kinect v2</h1>
-    <div id="status">connecting…</div>
+    <!-- The head does not scroll, and the nav is here rather than at the foot of the
+         column for the reason web/nav.css gives at length. The markup below is the
+         same on all three surfaces, character for character apart from which chip
+         carries `aria-current` - neither does here, because this is neither of them. -->
+    <div id="panelHead">
+      <div class="panelbar">
+        <h1>Kinect v2</h1>
+        <nav class="surfacenav" id="navRow" aria-label="Surfaces">
+          <a id="toMenu" href="/">menu</a>
+          <a id="toLibrary" href="/gallery">gallery</a>
+        </nav>
+      </div>
+      <div id="status">connecting…</div>
+    </div>
 
+  <!-- Everything below scrolls. Left at its old indentation on purpose: this is a box
+       drawn around a block that did not otherwise change, and re-indenting a hundred
+       and eighty lines to say so would bury the change that was actually made. -->
+  <div id="panelBody">
     <!-- The shooting controls, and the four-fifths of them that are load-bearing:
          record, mark and how much time is left. Nothing here is a look. -->
     <div class="group" id="recordGroup">
@@ -571,12 +605,8 @@
       <div id="viewNote">Not saved with the clip and not exported: these change what you
         are looking at, not what the frame is.</div>
     </div>
-
-    <div class="btnrow" id="navRow">
-      <button id="toLibrary" type="button">gallery</button>
-      <button id="toMenu" type="button">menu</button>
-    </div>
-  </div>
+  </div><!-- #panelBody -->
+  </div><!-- #panel -->
 
   <div id="hint">drag to orbit · scroll to zoom · right-drag to pan · <b>H</b> hides panel</div>
 

--- a/web/library.html
+++ b/web/library.html
@@ -4,6 +4,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Kinect v2 · library</title>
+<!-- Before the page's own rules on purpose: nav.css owns how the chips look and the
+     page owns where they sit, so a placement rule here has to win the tie. -->
+<link rel="stylesheet" href="/nav.css" />
 <style>
   /* The system defined in web/index.html, restated in this file's own names the
      way the viewer restates it - two copies of a palette is two things to keep in
@@ -145,7 +148,11 @@
 
   @media (max-width: 560px) {
     .grid { grid-template-columns: minmax(0, 1fr); }
+    /* `.where` takes a row of its own here and gives up the auto margin that was
+       right-aligning it, which would leave the nav starting a third row at the left
+       edge - so the nav takes the margin over, and top-right stays top-right. */
     .where { margin-left: 0; width: 100%; }
+    .surfacenav { margin-left: auto; }
   }
 </style>
 </head>
@@ -155,6 +162,13 @@
   <h1>Library</h1>
   <div class="sum" id="sum">reading…</div>
   <div class="where" id="where"></div>
+  <!-- The same two chips as the editor's sidebar head and the menu's, in the same
+       order and the same corner. This page had no way back to the menu at all before
+       it, which is the half of "hidden at the bottom of a sidebar" that was worse. -->
+  <nav class="surfacenav" id="navRow" aria-label="Surfaces">
+    <a id="toMenu" href="/">menu</a>
+    <a id="toLibrary" aria-current="page">gallery</a>
+  </nav>
 </header>
 
 <div class="tabs" id="tabs">

--- a/web/main.js
+++ b/web/main.js
@@ -4625,8 +4625,6 @@ const ui = {
   recLookNote: document.getElementById('recLookNote'),
   recRange: document.getElementById('recRange'),
   extended: document.getElementById('extended'),
-  toLibrary: document.getElementById('toLibrary'),
-  toMenu: document.getElementById('toMenu'),
 };
 
 // The chips strip hides its scrollbar so the bar keeps its 51px and the lanes stay
@@ -4999,7 +4997,13 @@ addEventListener('keydown', (e) => {
 
   if (e.key === 'h' || e.key === 'H') {
     const p = document.getElementById('panel');
-    p.style.display = p.style.display === 'none' ? 'block' : 'none';
+    // Back to the empty string rather than to `block`, because the panel is a flex
+    // column now - a head that does not scroll over a body that does - and putting
+    // `block` back would leave the body unable to shrink, so pressing H twice would
+    // return a panel taller than the window with its foot cut off by the radius.
+    // The empty string restores whatever the stylesheet says, which is the only
+    // answer that stays right when the stylesheet changes.
+    p.style.display = p.style.display === 'none' ? '' : 'none';
     return;
   }
   if ((e.metaKey || e.ctrlKey) && (e.key === 'z' || e.key === 'Z')) {
@@ -6988,8 +6992,6 @@ if (ui.recGo) {
     })).json();
     ui.recNote.textContent = body.error ?? `${body.label} at ${(body.sourceMs / 1000).toFixed(1)}s`;
   });
-  ui.toLibrary.addEventListener('click', () => { location.href = '/gallery'; });
-  ui.toMenu.addEventListener('click', () => { location.href = '/'; });
 }
 
 // Everything below the shooting controls, revealed rather than removed. The design

--- a/web/menu.html
+++ b/web/menu.html
@@ -4,6 +4,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Kinect v2</title>
+<!-- Before the page's own rules on purpose: nav.css owns how the chips look and the
+     page owns where they sit, so a placement rule here has to win the tie. -->
+<link rel="stylesheet" href="/nav.css" />
 <style>
   /* The same palette the gallery restates, restated again. web/index.html is
      the system and each page carries its own copy of the names it uses, which is the
@@ -72,6 +75,10 @@
   .entry .dest { font-size: 9px; color: var(--faint); letter-spacing: 0.14em; text-transform: uppercase; }
   .entry .dest.fallthrough { color: var(--warn); }
 
+  /* Nothing else in this header competes for the right-hand end, so the nav takes it
+     directly rather than through a neighbour's auto margin the way the gallery's does. */
+  .surfacenav { margin-left: auto; }
+
   @media (max-width: 560px) {
     .menu { grid-template-columns: minmax(0, 1fr); align-content: start; }
   }
@@ -82,6 +89,14 @@
 <header class="head">
   <h1>Kinect v2</h1>
   <div class="sum">record, keep, re-photograph</div>
+  <!-- Here the nav is mostly saying where you are, since the three tiles below it are
+       this page's whole reason to exist. It is drawn anyway, marked as current: two
+       chips in the same corner on every surface is the claim, and a control that
+       vanishes on one of the three is a control people stop looking for. -->
+  <nav class="surfacenav" id="navRow" aria-label="Surfaces">
+    <a id="toMenu" aria-current="page">menu</a>
+    <a id="toLibrary" href="/gallery">gallery</a>
+  </nav>
 </header>
 
 <main class="menu" aria-label="Main menu">

--- a/web/nav.css
+++ b/web/nav.css
@@ -1,0 +1,59 @@
+/* The way out of a surface, in the same place on every surface.
+ *
+ * **This is the one thing the three pages share as a file rather than as a copy, and
+ * the palette's argument does not apply to it.** Each page restates the palette in its
+ * own names because a page should name only the tokens it uses and a colour that drifts
+ * is visible the moment you look at it. A navigation control is the opposite case on
+ * both counts: being the same control in the same place on every surface *is* the
+ * feature, so a copy that drifts is not a cosmetic slip but the defect itself, and it
+ * drifts silently because nobody has all three pages open at once.
+ *
+ * It was at the bottom of the editor's sidebar, below thirteen groups of sliders in a
+ * column that scrolls - which is to say it was unreachable without knowing it was
+ * there, on the surface where you most need to leave. The gallery had no way back to
+ * the menu at all.
+ *
+ * Placement stays with the page and only appearance lives here: the editor hangs this
+ * off a 252px sidebar head and the other two off a full-width header bar, and a
+ * `margin-left: auto` baked in here would fight the gallery's `.where`, which already
+ * uses one. What this file owns is that the chips look and behave identically.
+ *
+ * That split is why all three pages link this file *above* their own `<style>` block
+ * rather than below it. Nothing overlaps today - the only page-level rules are the two
+ * `margin-left` overrides - but a page reaching for something this file also sets is
+ * the page saying "not here", and losing that tie to a shared file by an accident of
+ * source order is the kind of divergence nobody would think to look for.
+ *
+ * Every custom property below is one all three pages already declare - checked against
+ * their `:root` blocks rather than assumed, because a token this file names and a page
+ * does not would render as an unstyled chip on that page alone, which is precisely the
+ * divergence the file exists to prevent.
+ */
+.surfacenav { display: flex; align-items: center; gap: 4px; flex: none; }
+
+/* Anchors, never buttons driving `location.href`. These are real URLs: the browser can
+ * show where they go, open one in a tab and come back from it - the argument menu.html
+ * already makes for its tiles, and the reason the editor's two lost their click
+ * handlers when they moved here. */
+.surfacenav a {
+  display: inline-flex; align-items: center; height: 22px; padding: 0 8px;
+  border: 1px solid var(--line); border-radius: 4px;
+  background: transparent; color: var(--dim); text-decoration: none;
+  font: inherit; font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase;
+  white-space: nowrap;
+}
+.surfacenav a[href]:hover { color: var(--ink); border-color: var(--line-3); }
+
+/* Where you already are, marked with the idiom the two pages that had one already use:
+ * menu.html greys a tile that has no `href` to make it unclickable rather than merely
+ * styled as if it were, and the gallery's state pips and `.where` dot say "this one" in
+ * accent. So the current surface is faint - the eye belongs on the place you can still
+ * go - and carries the dot to say faint means here rather than broken.
+ *
+ * It stays in the row rather than being dropped, so the control is two chips wide on
+ * every surface and neither of them moves when you arrive somewhere. */
+.surfacenav [aria-current="page"] { color: var(--faint); cursor: default; }
+.surfacenav [aria-current="page"]::before {
+  content: ''; width: 5px; height: 5px; border-radius: 50%; flex: none;
+  background: var(--accent); margin-right: 6px;
+}


### PR DESCRIPTION
The editor's `gallery` and `menu` buttons sat at the foot of the panel, under
thirteen groups of sliders in a column that scrolls, so on any window the panel
filled they were off screen until somebody scrolled for them - present in the
document, covered by a driver rule, and invisible to the person using the editor.
The gallery had no way back to the menu at all.

Both are now a two-chip nav in the top-right of all three surfaces, in the same
order, with the current surface marked `aria-current="page"` and rendered inert
rather than dropped - so the control is the same width in the same corner
whichever page you are on, and neither chip moves when you arrive somewhere. The
faint-plus-accent-dot treatment for "you are here" is the idiom menu.html already
uses for its unclickable Editor tile and the gallery uses for its state pips.

They are anchors with real hrefs now rather than buttons calling `location.href`,
which is the argument menu.html already makes for its tiles: a browser can show
where they go, open one in a tab and come back from it. The two click handlers in
main.js went with them, so there is one implementation rather than a link and a
handler that could disagree.

**web/nav.css is the one thing the three pages share as a file, and the palette's
argument does not apply to it.** Each page restates the palette in its own names
because a page should name only the tokens it uses and a drifted colour is visible
the moment you look at it. A navigation control is the opposite on both counts:
being the same control in the same place *is* the feature, so a copy that drifts
is the defect itself, and it drifts silently because nobody has all three pages
open at once. Placement stays with the page - the editor hangs it off a 252px
sidebar head, the other two off a full-width header bar - and the file is linked
above each page's `<style>` so a placement rule wins the tie.

**The panel is a head that does not scroll over a body that does.** A sticky head
inside the old single scroller was the smaller change and the wrong one: the panel
is translucent over the live cloud, so a sticky child would have had the grade
sliders visibly travelling underneath it. The `h` toggle had to follow, from
`display = 'block'` back to `''`: measured on the editor, `block` leaves
`#panelBody` with clientHeight === scrollHeight === 1883 and no scrollbar, so
everything past the panel's 720px is clipped by `overflow: hidden` and permanently
unreachable. The empty string restores whatever the stylesheet says, which is the
only answer that stays right when the stylesheet changes.

`body.editing #panel` narrowing max-height to `100vh - --timeline-h - 32px` is why
the panel is 720px rather than 868 at a 900px viewport. It sets nothing else this
change moved.

## The proof

`editor-check` section 1 gains four rows and `nav-at-the-foot` is the control for
them, restoring the nav to the foot of the scrolling column. Two flaws in the
probe were found by running that mutation rather than by reading the probe, and
both are the shapes CLAUDE.md already names:

- **The first probe changed the state it sampled.** It scrolled the panel body to
  the end and left it there, which put section 8's crop sliders under different
  pointer coordinates: the crop rows went from 0.005% apart to 0.446% and read as
  a rendering regression this change had caused. It restores the scroll position.
- **The second sat in a dead zone.** Scrolling to the *end* is exactly where a
  nav at the foot of the column is visible - the mutation came back 683px down and
  comfortably inside the panel, reddening only the structural half of the row. The
  end a foot-nav fails is the top, where the panel sits when you arrive, so both
  ends are read now and the mutated build answers 1958px.

The sweep selector gains `a`, because a nav moved out of `input, select, button`
would have left the sweep by disappearing rather than by failing. `sensor-view-check`'s
panel probe follows the groups into `#panelBody` and names `.surfacenav` beside
them, so the nav stays inside the closing row that asserts every unnamed block is
on both surfaces.

## Measurements

Method: one server on 8080 against `captures/sample.knct`, a fixture of 16 loops
of the repo's sample - 1440 frames, 48.0s of source time, 625MB - since the sample
itself is 2.97s and the check seeks to 10s and 24s. Every arm was paired against
the unmodified tree in the same session.

- `editor-check --no-render`: 86 assertions, 1 failed, against a baseline of 81/1.
  The one failure is the pre-existing crop-plane row at identical numbers either
  way (0.338 against 0.545, -0.206 of the stage apart).
- `editor-check --mutate nav-at-the-foot`: caught, 3 assertions fired, two of them
  the new geometric and structural rows.
- `plant-unswept-control` and `lanes-clear-siblings` both still anchor and still
  fire their own rows (2 and 9 assertions).
- `library-check`: 256 assertions, 3 failed - identical to baseline, row for row.
- `registry-check`: 2 failed (`snapDelta` unexplained), identical to baseline.
- `sensor-view-check`: 118 assertions, 2 failed, exit 2 UNTESTED for want of a
  sensor - identical to baseline. `fov-hardcoded` still fires 74.
- `syntax-check`: 34 files, 0 failed.

**The gallery's and the menu's nav is covered by browser evidence only.** No proof
tool sweeps either surface and none was added, so the editor's green says nothing
about them. Both were driven with playwright-cli: the nav renders top-right on all
three surfaces, the menu link navigates from the editor, and at 500px wide the
gallery's nav wraps to its own row and stays right-aligned.

Also worth knowing and deliberately not guarded: leaving `/record` mid-take does
not stop the recorder, which is server-side and keyed on the HTTP routes. This
change makes that exit more prominent.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>