### PR TITLE
Split the instruction file, and point one arm at the picture the sensor view button moves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,30 @@ enforced — in the code's comments, which are long on purpose, and in the proof
 
 What has not changed is what to do when reality disagrees with an intention: **report the
 contradiction rather than silently redesigning**. That has happened repeatedly and
-reporting was the right move every time. The difference is only that the intention is now
-read out of the code and its comments rather than out of a document that could quietly
-stop being true.
+reporting was the right move every time.
+
+## Where the rest of this lives
+
+This file is the part that has to be in your head before you touch anything. The case files
+behind each rule — what was measured, what the instrument got wrong, and how it was closed —
+are three documents deep, and each one has a condition attached rather than an invitation:
+
+- **`docs/instruments.md`** — read it **before writing or modifying any proof tool**. Every
+  way a check in this repo has claimed a property it was not testing.
+- **`docs/measurement.md`** — read it **before reporting a number**. Which runs get thrown
+  away, and the rig's two pieces of hardware that read differently from how they measure.
+- **`docs/proof-tools.md`** — read it **before running or editing a specific tool**. What
+  each needs, what its exit codes mean, and the fixtures.
+
+**New lessons go in those files, not in this one.** A correction learned during a session
+belongs beside its neighbours in the relevant document, with this file gaining a line only
+if an agent would get the *next* task wrong without it. The version of this file that
+absorbed everything reached 704 lines and stopped being read.
+
+That chain is enforced rather than trusted: `syntax-check` walks every `docs/*.md` path
+cited here or under `tools/` and fails on one that does not exist, because a pointer that
+outlives its target teaches a document nobody can read. Its control is moving one of the
+three away and running it.
 
 ## Measurement culture
 
@@ -27,348 +48,51 @@ corrections are recorded beside the numbers rather than replacing them silently.
   whether the page cache was warm.
 - **Proxy evidence does not close a user-visible change.** Drive the real UI with
   `playwright-cli` and show it working. A passing unit test is not a rendered frame.
-- **Read a health number the measurement itself reports, and throw the run away when
-  it is wrong.** Delivered fps is that number for anything using the grabber: the
-  loop idles 55% of every interval, so a run that does not sustain ~30.0 was
-  competing for the machine and its per-segment timings are noise. A threading A/B
-  came back 22.75fps with registration p50 swinging 11.50/13.65/8.30ms across three
-  rounds of one arm, which reads as a wildly variable optimisation and was actually
-  Spotlight - `mds_stores` at 45% indexing the 280MB corpus and the build trees the
-  session had just created. `captures/` and `vendor/` now carry
-  `.metadata_never_index`. Re-run on a settled machine and the same comparison was
-  flat: all six arms 30.03-30.04fps, all three paired deltas the same sign.
+- **Read a health number the measurement itself reports, and throw the run away when it is
+  wrong.** Delivered fps is that number for anything using the grabber - a run that does not
+  sustain ~30.0 was competing for the machine and its per-segment timings are noise.
+- **An offline harness is for correctness; `grabber --profile` on the sensor is for cost.** A
+  screening measurement that removes the effect will confidently report its absence.
 
-### A tight loop cannot measure an allocation
+## Writing a check
 
-Two arms that both hit the allocator back to back are not an A/B of allocation
-cost. `Registration::apply` new/deletes 9.2MB per call, and measured offline by
-applying one frame five times in a row, hoisting those buffers came out *slower*
-in all three paired rounds - because the allocator hands the same block straight
-back and the baseline arm was already effectively persistent, leaving buffer
-alignment as the only real variable. On the real loop, where 33ms and a JPEG
-encode sit between calls, the same change is worth 0.30ms of 5.71ms. **An offline
-harness is for correctness; `grabber --profile` on the sensor is for cost** - and a
-screening measurement that removes the effect will confidently report its absence.
+The five rules that survive out of context. `docs/instruments.md` carries the case file for
+each, and there is a case file for each because every one of them was learned by shipping the
+mistake.
 
-### An instrument must enforce its claims, not assert them
+1. **An instrument must enforce its claims, not assert them.** Ask what a broken
+   implementation would have to do to still pass, and close that. **Every proof tool needs a
+   falsification control**: something that must FAIL if the thing under test were not doing
+   the work.
+2. **Mutation-test the instrument rather than reasoning about it.** Report which mutations you
+   ran and what each caught. Before believing a mutation was *missed*, confirm the mutation
+   did something; before believing one was *caught*, confirm it was caught for the reason
+   claimed.
+3. **Count failed assertions, never exit codes, and read which assertions fired.** The tools
+   disagree about what a caught mutation exits and the disagreement runs the dangerous way. A
+   run with zero failed assertions and a non-zero exit is a crash to investigate, not a catch
+   to record.
+4. **Place a probe where its answer would be different, not where it is convenient** — and ask
+   what all of your probes agree about, because a set of arms that agree on a quantity cannot
+   measure it however many of them there are.
+5. **Ask whether there is an object here that every observation happens to skip**, and be most
+   suspicious where the skipping was deliberate: a deliberate exclusion comes with a
+   justification that stops anybody looking twice. This has now cost three separate holes —
+   the take being recorded, and the editor's picture twice.
 
-This is the failure mode this repo keeps producing, so check for it by name. Twice now a
-proof tool has stated a condition in its header while doing nothing to bring it about:
+**Close the class, not the instance.** Fixing the six routes that were found leaves the
+seventh outside the list; making the route table *be* the dispatch and having the check walk
+it means a route added later is asked by existing.
 
-- `determinism-check --clock` claimed "no frame ever arriving" but left the socket to
-  whatever the server was doing, and returned FAIL/PASS/PASS on an unchanged tree.
-- `index-check` claimed the scan never holds the file, while an implementation that appended
-  every chunk to an array would have passed every assertion it made.
-
-Both are fixed and both now enforce the condition — the first intercepts the socket and
-*verifies the interception held*, the second asserts resident memory against a ceiling and a
-growth bound. When you write a proof tool, ask what a broken implementation would have to do
-to still pass it, and close that. **Every proof tool needs a falsification control**:
-something that must FAIL if the thing under test were not actually doing the work.
-
-### Mutation-test the instrument, don't just reason about it
-
-Deliberately break the thing under test, run the check, and confirm it fails on the
-assertions it should. This is the method that turns the rule above from an intention into a
-result, and it has now caught two flaws that reading the code did not:
-
-- A serialisation check whose `||` clause let it pass on key count alone.
-- A malformed-value table that passed its cases into the page through `JSON.stringify` —
-  which turns `NaN` and `undefined` into `null`, so three cases labelled as NaN were silently
-  testing null a second and third time. **If you send test values into a browser, send them
-  as source, not as JSON**, or your labels will claim coverage you do not have.
-
-Report which mutations you ran and what each one caught. A check nobody has broken on purpose
-is a check nobody knows the sensitivity of.
-
-**A mutation that does nothing reads as a check that found nothing.** Step 5 produced one:
-a mutation meant to draw editor furniture into the rendered frame reached for `gl.scissor`
-and `gl.clear` directly, which three's own state cache overrode, so the pixels never changed
-and the check reported a clean pass. Rewritten through `renderer.setScissor` it fails at
-`max 189/255`. **Before believing a mutation was missed, confirm the mutation did something** -
-have it move a number the check already prints, or the verdict is about the mutation rather
-than about the check.
-
-**And the converse, which is worse, because it reads as coverage: before believing a mutation
-was *caught*, confirm it was caught for the reason claimed.** Step 7 built a plant for the
-route sweep - a read route that writes a document and puts it back inside the same request,
-which a before-and-after comparison of the contents cannot see by construction, since both
-readings are taken outside the request. It failed two rows, and one of them was the contents
-comparison it was written to walk past. The reason had nothing to do with the property under
-test: APFS keeps modification times to the nanosecond, `utimesSync` takes a `Date` carrying
-milliseconds, and the 0.13ms the restore could not put back is what failed the row -
-`1785523816453.8726` against `1785523816454`. On a filesystem with coarser stamps the identical
-plant walks straight through, so the control was asserting the platform rather than the design,
-while looking exactly like a control that works. **This was found by measuring, not by reading**
-- the mutation was run and the two snapshots diffed field by field, which is the only thing that
-distinguishes a row that went red for its own reason from one that went red for a neighbouring
-one. The fix was to rebuild the plant so nothing about it depends on the filesystem:
-write-then-remove touches nothing that survives, leaves the listing identical, and moves only
-the monotonic write count. It now fails that one row and leaves the contents row passing, which
-is what makes the count load-bearing rather than a second way of saying the same thing.
-
-**A mutation run that exits non-zero with zero failed assertions did not run.** Both tools
-refuse a mutation whose anchor text they cannot find, and Playwright occasionally dies with
-`Execution context was destroyed` partway through a run - and all three outcomes exit 1,
-which reads as a caught mutation to anything checking only the exit code. Seen twice on step
-5, on two different mutations in two different suite runs. **Count failed assertions, not
-exit codes**, and treat `fails=0` as a crash to investigate rather than a success to record.
-
-**And `fails=1` can be the same crash wearing the count.** Counting assertions is not enough
-on its own if the harness's own failure is one of the things it counts. `monitor-check` caught
-its `catch` in `failed++`, so `expand-shifts-by-a-block` on a machine busy with an unrelated
-export timed out waiting for the take, fired exactly one assertion — that timeout — and printed
-`caught, as required (1 assertion fired)`. Nothing about sample placement had been tested. Run
-again on a settled machine it fires eight, all of them the intended row. So a throw is now
-`crashed` rather than `failed`, and the verdict is `DID NOT RUN` with exit **2**, checked before
-the mutation verdict and before `untested`. **Read which assertions fired, not how many** — and
-a proof tool must never count its own crash as a finding in either direction.
-
-**A cumulative table hides which term is wrong.** Step 6 measured the look at two
-output sizes down one pipeline - points, then trails, then "grade" - and reverting
-any single grade term moved that row by less than the row's own sampling residual,
-so three mutations passed. One row per term fixed it: `rgbsplit-absolute` now fails
-the rgbsplit row and leaves the grain and scanline rows alone, which is a check
-saying *what* broke rather than *that* something did.
-
-**Three of step 6's probes were also standing in dead zones**, each for its own
-reason, and each was found by mutation rather than by reading. The additive
-normalisation is clamped to 1 beyond 0.83m, so at the default framing a mutation of
-it changed nothing at all - the probe needed a camera inside the cloud. Grain at the
-preset's 0.22 is about one part in 255, so reverting its reference grid moved every
-number by 4% - the probe needed the slider at full. And an export at the editor's
-own buffer size cannot tell an output size that reached the renderer from one that
-did not - that probe needed a size the editor is not.
-
-**Close the class, not the instance — and have the check enumerate it.** A review of step 7
-found six HTTP routes that changed something while dispatching on the path alone, one at a
-time, which makes six a floor rather than a total. Fixing them individually would have left
-the next route anybody adds outside the list. The routes are now one table that *is* the
-dispatch, served at `/library/routes`, and `library-check` walks it: every route with a write
-handler is asked for its method, its content type and its origin, so a route added later is
-asked by existing. Enumerating turned up four mutating routes the individual poking missed -
-`/library/delete/:id`, `/library/sync-marks/:id`, `/record/mark` and `/presets/:name`, ten
-against six. **The falsification control has to be a mutation that adds a mutating route
-without registering it** — and for one round this paragraph said so while the suite had
-no such mutation. What it had was `stop-route-reads`, which *moves* `/record/stop`'s
-handler into the `read` slot, caught by a hardcoded floor on the route counts
-(`mutating.length >= 10 && writeOnly.length >= 7`). Moving a route drops both counts and
-trips the floor; **adding** one moves neither in the failing direction, so the floor was
-blind by construction to the shape this paragraph names. A planted read route writing a
-project passed the whole suite at 241 of 241, exit 0, with its file on disk afterwards.
-`read-route-writes` is the control now, and what catches it is a snapshot of every store
-rather than a count of registered routes — because a count cannot answer "did a read
-handler mutate something".
-
-**Two agreements made that sweep blind, and both are the same question as step 6's
-aspect ratio.** The shooting server was spawned with **no `--projects` and no
-`--presets`**, so three of the library's five stores sat outside the one directory being
-snapshotted — which is the mechanical reason the plant was invisible. And the
-**recording** take's id was substituted into every `:id`, where `beingRecorded` answers
-409 before the handler runs: five capture routes were driven and never executed, counted
-as swept and not swept. The sweep now drives an open take and a closed one, GET and HEAD,
-document names that exist and names that do not, and asserts by name that every route got
-past the 409 — with any route it cannot build a concrete URL for named rather than
-silently driven at a URL still carrying a literal `:foo`.
-
-**Assert against the resource, not against the bookkeeping that claims to track it.**
-`/library/descriptors` reported `openCaptures.size`, and the bug underneath it dropped the map
-entry while leaving the `FileHandle` open - so the number *fell* while the real count rose, and
-an arm reading it watched a descriptor leak and recorded a descriptor being released, 0 against
-a real 2. It reports `readdirSync('/dev/fd').length` beside it now and the arm asserts on that.
-The same question is worth asking of any count a proof tool reads back from the thing under
-test.
-
-**`p.x.__proto__ = v` in a probe is not what a file on disk does.** Assignment invokes the
-`__proto__` setter and creates no own property at all, so `Object.entries` never sees it and
-the document handed to the loader is unchanged - two rows labelled `__proto__` passed against
-a build that accepted `__proto__`, because the probe never contained one. `JSON.parse` and
-`Object.defineProperty` both create the own, enumerable property that a real file produces.
-This is the mirror of the `JSON.stringify` trap already recorded above: values sent as source
-survive, except this one key, where source is the shape that does not.
-
-**A mean absolute difference cannot see noise that moved.** Grain that has shifted
-is as different from grain that has not as grain that has thinned, so both grade
-mutations survived every difference-based threshold the sampling residual left room
-for. What catches them is a correlation: high-pass both images and correlate, and a
-structure quantised onto a shared reference grid correlates 0.94 where a continuously
-sampled one correlates 0.77.
-
-**Playwright drops the page's execution context here, and it is not the code.** A
-second live WebGL page while an export is reading pixels back will sometimes take
-the renderer process down, and it arrives as `Execution context was destroyed` -
-with the server log showing the export it happened during completing normally, all
-frames present. `export-check` runs one browser at a time and retries that specific
-error up to three times, printing the retry count; anything else propagates on the
-first attempt, because a check that retried real failures would report whichever
-attempt it liked.
-
-**`page.evaluate(fnSourceString, arg)` does not call the function.** Playwright
-evaluates the string as an expression, so the arrow function is created, never
-invoked, and `undefined` comes back - which surfaced three helpers later as a
-missing shot rather than as a call that did not happen. The house pattern is
-`page.evaluate(\`(${FN})(${JSON.stringify(opts)})\`)`, and it is what the other
-tools already do.
-
-**Place a probe where its answer would be different, not where it is convenient.** A third
-flaw came out of this on step 5: a mutation replacing the pre-roll's window query with the
-tangent it replaced was caught by only one of five probe positions, because four of them sat
-inside a single straight segment of the retime curve where the tangent *is* the curve. The
-probes were moved onto the knees and onto an eased ramp and the same mutation now fails four.
-Ask what the wrong implementation would agree with, and probe somewhere it cannot.
-
-**A probe that changes the state it samples proves whatever it did to it.** This is a
-distinct failure from the two above - not a probe in a dead zone and not a vacuous
-assertion, but an observer effect inside the instrument, and it is easy to write because
-the sampling call looks passive. Step 7's recorder check waited for takes by polling the
-library, then asserted each closed take held all the frames its writer emitted. Listing
-the library scans every capture in the directory *including the one still being written*,
-and the scan writes a sidecar - so "does a sidecar exist" stopped meaning "the take is
-finished" the moment something asked the question, and the take that was mid-recording
-was counted against a total it was never going to reach. It came in at 10 frames and at
-11 on two runs, which is the burst plus however long the last poll took, and it fired on
-four unrelated mutations before it was pinned - a check red for reasons that have nothing
-to do with what is under test, which is how a gating check teaches people to re-run until
-green. The fix was to take "closed" from the writer's own log rather than from an artifact
-the reader creates. **Before polling for a condition, ask what the polling call itself
-writes, opens or caches** - anything that lists, scans or indexes a directory something
-else is writing is a candidate.
-
-**When one probe turns out to be blind to something, ask what all of them are blind to
-together.** Step 6 got the first half of this right and stopped one question short, which is
-why it is a rule rather than a note. Its commit reasons that `pointsize-absolute` passes the
-1728x1080 arm because the scale factor is exactly 1 there, and keeps a second arm at
-1920x1200 for that reason - correct, and it never asked what every arm agreed about at once.
-The answer was the aspect ratio. Every arm in `export-check` was 1.6 - 960x600, 1920x1200,
-1728x1080, the 640x400 stage - and at 1.6 `bufferWidth / 1728` and `bufferHeight / 1080` are
-not close but *identical*, so a build referencing the width was bit-identical on every arm
-and would have passed all 30 assertions while drawing 11.1% too large on every size the
-export menu offers. A set of probes that agree about a quantity cannot measure it however
-many of them there are, and the agreement is invisible precisely because each arm confirms
-the others. **The tell was there to be read: the values the instrument tested were not the
-values the product ships** - four sizes in the menu, all 16:9, and not one of them in the
-check. Compare the constants a tool sweeps against the constants the UI offers, and treat a
-disjoint pair as a hole until measured otherwise. The fix was one cross-build arm at
-1920x1080 and a `scale-by-width` mutation, which now fails that row and leaves every other
-assertion in the file passing.
-
-**That rule has a second form, and it hides better: not every arm agreeing about one
-quantity, but every observation of a single *object* switched off at once, each for its own
-locally defensible reason.** Step 7's route sweep watched five stores, a write counter and the
-recorder's own state, and a read route appending 64KB to the take being recorded passed all
-251 assertions at exit 0 — leaving nine 4096-byte runs of 0x07 in the file and
-`stream desync at 6349028: expected magic KNCT, got 0x7070707` when it finally closed. Three
-decisions assembled into that hole and every one of them is right on its own: the open take's
-size and modification time are excluded from the snapshot **by name**, because they move on
-their own and comparing them would flake; no write counter covers the captures directory,
-because the counters were built for the document stores; and the recorder's state field tracks
-the recorder rather than the file, which is what it is for. Reading any one of them finds
-nothing wrong. **The file they all skipped was the take being shot** — the most valuable thing
-in the system, excluded on purpose, for a good reason.
-
-So ask the question in both directions. Not only "what do my arms agree about", but **"is there
-an object here that every observation happens to skip"** — and be most suspicious where the
-skipping was deliberate, because a deliberate exclusion comes with a justification that stops
-anybody looking twice. The fix was to assert the identity `bytes === on-disk size` after the
-take closes, where nothing is in flight and it is exact, with `plant-open-take` as the control.
-
-**A mutation can erase its own evidence.** `plant-open-take` originally appended its foreign
-bytes through a second file descriptor. After the recorder moved onto `createWriteStream`, that
-descriptor and the recorder's descriptor had independent offsets: the append extended the file,
-then the next real frame wrote from the recorder's older offset and overwrote all 64KB before the
-take closed. The mutated build passed 256 assertions because it no longer contained the damage
-the control claimed to plant. The control now writes through the recorder's own stream, between
-two real frames, so the foreign bytes survive to the scan. When a mutation is unexpectedly green,
-inspect the mutated artifact before weakening the assertion; the code change may have undone
-itself rather than escaped the observation.
-
-**Step 9 produced the same shape one step later, and this time the skipped object was the
-picture.** `monitor-check` had four sections and every arm in all four watched the server —
-what it grants, what it puts on the wire, what it writes to disk — so a viewer that rendered a
-÷4 frame as a *different scene* passed all 49 assertions. It did: `bindDepth` wrote the smaller
-grid into the head of the 512x424 texture, because `TypedArray.set` only objects to a source
-that is too **long**, and 93.8% of the grid then held the last full-rate frame while the live
-cloud collapsed into a band a metre above the optical axis. Nothing was excluded on purpose
-here — the monitor's own output simply never occurred to anyone as a thing to measure, which is
-the harder version, since there is no justification to argue with. **A tool named after a
-user-facing surface should have at least one arm pointed at that surface.** Section 5 drives a
-browser; `bind-ignores-grid` and `expand-shifts-by-a-block` are one control each, and the
-second exists because the first reddens every row and a control that fails everything cannot
-say which row carries the claim.
-
-**A counter that reports zero may be counting a string nothing emits.** Step 9's
-monitor-cost harness grepped `not all subsequences received` — the phrase
-`grabber --help` itself names when describing the dropped-isochronous counter. The node
-emits `skipping depth packet` in quantity and the other one almost never, so the delta was
-**zero in every arm across two full runs**, and that got written into the design doc as the
-loss happening with no USB packet loss at all — a result that appeared to refute the
-mechanism the doc claimed. Counted properly it is 24 packets per 40s with no client against
-347 with a full-rate monitor. A zero delta from a wrong pattern is indistinguishable from a
-real absence, and an absence is the one result nobody re-checks because it looks like the
-instrument working. **Before believing a counter that reports no change, grep the raw log
-for what the system actually says and confirm the phrase appears at all** — a phrase in the
-tool's own help text is not evidence the running build emits it. This one was caught by
-reading journald after installing a systemd unit, entirely by accident, which is not a method.
-
-**A gate calibrated on earlier runs and then passed marginally by the run that matters is
-not a gate.** The same harness inherited `prof-summary`'s 29.5fps floor, which belongs to a
-profiling run that writes nothing; a continuously recording run legitimately sits under it,
-as the design doc already says at 29.86 over two minutes. Three windows at 28.90/29.19/28.83
-were thrown away as contended when a spread of 0.36 is what a settled rig looks like — the
-tell for contention in the thread-count sweep was *variance and non-monotonicity*, not the
-absolute level. The gate is baseline spread now. Note the trap in the fix as well: the
-threshold was set from two earlier runs' spreads and the run carrying the only correct packet
-data cleared it by 0.04, so that column is recorded as measured once rather than replicated.
-
-**Letterboxing the editor stage moved every pointer coordinate and every buffer-size
-expectation, and four proof tools found out one at a time.** `export-check` needed two
-separate fixes, `registry-check` failed its render-scale row, and `keyframe-check` failed
-four rows in a way that read as a missing feature — `camera.project()` answers in canvas
-coordinates and `page.mouse` takes viewport ones, which were the same number only while the
-canvas sat at the window's corner. **When a change moves where the canvas is, the tools that
-drive it by coordinate are all suspect, not just the ones that mention size.**
-
-**`await ssh(...)` cannot launch a long-lived remote process.** ssh does not return until the
-channel has no holders, and a backgrounded remote process holds it whatever `nohup` and
-`< /dev/null` are given — the symptom is a driver frozen with the server running perfectly
-well on the other side, and it cost two runs before the cause was read off the fact that the
-next log line never printed. Detach and poll for readiness. Likewise **a multi-line script
-through `bash -c "..."` loses twice**: the outer shell expands every `$(...)` before bash sees
-it, and JSON quoting carries newlines as two literal characters. Ship it base64. And on this
-node `pkill -f` matches the remote shell running your own command — resolve listeners by port
-through `ss`.
-
-**Never `git stash` in a worktree of this repo.** The stash is a single ref in the shared
-`.git`, so every worktree pushes onto one stack. A session here stashed to take a baseline
-measurement, a concurrent session in `ridgehead` stashed ninety seconds later, and the pop
-restored *ridgehead's* `server/index.js` into this tree while orphaning six files of this
-one's — silently, because the pop was redirected to `/dev/null` and only its exit code would
-have said so. Nothing is lost when it happens, since the stash commits survive as unreachable
-objects (`git fsck --unreachable`, then read `%s` for `On <branch>:` and take `^3` for the
-untracked file), but the recovery is long and the interference runs both ways. To take a
-baseline, copy the modified files somewhere outside the repo, `git checkout --` them, measure,
-and copy them back.
-
-**And that session was the reason four proof-tool runs failed, in two different ways.**
-`library-check` binds **fixed** ports — 8210 and 8211, plus `MAC_PORT + 2/4/5` — so two
-worktrees running it at once do not get an address-in-use error, they get each other's server:
-the arm here stat-ed `three-warning-take.knct`, a fixture belonging to the other tree, and
-reported the run as not finishing. Pass `--node-port`/`--mac-port` and take a range nothing
-else holds. The second way is quieter and worse, because it looks like a finding: under
-contention the preset-apply evaluate dies with `Resulting promise was garbage collected`, a
-sibling of the `Execution context was destroyed` the call is already wrapped against, and the
-run stops at 139 of 256 assertions. That reproduced **five times** against a change while a
-baseline taken on an idle machine passed twice, which reads as a regression with a clean
-control — and the change was innocent. What settled it was running the *unmodified* tree
-back to back in the same conditions, where it crashed identically. **Before believing a
-proof tool caught your change, re-run the baseline in the conditions the failure happened
-in, not the conditions the baseline happened in** — and check `pgrep -f "tools/.*-check.mjs"`
-first, because on this machine another agent's run is the normal state rather than the
-exception.
+**Before believing a proof tool caught your change, re-run the baseline in the conditions the
+failure happened in**, not the conditions the baseline happened in. A contended machine makes
+a check fail in ways that read as a finding — this cost five reproductions against an innocent
+change, with a clean control taken on an idle machine.
 
 ## Proof tools
 
