### PR TITLE
Give the instruction file the name other agents look for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
`AGENTS.md` is now a symlink to `CLAUDE.md`. Codex and several other harnesses look for that name; Claude Code looks for the other one.

A copy would have been the obvious move and it is the failure this repo rejects by name — a second representation of something that already exists can only drift out of step with the first, and an instruction file that has drifted is worse than one that is missing, because an agent will follow it. A symlink is one file with two names and has nothing to keep in sync.

Named so it can be objected to cheaply: the file is `AGENTS.md` uppercase, matching the ecosystem convention and every other root document here. Say the word and it becomes `agents.md`.

**What was verified.** Git records the entry as mode `120000` with `CLAUDE.md` as the blob — checked with `git ls-files -s AGENTS.md` rather than by reading the arrow out of `ls -la`, because a clone with `core.symlinks` off commits a nine-byte regular file that looks identical to `git status` either way. The target is relative, so it resolves in every clone rather than only in this one.

**Proof tools.** `syntax-check` passes — 35 files, 0 failed, all 25 tools named in `CLAUDE.md`, which is the assertion a new root file could plausibly have disturbed. No other tool applies: this touches no code, and the rest of the suite needs a running server, a GPU browser or the sensor.

**One expected consequence.** GitHub's web UI renders a symlinked `.md` as its target path with a symlink icon rather than as the rendered contents. Anything that clones the repo follows it normally.