-Each takes a running server and exits non-zero on failure.
+Each takes a running server and exits non-zero on failure. `docs/proof-tools.md` says what
+each one needs.
 
 ```
 node tools/determinism-check.mjs                    # step 1: same program time, same image
@@ -393,6 +117,7 @@ node tools/monitor-check.mjs --mutate bind-ignores-grid          # ... and must 
 node tools/monitor-check.mjs --mutate expand-shifts-by-a-block   # ... and must FAIL mutated
 node tools/sensor-view-check.mjs                          # the intrinsics a take was shot with, against a build that assumes them
 node tools/sensor-view-check.mjs --mutate fov-hardcoded   # ... and must FAIL mutated
+node tools/sensor-view-check.mjs --mutate no-repaint      # ... and must FAIL mutated
 node tools/guard-check.mjs                                # the socket's origin rule, the bind, and the rebinding rule
 node tools/guard-check.mjs --mutate upgrade-skips-origin  # ... and must FAIL mutated
 node tools/guard-check.mjs --mutate host-accepts-a-name   # ... and must FAIL mutated
@@ -400,60 +125,17 @@ node tools/jobs-check.mjs                                 # step 8: the queue, t
 node tools/jobs-check.mjs --mutate claim-ignores-renderer # ... and must FAIL mutated
 ```
 
-`jobs-check` spawns its own server and renders one real job through
-`tools/render-worker.mjs`, so it needs a GPU browser and ffprobe. `--no-render` drops
-that row and says so - the queue rows are seconds, the render row is a minute. Its
-mutation runs use `--no-render` because all five are queue semantics.
+`jobs-check` needs a GPU browser and ffprobe and renders one real job through
+`tools/render-worker.mjs`; `--no-render` drops that row. `guard-check` and `library-check`
+spawn their own servers. `export-check` needs ffmpeg and ffprobe.
 
-**The worker reads its renderer class out of the browser it will render in and cannot
-be told one.** `channel: 'chromium'` rather than the bundled headless shell, which has
-no GPU and falls back to SwiftShader - a class nothing else can reproduce, which the
-worker refuses outright rather than pinning jobs to.
+**`library-check` binds fixed ports** — 8210, 8211 and `MAC_PORT + 2/4/5` — so two worktrees
+running it at once do not collide, they get each other's server. Pass `--node-port` and
+`--mac-port` a range nothing else holds, and check `pgrep -f "tools/.*-check.mjs"` before any
+run, because on this machine another agent's is the normal state.
 
-`guard-check` spawns its own servers and needs none running. It exits **2** when the
-machine has no non-internal IPv4, because "not listening on the network" is only a
-claim if there is a second address a client could have arrived on - the same reading
-as `library-check`'s low-space row. Every refusal it asserts has a positive twin, so
-a server that refused every upgrade, or bound to nothing, fails it rather than
-passing quietly.
-
-`library-check` had no invocation line at all until this merge, while being referenced
-twice below it — so the list taught a six-tool sweep where there are seven. `plant-open-take`
-is the right mutation to name here rather than a milder one: it is the control for the hole
-that let a read route destroy the take being shot.
-
-`editor-check` enumerates rather than lists, and it exists because **the suite tested the
-model and never the control**. The clip in/out markers were detached from the document
-during boot for the whole life of the feature — `rebuildLanes` cleared `#tBeds` of every
-child that was neither `.ruler` nor the playhead, and `#tIn`/`#tOut` were neither. Nothing
-caught it because nothing looked: no proof tool referenced `#tIn`, `#tOut` or `.tcut` at
-all, and `export-check` drives in/out through `activeDeliverable`, which is the model. The
-model was perfect throughout; `paintTimeline` simply wrote `style.left` onto two nodes no
-document contained. So section 1 walks every interactive control the page renders and fails
-on any it has no driver for, with `plant-unswept-control` as the control for that claim —
-without it, "every control was tested" is a sentence the tool writes about itself.
-**Aiming its layout mutation took three attempts, and the two misses are recorded in the
-file** because each was NOT CAUGHT against a build with a fix removed: the rule they named
-had been made redundant by the two-row bar, which is worth knowing about the fix as well as
-about the check.
-
-`nav-at-the-foot` is the control for a second claim section 1 makes, that the way out of the
-editor is *reachable* rather than merely present — it was under thirteen groups of sliders at
-the end of a column that scrolls, which is being in the document and nowhere on the screen.
-**Its first probe sat in a dead zone of exactly the kind recorded above**: it scrolled the
-column to its end and asked whether the nav was inside the panel, and the end of the travel is
-precisely where a nav at the foot *is* visible — the mutation came back 683px down and
-comfortably in view, reddening only the structural half of the row. The end a foot-nav fails is
-the top, where the panel sits when you arrive, so both ends are read now and the mutated build
-answers 1958px. The probe is also the one thing in section 1 that moves the page it measures,
-and leaving the column scrolled put section 8's crop sliders under different pointer
-coordinates: the crop rows went from 0.005% apart to 0.446% and read as a rendering regression
-the change had caused. It restores the scroll position now. **Both flaws were found by running
-the mutation and reading which rows fired, not by reading the probe.**
-
-The two below need no server, and `registration-check` needs no sensor either -
-it runs on a corpus of `Registration::apply` inputs dumped by
-`grabber --dump-corpus`.
+The two below need no server, and `registration-check` needs no sensor either - it runs on a
+corpus of `Registration::apply` inputs dumped by `grabber --dump-corpus`.
 
 ```
 node tools/vendor-check.mjs                          # third_party is upstream v0.2.1 + declared edits
@@ -462,8 +144,9 @@ node tools/registration-check.mjs                    # our registration == upstr
 node tools/registration-check.mjs --mutate one-lsb   # ... and must FAIL mutated
 ```
 
-These two are what CI runs. `syntax-check` needs nothing at all; `release-gate-check`
-needs the registry, for the reason below, and exits 2 when it cannot reach it:
+The two below are what CI runs. `syntax-check` needs nothing at all; `release-gate-check` needs the
+registry and exits 2 when it cannot reach it, because it proves the gate by npm's refusal
+rather than by reading a config key:
 
 ```
 node tools/syntax-check.mjs                          # every JS file this repo ships parses
@@ -471,190 +154,27 @@ node tools/release-gate-check.mjs                    # the .npmrc supply-chain g
 node tools/release-gate-check.mjs --mutate wrong-unit # ... and must FAIL (also: no-gate, absent)
 ```
 
-**npm 12 is the version this repo uses.** CI installs `npm@12.0.2` explicitly in the
-gate job rather than taking whatever `setup-node` bundles, because this check is the one
-thing here whose answer depends on the npm running it.
-
-**`release-gate-check` used to read `npm config get before`, and that method was wrong
-in the direction that looks like a failure.** npm derives its cutoff from the age
-internally; npm 11.12.1 exposed the derived date through `before`, and 11.16.0 and
-12.0.2 answer `null` there while enforcing the gate identically. So the first public
-push went red against a repository whose gate had never been open - the config reading
-was bookkeeping that had stopped tracking the resource. The check now asks npm to
-resolve a package and reads the cutoff out of the refusal, which is measured identical
-on all three versions.
-
-**And this file used to say npm fails open on a value it cannot parse, which it does
-not.** Measured on 11.12.1, 11.16.0 and 12.0.2: `min-release-age=2d` warns `invalid
-config` and then stops with `npm error Invalid time value`, exit 1, nothing installed.
-A wrong *unit* is loud. What is silent is an npm older than 11, which does not know the
-key and installs ungated without a word, and a value npm accepts that nobody meant -
-`0` puts the cutoff at this instant and `-1` puts it tomorrow, neither warning about
-anything, which is what the tool's two bounds rows are for.
-
-It masks the user and global config layers while it runs, and that is load-bearing
-rather than tidiness: this machine carries the same gate in `~/.npmrc`, so an unmasked
-run inherits it and proves nothing about the repo. Rewriting the check reproduced that
-exact mistake in a throwaway probe - with the layers unmasked, the *no gate* arm came
-back carrying a cutoff.
-
-`syntax-check` refuses to pass on finding no files, for the reason this file keeps
-restating: a checker that globbed wrong prints a clean result about nothing. The roots
-must exist, each must yield files, and the count is printed beside the verdict so a
-number that has quietly halved is visible rather than implied. It also asserts that
-every tool in `tools/` is named in this file - see below.
-
-And the seven with no home anywhere above, listed because a tool nobody documented is
-a tool nobody runs. The arithmetic, written down because a count nobody adds up is how
-this list rotted the first time: `tools/` holds **25** files, of which **16** are
-`*-check` proof tools, **7** are the block below, and **2** — `prof-summary.mjs` and
-`render-worker.mjs` — are described further up beside the tools that drive them rather
-than here. This line said "four" over a list of six until that was counted instead of
-recalled, which is the same drift the paragraph below it warns about, happening to the
-paragraph that warns about it:
+And the ones that are not proof tools, listed because a tool nobody documented is a tool
+nobody runs. **`syntax-check` enforces that list**: anything in `tools/` this file does not
+mention fails it, so a tool added next year is asked by existing. The arithmetic, written
+down because a count nobody adds up is how this list rotted the first time: `tools/` holds
+**25** files, of which **16** are `*-check` proof tools and **9** are the block below.
 
 ```
 node tools/build-native.mjs        # builds libfreenect2 into vendor/prefix, then the grabber
 node tools/fake-grabber.mjs        # a grabber that needs no sensor, for driving the server
 node tools/make-fixture.js         # loops one short capture into an arbitrarily long one
-node tools/sweep-all.mjs           # every mutation of every tool; needs a server and hours
+node tools/sweep-all.mjs           # every mutation of four tools; needs a server and hours
 node tools/settle-probe.mjs        # does settle()'s drain scale with the take or the ceiling
+node tools/prof-summary.mjs        # reads grabber --profile output, flags contended runs
+node tools/render-worker.mjs       # renders one queued job; jobs-check drives it
 tools/monitor-cost-ab.mjs          # the monitor's cost on a capture node, over SSH
 tools/pi-registration-ab.sh        # the threading A/B runbook for a capture node
 ```
 
-**That list is enforced rather than maintained, because the version of it that was
-maintained had already rotted.** This file said "all six" tools refuse an unmatched
-mutation when eleven do, said "the four server tools" invert nothing when five do,
-documented a `--url` flag `library-check` does not have, and omitted `sensor-view-check`
-entirely - a 1277-line proof tool that `editor-check` cites three times. Every one of
-those was found by counting rather than by reading.
-
-Fixing the six names would have closed the instance and left the class open, which is
-the mistake this file names elsewhere. So `syntax-check` now walks `tools/` and fails
-on any file not mentioned here, and the check runs in CI - a tool added later is asked
-by existing. The falsification control is adding a tool without documenting it.
-**`vendor-check` reads the built artifact as well as the source, and that closes most
-of the gap it landed with.** Sections 1-4 prove `third_party/` is upstream plus the
-declared edits; section 5 asserts the library actually installed at `vendor/prefix`
-carries `LIBFREENECT2_REG_THREADS`, the env override the threading edit introduces.
-Without it the check passed identically whether the grabber loaded that source or a
-stale prefix built from something else - and it silently would have, because the
-grabber's call passes two optional out-parameters any libfreenect2 0.2 accepts, so an
-old prefix links and streams single-threaded with nothing looking wrong. The control
-is `--mutate stale-prefix`, which points the assertion at `vendor/prefix-oracle` -
-a real library registration-check builds from upstream's own registration.cpp, rather
-than a doctored copy of ours - and it must FAIL. **What is still source-only is the
-sub-9 fix**, whose `& 0x1ff` compiles to an immediate and leaves nothing in the binary
-to look for; the tool says so rather than implying it covers both. Exit **2** where no
-prefix exists, on the same reading as `library-check`'s: untested is not passed.
-
-`registration-check` builds both sides every run - a pristine upstream prefix and
-ours - because a stale oracle `.dylib` turns the whole thing into a build compared
-against itself and nothing about a stale library looks wrong. It exits **2** for a
-build or runtime failure and **1** only when assertions fired, so a mutation that
-failed to compile can never be recorded as a mutation that was caught.
-
-`tools/prof-summary.mjs <profile> [warmup]` reads `grabber --profile` output and
-flags any run under 29.5fps as contended, because the segment timings from a run
-that dropped frames are noise. `tools/pi-registration-ab.sh` is the unrun runbook
-for measuring the threading on a capture node; it builds both arms, checks with
-`ldd` that they load different libraries, and refuses to report milliseconds from
-an arm that lost frames.
-
-The registration corpus is gitignored like every other capture. Regenerate it with
-the sensor attached, and vary the scene while it runs - a hand near the lens, a
-person against a far wall, something occluding something further - because the
-occlusion filter only does work at depth discontinuities:
-
-```
-./native/build/grabber --dump-corpus captures/reg-corpus --dump-count 40 --dump-every 45
-```
-
-Coverage is measurable rather than assumed: `registration-check --mutate
-filter-never-rejects` reports what fraction of pixels the filter actually
-rejects. The committed corpus's 72 frames sit at 6.93%; a first capture of one
-static-ish scene managed 6.55%.
-
-`export-check` needs ffmpeg and ffprobe (`--ffmpeg`, `--ffprobe`; 8.1.1 at
-`/opt/homebrew/bin`) and writes into `exports/`, which is gitignored.
-
-`--clock` refuses a rev whose `main.js` already contains the transport, so it needs
-`--before` pointing at a commit before step 1.
-
-`library-check` exits **2**, not 0, when a claim went unproven - the low-space refusal needs a
-real small filesystem and only macOS gets one here. The verdict line says so too. Anything
-gating on `!== 0` therefore treats a Linux run as not-a-pass, which is the intended reading:
-"some claims were not tested here" and "a claim failed" are different answers and 1 already
-means the second. `registration-check` reserves 2 for the same reason on the other side of
-the merge — a build or runtime failure there is "the harness did not run", not "the harness
-found something" — so the convention was reached twice independently and the two paragraphs
-are describing one rule rather than two.
-
-`--mutate <name>` serves a deliberately broken `main.js` into the running server, or for the
-two vendoring tools rebuilds a deliberately broken source tree. **Eleven tools carry
-mutations** — editor, export, guard, jobs, keyframe, library, monitor, registration,
-sensor-view, timeline and vendor — and all of them refuse a mutation whose text they cannot
-find exactly once, because a replacement that silently matched nothing would run the unmutated
-page and be recorded as the check having missed a bug it was never shown. **A mutation is a
-piece of source text, so a mutation stops matching the moment the code it names is edited** —
-three of `timeline-check`'s nine had to be re-anchored when step 5 rewrote the retime seam,
-and the refusal is what surfaced that rather than a silent pass.
-
-**The tools disagree about what a caught mutation exits, the disagreement runs the dangerous
-way, and it is worse than this paragraph used to say — so read the assertion count and never
-the code.** Counted rather than recalled, because the previous count here said "six" and
-"four" when the real numbers were eleven and five, which is the drift this file warns about
-happening to this file:
-
-- **Five exit non-zero on a catch and say `NOT CAUGHT` when they miss**: `guard-check`,
-  `jobs-check`, `editor-check`, `monitor-check`, `sensor-view-check`.
-- **Two invert it**: `vendor-check` and `registration-check`, where caught is exit **0** with
-  `caught, as required (N assertions fired)` and exit **1** is `NOT CAUGHT`. Anything gating on
-  "non-zero means caught" reads a genuine miss by these two as a catch.
-- **Four have no `NOT CAUGHT` branch at all** and simply exit on their failure count:
-  `timeline-check`, `export-check`, `keyframe-check`, `library-check`. **A mutation these four
-  fail to catch exits 0**, which reads as a clean pass rather than as the check being blind.
-  That is the same direction as the inverted pair and it is silent rather than merely
-  confusing, so it is the worse of the two shapes.
-
-Which is why the rule is worded the way it is: count failed assertions, never exit codes — and
-read *which* assertions fired, because a tool that counts its own crash as a failure reports a
-catch it never made.
-
-`keyframe-check` runs its cheapest claim first, on a 60-second budget, and stops the run if
-it fails. That is not ordering by cost: an evaluator that announces its writes schedules a
-seek per frame, each of which renders a pre-roll which evaluates, so the page never answers
-and never errors - it runs out of memory some minutes later, somewhere else. A bounded probe
-turns that into a sentence.
-
-## Fixtures
-
-`captures/` is gitignored; the generator is committed and the artifacts are not.
-
-```
-node tools/make-fixture.js captures/sample.knct captures/fixture-large.knct --loops 32
-```
-
-**The sample was captured on a degraded link — median gap 64ms, mean 107ms, about 9.3fps
-rather than 30.** So size fixtures by *frame count*, not duration: five minutes of its source
-time is 1.38 GB where a real full-rate five-minute take is 4.42 GB. A fixture is the sample
-looped with rewritten monotonic stamps — real depth and real JPEGs, only the u64 at payload
-offset 8 moves. Say so whenever a number rests on one.
-
-## The Mac's USB topology reads worse than it measures
-
-`ioreg -p IOUSB -w0` shows the sensor as controller -> `USB3.0 Hub` -> `NuiSensor
-Adaptor` -> `Xbox NUI Sensor`, with a gigabit ethernet adapter on that same hub.
-Against the README's "1 hub, own controller" that looks like the degraded
-topology which measures 12.82fps, and it is not - **this rig sustains 30.02fps
-with 2 subsequence warnings in 1921 frames.** The `USB3.0 Hub` is a good
-high-speed one and the count is not the thing that matters.
-
-Note also that `system_profiler SPUSBDataType` returns *nothing at all* on this
-machine, so a check built on it reads as "no Kinect attached" whether one is
-attached or not. Use `ioreg`. And settle the question by running the grabber and
-reading delivered fps rather than by counting boxes in a tree.
+`captures/` is gitignored; `make-fixture` regenerates what the suite needs, and **the sample it
+loops was shot on a degraded link at about 9.3fps**, so size fixtures by frame count rather
+than by duration. See `docs/proof-tools.md`.
 
 ## Two things that are easy to get backwards
 
@@ -677,32 +197,23 @@ thing that should be touching capture bytes.
   Match the density and voice already in the file.
 - Commits: imperative subject, then a body explaining the why and carrying the measurements
   with their methods.
-- **`pointSize` is pixels at 1080p.** Step 6 made every screen-space term relative to a
-  1080p reference, and that rebased both presets and the registry default by 1080/600 -
-  the 600 being the buffer the look was graded against. `registry-check` asserts the
-  factor rather than skipping the value, so a preset re-tuned by hand to something near
-  it fails. A project saved before that change needs its point size scaled by the buffer
-  height it was authored at.
-- **1080p is the unit; 600 is the graded chain, and both numbers are correct.** Every
-  screen-space term is *expressed* against a 1080p reference - that is what `pointSize`,
-  the grade's frequencies and the split's offset are all in. Bloom is the one term with
-  no parameter to express, because its width lives in a tap count baked into three's
-  shaders, so instead its mip chain is *frozen* at what the old code produced at the
-  600-tall buffer the look was authored on (`resize` calls `setSize(aspect * 300, 300)`).
-  Freezing it at 1080 makes it constant across output sizes and 1.8x too tight, which is
-  a look nobody graded. Same reference, two ways of holding it.
-
-  **Two references are in play and they are not the same thing, so do not reconcile them.**
-  1080p is the *unit* every screen-space term is expressed in — a value means the pixels it
-  would draw at 1080p, so `k = drawingBufferHeight / 1080` scales it wherever the frame
-  actually lands. 600 is the *graded chain*: bloom's mip chain is frozen at what the old
-  build produced at a 600-tall buffer, because `UnrealBloomPass` bakes a fixed tap count in
-  at construction, so its halo's width is a tap count over a texel count and freezing the
-  chain anywhere else changes the glow rather than preserving it. Both were measured — a
-  1080-frozen chain lands 7.16/255 on the worst of forty tile means against the graded look,
-  where the 600-frozen one lands 1.10. So `main.js` correctly reads `bufferHeight / 1080.0`
-  in the shaders and `(buf.x / buf.y) * 600` at `bloom.setSize`, and neither is a typo for
-  the other.
+- **`pointSize` is pixels at 1080p**, and every screen-space term with it. A project saved
+  before step 6 needs its point size scaled by the buffer height it was authored at, and
+  `registry-check` asserts the 1080/600 rebase factor rather than skipping the value, so a
+  preset re-tuned by hand to something near it fails.
+- **1080p is the unit; 600 is bloom's frozen chain; both are correct and do not reconcile
+  them.** Every screen-space term is *expressed* against 1080p, which is why `main.js` reads
+  `bufferHeight / 1080.0` in the shaders. Bloom has no parameter to express, because
+  `UnrealBloomPass` bakes its tap count in at construction, so its mip chain is instead frozen
+  at the 600-tall buffer the look was graded on: `resize` computes
+  `refWidth = (buf.x / buf.y) * 600` and then sets the chain at half of it,
+  `setSize(aspect * 300, 300)`. Neither reference is a typo for the other, and the mechanism
+  is the reason - the halo's width is a tap count over a texel count, so a chain with 1.8x
+  the texels has a halo 1.8x tighter, constant at last and constant at a glow nobody tuned.
+  Measured: a 1080-frozen chain lands 7.16/255 off the graded look on the worst of forty
+  tile means where the 600-frozen one lands 1.10. The comment above `bloom.setSize` in
+  `web/main.js` carries the rest, including the undersampling gap above 1200 that nothing
+  has measured.
 
 ## Process hygiene
 
@@ -714,3 +225,14 @@ for p in $(lsof -ti tcp:8080 -sTCP:LISTEN); do kill "$p"; done
 
 A bare `lsof -ti tcp:8080` also matches processes *connected to* the port, and `pkill -f`
 matches the shell running your own command.
+
+**Never `git stash` in a worktree of this repo.** The stash is a single ref in the shared
+`.git`, so every worktree pushes onto one stack. A session here stashed to take a baseline
+measurement, a concurrent session in `ridgehead` stashed ninety seconds later, and the pop
+restored *ridgehead's* `server/index.js` into this tree while orphaning six files of this
+one's — silently, because the pop was redirected to `/dev/null` and only its exit code would
+have said so. Nothing is lost when it happens, since the stash commits survive as unreachable
+objects (`git fsck --unreachable`, then read `%s` for `On <branch>:` and take `^3` for the
+untracked file), but the recovery is long and the interference runs both ways. To take a
+baseline, copy the modified files somewhere outside the repo, `git checkout --` them, measure,
+and copy them back.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,15 +46,17 @@ about it:
 - **A passing unit test is not a rendered frame.** For anything user-visible, drive the real UI
   and show it working.
 
-`CLAUDE.md` carries the long version, including the war stories behind each rule. It is written
-for an AI agent working in the repository, but the method is not agent-specific and it is
-probably the most transferable thing here.
+`CLAUDE.md` carries the short version, and `docs/instruments.md` and `docs/measurement.md` carry
+the war stories behind each rule — how a check claimed a property it was not testing, and which
+runs get thrown away. They are written for an AI agent working in the repository, but the method
+is not agent-specific and it is probably the most transferable thing here.
 
 ## Proof tools
 
 There is no `npm test` that runs everything, because most of the suite needs a server, a GPU
 browser, or a sensor. Instead `tools/` holds a set of proof tools, each of which takes a running
-server and exits non-zero on failure. `CLAUDE.md` lists them with what each one needs.
+server and exits non-zero on failure. `CLAUDE.md` lists them and `docs/proof-tools.md` says what
+each one needs.
 
 Two conventions matter if you touch them:
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -1,0 +1,348 @@
+# Writing a proof tool that means something
+
+Read this before writing or modifying any proof tool. It is the case file behind the
+short rules in `CLAUDE.md`, and every entry is something that was found by running the
+thing rather than by reading it.
+
+Two neighbouring documents, and the seam between them is worth stating so a new lesson
+lands in the right one. **This file is about a check that must fail when the thing under
+test is broken.** `docs/measurement.md` is about a number you would report. And
+`docs/proof-tools.md` is the suite reference — what each tool needs and what its exit
+codes mean.
+
+## An instrument must enforce its claims, not assert them
+
+This is the failure mode this repo keeps producing, so check for it by name. Twice now a
+proof tool has stated a condition in its header while doing nothing to bring it about:
+
+- `determinism-check --clock` claimed "no frame ever arriving" but left the socket to
+  whatever the server was doing, and returned FAIL/PASS/PASS on an unchanged tree.
+- `index-check` claimed the scan never holds the file, while an implementation that appended
+  every chunk to an array would have passed every assertion it made.
+
+Both are fixed and both now enforce the condition — the first intercepts the socket and
+*verifies the interception held*, the second asserts resident memory against a ceiling and a
+growth bound. When you write a proof tool, ask what a broken implementation would have to do
+to still pass it, and close that. **Every proof tool needs a falsification control**:
+something that must FAIL if the thing under test were not actually doing the work.
+
+## Mutation-test the instrument, don't just reason about it
+
+Deliberately break the thing under test, run the check, and confirm it fails on the
+assertions it should. This is the method that turns the rule above from an intention into a
+result, and it has now caught two flaws that reading the code did not:
+
+- A serialisation check whose `||` clause let it pass on key count alone.
+- A malformed-value table that passed its cases into the page through `JSON.stringify` —
+  which turns `NaN` and `undefined` into `null`, so three cases labelled as NaN were silently
+  testing null a second and third time. **If you send test values into a browser, send them
+  as source, not as JSON**, or your labels will claim coverage you do not have.
+
+Report which mutations you ran and what each one caught. A check nobody has broken on purpose
+is a check nobody knows the sensitivity of.
+
+### A mutation that does nothing reads as a check that found nothing
+
+Step 5 produced one: a mutation meant to draw editor furniture into the rendered frame
+reached for `gl.scissor` and `gl.clear` directly, which three's own state cache overrode, so
+the pixels never changed and the check reported a clean pass. Rewritten through
+`renderer.setScissor` it fails at `max 189/255`. **Before believing a mutation was missed,
+confirm the mutation did something** - have it move a number the check already prints, or the
+verdict is about the mutation rather than about the check.
+
+### Before believing a mutation was *caught*, confirm it was caught for the reason claimed
+
+This is the converse of the rule above and it is worse, because it reads as coverage. Step 7
+built a plant for the route sweep - a read route that writes a document and puts it back
+inside the same request, which a before-and-after comparison of the contents cannot see by
+construction, since both readings are taken outside the request. It failed two rows, and one
+of them was the contents comparison it was written to walk past. The reason had nothing to do
+with the property under test: APFS keeps modification times to the nanosecond, `utimesSync`
+takes a `Date` carrying milliseconds, and the 0.13ms the restore could not put back is what
+failed the row - `1785523816453.8726` against `1785523816454`. On a filesystem with coarser
+stamps the identical plant walks straight through, so the control was asserting the platform
+rather than the design, while looking exactly like a control that works.
+
+**This was found by measuring, not by reading** - the mutation was run and the two snapshots
+diffed field by field, which is the only thing that distinguishes a row that went red for its
+own reason from one that went red for a neighbouring one. The fix was to rebuild the plant so
+nothing about it depends on the filesystem: write-then-remove touches nothing that survives,
+leaves the listing identical, and moves only the monotonic write count. It now fails that one
+row and leaves the contents row passing, which is what makes the count load-bearing rather
+than a second way of saying the same thing.
+
+### A mutation run that exits non-zero with zero failed assertions did not run
+
+Every tool that carries mutations refuses one whose anchor text it cannot find, and
+Playwright occasionally dies with `Execution context was destroyed` partway through a run -
+and all three outcomes exit 1, which reads as a caught mutation to anything checking only the
+exit code. Seen twice on step 5, on two different mutations in two different suite runs.
+**Count failed assertions, not exit codes**, and treat `fails=0` as a crash to investigate
+rather than a success to record.
+
+### And `fails=1` can be the same crash wearing the count
+
+Counting assertions is not enough on its own if the harness's own failure is one of the
+things it counts. `monitor-check` caught its `catch` in `failed++`, so
+`expand-shifts-by-a-block` on a machine busy with an unrelated export timed out waiting for
+the take, fired exactly one assertion — that timeout — and printed `caught, as required
+(1 assertion fired)`. Nothing about sample placement had been tested. Run again on a settled
+machine it fires eight, all of them the intended row. So a throw is now `crashed` rather than
+`failed`, and the verdict is `DID NOT RUN` with exit **2**, checked before the mutation
+verdict and before `untested`. **Read which assertions fired, not how many** — and a proof
+tool must never count its own crash as a finding in either direction.
+
+### A mutation can erase its own evidence
+
+`plant-open-take` originally appended its foreign bytes through a second file descriptor.
+After the recorder moved onto `createWriteStream`, that descriptor and the recorder's
+descriptor had independent offsets: the append extended the file, then the next real frame
+wrote from the recorder's older offset and overwrote all 64KB before the take closed. The
+mutated build passed 256 assertions because it no longer contained the damage the control
+claimed to plant. The control now writes through the recorder's own stream, between two real
+frames, so the foreign bytes survive to the scan. When a mutation is unexpectedly green,
+inspect the mutated artifact before weakening the assertion; the code change may have undone
+itself rather than escaped the observation.
+
+## Where a probe stands
+
+### A cumulative table hides which term is wrong
+
+Step 6 measured the look at two output sizes down one pipeline - points, then trails, then
+"grade" - and reverting any single grade term moved that row by less than the row's own
+sampling residual, so three mutations passed. One row per term fixed it: `rgbsplit-absolute`
+now fails the rgbsplit row and leaves the grain and scanline rows alone, which is a check
+saying *what* broke rather than *that* something did.
+
+### Three of step 6's probes were standing in dead zones
+
+Each for its own reason, and each was found by mutation rather than by reading. The additive
+normalisation is clamped to 1 beyond 0.83m, so at the default framing a mutation of it
+changed nothing at all - the probe needed a camera inside the cloud. Grain at the preset's
+0.22 is about one part in 255, so reverting its reference grid moved every number by 4% - the
+probe needed the slider at full. And an export at the editor's own buffer size cannot tell an
+output size that reached the renderer from one that did not - that probe needed a size the
+editor is not.
+
+### Place a probe where its answer would be different, not where it is convenient
+
+A third flaw came out of this on step 5: a mutation replacing the pre-roll's window query
+with the tangent it replaced was caught by only one of five probe positions, because four of
+them sat inside a single straight segment of the retime curve where the tangent *is* the
+curve. The probes were moved onto the knees and onto an eased ramp and the same mutation now
+fails four. Ask what the wrong implementation would agree with, and probe somewhere it
+cannot.
+
+### `nav-at-the-foot` stood in a dead zone and then moved the page it measured
+
+Both flaws at once, in one probe, and both were found by running the mutation and reading
+which rows fired rather than by reading the probe. It is the control for section 1's second
+claim in `editor-check`, that the way out of the editor is *reachable* rather than merely
+present — it was under thirteen groups of sliders at the end of a column that scrolls, which
+is being in the document and nowhere on the screen.
+
+**The dead zone**: the first version scrolled the column to its end and asked whether the nav
+was inside the panel, and the end of the travel is precisely where a nav at the foot *is*
+visible — the mutation came back 683px down and comfortably in view, reddening only the
+structural half of the row. The end a foot-nav fails is the top, where the panel sits when you
+arrive, so both ends are read now and the mutated build answers 1958px.
+
+**The observer effect**: the probe is the one thing in section 1 that moves the page it
+measures, and leaving the column scrolled put section 8's crop sliders under different pointer
+coordinates — the crop rows went from 0.005% apart to 0.446% and read as a rendering regression
+the change had caused. It restores the scroll position now.
+
+### A probe that changes the state it samples proves whatever it did to it
+
+This is a distinct failure from the two above - not a probe in a dead zone and not a vacuous
+assertion, but an observer effect inside the instrument, and it is easy to write because the
+sampling call looks passive. Step 7's recorder check waited for takes by polling the library,
+then asserted each closed take held all the frames its writer emitted. Listing the library
+scans every capture in the directory *including the one still being written*, and the scan
+writes a sidecar - so "does a sidecar exist" stopped meaning "the take is finished" the moment
+something asked the question, and the take that was mid-recording was counted against a total
+it was never going to reach. It came in at 10 frames and at 11 on two runs, which is the burst
+plus however long the last poll took, and it fired on four unrelated mutations before it was
+pinned - a check red for reasons that have nothing to do with what is under test, which is how
+a gating check teaches people to re-run until green. The fix was to take "closed" from the
+writer's own log rather than from an artifact the reader creates. **Before polling for a
+condition, ask what the polling call itself writes, opens or caches** - anything that lists,
+scans or indexes a directory something else is writing is a candidate.
+
+## What do my arms agree about
+
+**When one probe turns out to be blind to something, ask what all of them are blind to
+together.** Step 6 got the first half of this right and stopped one question short, which is
+why it is a rule rather than a note. Its commit reasons that `pointsize-absolute` passes the
+1728x1080 arm because the scale factor is exactly 1 there, and keeps a second arm at 1920x1200
+for that reason - correct, and it never asked what every arm agreed about at once. The answer
+was the aspect ratio. Every arm in `export-check` was 1.6 - 960x600, 1920x1200, 1728x1080, the
+640x400 stage - and at 1.6 `bufferWidth / 1728` and `bufferHeight / 1080` are not close but
+*identical*, so a build referencing the width was bit-identical on every arm and would have
+passed all 30 assertions while drawing 11.1% too large on every size the export menu offers. A
+set of probes that agree about a quantity cannot measure it however many of them there are,
+and the agreement is invisible precisely because each arm confirms the others.
+
+**The tell was there to be read: the values the instrument tested were not the values the
+product ships** - four sizes in the menu, all 16:9, and not one of them in the check. Compare
+the constants a tool sweeps against the constants the UI offers, and treat a disjoint pair as
+a hole until measured otherwise. The fix was one cross-build arm at 1920x1080 and a
+`scale-by-width` mutation, which now fails that row and leaves every other assertion in the
+file passing.
+
+### The second form: an object every observation happens to skip
+
+The rule above has a second form, and it hides better: not every arm agreeing about one
+quantity, but every observation of a single *object* switched off at once, each for its own
+locally defensible reason. It has now produced three failures in a row.
+
+**Step 7, and the skipped object was the take being shot.** The route sweep watched five
+stores, a write counter and the recorder's own state, and a read route appending 64KB to the
+take being recorded passed all 251 assertions at exit 0 — leaving nine 4096-byte runs of 0x07
+in the file and `stream desync at 6349028: expected magic KNCT, got 0x7070707` when it finally
+closed. Three decisions assembled into that hole and every one of them is right on its own:
+the open take's size and modification time are excluded from the snapshot **by name**, because
+they move on their own and comparing them would flake; no write counter covers the captures
+directory, because the counters were built for the document stores; and the recorder's state
+field tracks the recorder rather than the file, which is what it is for. Reading any one of
+them finds nothing wrong. The file they all skipped was the most valuable thing in the system,
+excluded on purpose, for a good reason.
+
+So ask the question in both directions. Not only "what do my arms agree about", but
+**"is there an object here that every observation happens to skip"**
+— and be most suspicious where
+the skipping was deliberate, because a deliberate exclusion comes with a justification that
+stops anybody looking twice. The fix was to assert the identity `bytes === on-disk size` after
+the take closes, where nothing is in flight and it is exact, with `plant-open-take` as the
+control.
+
+**The sensor view button produced it a second time, where the skipped object was the picture
+and the excuse was that the camera is easier to read.** `sensor-view-check` had six sections
+asserting `freeCamera.position`, `fov`, the fit and the stores, and not one pixel: the pose is
+set several lines before `sensorView` asks for an image, so deleting `requestRepaint()` from
+it leaves **all 125 assertions green** while the editor's picture does not move until the next
+pointer gesture happens to render it. Section 7 and `--mutate no-repaint` are that gap closed,
+and what makes them worth reading is that the comparison was vacuous twice before it worked,
+both times reporting a picture that moved when nothing had rendered at all:
+
+- **The chrome overlay is a second canvas sitting exactly over the picture**, and `drawChrome`
+  repaints the path and the frustum from the new pose on the next animation frame whether or
+  not the renderer drew anything. A stage compared with it visible says CHANGED against the
+  mutated build.
+- **The panel is translucent over the picture's left edge**, so a comparison clipped to the
+  canvas rectangle contains the button being pressed - and the pixel row passed under
+  `no-repaint` on the *hover highlight of the button itself*. The rect is now hit-tested with
+  `elementFromPoint` on a grid and shrunk until every probe lands on the canvas, which is a
+  region defined by what is on top of it rather than by anybody's bounds.
+
+There is a third thing that had to be arranged and it is not furniture: **OrbitControls runs
+with damping, and `advanceNavigation` calls `controls.update()` inside every render**, so
+while the controls hold momentum two renders of one position genuinely differ - measured, as
+the section's own control row. Any before/after of the picture is therefore about the coasting
+camera unless the residual is spent first. **Anything comparing two frames of this editor
+needs all three: the overlay off, the region hit-tested, and the damping drained.**
+
+**Step 9 produced the same shape a third time, and the skipped object was again the picture.**
+`monitor-check` had four sections and every arm in all four watched the server — what it
+grants, what it puts on the wire, what it writes to disk — so a viewer that rendered a ÷4 frame
+as a *different scene* passed all 49 assertions. It did: `bindDepth` wrote the smaller grid
+into the head of the 512x424 texture, because `TypedArray.set` only objects to a source that is
+too **long**, and 93.8% of the grid then held the last full-rate frame while the live cloud
+collapsed into a band a metre above the optical axis. Nothing was excluded on purpose here —
+the monitor's own output simply never occurred to anyone as a thing to measure, which is the
+harder version, since there is no justification to argue with. **A tool named after a
+user-facing surface should have at least one arm pointed at that surface.** Section 5 drives a
+browser; `bind-ignores-grid` and `expand-shifts-by-a-block` are one control each, and the
+second exists because the first reddens every row and a control that fails everything cannot
+say which row carries the claim.
+
+## Close the class, not the instance — and have the check enumerate it
+
+A review of step 7 found six HTTP routes that changed something while dispatching on the path
+alone, one at a time, which makes six a floor rather than a total. Fixing them individually
+would have left the next route anybody adds outside the list. The routes are now one table
+that *is* the dispatch, served at `/library/routes`, and `library-check` walks it: every route
+with a write handler is asked for its method, its content type and its origin, so a route
+added later is asked by existing. Enumerating turned up four mutating routes the individual
+poking missed - `/library/delete/:id`, `/library/sync-marks/:id`, `/record/mark` and
+`/presets/:name`, ten against six.
+
+**The falsification control has to be a mutation that adds a mutating route without
+registering it.** For one round the document said so while the suite had no such mutation.
+What it had was `stop-route-reads`, which *moves* `/record/stop`'s handler into the `read`
+slot, caught by a hardcoded floor on the route counts (`mutating.length >= 10 &&
+writeOnly.length >= 7`). Moving a route drops both counts and trips the floor; **adding** one
+moves neither in the failing direction, so the floor was blind by construction to the shape
+the rule names. A planted read route writing a project passed the whole suite at 241 of 241,
+exit 0, with its file on disk afterwards. `read-route-writes` is the control now, and what
+catches it is a snapshot of every store rather than a count of registered routes — because a
+count cannot answer "did a read handler mutate something".
+
+**Two agreements made that sweep blind, and both are the same question as step 6's aspect
+ratio.** The shooting server was spawned with **no `--projects` and no `--presets`**, so three
+of the library's five stores sat outside the one directory being snapshotted — which is the
+mechanical reason the plant was invisible. And the **recording** take's id was substituted into
+every `:id`, where `beingRecorded` answers 409 before the handler runs: five capture routes
+were driven and never executed, counted as swept and not swept. The sweep now drives an open
+take and a closed one, GET and HEAD, document names that exist and names that do not, and
+asserts by name that every route got past the 409 — with any route it cannot build a concrete
+URL for named rather than silently driven at a URL still carrying a literal `:foo`.
+
+## Assert against the resource, not against the bookkeeping that claims to track it
+
+`/library/descriptors` reported `openCaptures.size`, and the bug underneath it dropped the map
+entry while leaving the `FileHandle` open - so the number *fell* while the real count rose, and
+an arm reading it watched a descriptor leak and recorded a descriptor being released, 0 against
+a real 2. It reports `readdirSync('/dev/fd').length` beside it now and the arm asserts on that.
+The same question is worth asking of any count a proof tool reads back from the thing under
+test.
+
+## Things that bite in a browser
+
+**`p.x.__proto__ = v` in a probe is not what a file on disk does.** Assignment invokes the
+`__proto__` setter and creates no own property at all, so `Object.entries` never sees it and
+the document handed to the loader is unchanged - two rows labelled `__proto__` passed against a
+build that accepted `__proto__`, because the probe never contained one. `JSON.parse` and
+`Object.defineProperty` both create the own, enumerable property that a real file produces.
+This is the mirror of the `JSON.stringify` trap recorded above: values sent as source survive,
+except this one key, where source is the shape that does not.
+
+**A mean absolute difference cannot see noise that moved.** Grain that has shifted is as
+different from grain that has not as grain that has thinned, so both grade mutations survived
+every difference-based threshold the sampling residual left room for. What catches them is a
+correlation: high-pass both images and correlate, and a structure quantised onto a shared
+reference grid correlates 0.94 where a continuously sampled one correlates 0.77.
+
+**A contended machine fails a check in a way that reads as a finding.** Two worktrees running
+proof tools at once produced four failed runs, and the quiet one is the dangerous one: under
+contention the preset-apply evaluate dies with `Resulting promise was garbage collected`, a
+sibling of the `Execution context was destroyed` the call is already wrapped against, and
+`library-check` stops at 139 of 256 assertions. That reproduced **five times** against a
+change while a baseline taken on an idle machine passed twice - a regression with a clean
+control, and the change was innocent. What settled it was running the *unmodified* tree back
+to back in the same conditions, where it crashed identically. **Re-run the baseline in the
+conditions the failure happened in**, and check `pgrep -f "tools/.*-check.mjs"` first. The
+loud half of the same collision is in `docs/proof-tools.md`: `library-check` binds fixed
+ports, so two runs get each other's server rather than an address-in-use error.
+
+**Playwright drops the page's execution context here, and it is not the code.** A second live
+WebGL page while an export is reading pixels back will sometimes take the renderer process
+down, and it arrives as `Execution context was destroyed` - with the server log showing the
+export it happened during completing normally, all frames present. `export-check` runs one
+browser at a time and retries that specific error up to three times, printing the retry count;
+anything else propagates on the first attempt, because a check that retried real failures would
+report whichever attempt it liked.
+
+**`page.evaluate(fnSourceString, arg)` does not call the function.** Playwright evaluates the
+string as an expression, so the arrow function is created, never invoked, and `undefined` comes
+back - which surfaced three helpers later as a missing shot rather than as a call that did not
+happen. The house pattern is `page.evaluate(\`(${FN})(${JSON.stringify(opts)})\`)`, and it is
+what the other tools already do.
+
+**Letterboxing the editor stage moved every pointer coordinate and every buffer-size
+expectation, and four proof tools found out one at a time.** `export-check` needed two separate
+fixes, `registry-check` failed its render-scale row, and `keyframe-check` failed four rows in a
+way that read as a missing feature — `camera.project()` answers in canvas coordinates and
+`page.mouse` takes viewport ones, which were the same number only while the canvas sat at the
+window's corner. **When a change moves where the canvas is, the tools that drive it by
+coordinate are all suspect, not just the ones that mention size.**

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -1,0 +1,87 @@
+# Taking a number in this repo
+
+Read this before reporting a measurement. It is the case file behind the short rules in
+`CLAUDE.md`: how a number gets taken here, which runs get thrown away, and the two pieces
+of hardware whose behaviour reads differently from how it measures.
+
+The seam against its neighbour: **this file is about a number you would report.**
+`docs/instruments.md` is about a check that must fail when the thing under test is broken.
+
+## Read a health number the measurement itself reports, and throw the run away when it is wrong
+
+Delivered fps is that number for anything using the grabber: the loop idles 55% of every
+interval, so a run that does not sustain ~30.0 was competing for the machine and its
+per-segment timings are noise.
+
+A threading A/B came back 22.75fps with registration p50 swinging 11.50/13.65/8.30ms across
+three rounds of one arm, which reads as a wildly variable optimisation and was actually
+Spotlight - `mds_stores` at 45% indexing the 280MB corpus and the build trees the session had
+just created. `captures/` and `vendor/` now carry `.metadata_never_index`. Re-run on a settled
+machine and the same comparison was flat: all six arms 30.03-30.04fps, all three paired deltas
+the same sign.
+
+## A tight loop cannot measure an allocation
+
+Two arms that both hit the allocator back to back are not an A/B of allocation cost.
+`Registration::apply` new/deletes 9.2MB per call, and measured offline by applying one frame
+five times in a row, hoisting those buffers came out *slower* in all three paired rounds -
+because the allocator hands the same block straight back and the baseline arm was already
+effectively persistent, leaving buffer alignment as the only real variable. On the real loop,
+where 33ms and a JPEG encode sit between calls, the same change is worth 0.30ms of 5.71ms.
+**An offline harness is for correctness; `grabber --profile` on the sensor is for cost** - and
+a screening measurement that removes the effect will confidently report its absence.
+
+## A gate calibrated on earlier runs and then passed marginally by the run that matters is not a gate
+
+The monitor-cost harness inherited `prof-summary`'s 29.5fps floor, which belongs to a profiling
+run that writes nothing; a continuously recording run legitimately sits under it, at 29.86 over
+two minutes. Three windows at 28.90/29.19/28.83 were thrown away as contended when a spread of
+0.36 is what a settled rig looks like — the tell for contention in the thread-count sweep was
+*variance and non-monotonicity*, not the absolute level. The gate is baseline spread now.
+
+Note the trap in the fix as well: the threshold was set from two earlier runs' spreads and the
+run carrying the only correct packet data cleared it by 0.04, so that column is recorded as
+measured once rather than replicated.
+
+## A counter that reports zero may be counting a string nothing emits
+
+Step 9's monitor-cost harness grepped `not all subsequences received` — the phrase
+`grabber --help` itself names when describing the dropped-isochronous counter. The node emits
+`skipping depth packet` in quantity and the other one almost never, so the delta was **zero in
+every arm across two full runs**, and that got written up as the loss happening with no USB
+packet loss at all — a result that appeared to refute the mechanism the rest of the work
+claimed. Counted properly it is 24 packets per 40s with no client against 347 with a full-rate
+monitor.
+
+A zero delta from a wrong pattern is indistinguishable from a real absence, and an absence is
+the one result nobody re-checks because it looks like the instrument working. **Before
+believing a counter that reports no change, grep the raw log for what the system actually says
+and confirm the phrase appears at all** — a phrase in the tool's own help text is not evidence
+the running build emits it. This one was caught by reading journald after installing a systemd
+unit, entirely by accident, which is not a method.
+
+## The Mac's USB topology reads worse than it measures
+
+`ioreg -p IOUSB -w0` shows the sensor as controller -> `USB3.0 Hub` -> `NuiSensor Adaptor` ->
+`Xbox NUI Sensor`, with a gigabit ethernet adapter on that same hub. Against the README's
+"1 hub, own controller" that looks like the degraded topology which measures 12.82fps, and it
+is not - **this rig sustains 30.02fps with 2 subsequence warnings in 1921 frames.** The
+`USB3.0 Hub` is a good high-speed one and the count is not the thing that matters.
+
+Note also that `system_profiler SPUSBDataType` returns *nothing at all* on this machine, so a
+check built on it reads as "no Kinect attached" whether one is attached or not. Use `ioreg`.
+And settle the question by running the grabber and reading delivered fps rather than by
+counting boxes in a tree.
+
+## Driving a capture node over ssh
+
+**`await ssh(...)` cannot launch a long-lived remote process.** ssh does not return until the
+channel has no holders, and a backgrounded remote process holds it whatever `nohup` and
+`< /dev/null` are given — the symptom is a driver frozen with the server running perfectly well
+on the other side, and it cost two runs before the cause was read off the fact that the next log
+line never printed. Detach and poll for readiness.
+
+Likewise **a multi-line script through `bash -c "..."` loses twice**: the outer shell expands
+every `$(...)` before bash sees it, and JSON quoting carries newlines as two literal
+characters. Ship it base64. And on this node `pkill -f` matches the remote shell running your
+own command — resolve listeners by port through `ss`.

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -1,0 +1,207 @@
+# The proof-tool suite in detail
+
+`CLAUDE.md` carries the invocation list — what exists and how to run it. This file is what
+each tool needs, what its exit codes mean, and the per-tool facts that are only worth having
+when you are about to run or edit that tool.
+
+For the method behind the suite, see `docs/instruments.md`.
+
+## Exit codes, and why reading them is a trap
+
+**The tools disagree about what a caught mutation exits,
+the disagreement runs the dangerous way, so read the assertion count and never the code.**
+Counted rather than recalled:
+
+- **Five exit non-zero on a catch and say `NOT CAUGHT` when they miss**: `guard-check`,
+  `jobs-check`, `editor-check`, `monitor-check`, `sensor-view-check`.
+- **Two invert it**: `vendor-check` and `registration-check`, where caught is exit **0** with
+  `caught, as required (N assertions fired)` and exit **1** is `NOT CAUGHT`. Anything gating on
+  "non-zero means caught" reads a genuine miss by these two as a catch.
+- **Four have no `NOT CAUGHT` branch at all** and simply exit on their failure count:
+  `timeline-check`, `export-check`, `keyframe-check`, `library-check`. **A mutation these four
+  fail to catch exits 0**, which reads as a clean pass rather than as the check being blind.
+  That is the same direction as the inverted pair and it is silent rather than merely
+  confusing, so it is the worse of the two shapes.
+
+Which is why the rule is worded the way it is: count failed assertions, never exit codes — and
+read *which* assertions fired, because a tool that counts its own crash as a failure reports a
+catch it never made.
+
+**Exit 2 means the harness did not run, or a claim went unproven.** `library-check` exits 2
+when the low-space refusal could not be tested — it needs a real small filesystem and only
+macOS gets one here — and the verdict line says so. Anything gating on `!== 0` therefore treats
+a Linux run as not-a-pass, which is the intended reading: "some claims were not tested here"
+and "a claim failed" are different answers and 1 already means the second. `registration-check`
+reserves 2 on the other side of the merge, where a build or runtime failure is "the harness did
+not run" rather than "the harness found something", so a mutation that failed to compile can
+never be recorded as a mutation that was caught. `guard-check` and `vendor-check` use it the
+same way. The convention was reached independently several times and it is one rule.
+
+## Mutations
+
+`--mutate <name>` serves a deliberately broken `main.js` into the running server, or for the
+two vendoring tools rebuilds a deliberately broken source tree.
+
+**Eleven tools carry mutations** — editor, export, guard, jobs, keyframe, library, monitor,
+registration, sensor-view, timeline and vendor — and all of them refuse a mutation whose text
+they cannot find exactly once, because a replacement that silently matched nothing would run
+the unmutated page and be recorded as the check having missed a bug it was never shown.
+
+**A mutation is a piece of source text, so a mutation stops matching the moment the code it
+names is edited** — three of `timeline-check`'s nine had to be re-anchored when step 5 rewrote
+the retime seam, and the refusal is what surfaced that rather than a silent pass. If you change
+something a mutation anchors to, re-anchor it in the same commit and say in the message which
+ones moved.
+
+## What each tool needs
+
+**`determinism-check --clock`** refuses a rev whose `main.js` already contains the transport,
+so it needs `--before` pointing at a commit before step 1.
+
+**`export-check`** needs ffmpeg and ffprobe (`--ffmpeg`, `--ffprobe`; 8.1.1 at
+`/opt/homebrew/bin`) and writes into `exports/`, which is gitignored.
+
+**`keyframe-check`** runs its cheapest claim first, on a 60-second budget, and stops the run if
+it fails. That is not ordering by cost: an evaluator that announces its writes schedules a seek
+per frame, each of which renders a pre-roll which evaluates, so the page never answers and
+never errors - it runs out of memory some minutes later, somewhere else. A bounded probe turns
+that into a sentence.
+
+**`jobs-check`** spawns its own server and renders one real job through
+`tools/render-worker.mjs`, so it needs a GPU browser and ffprobe. `--no-render` drops that row
+and says so - the queue rows are seconds, the render row is a minute. Its mutation runs use
+`--no-render` because all five are queue semantics.
+
+**The worker reads its renderer class out of the browser it will render in and cannot be told
+one.** `channel: 'chromium'` rather than the bundled headless shell, which has no GPU and falls
+back to SwiftShader - a class nothing else can reproduce, which the worker refuses outright
+rather than pinning jobs to.
+
+**`guard-check`** spawns its own servers and needs none running. It exits 2 when the machine has
+no non-internal IPv4, because "not listening on the network" is only a claim if there is a
+second address a client could have arrived on. Every refusal it asserts has a positive twin, so
+a server that refused every upgrade, or bound to nothing, fails it rather than passing quietly.
+
+**`library-check`** takes no `--url`; it spawns what it needs. `plant-open-take` is the mutation
+worth naming beside it rather than a milder one: it is the control for the hole that let a read
+route destroy the take being shot.
+
+**It binds fixed ports** — 8210 and 8211, plus `MAC_PORT + 2/4/5` — so two worktrees running it
+at once do not get an address-in-use error, they get each other's server: one run stat-ed
+`three-warning-take.knct`, a fixture belonging to the other tree, and reported itself as not
+finishing. Pass `--node-port`/`--mac-port` a range nothing else holds. The quieter half of that
+same collision is in `docs/instruments.md`, because it fails in a way that reads as a finding.
+
+**`editor-check` enumerates rather than lists, and it exists because the suite tested the model
+and never the control.** The clip in/out markers were detached from the document during boot
+for the whole life of the feature — `rebuildLanes` cleared `#tBeds` of every child that was
+neither `.ruler` nor the playhead, and `#tIn`/`#tOut` were neither. Nothing caught it because
+nothing looked: no proof tool referenced `#tIn`, `#tOut` or `.tcut` at all, and `export-check`
+drives in/out through `activeDeliverable`, which is the model. The model was perfect throughout;
+`paintTimeline` simply wrote `style.left` onto two nodes no document contained. So section 1
+walks every interactive control the page renders and fails on any it has no driver for, with
+`plant-unswept-control` as the control for that claim — without it, "every control was tested"
+is a sentence the tool writes about itself. **Aiming its layout mutation took three attempts,
+and the two misses are recorded in the file** because each was NOT CAUGHT against a build with
+a fix removed: the rule they named had been made redundant by the two-row bar, which is worth
+knowing about the fix as well as about the check.
+
+Its `nav-at-the-foot` mutation is the control for section 1's second claim, that the way out of
+the editor is *reachable* rather than merely present. Its own two flaws — a probe in a dead zone
+and a probe that moved the page it measured — are in `docs/instruments.md`, because both are
+instances of rules that were already written down.
+
+**`vendor-check` reads the built artifact as well as the source.** Sections 1-4 prove
+`third_party/` is upstream plus the declared edits; section 5 asserts the library actually
+installed at `vendor/prefix` carries `LIBFREENECT2_REG_THREADS`, the env override the threading
+edit introduces. Without it the check passed identically whether the grabber loaded that source
+or a stale prefix built from something else - and it silently would have, because the grabber's
+call passes two optional out-parameters any libfreenect2 0.2 accepts, so an old prefix links and
+streams single-threaded with nothing looking wrong. The control is `--mutate stale-prefix`,
+which points the assertion at `vendor/prefix-oracle` - a real library `registration-check`
+builds from upstream's own registration.cpp, rather than a doctored copy of ours - and it must
+FAIL. **What is still source-only is the sub-9 fix**, whose `& 0x1ff` compiles to an immediate
+and leaves nothing in the binary to look for; the tool says so rather than implying it covers
+both. Exit 2 where no prefix exists.
+
+**`registration-check` builds both sides every run** - a pristine upstream prefix and ours -
+because a stale oracle `.dylib` turns the whole thing into a build compared against itself and
+nothing about a stale library looks wrong. It needs no sensor: it runs on a corpus of
+`Registration::apply` inputs dumped by `grabber --dump-corpus`.
+
+**`syntax-check`** needs nothing at all, and it refuses to pass on finding no files: the roots
+must exist, each must yield files, and the count is printed beside the verdict so a number that
+has quietly halved is visible rather than implied. It also asserts that every tool in `tools/`
+is named in `CLAUDE.md`, which is why the invocation list lives there rather than here — a tool
+added later is asked by existing, and the falsification control is adding a tool without
+documenting it.
+
+**`prof-summary.mjs <profile> [warmup]`** reads `grabber --profile` output and flags any run
+under 29.5fps as contended, because the segment timings from a run that dropped frames are
+noise. That floor belongs to a profiling run that writes nothing — see the gate paragraph in
+`docs/measurement.md` before reusing it for a recording run.
+
+**`pi-registration-ab.sh`** is the unrun runbook for measuring the threading on a capture node;
+it builds both arms, checks with `ldd` that they load different libraries, and refuses to
+report milliseconds from an arm that lost frames.
+
+**`sweep-all` says "every mutation of every tool" and drives four of the eleven that carry
+mutations.** Its `TOOLS` is `['library', 'timeline', 'keyframe', 'export']`, so editor, guard,
+jobs, monitor, registration, sensor-view and vendor are outside the sweep a merge waits on -
+and the file's own header is an argument against exactly this shape, since it takes each tool's
+mutation *names* from that tool's refusal specifically so no list has to agree with anything.
+The names are enumerated and the tools are not. The seven that are missing each need something
+the sweep does not currently arrange - a private server, a GPU browser, a built prefix - so
+wiring them is real work rather than a longer array.
+
+## The supply-chain gate
+
+**npm 12 is the version this repo uses.** CI installs `npm@12.0.2` explicitly in the gate job
+rather than taking whatever `setup-node` bundles, because `release-gate-check` is the one thing
+here whose answer depends on the npm running it.
+
+**The gate is read out of npm's refusal, not out of its config.** npm derives its cutoff from
+the age internally; npm 11.12.1 exposed the derived date through `before`, and 11.16.0 and
+12.0.2 answer `null` there while enforcing the gate identically. A check reading `npm config
+get before` therefore went red against a repository whose gate had never been open - bookkeeping
+that had stopped tracking the resource. The check asks npm to resolve a package and reads the
+cutoff out of the refusal, which is measured identical on all three versions.
+
+**npm does not fail open on a value it cannot parse.** Measured on 11.12.1, 11.16.0 and 12.0.2:
+`min-release-age=2d` warns `invalid config` and then stops with `npm error Invalid time value`,
+exit 1, nothing installed. A wrong *unit* is loud. What is silent is an npm older than 11, which
+does not know the key and installs ungated without a word, and a value npm accepts that nobody
+meant - `0` puts the cutoff at this instant and `-1` puts it tomorrow, neither warning about
+anything, which is what the tool's two bounds rows are for.
+
+It masks the user and global config layers while it runs, and that is load-bearing rather than
+tidiness: this machine carries the same gate in `~/.npmrc`, so an unmasked run inherits it and
+proves nothing about the repo. Rewriting the check reproduced that exact mistake in a throwaway
+probe - with the layers unmasked, the *no gate* arm came back carrying a cutoff.
+
+## Fixtures and the registration corpus
+
+`captures/` is gitignored; the generator is committed and the artifacts are not.
+
+```
+node tools/make-fixture.js captures/sample.knct captures/fixture-large.knct --loops 32
+```
+
+**The sample was captured on a degraded link — median gap 64ms, mean 107ms, about 9.3fps rather
+than 30.** So size fixtures by *frame count*, not duration: five minutes of its source time is
+1.38 GB where a real full-rate five-minute take is 4.42 GB. A fixture is the sample looped with
+rewritten monotonic stamps — real depth and real JPEGs, only the u64 at payload offset 8 moves.
+Say so whenever a number rests on one.
+
+The registration corpus is gitignored like every other capture. Regenerate it with the sensor
+attached, and vary the scene while it runs - a hand near the lens, a person against a far wall,
+something occluding something further - because the occlusion filter only does work at depth
+discontinuities:
+
+```
+./native/build/grabber --dump-corpus captures/reg-corpus --dump-count 40 --dump-every 45
+```
+
+Coverage is measurable rather than assumed: `registration-check --mutate filter-never-rejects`
+reports what fraction of pixels the filter actually rejects. The committed corpus's 72 frames
+sit at 6.93%; a first capture of one static-ish scene managed 6.55%.

--- a/third_party/UPSTREAM.md
+++ b/third_party/UPSTREAM.md
@@ -180,7 +180,7 @@ Six, and the last two are the ones this list went without for a while, which is
 worth stating rather than quietly fixing: `oracle-drift` is the control for the
 oracle assertion and `stale-prefix` for the artifact assertion, so a list naming
 only the first four taught a four-control sweep of a tool that has six. Both are
-also the two the repo's `CLAUDE.md` names, so the two documents now agree.
+also the two the repo's `docs/proof-tools.md` names, so the two documents agree.
 
 Mutations run against a throwaway copy, so a falsification run never leaves the
 vendored tree altered. `stale-prefix` is the exception to "needs nothing built":

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -12,9 +12,10 @@
 // were all correct, `export-check` drove in/out through `activeDeliverable`, and
 // `paintTimeline` went on writing `style.left` onto two nodes no document contained.
 // **No proof tool in this repo referenced `#tIn`, `#tOut` or `.tcut` at all.** That is
-// `CLAUDE.md`'s "is there an object here that every observation happens to skip", one
-// step further on than the version already recorded there - here the skipped object
-// was not an excluded file but a control the interface tells the user it has.
+// `docs/instruments.md`'s "is there an object here that every observation happens to
+// skip", one step further on than the version already recorded there - here the
+// skipped object was not an excluded file but a control the interface tells the user
+// it has.
 //
 // So the organising rule of this file is two things at once:
 //
@@ -799,7 +800,7 @@ try {
   // reddened its four rows correctly and then died dereferencing a null `#tOut` -
   // which this file reports as DID NOT RUN with exit 2, the code reserved for the
   // harness failing. A mutation that is caught and then crashes reads as a mutation
-  // that was never tested, which is the same confusion `CLAUDE.md` records under
+  // that was never tested, the same confusion `docs/instruments.md` records under
   // "a mutation run that exits non-zero with zero failed assertions did not run",
   // arriving from the other direction. A check has to survive the fault it checks for.
   const markersUsable = boxes.in !== null && boxes.out !== null;
@@ -870,8 +871,8 @@ try {
   //
   // Two positions and two directions, because program and source time agree
   // trivially at program 0 and a single arm cannot tell holding one from holding the
-  // other. `CLAUDE.md` has this failure twice already under "what do my arms agree
-  // about".
+  // other. `docs/instruments.md` has this failure twice already under "what do my
+  // arms agree about".
   const rateArm = async (parkAt, to) => {
     await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
     await page.evaluate(`(() => { const el = document.getElementById('tRate'); el.value = '1'; el.dispatchEvent(new Event('input')); el.dispatchEvent(new Event('change')); })()`);
@@ -1070,8 +1071,8 @@ try {
   // is sampled at 7s, inside 5s..9s, and not at 3s. Sampling at 3s is what this row
   // did first and it failed against a working build: the handle had moved, the curve
   // it shapes had moved, and the probe was sitting in the neighbouring segment where
-  // the answer is the same either way. That is `CLAUDE.md`'s "place a probe where its
-  // answer would be different" arriving one more time.
+  // the answer is the same either way. That is `docs/instruments.md`'s "place a probe
+  // where its answer would be different" arriving one more time.
   //
   // Both samples are kept, which makes the row say more than it used to: the handle
   // shapes its own segment *and leaves its neighbour alone*, which is two claims a

--- a/tools/export-check.mjs
+++ b/tools/export-check.mjs
@@ -126,9 +126,9 @@ const STAGE = { width: 640, height: 400 };
 // arrived in a tool as a ten-second timeout that names nothing about the strip.** The
 // bar became two rows, `--timeline-h` went 104 to 148, and this file - which never
 // mentions the timeline except here - hung in `setStage` waiting for a buffer height
-// the fit had made 44px shorter. `CLAUDE.md` records the same shape when the stage
-// was first letterboxed and four tools found out one at a time. Measuring closes it:
-// the next change to the strip is absorbed instead of discovered.
+// the fit had made 44px shorter. `docs/instruments.md` records the same shape when
+// the stage was first letterboxed and four tools found out one at a time. Measuring
+// closes it: the next change to the strip is absorbed instead of discovered.
 const TIMELINE_H_GUESS = 148;
 
 // The document's own pair. Same 1.6 aspect, an exact 2x so the downsample is a
@@ -1216,7 +1216,7 @@ const PIPELINES = [
 // the noise, which is the kind of margin this file refuses to call a detection when
 // it finds one anywhere else. The per-term rows are load-bearing here and `full` is
 // the integration row, which is the same conclusion the cumulative-table rule in
-// CLAUDE.md reached from the other direction.
+// `docs/instruments.md` reached from the other direction.
 //
 // One bound this table does not cover, named here rather than left to be found:
 // both arms are 600 and 1200 and the export menu goes to 2160. Bloom's bright pass

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -926,10 +926,10 @@ async function loadPlaywright() {
 
 /**
  * Playwright drops the page's execution context on this rig, and it is not the
- * code: CLAUDE.md records it as a measured flake, with the server log showing the
- * work it happened during completing normally. Retried on that signature alone and
- * with the retry count printed, because a check that retried real failures would
- * report whichever attempt it liked.
+ * code: `docs/instruments.md` records it as a measured flake, with the server log
+ * showing the work it happened during completing normally. Retried on that signature
+ * alone and with the retry count printed, because a check that retried real failures
+ * would report whichever attempt it liked.
  */
 async function retryOnContextLoss(label, work) {
   for (let attempt = 1; attempt <= 3; attempt++) {
@@ -1209,7 +1209,7 @@ async function runChecks() {
   // **This section runs against a replay server, and that is the whole of what it
   // learned.** The first version of it spawned a server with no `--replay` at all,
   // so every arm agreed about a quantity none of them measured - which is the
-  // failure `CLAUDE.md` names in the paragraph immediately above this step's work,
+  // failure `docs/instruments.md` names under "what do my arms agree about",
   // reproduced in a section written after reading it. Two hours is apparently not
   // long enough for a rule to stick, so the example lives here beside the code
   // rather than only in the document: the replay is the one reader that holds a
@@ -2910,8 +2910,8 @@ async function runChecks() {
     // and throws `ERR_INVALID_STATE` at the top level, and the process is gone -
     // measured here at between 300ms and one second after the reader let go. An
     // unguarded poll then throws out of `runChecks` and the run ends with an exit
-    // code and *zero failed assertions*, which is the shape `CLAUDE.md` records as a
-    // crash wearing a catch's status. This turns it back into rows.
+    // code and *zero failed assertions*, which is the shape `docs/instruments.md`
+    // records as a crash wearing a catch's status. This turns it back into rows.
     //
     // **One reading at a fixed delay, and deliberately not a poll-until-it-passes.**
     // A loop that retried until the count came back turned this into a race with the
@@ -3241,7 +3241,7 @@ async function runChecks() {
   // **Measured by the sidecar rather than by a stopwatch.** `buildIndex` writes a
   // `.idx` beside the take, so "the manifest scanned it" leaves a file - which is
   // deterministic where a timing threshold would be a flake, and is the same
-  // observer effect `CLAUDE.md` records from this step's own first draft.
+  // observer effect `docs/instruments.md` records from this step's own first draft.
   console.log('\n[library] listing a library does not scan the take still being written');
   {
     const liveDir = join(WORK, 'while-recording');

--- a/tools/monitor-check.mjs
+++ b/tools/monitor-check.mjs
@@ -696,8 +696,9 @@ try {
   // those bytes after a client has them, so a viewer that rendered a ÷4 frame as a
   // different scene passed the whole file - and did, for two steps.
   //
-  // It is the shape CLAUDE.md names: an object every observation skips. The monitor's
-  // *picture* is the thing a monitor is, and every arm here was pointed at the take.
+  // It is the shape `docs/instruments.md` names: an object every observation skips.
+  // The monitor's *picture* is the thing a monitor is, and every arm here was pointed
+  // at the take.
   //
   // Two questions, and they are separate. Does an arriving frame reach the whole grid,
   // and does each of its samples land on the ray it was measured on. The first alone

--- a/tools/release-gate-check.mjs
+++ b/tools/release-gate-check.mjs
@@ -53,10 +53,10 @@
 // cutoff date, because it was reading the user config. The positive twin below is what
 // makes the date mean something, and it is asserted rather than assumed.
 //
-// Mutation convention, stated because the suite has two and CLAUDE.md records that the
-// disagreement runs the dangerous way: this file follows `vendor-check`. A caught
-// mutation is exit **0** with the assertion count printed, and exit **1** is NOT CAUGHT.
-// Read the count, never the code.
+// Mutation convention, stated because the suite has two and `docs/proof-tools.md`
+// records that the disagreement runs the dangerous way: this file follows
+// `vendor-check`. A caught mutation is exit **0** with the assertion count printed,
+// and exit **1** is NOT CAUGHT. Read the count, never the code.
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/sensor-view-check.mjs
+++ b/tools/sensor-view-check.mjs
@@ -32,6 +32,26 @@
 // - and that exactly one of them equals it - tightness. Containment alone is a
 // one-sided test that a 179 degree frustum passes. Tightness is what makes it a fit.
 //
+// **Four sections asserted against the camera object and none against the picture,
+// and that gap shipped as a bug.** The pose rows below read `freeCamera.position`,
+// which is set several lines before `sensorView` asks for an image - so deleting
+// `requestRepaint()` from it left all 125 assertions green while the editor's picture
+// did not move until the next pointer gesture happened to render it. That is the
+// repo's own rule arriving as a defect: a tool named after a user-facing surface
+// should have at least one arm pointed at that surface. Section 7 is that arm and
+// `no-repaint` is its control.
+//
+// It took two attempts to make the comparison mean anything, and both misses are
+// recorded rather than tidied away, because each was a probe that reported a picture
+// moving when the picture had not moved at all. The chrome overlay redraws the path
+// and the frustum from the new pose on the next animation frame, so a stage compared
+// with it visible says CHANGED against a build that rendered nothing. And the panel
+// is translucent over the picture's left edge, so a comparison clipped to the canvas
+// contains the button's own hover state - which passed the pixel row under
+// `no-repaint` on the highlight of the button being pressed. The region is therefore
+// hit-tested with `elementFromPoint` and shrunk until every probe lands on the
+// canvas, rather than computed from anybody's bounds.
+//
 // **Writing nothing is asserted against the stores, not against the page's word for
 // it.** The click window is watched three ways at once: every non-GET request the
 // page makes, the server's own monotonic write counters per store, and the bodies of
@@ -57,6 +77,7 @@
 //   node tools/sensor-view-check.mjs --mutate sensor-view-keys-camera  # must FAIL
 //   node tools/sensor-view-check.mjs --mutate keyframes-on-every-surface # must FAIL
 //   node tools/sensor-view-check.mjs --mutate extended-always-open     # must FAIL
+//   node tools/sensor-view-check.mjs --mutate no-repaint               # must FAIL
 //
 // Exit 1 means a claim failed. Exit **2** means the harness did not run - a mutation
 // whose anchor text has gone stale, a browser that never came up, or the record arm
@@ -76,7 +97,14 @@
 // that every block the other rules do not name has to be on both surfaces, so a group
 // added later is asked about by existing.
 //
-// **What the mutations catch, measured rather than reasoned.** Clean: 125
+// **What the mutations catch, measured rather than reasoned.** Every count in this
+// paragraph belongs to one rig - the real corpus with a sensor attached - and it was
+// taken **before section 7 existed**, so the same rig should now read eight rows more
+// throughout. That is arithmetic rather than a measurement and the numbers are left at
+// what was actually observed rather than quietly incremented; section 7's own counts,
+// on a different rig, are in the paragraph below.
+//
+// Clean: 125
 // assertions, 0 failed. `fov-hardcoded`: 42 fired, and the split across them is the
 // argument for the synthetic arms rather than a rhetorical one. On arm A - the only
 // intrinsics any take carries - it reddens the two 1:1 sizes and *nothing else*: ten
@@ -96,6 +124,22 @@
 // the toggle is closed again, with the row that says one press reveals them all left
 // green - a rule that has stopped hiding cannot be told from a button that works by
 // looking only at the state after the click.
+//
+// `no-repaint` was measured on a different rig from the numbers above and the method is
+// worth stating rather than folding in: a depth-only synthetic take, one take in the
+// library and no sensor attached, so row 0 fires on the single-take library and the
+// recorder arm reads UNTESTED. On that rig the clean run is 126 assertions with 1 failed
+// - the library row - and `no-repaint` is 4, the same row plus **three, all of them
+// section 7's**: `renders 3 then 3`, the picture unchanged, and the image the press
+// produced differing from a forced seek taken after it. The pose, angle and fit rows are
+// green beside them, which is the whole argument for a seventh section rather than a
+// tighter tolerance somewhere in the first six.
+//
+// **And the specificity was checked in the other direction, because a row that reddens
+// on everything says nothing.** Under `fov-hardcoded` 43 rows fire and section 7 is
+// entirely green; under `sensor-view-keys-camera` 8 fire, all of them in section 4, and
+// section 7 is entirely green again. So these rows answer "did the press reach the
+// screen" rather than "did something change".
 //
 // The instrument's own refusals were mutation-tested too, since a guard nobody has
 // broken on purpose is a guard nobody knows the sensitivity of. Breaking the hello
@@ -255,6 +299,23 @@ const MUTATIONS = {
     edits: [[
       'body:not(.editing) .lookgroup { display: none; }',
       'body:not(.editing) .lookgroup { display: block; }',
+    ]],
+  },
+  // The button stops asking for an image. Everything above it in `sensorView` still
+  // runs, so the camera lands on the sensor exactly as before and every pose, angle
+  // and fit row in this file stays green - which is the entire reason this mutation
+  // exists. It was measured: with `requestRepaint()` deleted the suite passed 125 of
+  // 125 while the editor's picture did not move until the next pointer gesture
+  // rendered it, which is the bug as reported.
+  //
+  // The anchor is the `controls.update()` / `requestRepaint()` pair rather than the
+  // click handler, because `sensor-view-keys-camera` already anchors on the handler
+  // and two mutations sharing one piece of source text both go stale together.
+  'no-repaint': {
+    file: 'web/main.js',
+    edits: [[
+      '  controls.update();\n  requestRepaint();',
+      '  controls.update();',
     ]],
   },
   'sensor-view-keys-camera': {
@@ -467,6 +528,108 @@ const PROBE = `(() => {
     },
 
     settled: () => k.timeline.settled(),
+
+    /**
+     * The overlay off, and answered rather than assumed.
+     *
+     * \`drawChrome\` paints the camera path, its nodes and the program camera's frustum
+     * onto a second canvas sitting exactly over the picture, and it repaints them from
+     * the new pose on the next animation frame whether or not the picture itself moved.
+     * So a stage compared with it visible reports a change against a build that
+     * rendered nothing at all - measured, not feared: the first version of section 7
+     * said CHANGED against \`no-repaint\` for precisely this reason.
+     */
+    hideChrome() {
+      k.keyframes.chrome.set(false);
+      return document.getElementById('chrome')?.hidden === true;
+    },
+
+    /**
+     * The largest part of the picture that nothing is drawn over, and the count that
+     * proves nothing is.
+     *
+     * The canvas's own rectangle is not it. The panel is translucent and sits on top
+     * of the picture's left edge, so a screenshot clipped to the canvas contains the
+     * button being pressed - and \`no-repaint\` passed the pixel row on that button's
+     * own hover state while the picture behind it had not moved at all. This is the
+     * second time the same class caught this section: the first was the chrome
+     * overlay, which \`hideChrome\` deals with.
+     *
+     * So the rect is taken to the right of the panel and then hit-tested on a grid,
+     * because a rect computed from one element's bounds is a claim about that element
+     * rather than about what happens to be over it. \`covered\` is what the arm asserts.
+     */
+    picture() {
+      const canvas = k.renderer.domElement;
+      const r = canvas.getBoundingClientRect();
+      // The grid, and it is the definition rather than a check on one: a rect worked
+      // out from another element's bounds is a claim about that element, and the two
+      // things that have already fooled this section - the chrome overlay and the
+      // panel - were both found by a picture that moved rather than by geometry.
+      const clean = (rect) => {
+        let covered = 0;
+        const over = new Set();
+        for (let i = 0; i <= 4; i++) {
+          for (let j = 0; j <= 4; j++) {
+            const at = document.elementFromPoint(
+              rect.x + (rect.width * i) / 4, rect.y + (rect.height * j) / 4,
+            );
+            if (at !== canvas) {
+              covered++;
+              over.add(at ? (at.id ? '#' + at.id : at.tagName.toLowerCase()) : 'nothing');
+            }
+          }
+        }
+        return { covered, over: [...over].join(' ') };
+      };
+      // Shrunk toward the middle until every probe lands on the canvas, so whatever
+      // the furniture is and wherever it moves to, the region compared is picture.
+      let rect = {
+        x: Math.ceil(r.x) + 1, y: Math.ceil(r.y) + 1,
+        width: Math.floor(r.width) - 2, height: Math.floor(r.height) - 2,
+      };
+      let hits = clean(rect);
+      for (let step = 0; step < 40 && hits.covered > 0 && rect.width > 64 && rect.height > 64; step++) {
+        const dx = Math.max(2, Math.round(rect.width * 0.05));
+        const dy = Math.max(2, Math.round(rect.height * 0.05));
+        rect = { x: rect.x + dx, y: rect.y + dy, width: rect.width - 2 * dx, height: rect.height - 2 * dy };
+        hits = clean(rect);
+      }
+      return { ...rect, covered: hits.covered, over: hits.over };
+    },
+
+    renders: () => k.timeline.counters.renders,
+
+    /**
+     * Spends whatever damping momentum the controls are holding, and says how many
+     * updates it took.
+     *
+     * OrbitControls runs with \`enableDamping\`, so a gesture leaves a residual in
+     * \`sphericalDelta\` that every later \`controls.update()\` spends 7% of - and
+     * \`advanceNavigation\` calls one inside every render. Two renders of one position
+     * therefore disagree while any is left, which would leave the rows below unable to
+     * tell a picture that moved because the button worked from one that moved because
+     * the camera was still coasting. The control row proves the drain worked.
+     */
+    drain() {
+      let last = k.freeCamera.position.clone();
+      for (let i = 0; i < 500; i++) {
+        k.controls.update();
+        if (k.freeCamera.position.distanceTo(last) < 1e-12) return i;
+        last = k.freeCamera.position.clone();
+      }
+      return -1;
+    },
+
+    /**
+     * One render through the transport - the door the orbit's own \`end\` handler uses,
+     * which consults none of the four flags \`requestRepaint\` consults.
+     */
+    async forceSeek() {
+      const t = k.timeline.transport();
+      await t.seek(t.programSec);
+      await k.timeline.settled();
+    },
 
     /**
      * The panel as the browser lays it out, rather than as the markup declares it.
@@ -1242,6 +1405,110 @@ try {
     check(rec.surface === 'record' && ed.surface === 'edit',
       'and each arm is the surface it claims, so neither table is about the other page',
       `${rec.surface} and ${ed.surface}`);
+  }
+
+  // ================================================ 7. the button reaches the picture
+  //
+  // Every section above this one asserts against the camera object, and the camera
+  // object is not what anybody presses the button to see. That gap was open for the
+  // whole life of the feature and it is what this section closes: delete
+  // `requestRepaint()` from `sensorView` and the pose, the angles, the fit and the
+  // writes-nothing rows all stay green while the editor's picture does not move until
+  // the next pointer gesture happens to render it. `no-repaint` is that mutation, and
+  // it is the reason this section exists rather than a hypothetical.
+  //
+  // **Two things make the comparison mean anything, and both were found by measuring
+  // rather than by reading.** The overlay has to be off, because it redraws the
+  // frustum from the new pose on the next animation frame whether or not the picture
+  // did - with it visible, the first version of this section reported CHANGED against
+  // the mutated build. And the damping has to be drained, because `advanceNavigation`
+  // calls `controls.update()` inside every render, so while the controls hold momentum
+  // two renders of one position genuinely differ and a difference proves nothing. The
+  // control row drives exactly that pair and must agree before any row below is read.
+  console.log('\n[7] the press puts the sensor\'s view on the screen, not only on the camera');
+  const pictureRun = await onFreshPage('the picture arm', {}, async ({ page }) => {
+    const overlayHidden = await page.evaluate('globalThis.__sv.hideChrome()');
+    const drainedAfter = await page.evaluate('globalThis.__sv.drain()');
+    const picture = await page.evaluate('globalThis.__sv.picture()');
+    const clip = { x: picture.x, y: picture.y, width: picture.width, height: picture.height };
+
+    // The instrument's own control: two renders of one state, nothing between them.
+    // If these disagree this arm cannot attribute a difference to anything, and the
+    // rows below are about the damping rather than about the button.
+    await page.evaluate('globalThis.__sv.forceSeek()');
+    const ctrlA = await page.screenshot({ clip });
+    await page.evaluate('globalThis.__sv.forceSeek()');
+    const ctrlB = await page.screenshot({ clip });
+
+    // Somewhere that is not the sensor's, so "the picture moved" cannot be satisfied
+    // by a button with nothing to do.
+    const displaced = await page.evaluate('globalThis.__sv.displace({})');
+    // Rendered, and this line is load-bearing rather than tidiness. `displace` writes
+    // the camera and updates the controls but asks for no image - `params.set('spin')`
+    // is tagged `view` and `paramWritten` returns on it - so without a render here
+    // `before` is still the *boot* camera's picture and the row below compares the
+    // default pose to the sensor rather than the displaced one. It would pass today,
+    // because the default sits 1.6m back along the same axis, and it would go vacuous
+    // the day somebody moves the boot pose, which is the silent direction.
+    await page.evaluate('globalThis.__sv.forceSeek()');
+    const before = await page.screenshot({ clip });
+    const rendersBefore = await page.evaluate('globalThis.__sv.renders()');
+
+    // The button, clicked, and then nothing at all - no settle, no seek, no pointer.
+    // A person who presses it and sits still is what the report describes, so the
+    // wait is the whole gesture rather than an await that would do the work for it.
+    await page.click('#camSensor');
+    await page.waitForTimeout(2000);
+    const after = await page.screenshot({ clip });
+    const rendersAfter = await page.evaluate('globalThis.__sv.renders()');
+    const pose = await page.evaluate('globalThis.__sv.pose()');
+
+    // And the tightening row: the image the press produced is already the settled
+    // one. Without this the section would pass a build whose repaint rendered a
+    // stale camera and was corrected by whatever rendered next.
+    await page.evaluate('globalThis.__sv.forceSeek()');
+    const forced = await page.screenshot({ clip });
+
+    return {
+      overlayHidden,
+      drainedAfter,
+      picture,
+      controlAgrees: ctrlA.equals(ctrlB),
+      displaced,
+      pose,
+      rendersBefore,
+      rendersAfter,
+      moved: !before.equals(after),
+      settledAlready: after.equals(forced),
+    };
+  });
+  if (!pictureRun.ok) throw new Error(`the picture arm did not run: ${pictureRun.error}`);
+  {
+    const p = pictureRun.value;
+    // The two conditions this section's comparison rests on, enforced rather than
+    // stated - the failure this repo keeps producing is a tool that names a condition
+    // in its header and does nothing to bring it about.
+    check(p.overlayHidden, 'the chrome overlay is off, so what is compared is the picture and not the annotation',
+      '#chrome hidden');
+    check(p.picture.covered === 0 && p.picture.width > 200 && p.picture.height > 200,
+      'and nothing at all is drawn over the region compared, hit-tested rather than assumed',
+      `${p.picture.width}x${p.picture.height} at ${p.picture.x},${p.picture.y}, `
+      + `${p.picture.covered} of 25 probes covered${p.picture.over ? ` by ${p.picture.over}` : ''}`);
+    check(p.drainedAfter >= 0, 'the controls hold no damping momentum before anything is photographed',
+      p.drainedAfter >= 0 ? `drained in ${p.drainedAfter} updates` : 'still moving after 500 updates');
+    check(p.controlAgrees, 'control: two renders of one state agree, so a difference below is attributable',
+      'forceSeek twice, nothing in between');
+
+    // The claim.
+    check(Math.hypot(...p.displaced.position) > 1 && Math.hypot(...p.pose.position) < DUST,
+      'the press moved the camera off the displaced pose and onto the sensor',
+      `[${p.displaced.position.map((v) => fixed(v, 2)).join(', ')}] to |position| ${Math.hypot(...p.pose.position).toExponential(2)}`);
+    check(p.rendersAfter > p.rendersBefore, 'the press rendered a frame, with no pointer input to do it for the button',
+      `renders ${p.rendersBefore} then ${p.rendersAfter}`);
+    check(p.moved, 'and the picture itself changed',
+      'the uncovered region of the renderer\'s canvas, before and after the click');
+    check(p.settledAlready, 'the image the press produced is the settled one, not one a later render corrected',
+      'identical to a forced seek taken after it');
   }
 
   check(pageErrors.length === 0, 'no page reported an error while any of this happened',

--- a/tools/sensor-view-check.mjs
+++ b/tools/sensor-view-check.mjs
@@ -12,10 +12,11 @@
 // build that hardcoded 60.157 degrees and a build that computes from `fy` therefore
 // agree on every take anybody can open, so a mutation replacing the computation
 // with a constant would pass while the feature was entirely broken. This is the
-// failure `CLAUDE.md` describes at length under "what do my arms agree about": a set
-// of probes that agree about a quantity cannot measure it however many of them there
-// are. So the intrinsics claim is driven on three arms, two of which do not exist on
-// disk - the hello is intercepted and answered with numbers of this tool's own.
+// failure `docs/instruments.md` describes at length under "what do my arms agree
+// about": a set of probes that agree about a quantity cannot measure it however
+// many of them there are. So the intrinsics claim is driven on three arms, two of
+// which do not exist on disk - the hello is intercepted and answered with numbers
+// of this tool's own.
 //
 // The third arm exists for the second half of that question. `fx` and `fy` are equal
 // on every take *and* on the obvious synthetic arm, so a build reading `fx` where it
@@ -334,8 +335,8 @@ let failures = 0;
 let checks = 0;
 // The labels rather than only the count. A mutation run that says "3 assertions
 // fired" cannot be checked for having been caught *for the reason claimed*, which
-// is the distinction `CLAUDE.md` spends a paragraph on - a control that goes red
-// for a neighbouring reason looks exactly like a control that works.
+// is the distinction `docs/instruments.md` spends a paragraph on - a control that
+// goes red for a neighbouring reason looks exactly like a control that works.
 const fired = [];
 const check = (ok, label, detail = '') => {
   checks++;
@@ -1006,9 +1007,10 @@ try {
   //
   // Navigation, and the design's rule for navigation is that it leaves no trace. The
   // observation is deliberately not one thing: the page's own requests, the server's
-  // monotonic per-store counters, and the bodies of the stores. `CLAUDE.md`'s second
-  // form of the agreement rule is what this is answering - not "what do my arms agree
-  // about" but "is there an object here that every observation happens to skip".
+  // monotonic per-store counters, and the bodies of the stores. The second form of
+  // the agreement rule in `docs/instruments.md` is what this is answering - not "what
+  // do my arms agree about" but "is there an object here that every observation
+  // happens to skip".
   console.log('\n[4] pressing it writes nothing: no key, no undo entry, no document change');
   const beforeStores = await stores(PRIVATE_BASE);
   const writeRun = await onFreshPage('the writes-nothing arm', { }, async ({ page }) => {

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -42,6 +42,21 @@ const ROOT = argv.includes('--root') ? argv[argv.indexOf('--root') + 1] : REPO;
 // either vendored, built or a capture, and none of those are ours to parse.
 const FLOORS = { server: 5, tools: 12, web: 2 };
 
+// **Two different questions, so two different sets, and the difference is the point.**
+// `PARSES` is what `node --check` can be handed and have its answer mean anything - a
+// shell script fed to it fails as a syntax error about JavaScript, which would be a red
+// light wired to the wrong thing. `SHIPPED` is what counts as a tool this repo ships,
+// and it is wider because the questions asked of `tools/` below - is it documented, does
+// its citation resolve - are about the file being ours rather than about it parsing.
+//
+// Named once and used by both because the version where each block spelled its own set
+// out drifted immediately: the documentation block already read `.sh` while the citation
+// scan reused the JavaScript walker, so `pi-registration-ab.sh` was required to be named
+// in CLAUDE.md and then never read for the `docs/` pages it might cite. A tool added in
+// another language next year joins both questions at once by being added here.
+const PARSES = /\.(js|mjs)$/;
+const SHIPPED = /\.(js|mjs|sh)$/;
+
 const check = (file) => {
   try {
     execFileSync(process.execPath, ['--check', file], { stdio: ['ignore', 'pipe', 'pipe'] });
@@ -85,19 +100,21 @@ try {
 // shared trees are symlinked back to the main checkout - .gitignore's own header
 // records vendor and node_modules arriving that way - and following one turns a
 // six-second check into a parse of somebody else's library.
-function walk(dir, out = []) {
+// Which files it yields is the caller's question rather than the walker's, so the two
+// sets above stay one decision made in one place.
+function walk(dir, matches, out = []) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (entry.isSymbolicLink()) continue;
     const p = join(dir, entry.name);
-    if (entry.isDirectory()) walk(p, out);
-    else if (entry.name.endsWith('.js') || entry.name.endsWith('.mjs')) out.push(p);
+    if (entry.isDirectory()) walk(p, matches, out);
+    else if (matches.test(entry.name)) out.push(p);
   }
   return out;
 }
 
 let total = 0;
 for (const [name, floor] of Object.entries(FLOORS)) {
-  const files = walk(join(ROOT, name));
+  const files = walk(join(ROOT, name), PARSES);
   total += files.length;
   if (files.length < floor) {
     fail(`${name}/ holds ${files.length} JavaScript files, under the floor of ${floor} - either the tree lost something or this walk stopped finding it`);
@@ -136,7 +153,7 @@ if (!existsSync(DOC)) {
 } else {
   const doc = readFileSync(DOC, 'utf8');
   const shipped = readdirSync(join(ROOT, 'tools'))
-    .filter((f) => /\.(mjs|js|sh)$/.test(f))
+    .filter((f) => SHIPPED.test(f))
     .sort();
   const undocumented = shipped.filter((f) => !doc.includes(f));
   if (shipped.length === 0) {
@@ -158,8 +175,19 @@ if (!existsSync(DOC)) {
 // Enumerated rather than listed: the paths are read out of what actually cites them, so a
 // fourth document added next year is checked by existing and a pointer that outlives its
 // target fails here. The control is `mv docs/instruments.md /tmp` and a run.
+//
+// **Every shipped tool, and not every parseable one.** The first version of this block
+// reused the JavaScript walker, which is the same class of hole it was written to close:
+// `pi-registration-ab.sh` is a documented tool that the scan could not read, so a `docs/`
+// page cited from a shell runbook was covered by an assertion that printed "all N cited
+// pages exist" and had never opened the file. Measured rather than argued - a citation of
+// an absent page appended to that runbook left the check green, and fails here now that
+// the walk asks for `SHIPPED`. That is the control, and running it takes a path this
+// comment deliberately does not spell: the scan reads its own prose, so a filename
+// written here as an example is a citation like any other and fails the run that quotes
+// it. Append the line to the runbook, run, revert.
 {
-  const citing = [join(ROOT, 'CLAUDE.md'), ...walk(join(ROOT, 'tools'))];
+  const citing = [join(ROOT, 'CLAUDE.md'), ...walk(join(ROOT, 'tools'), SHIPPED)];
   const cited = new Set();
   for (const file of citing) {
     if (!existsSync(file)) continue;

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -148,6 +148,33 @@ if (!existsSync(DOC)) {
   }
 }
 
+// **And every `docs/*.md` anything points at has to exist**, for the same reason and by
+// the same shape as the block above. `CLAUDE.md` was 704 lines and was split into three
+// documents it now sends you to by name, with fourteen comments in `tools/` citing those
+// documents by section - so the disclosure chain is load-bearing and nothing was checking
+// it. Delete one of the three and every citation resolves to nothing while this tool stays
+// green, which is a claim asserted in prose with nothing bringing it about.
+//
+// Enumerated rather than listed: the paths are read out of what actually cites them, so a
+// fourth document added next year is checked by existing and a pointer that outlives its
+// target fails here. The control is `mv docs/instruments.md /tmp` and a run.
+{
+  const citing = [join(ROOT, 'CLAUDE.md'), ...walk(join(ROOT, 'tools'))];
+  const cited = new Set();
+  for (const file of citing) {
+    if (!existsSync(file)) continue;
+    for (const m of readFileSync(file, 'utf8').matchAll(/\bdocs\/[A-Za-z0-9._-]+\.md\b/g)) cited.add(m[0]);
+  }
+  const missing = [...cited].filter((p) => !existsSync(join(ROOT, p))).sort();
+  if (cited.size === 0) {
+    fail('nothing cites a docs/ page, so this assertion passed on nothing - the disclosure chain is gone or this scan is looking in the wrong place');
+  } else if (missing.length) {
+    fail(`${missing.join(', ')} is cited but does not exist - a pointer that outlives its target teaches a document nobody can read`);
+  } else {
+    console.log(`  docs/   all ${cited.size} cited pages exist`);
+  }
+}
+
 console.log(`\n${total} JavaScript files, ${failed} failed`);
 // Said out loud because `npm test` runs this, and a green `npm test` that meant "the
 // suite passed" would be the most expensive wrong impression in the repo. Nothing here


### PR DESCRIPTION
Two commits. The first is the one that was asked for; the second is work from the same
session that the first one's citations depend on being described accurately.

## Split the instruction file into what is always loaded and what is fetched

`CLAUDE.md` had reached 704 lines, all of them in context before the first question was
read. It is **238** now, with the case files behind each rule in three documents read on a
condition rather than by default:

- `docs/instruments.md` — before writing or modifying a proof tool
- `docs/measurement.md` — before reporting a number
- `docs/proof-tools.md` — before running or editing a specific tool

Nothing technical was dropped; the split is a move. What was dropped is the changelog the
file kept about itself — "library-check had no invocation line until this merge", an audit
of its own rotted counts, "this file used to say npm fails open". In each case the rule
survives and the diff against a previous revision does not.

**The invocation fences stay in `CLAUDE.md` deliberately.** `syntax-check` asserts every
tool in `tools/` is named there, so moving the list would have meant editing a CI-gating
proof tool as collateral of a documentation change. It printed `all 25 named` before and
after, and the control still fires.

**`syntax-check` gained an assertion rather than a change.** The new structure rested on
three files existing and nothing checked it: delete `docs/instruments.md` and all seventeen
code citations resolve to nothing while CI stays green. It now collects every `docs/*.md`
path cited in `CLAUDE.md` or under `tools/` and fails on one that does not exist —
enumerated, so a fourth document is checked by existing.

One correction fell out of the compression: the file said `main.js` reads
`(buf.x / buf.y) * 600` "at `bloom.setSize`", where it computes that as `refWidth` on the
line above and sets the chain at half of it, `setSize(aspect * 300, 300)`. Both spellings
are there now.

## Point one arm of sensor-view-check at the picture

Reported symptom: press sensor view in the editor and nothing happens until you pan
slightly, at which point it snaps into place. **The mechanism is proven and the trigger is
not reproduced, so `web/main.js` is deliberately unchanged.** Deleting `requestRepaint()`
from `sensorView()` reproduces the report exactly, and the pan that appears to fix it is
the orbit controls' `end` handler calling `timeline.seek()` directly — a path that consults
none of the four flags `requestRepaint()` consults. Six page states, both surfaces, fourteen
gestures and a twelve-round interleaving storm left every flag down and lost no repaint.

What did land is the hole that let it ship: six sections asserting `freeCamera.position`,
`fov`, the fit and the stores, and **not one pixel** — so deleting `requestRepaint()` left
all 125 assertions green while the feature was visibly broken. Section 7 presses the button,
sits still, and asserts the render counter moved, the picture changed, and the image is
already the settled one. The comparison was vacuous twice before it worked; both failures
are recorded in the file.

## Verification

| run | result |
|---|---|
| `syntax-check` | 0 failed, `all 25 named`, `all 3 cited pages exist` |
| `syntax-check` + undocumented tool | 1 failed assertion, exit 1 |
| `syntax-check` + `mv docs/instruments.md /tmp` | 1 failed assertion, exit 1 |
| `release-gate-check` | 0 failed |
| `sensor-view-check` clean | 126 assertions, 1 failed — the pre-existing one-take row |
| `--mutate no-repaint` | 126 assertions, 4 failed — that row plus exactly section 7's three claim rows, all four enforcement rows green |
| `--mutate fov-hardcoded` | 43 fired, section 7 entirely green |
| `--mutate sensor-view-keys-camera` | 8 fired, section 7 entirely green |

Content loss was checked mechanically rather than by reading: all 309 numbers and backticked
identifiers were extracted from `main`'s `CLAUDE.md` and each confirmed to have a home. The
eight that appeared missing were line-wrap artifacts, confirmed against a flattened copy.

Rebased onto current `main` rather than the base this was written on, which is twelve commits
back — that base predates the `git stash` and contention lessons, `nav-at-the-foot`,
`build-native.mjs` and the `panelHead`/`panelBody` restructure. All of that new content was
placed in the split rather than reverted, and the proof runs above are from after the rebase.
`AGENTS.md` still resolves through the symlink.

Not addressed: `sweep-all.mjs` still drives 4 of the 11 mutation-carrying tools while its
header argues against exactly that shape. The description is corrected to say four; wiring
the other seven needs prerequisites it does not arrange.
