### PR TITLE
Serve the viewport and colour camera to OBS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,9 @@ node tools/monitor-check.mjs --mutate expand-shifts-by-a-block   # ... and must 
 node tools/sensor-view-check.mjs                          # the intrinsics a take was shot with, against a build that assumes them
 node tools/sensor-view-check.mjs --mutate fov-hardcoded   # ... and must FAIL mutated
 node tools/sensor-view-check.mjs --mutate no-repaint      # ... and must FAIL mutated
+node tools/vcam-check.mjs                                 # the output to OBS: the colour camera, the take it must not touch, and the source's picture
+node tools/vcam-check.mjs --mutate hd-upscales-registered # ... and must FAIL mutated
+node tools/vcam-check.mjs --mutate hd-reaches-recorder    # ... and must FAIL mutated
 node tools/guard-check.mjs                                # the socket's origin rule, the bind, and the rebinding rule
 node tools/guard-check.mjs --mutate upgrade-skips-origin  # ... and must FAIL mutated
 node tools/guard-check.mjs --mutate host-accepts-a-name   # ... and must FAIL mutated
@@ -220,7 +223,7 @@ And the ones that are not proof tools, listed because a tool nobody documented i
 nobody runs. **`syntax-check` enforces that list**: anything in `tools/` this file does not
 mention fails it, so a tool added next year is asked by existing. The arithmetic, written
 down because a count nobody adds up is how this list rotted the first time: `tools/` holds
-**26** files, of which **16** are `*-check` proof tools and **10** are the block below.
+**27** files, of which **17** are `*-check` proof tools and **10** are the block below.
 
 ```
 node tools/convert-presets.mjs presets projects jobs # version 3 documents -> version 4, in place

--- a/README.md
+++ b/README.md
@@ -348,6 +348,55 @@ rising to 10mm at 4.25m. `render %` scales the drawing buffer, and it is the one
 control that reliably buys back frame time on a large display, for the reason the
 [rendering cost](#rendering-cost) table gives.
 
+## Output to OBS
+
+Two outputs, and they are different pictures rather than two views of one. Add them in
+OBS from the panel's *Output to OBS* group, which prints both URLs.
+
+| What | How | What it is |
+| --- | --- | --- |
+| the viewport | browser source on `/program` | this renderer, at a fixed size, no chrome |
+| the webcam | media source on `/camera.mjpg` | the colour camera's own 1920x1080 frame |
+
+OBS's own virtual camera then publishes either one to Zoom, Meet or anything else, so
+nothing here installs a system camera extension.
+
+**The webcam is not the colour on the wire.** Type 2 carries the *registered* colour —
+`Registration::apply`'s resample of the colour camera into the depth camera's
+viewpoint, wearing its 70.6° frustum instead of the colour camera's 84.1° and punched
+through with holes wherever the depth solve returned nothing. Right for texturing a
+cloud, useless as a picture of a room. So the grabber encodes the native frame as a
+second stream, on its own thread: a 1080p TurboJPEG encode measures **5.50 ms mean**
+here (90 real sensor frames over a six-second subscription, no warmup discarded, zero
+busy drops, q80, TJSAMP_420, FASTDCT), against a 7.1 ms serial frame loop with a 33 ms
+budget — so putting it on the loop would add the full encode to capture-to-wire
+latency, and off it the loop pays only the copy. It is emitted only while something
+is subscribed, because it is another ~50 Mbit/s on a pipe whose backpressure reaches
+the grabber and costs the take.
+
+The viewport source has two modes. *Program camera* frames the keyed camera at a fixed
+output size; *mirror* follows what the operator is orbiting. Mirror is a second render
+of the operator's viewpoint rather than their pixels, because a browser source renders
+its own context — OBS window capture would give the exact pixels and was rejected for
+being window-sized and carrying whatever chrome is not hidden.
+
+**It renders once per sensor frame, and OBS is the clock after that.** Nothing is
+invented and nothing repeated on this side, but a browser source cannot hand frames to
+an encoder: CEF renders offscreen and OBS pulls the latest texture at canvas rate, so
+the two clocks beat. Negligible on a healthy link, where the sensor is a flat 30.00fps;
+uneven on a degraded one, where nothing available would fix it. The source shows its
+delivered rate and its missed count for that reason, and says the decimation it was
+granted if it is being served coarse — an output that quietly upscaled ÷4 depth would
+be the misattribution the monitor negotiation exists to prevent, arriving by another
+door.
+
+Two things worth knowing before you rely on it. Turning colour off restarts the grabber
+and **drops a live webcam mid-call**; that is allowed rather than refused, and the
+endpoint answers 503 with the reason instead of going silent. And `/camera.mjpg` serves
+the camera to anything that can reach the port — the origin rule refuses a browser
+declaring a foreign origin and nothing else, so see [SECURITY.md](SECURITY.md) before
+`--host 0.0.0.0`.
+
 ## Surface memory
 
 A ray landing on a different surface between frames is a death and a birth, and
@@ -542,7 +591,17 @@ type 1  hello  UTF-8 JSON, once, before any frame:
 type 2  frame  [u32 depthBytes][u32 colorBytes][u64 timestampMs]
                [u16 depth[512*424] millimetres, 0 = no reading]
                [JPEG of the registered 512x424 colour image]
+type 3  colour [u64 timestampMs][JPEG of the native 1920x1080 colour image]
+               Live only, and only while something is subscribed.
 ```
+
+**Type 3 is live-only, so "byte-identical" now means identical to the type 1 and 2
+subsequence.** A capture file is still exactly what the grabber emitted of the stream
+the recorder writes, and the colour message is not part of that stream — it is
+interleaved on the wire and dropped at the recorder, because a third message type in
+the file would move every take's content hash, which is the key the library joins two
+machines on. `vcam-check --mutate hd-reaches-recorder` is what keeps that true.
+Recording it is an open decision rather than a closed door.
 
 Measured over a real capture: 434,176 bytes of depth plus a 49–59KB JPEG, 486KB per
 frame all in. At 30fps that is 14.6MB/s, or 117Mbit/s per connected browser. Fine

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,15 @@ Everything, to everyone who can route to the port:
 - `PUT /projects/:name`, `/presets/:name`, `/deliverables/:name`: overwrite saved work.
 - `POST /jobs`: queue renders, without limit, on the disk your takes are being written to.
 - The WebSocket: the live sensor feed, and the recorder's controls.
+- `GET /camera.mjpg`: **the colour camera, live, as an ordinary MJPEG stream.** This is the
+  plainest thing on the list — no framing to decode and no client to write, just a URL that
+  shows the room to anyone who opens it. Nothing has to be recording for it to work, and
+  opening it starts the encode rather than joining one already running.
+
+The origin rule covers this route as it covers the mutating ones, and it buys the same narrow
+thing: a browser that *declares* a foreign origin is refused. An `<img>` tag sends no origin at
+all, and neither does curl, ffmpeg, VLC or another machine on the Wi-Fi, so none of them is
+stopped. Treat the route as public to the network you bound to.
 
 `POST /library/reveal/:id` is the one route that does **not** widen with the bind, and it is
 called out here because it is the only route in the program that starts a process — the

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -55,6 +55,18 @@ where 33ms and a JPEG encode sit between calls, the same change is worth 0.30ms 
 **An offline harness is for correctness; `grabber --profile` on the sensor is for cost** - and
 a screening measurement that removes the effect will confidently report its absence.
 
+## Synthetic pictures cannot price a live image path
+
+The HD colour encoder first measured 3.12ms p50 over 200 structured synthetic images,
+after discarding 20 warmups. The real sensor then measured 5.50ms mean over 90 native
+1920x1080 frames during a six-second subscription at the same q80, TJSAMP_420 and
+FASTDCT settings. The grabber delivered 180 depth frames in that interval - 30.0fps -
+and reported zero encoder-busy drops. No encoder warmup was discarded.
+
+Those runs use different summary statistics, so their difference is not a percentage
+claim about content. The live run is the cost of the path that ships. Use generated
+images to test an encoder and real producer content to price it.
+
 ## Replacing a shader literal with a uniform is not one question but two
 
 And the second one is about the expression rather than the value. Step 3 of the effects rework

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -12,13 +12,13 @@ For the method behind the suite, see `docs/instruments.md`.
 the disagreement runs the dangerous way, so read the assertion count and never the code.**
 Counted rather than recalled:
 
-- **Five exit non-zero on a catch and say `NOT CAUGHT` when they miss**: `guard-check`,
-  `jobs-check`, `editor-check`, `monitor-check`, `sensor-view-check`.
+- **Six exit non-zero on a catch and say `NOT CAUGHT` when they miss**: `guard-check`,
+  `jobs-check`, `editor-check`, `monitor-check`, `sensor-view-check`, `vcam-check`.
 - **Three invert it**: `vendor-check`, `registration-check` and `registry-check`, where caught
   is exit **0** with `caught, as required (N assertions fired)` and exit **1** is `NOT CAUGHT`.
   Anything gating on "non-zero means caught" reads a genuine miss by these three as a catch.
   `registry-check` joined this group rather than the first deliberately, because it is the only
-  one of the twelve where all three outcomes have their own code: it exits **2** with `DID NOT
+  one of the thirteen where all three outcomes have their own code: it exits **2** with `DID NOT
   RUN` on a crash, on the same reading `registration-check` reserves 2 for. That is not
   hypothetical — two of its four mutations reddened their intended row and *then* died on
   Playwright's `Target page, context or browser has been closed`, and without the crash handler
@@ -48,11 +48,11 @@ same way. The convention was reached independently several times and it is one r
 `--mutate <name>` serves a deliberately broken `main.js` into the running server, or for the
 two vendoring tools rebuilds a deliberately broken source tree.
 
-**Twelve tools carry mutations** — editor, export, guard, jobs, keyframe, library, monitor,
-registration, registry, sensor-view, timeline and vendor — and all of them refuse a mutation
-whose text they cannot find exactly once, because a replacement that silently matched nothing
-would run the unmutated page and be recorded as the check having missed a bug it was never
-shown.
+**Thirteen tools carry mutations** — editor, export, guard, jobs, keyframe, library, monitor,
+registration, registry, sensor-view, timeline, vcam and vendor — and all of them refuse a
+mutation whose text they cannot find exactly once, because a replacement that silently matched
+nothing would run the unmutated page and be recorded as the check having missed a bug it was
+never shown.
 
 **A mutation is a piece of source text, so a mutation stops matching the moment the code it
 names is edited** — three of `timeline-check`'s nine had to be re-anchored when step 5 rewrote
@@ -92,6 +92,23 @@ and says so - the queue rows are seconds, the render row is a minute. Its mutati
 one.** `channel: 'chromium'` rather than the bundled headless shell, which has no GPU and falls
 back to SwiftShader - a class nothing else can reproduce, which the worker refuses outright
 rather than pinning jobs to.
+
+**`vcam-check`** spawns its own server on 8361 and needs none running, but it needs a capture at
+`captures/sample.knct` to loop, ffmpeg and ffprobe, and a GPU browser for section 5
+(`--no-browser` drops it and says so). It writes takes into its own staged tree, so it never
+touches `captures/`.
+
+**Its discriminator is geometry rather than resolution, and that is the whole design of the
+tool.** The webcam's claim is that it serves the colour camera and not the registered 512x424
+image the point cloud is textured with — and an implementation that upscaled the registered
+image to 1080p would pass every dimension check there is. What it cannot pass is a margin: the
+colour camera sees 84.1° where the registered frustum sees 70.6°, so a real colour frame carries
+content down the sides that no upscale can invent. `fake-grabber --hd` builds the fixture as
+*the registered frame upscaled* plus a magenta left margin and a cyan right one, so a cheating
+implementation matches most of the picture and still fails on the 12% at each edge. Run
+`--mutate hd-upscales-registered` and read which rows fire: the two margin rows and the
+re-encode row, and nothing else. `--mutate hd-reaches-recorder` fires the two rows about the
+take. A control that failed on a neighbouring row would not be a control for the thing it names.
 
 **`guard-check`** spawns its own servers and needs none running. It exits 2 when the machine has
 no non-internal IPv4, because "not listening on the network" is only a claim if there is a
@@ -169,12 +186,12 @@ noise. That floor belongs to a profiling run that writes nothing — see the gat
 it builds both arms, checks with `ldd` that they load different libraries, and refuses to
 report milliseconds from an arm that lost frames.
 
-**`sweep-all` says "every mutation of every tool" and drives four of the eleven that carry
+**`sweep-all` says "every mutation of every tool" and drives four of the thirteen that carry
 mutations.** Its `TOOLS` is `['library', 'timeline', 'keyframe', 'export']`, so editor, guard,
-jobs, monitor, registration, sensor-view and vendor are outside the sweep a merge waits on -
+jobs, monitor, registration, registry, sensor-view, vcam and vendor are outside the sweep a merge waits on -
 and the file's own header is an argument against exactly this shape, since it takes each tool's
 mutation *names* from that tool's refusal specifically so no list has to agree with anything.
-The names are enumerated and the tools are not. The seven that are missing each need something
+The names are enumerated and the tools are not. The nine that are missing each need something
 the sweep does not currently arrange - a private server, a GPU browser, a built prefix - so
 wiring them is real work rather than a longer array.
 

--- a/native/grabber.cpp
+++ b/native/grabber.cpp
@@ -8,6 +8,8 @@
 //   type 2 (frame) : [u32 depthBytes][u32 colorBytes][u64 timestampMs]
 //                    [u16 depth[512*424] millimetres, 0 = no reading]
 //                    [JPEG of the registered 512x424 colour image]
+//   type 3 (colour): [u64 timestampMs][JPEG of the native 1920x1080 colour image]
+//                    Only while the server has asked for it - see `hd-color` below.
 
 #include <cstdio>
 #include <cstdlib>
@@ -18,6 +20,10 @@
 #include <string>
 #include <vector>
 #include <chrono>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -34,6 +40,10 @@
 static const uint32_t MAGIC = 0x4B4E4354; // 'KNCT'
 static const uint32_t TYPE_HELLO = 1;
 static const uint32_t TYPE_FRAME = 2;
+static const uint32_t TYPE_COLOR = 3;
+
+static const int CW = 1920;
+static const int CH = 1080;
 
 // A corpus is deliberately not KNCT: the wire format carries u16 millimetre depth
 // and a JPEG, which are both lossy relative to what Registration::apply actually
@@ -90,7 +100,17 @@ static bool write_file(const std::string &path, const void *const *parts,
   return ok;
 }
 
+// **stdout has two writers, so framing a message is a critical section.** The frame
+// loop writes type 1 and type 2; the colour encoder thread below writes type 3. A
+// message is a header followed by its payload as two separate `write_all` calls over
+// a pipe that partial-writes at 64KB, so without this lock the two interleave - a
+// header claiming 215KB followed by the first 64KB of somebody else's depth grid.
+// The parser on the other end reads that as a desync and restarts the grabber, and
+// it would do it rarely, unreproducibly, and only once a webcam was attached.
+static std::mutex g_writeMutex;
+
 static bool write_message(int fd, uint32_t type, const void *payload, uint32_t payloadLen) {
+  std::lock_guard<std::mutex> lock(g_writeMutex);
   uint32_t header[3] = {MAGIC, type, payloadLen};
   if (!write_all(fd, header, sizeof(header))) return false;
   if (payloadLen && !write_all(fd, payload, payloadLen)) return false;
@@ -110,6 +130,135 @@ static uint64_t now_us() {
   return (uint64_t)duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
 }
 
+/**
+ * The webcam output's producer: the colour camera's own picture, encoded off the
+ * frame loop.
+ *
+ * **Why a second encode at all.** Type 2 already carries colour, but it carries the
+ * *registered* colour - `Registration::apply`'s resample of the colour camera into
+ * the depth camera's viewpoint. That image wears the depth camera's 70.6 degree
+ * frustum rather than the colour camera's 84.1, and it is punched through with holes
+ * wherever the depth solve returned nothing, because registration has no depth to
+ * carry a colour sample on. It is a texture for a point cloud and not a picture of a
+ * room, so a webcam has to start from the 1920x1080 frame instead.
+ *
+ * **Why its own thread.** A 1080p TurboJPEG encode at the same settings measures
+ * 5.50ms mean on this machine - 90 real sensor frames over a six-second subscription,
+ * no warmup discarded, zero busy drops, q80, TJSAMP_420, FASTDCT. The serial half of
+ * the frame loop is 7.1ms against a 33ms budget with `Registration::apply` taking 6.3
+ * of it, so encoding here would add the full encode to capture-to-wire latency for an
+ * output most runs do not have attached. On its own thread the loop pays the copy
+ * below and nothing else.
+ *
+ * **Why it copies rather than borrows.** The `Frame` handed in belongs to
+ * libfreenect2's listener and is released when the next colour frame arrives. At
+ * 30fps that is 33ms against a 5.50ms mean encode, so borrowing would be safe almost
+ * always - and "almost always" is a data race that surfaces as a torn picture on a
+ * dim-light run nobody can reproduce.
+ *
+ * **Drop-to-latest rather than a queue.** A colour frame arriving while the encoder
+ * is busy overwrites the pending one. A queue would grow latency under exactly the
+ * condition a live output cannot afford it, and a webcam wants the newest frame
+ * rather than every frame.
+ */
+class HdEncoder {
+public:
+  explicit HdEncoder(int quality) : quality_(quality) {}
+
+  void start() { thread_ = std::thread(&HdEncoder::run, this); }
+
+  void stop() {
+    {
+      std::lock_guard<std::mutex> lock(m_);
+      stop_ = true;
+    }
+    cv_.notify_all();
+    if (thread_.joinable()) thread_.join();
+  }
+
+  bool enabled() const { return enabled_.load(std::memory_order_relaxed); }
+  void setEnabled(bool on) { enabled_.store(on, std::memory_order_relaxed); }
+  uint64_t sent() const { return sent_.load(std::memory_order_relaxed); }
+  uint64_t encodeUs() const { return encodeUs_.load(std::memory_order_relaxed); }
+  uint64_t dropped() const { return dropped_.load(std::memory_order_relaxed); }
+
+  /** Called on the frame loop, and the only thing it costs is the copy. */
+  void submit(const uint8_t *bgrx, size_t bytes, uint64_t ts) {
+    {
+      std::lock_guard<std::mutex> lock(m_);
+      // An unconsumed frame still in the slot is one the encoder never got to, and
+      // it is counted rather than silently replaced: a webcam delivering 12fps off a
+      // 30fps sensor is a fact about this machine, and the alternative is somebody
+      // attributing it to the sensor.
+      if (hasPending_) dropped_.fetch_add(1, std::memory_order_relaxed);
+      pending_.assign(bgrx, bgrx + bytes);
+      pendingTs_ = ts;
+      hasPending_ = true;
+    }
+    cv_.notify_one();
+  }
+
+private:
+  void run() {
+    tjhandle jpeg = tjInitCompress();
+    if (!jpeg) {
+      std::fprintf(stderr, "[grabber] cannot start the hd colour encoder: %s\n", tjGetErrorStr());
+      return;
+    }
+    std::vector<uint8_t> work;
+    std::vector<uint8_t> payload;
+    unsigned char *buf = nullptr;
+    // Declared out here and never reset for the same reason the frame loop's is:
+    // TurboJPEG reads it as the capacity of the buffer it allocated last time, and
+    // zeroing it claims a zero-length buffer that the encode then runs off the end of.
+    unsigned long size = 0;
+
+    for (;;) {
+      uint64_t ts;
+      {
+        std::unique_lock<std::mutex> lock(m_);
+        cv_.wait(lock, [this] { return hasPending_ || stop_; });
+        if (stop_) break;
+        work.swap(pending_);
+        ts = pendingTs_;
+        hasPending_ = false;
+      }
+
+      uint64_t t0 = now_us();
+      if (tjCompress2(jpeg, work.data(), CW, 0, CH, TJPF_BGRX, &buf, &size,
+                      TJSAMP_420, quality_, TJFLAG_FASTDCT) != 0) {
+        std::fprintf(stderr, "[grabber] hd colour encode failed: %s\n", tjGetErrorStr());
+        continue;
+      }
+      encodeUs_.fetch_add(now_us() - t0, std::memory_order_relaxed);
+
+      payload.resize(8 + (size_t)size);
+      std::memcpy(payload.data(), &ts, 8);
+      std::memcpy(payload.data() + 8, buf, (size_t)size);
+      // Through the same locked writer as everything else, which is what keeps this
+      // thread's 215KB from landing inside the frame loop's 486KB.
+      if (!write_message(STDOUT_FILENO, TYPE_COLOR, payload.data(), (uint32_t)payload.size())) break;
+      sent_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    if (buf) tjFree(buf);
+    tjDestroy(jpeg);
+  }
+
+  const int quality_;
+  std::thread thread_;
+  std::mutex m_;
+  std::condition_variable cv_;
+  std::vector<uint8_t> pending_;
+  uint64_t pendingTs_ = 0;
+  bool hasPending_ = false;
+  bool stop_ = false;
+  std::atomic<bool> enabled_{false};
+  std::atomic<uint64_t> sent_{0};
+  std::atomic<uint64_t> encodeUs_{0};
+  std::atomic<uint64_t> dropped_{0};
+};
+
 // Low light on is the sensor's own behaviour: it lengthens integration until the
 // image is properly exposed, which drops the colour camera to 15fps. Off pins the
 // exposure to a single mains-flicker period - 16.667 pseudo-ms resolves to 10ms
@@ -124,7 +273,8 @@ static void applyLowLight(libfreenect2::Freenect2Device *dev, bool on) {
 // Commands arrive newline terminated on stdin so the server can retune a running
 // grabber. Restarting instead would cost a multi-second blackout, because closing
 // the device on macOS sleeps 4s inside libfreenect2.
-static void pollCommands(libfreenect2::Freenect2Device *dev, std::string &pending, bool wantColor) {
+static void pollCommands(libfreenect2::Freenect2Device *dev, std::string &pending, bool wantColor,
+                         HdEncoder *hd) {
   char buf[256];
   ssize_t n;
   while ((n = ::read(STDIN_FILENO, buf, sizeof(buf))) > 0) pending.append(buf, (size_t)n);
@@ -137,6 +287,19 @@ static void pollCommands(libfreenect2::Freenect2Device *dev, std::string &pendin
 
     if (line == "low-light on" || line == "low-light off") {
       if (wantColor) applyLowLight(dev, line == "low-light on");
+    } else if (line == "hd-color on" || line == "hd-color off") {
+      // Asked for rather than always on, because a 1080p JPEG is roughly 215KB and
+      // another ~50Mbit/s down a pipe whose backpressure reaches this process and
+      // makes it miss USB deadlines. With colour off there is no frame to encode, and
+      // saying so on stderr is what stops the server waiting for a stream that is
+      // never coming.
+      const bool on = line == "hd-color on";
+      if (!wantColor && on) {
+        std::fprintf(stderr, "[grabber] refusing hd colour: this grabber was started with --no-color\n");
+      } else if (hd) {
+        hd->setEnabled(on);
+        std::fprintf(stderr, "[grabber] hd colour %s\n", on ? "on" : "off");
+      }
     } else if (!line.empty()) {
       std::fprintf(stderr, "[grabber] unknown command: %s\n", line.c_str());
     }
@@ -229,6 +392,14 @@ int main(int argc, char **argv) {
         "  the time spent blocked waiting for the next depth frame, which is the\n"
         "  headroom left over. One CSV row per frame, all of them written to\n"
         "  stderr at exit so the reporting stays out of the loop being measured.\n"
+        "  hd_copy_us is the webcam's share: the 1080p encode itself runs on\n"
+        "  another thread and is summarised separately, so what lands on the loop\n"
+        "  is the copy that hands the frame over and nothing else.\n"
+        "\n"
+        "  On stdin, one command per line: 'low-light on|off' and\n"
+        "  'hd-color on|off'. The second starts and stops the type 3 colour\n"
+        "  stream the webcam output reads, and it is off until asked because a\n"
+        "  1080p JPEG is roughly 215KB a frame of pipe nobody is reading.\n"
         "\n"
         "  --min-depth/--max-depth clip on the GPU before the frame is built, so\n"
         "  they decide what exists at all - the viewer's own clip only hides what\n"
@@ -433,11 +604,22 @@ int main(int argc, char **argv) {
   unsigned char *jpegBuf = nullptr;
   unsigned long jpegSize = 0;
 
+  // Started with the stream rather than on the first request, because a thread parked
+  // on a condition variable costs nothing and starting one on demand would put the
+  // thread's own startup inside the latency of the first webcam frame. It encodes
+  // only what `hd-color on` lets the loop below hand it.
+  HdEncoder hdEncoder(jpegQuality);
+  if (wantColor) hdEncoder.start();
+
   std::vector<uint8_t> depthOut(DEPTH_PIXELS * sizeof(uint16_t));
   std::vector<uint8_t> payload;
 
   libfreenect2::FrameMap depthFrames, colorFrames;
   bool haveColor = false;
+  // Said once rather than per frame: a decoder producing something the webcam cannot
+  // encode does it thirty times a second, and a log that repeats at frame rate is a
+  // log nobody reads.
+  bool hdFormatWarned = false;
   uint64_t frameCount = 0;
   uint64_t colorCount = 0;
   int dumped = 0;
@@ -446,7 +628,7 @@ int main(int argc, char **argv) {
   // the profiling I/O cannot land inside the loop it is measuring.
   struct ProfRecord {
     uint64_t arrival;
-    uint32_t newColor, wait, acq, reg, conv, enc, asm_, write, jpegBytes;
+    uint32_t newColor, wait, acq, reg, conv, enc, asm_, write, jpegBytes, hdCopy;
   };
   std::vector<ProfRecord> prof;
   if (profile) prof.reserve(1 << 17); // ~an hour at 30fps, so no realloc mid-loop
@@ -459,7 +641,7 @@ int main(int argc, char **argv) {
     }
     uint64_t tArrived = now_us();
 
-    pollCommands(dev, pendingCommands, wantColor);
+    pollCommands(dev, pendingCommands, wantColor, &hdEncoder);
 
     // Take a new colour frame only if one is already waiting; never block on it.
     // The previous one is released first so at most one is held outside the pool.
@@ -473,6 +655,40 @@ int main(int argc, char **argv) {
     libfreenect2::Frame *depth = depthFrames[libfreenect2::Frame::Depth];
     libfreenect2::Frame *rgb = haveColor ? colorFrames[libfreenect2::Frame::Color] : nullptr;
     uint64_t tAcquired = now_us();
+
+    // The webcam's picture, handed off before registration rather than after, because
+    // nothing it needs happens downstream and every microsecond it waits here is
+    // latency in somebody's video call.
+    //
+    // **Only on a new colour frame.** The loop reuses the last colour when none has
+    // arrived - that is the whole point of the decoupled listeners - so submitting
+    // every iteration would re-encode one picture at the depth rate and bill a
+    // stationary webcam for 30fps of identical JPEGs. Gated this way, the output runs
+    // at the colour camera's real rate, which halves to 15 in dim light and is the
+    // honest number to show.
+    uint64_t tHdCopied = tAcquired;
+    if (newColor && rgb && hdEncoder.enabled()) {
+      // Checked rather than assumed: both JPEG decoders this library can be built
+      // with produce BGRX today, and a build that produced RGBX would hand the webcam
+      // a picture with its red and blue swapped - wrong in a way that looks like a
+      // colour-grading choice rather than a bug.
+      if (rgb->format != libfreenect2::Frame::BGRX) {
+        if (!hdFormatWarned) {
+          std::fprintf(stderr, "[grabber] hd colour off: the colour decoder produced format %d, not BGRX\n",
+                       (int)rgb->format);
+          hdFormatWarned = true;
+        }
+      } else if ((int)rgb->width != CW || (int)rgb->height != CH) {
+        if (!hdFormatWarned) {
+          std::fprintf(stderr, "[grabber] hd colour off: the colour frame is %dx%d, not %dx%d\n",
+                       (int)rgb->width, (int)rgb->height, CW, CH);
+          hdFormatWarned = true;
+        }
+      } else {
+        hdEncoder.submit((const uint8_t *)rgb->data, (size_t)CW * CH * 4, now_ms());
+      }
+      tHdCopied = now_us();
+    }
 
     // Dumped before apply() rather than after, because these two frames are the
     // harness's input and apply() writes into buffers it also reads maps from.
@@ -561,7 +777,11 @@ int main(int argc, char **argv) {
       r.newColor  = newColor ? 1 : 0;
       r.wait      = (uint32_t)(tArrived - tWaitStart);
       r.acq       = (uint32_t)(tAcquired - tArrived);
-      r.reg       = (uint32_t)(tRegistered - tAcquired);
+      // The webcam's copy sits between acquisition and registration, so it comes out
+      // of the span rather than being buried inside `reg`. A cost that hides in a
+      // neighbouring segment is a cost the next person attributes to registration.
+      r.hdCopy    = (uint32_t)(tHdCopied - tAcquired);
+      r.reg       = (uint32_t)(tRegistered - tHdCopied);
       r.conv      = (uint32_t)(tConverted - tRegistered);
       r.enc       = (uint32_t)(tEncoded - tConverted);
       r.asm_      = (uint32_t)(tAssembled - tEncoded);
@@ -579,17 +799,32 @@ int main(int argc, char **argv) {
                    (unsigned long long)frameCount, (unsigned long long)colorCount);
   }
 
+  // Stopped before the listener releases its frame and before the counters below are
+  // read, so the thread is quiescent rather than mid-encode when either happens.
+  hdEncoder.stop();
   if (haveColor) colorListener.release(colorFrames);
 
   if (profile) {
-    std::fprintf(stderr, "[prof] n,arrival_us,newColor,wait_us,acq_us,reg_us,conv_us,enc_us,asm_us,write_us,jpeg_bytes\n");
+    std::fprintf(stderr, "[prof] n,arrival_us,newColor,wait_us,acq_us,reg_us,conv_us,enc_us,asm_us,write_us,jpeg_bytes,hd_copy_us\n");
     for (size_t i = 0; i < prof.size(); i++) {
       const ProfRecord &r = prof[i];
-      std::fprintf(stderr, "[prof] %zu,%llu,%u,%u,%u,%u,%u,%u,%u,%u,%u\n",
+      std::fprintf(stderr, "[prof] %zu,%llu,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u\n",
                    i, (unsigned long long)r.arrival,
-                   r.newColor, r.wait, r.acq, r.reg, r.conv, r.enc, r.asm_, r.write, r.jpegBytes);
+                   r.newColor, r.wait, r.acq, r.reg, r.conv, r.enc, r.asm_, r.write, r.jpegBytes,
+                   r.hdCopy);
     }
     std::fflush(stderr);
+  }
+
+  // The webcam's own cost, reported off the per-frame table because the encode does
+  // not happen on the frame loop's clock. `dropped` is the number that says whether
+  // this machine kept up: a colour frame arriving while the encoder was still busy is
+  // one the webcam never showed, and a viewer counting a low frame rate needs to know
+  // it was this and not the sensor.
+  if (wantColor && hdEncoder.sent() > 0) {
+    std::fprintf(stderr, "[grabber] hd colour: %llu sent, %llu dropped busy, %.2f ms mean encode\n",
+                 (unsigned long long)hdEncoder.sent(), (unsigned long long)hdEncoder.dropped(),
+                 (double)hdEncoder.encodeUs() / (double)hdEncoder.sent() / 1000.0);
   }
 
   if (jpegBuf) tjFree(jpegBuf);

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ import { pipeline } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import { basename, dirname, join, normalize, extname, sep, resolve } from 'node:path';
 import { WebSocketServer } from 'ws';
-import { MessageParser, encodeMessage, TYPE_HELLO, TYPE_FRAME } from './protocol.js';
+import { MessageParser, encodeMessage, TYPE_HELLO, TYPE_FRAME, TYPE_COLOR } from './protocol.js';
 import { openCapture, withCapture, captureIdFor, openCaptureCount, decimatePayload } from './capture.js';
 import { handleExportSocket, MAX_FRAME_BYTES } from './export.js';
 import {
@@ -18,6 +18,7 @@ import {
 } from './library.js';
 import { Recorder } from './recorder.js';
 import { JobStore } from './jobs.js';
+import { Webcam } from './webcam.js';
 import { requireMutation, originAllowed } from './http-guard.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -981,14 +982,33 @@ const shooting = (run) => async (req, res, args, query) => {
 };
 
 /**
- * Every monitor whose frames cross the link at a setting finer than the cap.
+ * Every consumer whose frames cross the link and cost the take.
  *
  * Read off the live sockets rather than off anything a caller sends, because the
  * question is what is attached right now, and the answer has to be the same one
  * `broadcastFrame` is about to act on.
+ *
+ * **This asks about consumers rather than about monitors, and the difference is the
+ * whole reason it was rewritten.** The cost being refused is backpressure: a link
+ * that cannot carry what is being pushed down it reaches back through this server's
+ * stdin pipe into the grabber, which then misses USB deadlines and drops depth
+ * packets that never reach the file. A WebSocket monitor at ÷1 does that. So does a
+ * webcam subscriber pulling ~50Mbit/s of MJPEG over the same radio, and it does it
+ * through a route that has no divisor and no stride to name.
+ *
+ * Written as "every kind of consumer, asked the same question" rather than as
+ * monitors-plus-a-webcam-clause, so the third kind is refused by being in this list
+ * rather than by somebody remembering this function exists. A cost the refusal cannot
+ * see is a cost it silently under-reports, and the only thing the refusal has going
+ * for it is that its number is true.
  */
-function monitorsCostingTheTake() {
-  return attachedMonitors().filter(costsTheTake).map((m) => ({ divisor: m.divisor, stride: m.stride }));
+function consumersCostingTheTake() {
+  return [
+    ...attachedMonitors().filter(costsTheTake)
+      .map((m) => ({ kind: 'monitor', at: `÷${m.divisor} ×${m.stride}` })),
+    ...webcam.describe().filter((s) => !s.loopback)
+      .map(() => ({ kind: 'webcam', at: 'the colour camera at full rate' })),
+  ];
 }
 
 /**
@@ -1029,18 +1049,19 @@ function attachedMonitors() {
  */
 const serveRecordStart = shooting(async (req, res) => {
   const body = await readBody(req);
-  const costly = monitorsCostingTheTake();
+  const costly = consumersCostingTheTake();
   if (costly.length && body.acceptMonitorCost !== true) {
-    const at = costly.map((m) => `÷${m.divisor} ×${m.stride}`).join(', ');
+    const at = costly.map((c) => `${c.kind} at ${c.at}`).join(', ');
     throw new Error(
-      `refusing to start a take: ${costly.length} monitor${costly.length > 1 ? 's are' : ' is'} watching over the `
-      + `network at ${at}, finer than the ÷${RECORDING_CAP.divisor} ×${RECORDING_CAP.stride} a recording take `
-      + 'allows - backpressure from that link reaches the grabber and costs the take frames that never reach the '
-      + 'file, so coarsen the monitor or start again with acceptMonitorCost',
+      `refusing to start a take: ${costly.length} consumer${costly.length > 1 ? 's are' : ' is'} reading over the `
+      + `network (${at}), past what a recording take allows - a monitor may go no finer than `
+      + `÷${RECORDING_CAP.divisor} ×${RECORDING_CAP.stride}, and the webcam has no coarser setting to offer at all. `
+      + 'Backpressure from that link reaches the grabber and costs the take frames that never reach the file, so '
+      + 'coarsen the monitor, detach the webcam, or start again with acceptMonitorCost',
     );
   }
   if (costly.length) {
-    console.log(`[server] starting a take with ${costly.length} full-rate monitor(s): the operator accepted the cost`);
+    console.log(`[server] starting a take with ${costly.length} costly consumer(s): the operator accepted the cost`);
   }
   sendJson(res, await recorder.start(helloJson));
 });
@@ -1073,6 +1094,10 @@ function serveRoutes(req, res) {
       // A route that changes something is a route with a write, and this is that
       // fact rather than a label beside it.
       mutates: Boolean(r.write),
+      // And a route that serves what the sensor is seeing right now says so, for the
+      // same reason: the origin rule applies to it, and a check that walks this table
+      // can then ask every one of them rather than the ones a reviewer thought of.
+      live: Boolean(r.live),
       methods: r.write?.methods ?? [],
     })),
   });
@@ -1235,7 +1260,7 @@ const serveDescriptors = (req, res) => sendJson(res, { open: openCaptureCount(),
  * are the reason.
  */
 const serveRecordState = async (req, res) => {
-  const costly = monitorsCostingTheTake();
+  const costly = consumersCostingTheTake();
   sendJson(res, {
     ...recorder.state,
     storage: await remaining(CAPTURES_DIR, recordingRate()),
@@ -1248,6 +1273,16 @@ const serveRecordState = async (req, res) => {
       watching: attachedMonitors().map((m) => ({ divisor: m.divisor, stride: m.stride, loopback: m.loopback })),
       costingTheTake: costly,
       wouldRefuse: costly.length > 0,
+    },
+    // Beside the monitors rather than inside them, because it is a different kind of
+    // consumer reached through a different door - but it is in the same `costly` list
+    // above, which is the number the refusal is actually made of.
+    webcam: {
+      subscribers: webcam.describe(),
+      available: webcam.unavailable === null,
+      unavailable: webcam.unavailable,
+      served: webcam.served,
+      dropped: webcam.dropped,
     },
   });
 };
@@ -1355,6 +1390,16 @@ const ROUTES = [
     write: { methods: ['PUT', 'POST', 'DELETE'], run: (req, res, args) => writeDocument(req, res, DELIVERABLES, args[0]) },
   },
 
+  // ---- the webcam
+  //
+  // `live` rather than `write`: it changes nothing, so it is not a mutation, but it
+  // hands out what the colour camera is seeing this second and the origin rule
+  // applies to it for that reason alone. The dispatcher asks the rule of every entry
+  // carrying this flag, so the next route that serves live sensor bytes is covered by
+  // declaring itself rather than by somebody remembering - the same move the table
+  // already made for mutations.
+  { path: '/camera.mjpg', pattern: /^\/camera\.mjpg$/, live: true, read: (req, res) => webcam.attach(req, res) },
+
   // ---- recording
   { path: '/record/state', pattern: /^\/record\/state$/, read: serveRecordState },
   { path: '/record/start', pattern: /^\/record\/start$/, write: { methods: ['POST'], run: serveRecordStart } },
@@ -1410,6 +1455,12 @@ const PAGES = {
   '/record': 'index.html',
   '/edit': 'index.html',
   '/gallery': 'library.html',
+  // The program-out source, which OBS opens as a browser source. The same file as
+  // the viewer and the editor for the same reason those two are one file: it is the
+  // same renderer drawing the same scene, and a second page would be a second
+  // renderer to keep in step with this one. The URL is what tells `main.js` which of
+  // the three it is.
+  '/program': 'index.html',
 };
 
 /**
@@ -1428,6 +1479,20 @@ async function serveRoute(req, res, urlPath, query) {
     if (!m) continue;
     const args = m.slice(1).map((a) => decodeURIComponent(a));
     if (reading && r.read) {
+      // **The second gate, and it is here for the same reason the first one is.** A
+      // route marked `live` serves what the sensor is seeing right now. It mutates
+      // nothing, so `requireMutation` is the wrong rule - a GET declares no content
+      // type and there is no state to protect - but a page on another origin has no
+      // business reading the camera, and the answer to "which page is asking" is the
+      // same answer the mutating routes already get. Asked from the dispatcher rather
+      // than inside the handler, so a live route added later is guarded by declaring
+      // itself; `guard-check` walks the table and asks every entry carrying the flag.
+      if (r.live && !originAllowed(req)) {
+        sendJson(res, {
+          error: `${req.headers.origin} is not this server, and this route serves what the sensor is seeing`,
+        }, 403);
+        return true;
+      }
       await r.read(req, res, args, query);
       return true;
     }
@@ -1656,6 +1721,10 @@ function broadcastText(text) {
 function setSensorState(state) {
   sensorState = state;
   broadcastText(JSON.stringify({ status: state }));
+  // The webcam cannot outlive the sensor being live, and hanging it off the state
+  // change rather than off each of the paths that cause one is what keeps a route
+  // added later from missing a case. Only revoked here - a hello is what restores it.
+  if (state !== 'live') webcam.setUnavailable(`the sensor is ${state}`);
 }
 
 // Live camera settings the viewer can change. Colour on/off has to restart the
@@ -1778,6 +1847,28 @@ wss.on('connection', (ws, req) => {
       return;
     }
 
+    // What the operator's surface is telling the program-out source to draw: which
+    // camera, what size, and every parameter write as it happens.
+    //
+    // **Relayed rather than interpreted.** The server has no opinion about what a
+    // parameter means and must not acquire one - `web/main.js`'s registry is the only
+    // thing that knows a parameter's range, its kind and what applying it does, and a
+    // second copy of any of that here would be the drift the registry exists to
+    // prevent. So this forwards the message to every other client and reads nothing
+    // out of it, which also means a parameter added to the registry next year reaches
+    // the program-out page without this line changing.
+    //
+    // To others only, never back to the sender: a surface that received its own
+    // writes would apply each one twice, and in mirror mode that is a camera pose
+    // fighting the hand that is dragging it.
+    if (typeof msg.programOut === 'object' && msg.programOut) {
+      const text = raw.toString('utf8');
+      for (const other of wss.clients) {
+        if (other !== ws && other.readyState === other.OPEN) other.send(text);
+      }
+      return;
+    }
+
     if (typeof msg.camera !== 'object' || !msg.camera) return;
     if (!applyCamera) return;
 
@@ -1874,6 +1965,23 @@ function broadcastFrame(payload) {
   }
 }
 
+// Asks the grabber to start or stop encoding the colour camera. Wired up by
+// `startLive` and absent in replay, for the same reason `applyCamera` is: a capture
+// on a loop has no colour camera to turn on, and the webcam says so rather than
+// serving frames from a recording as though they were live.
+let requestHdColor = null;
+
+// The webcam output. Created out here beside the recorder rather than inside
+// `startLive`, because the route above has to answer on a machine where no grabber
+// ever starts - an editing station with nothing plugged in should say why the camera
+// is unavailable, not 404 as though the feature did not exist.
+const webcam = new Webcam({
+  request: (wanted) => requestHdColor?.(wanted),
+});
+if (REPLAY) {
+  webcam.setUnavailable(`this server is replaying ${basename(REPLAY)}, so there is no colour camera to serve`);
+}
+
 // One take is one file, and the recorder is what holds that identity. It is
 // created here rather than inside `startLive` because the HTTP routes above have
 // to be able to reach it whether or not a sensor ever appears - a library on a
@@ -1932,6 +2040,24 @@ function handleMessage(msg) {
     // tick's catch - no frame reached any client, the status flapped between lost
     // and live, and `/record/state` reported a healthy recording the whole time.
     recorder.write(msg.raw);
+  } else if (msg.type === TYPE_COLOR) {
+    // **The webcam and nothing else. There is deliberately no `recorder.write` on
+    // this branch.**
+    //
+    // A capture file is the wire verbatim, so a type 3 landing in one would change
+    // what a `.knct` file contains - and the content hash of every take with it,
+    // which is the key `library.js` joins two machines on. `capture.js`'s sidecar
+    // index and frame API both walk the file assuming types 1 and 2, so a third would
+    // have to be skipped correctly at both ends including for takes written before
+    // today. None of that is hard and none of it has been decided, so the live-only
+    // rule holds until it is: issue #9 carries what recording it would take.
+    //
+    // This is the `nearClip` versus `--min-depth` failure class - footage changed in
+    // the one situation nobody is watching for it - so it is not left to this comment.
+    // `vcam-check --mutate hd-reaches-recorder` adds the write back and has to fail.
+    //
+    // The payload is [u64 timestampMs][JPEG], and the JPEG goes out untouched.
+    webcam.offer(Buffer.from(msg.payload.subarray(8)), Number(msg.payload.readBigUInt64LE(0)));
   }
 }
 
@@ -2119,6 +2245,18 @@ function startLive() {
             attempt = 0; // a clean handshake means the link is healthy again
             everLive = true;
             setSensorState('live');
+            // **A new grabber has never heard of the subscriber that is still
+            // attached.** Its encoder starts off, so without this the webcam comes
+            // back from a colour toggle or a USB drop as a socket that is open,
+            // subscribed and permanently silent - and everything on both ends looks
+            // connected while it happens.
+            //
+            // This is also the one place the webcam becomes available at all: a
+            // handshake from a grabber with colour on is the only evidence that there
+            // is a colour camera to serve, and everything else in this file can only
+            // revoke it.
+            if (camera.color) webcam.setAvailable();
+            webcam.reassert();
           }
         }
       } catch (err) {
@@ -2143,6 +2281,11 @@ function startLive() {
       // matters - the restart branch below returns before the state is set, and that
       // branch is the colour toggle.
       helloJson = null;
+      // The picture goes with the grabber too. Said as a sentence rather than left as
+      // a stalled stream, because the reason is the whole value: a webcam that stops
+      // mid-call and answers "the grabber is restarting" is one somebody waits three
+      // seconds for, and a webcam that stops and answers nothing is one they debug.
+      webcam.setUnavailable('the grabber is restarting');
       // The take ends here. One take is one continuous stream with one hello and
       // monotonic timestamps, and the index, the retime curve and `mixT` all depend
       // on it - a blend fraction across a restart seam has no meaning, and the
@@ -2161,6 +2304,15 @@ function startLive() {
       }
       scheduleRetry();
     });
+  };
+
+  // One line down the grabber's own stdin command channel, the same one the low-light
+  // toggle uses. Refused rather than sent when colour is off, because the grabber
+  // would refuse it too and the webcam should hear the reason from the side that
+  // knows it rather than from a stream that never starts.
+  requestHdColor = (wanted) => {
+    if (!camera.color) return;
+    child?.stdin.write(`hd-color ${wanted ? 'on' : 'off'}\n`);
   };
 
   applyCamera = (next) => {
@@ -2190,6 +2342,15 @@ function startLive() {
       // retry is a genuine backoff step, and zeroing it would restart the table - so a
       // sensorless editing station whose colour toggle gets touched now and then would
       // never reach `absent`, which is the one conclusion that machine needs.
+      // **Turning colour off drops a live webcam, and that is allowed rather than
+      // refused.** The alternative - refusing the toggle while somebody is subscribed
+      // - puts the decision on the person at the keyboard, who did not necessarily
+      // know a call was running; this puts a legible reason in front of whoever loses
+      // the picture. It is the one place this feature makes something worse, and it
+      // is a deliberate trade rather than an oversight.
+      if (!camera.color) {
+        webcam.setUnavailable('colour is off on this grabber, so there is no colour camera to serve');
+      }
       console.log(`[server] colour camera ${camera.color ? 'on' : 'off'} - ${child ? 'restarting grabber' : 'takes effect on the next spawn'}`);
       if (child) {
         restarting = true;

--- a/server/protocol.js
+++ b/server/protocol.js
@@ -5,18 +5,38 @@
 export const MAGIC = 0x4b4e4354;
 export const TYPE_HELLO = 1;
 export const TYPE_FRAME = 2;
+// The colour camera's own picture, at its native 1920x1080, for the webcam output.
+//
+// **A separate message rather than a second field on the frame, because it is a
+// different picture of a different thing.** Type 2 carries the *registered* colour:
+// `Registration::apply`'s resample of the colour camera into the depth camera's
+// viewpoint, which is a texture for the point cloud - it wears the depth camera's
+// 70.6 degree frustum instead of the colour camera's 84.1, and it is punched through
+// with holes wherever the depth solve returned nothing for a ray to carry colour on.
+// Useful for shading a cloud, useless as a picture of a room.
+//
+// **It is live-only: the recorder never writes one.** A capture file is the wire
+// verbatim, so a type 3 landing in one would move every take's content hash, and that
+// hash is the key the library joins two machines on. `vcam-check --mutate
+// hd-reaches-recorder` is the arm that fails if this ever stops being true. Recording
+// it is a decision nobody has taken - see issue #9.
+//
+// Emitted only while something is subscribed, because at roughly 215KB a frame it is
+// another ~50Mbit/s on a pipe whose backpressure reaches the grabber and costs the
+// take. The server asks for it over the grabber's stdin command channel.
+export const TYPE_COLOR = 3;
 export const HEADER_BYTES = 12;
 
 // The largest payload this format admits, and the reason it needs one at all:
 // `payloadLen` is a u32 off the wire, so a desynced stream can declare four
 // gigabytes and the reassembly below would buffer toward it a chunk at a time,
 // holding every byte for a message that is never going to be whole. A frame is a
-// 512x424 depth grid plus a JPEG - 486KB measured on this sensor - and a hello is a
-// few hundred bytes of JSON, so eight megabytes is more than an order of magnitude
-// of headroom over anything this format has ever carried, and a length past it is a
-// lie rather than a large frame. Named here rather than in either reader, because
-// the live parser and the sidecar index are both bounded by the same fact about the
-// format.
+// 512x424 depth grid plus a JPEG - 486KB measured on this sensor - a hello is a few
+// hundred bytes of JSON, and a 1080p colour message measures about 215KB, so eight
+// megabytes is more than an order of magnitude of headroom over anything this format
+// has ever carried, and a length past it is a lie rather than a large frame. Named
+// here rather than in either reader, because the live parser and the sidecar index
+// are both bounded by the same fact about the format.
 export const MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;
 
 /**

--- a/server/webcam.js
+++ b/server/webcam.js
@@ -1,0 +1,270 @@
+// The webcam output: the colour camera's own picture, served as MJPEG over HTTP so
+// OBS can open it as a source URL.
+//
+// **This is a different picture from the one the point cloud is textured with, and
+// that is the whole reason this file exists.** A type 2 frame carries the *registered*
+// colour - `Registration::apply`'s resample of the colour camera into the depth
+// camera's viewpoint. It wears the depth camera's 70.6 degree frustum instead of the
+// colour camera's 84.1, and it is punched through with holes wherever the depth solve
+// returned nothing for a ray to carry colour on. Shading a cloud with it is exactly
+// right; handing it to somebody's video call is a 512x424 picture that speckles black
+// whenever depth drops out. So the grabber encodes the native 1920x1080 frame as a
+// second stream, and this serves those bytes through untouched.
+//
+// **Untouched is load-bearing rather than lazy.** Nothing here decodes, scales,
+// mirrors or crops, so the endpoint has no picture pipeline in it and cannot grow one
+// by accident. Whether it ever should is an open question with an issue on it (#16);
+// until that is answered the boundary is that a processed webcam is a renderer job,
+// because the renderer is the one image pipeline this program already has and a
+// second one beside it is the drift the whole design rejects.
+//
+// **Availability is the property this is built around.** A webcam has to survive an
+// hour-long call with the Braindance UI closed and the window minimised, which is why
+// the bytes come straight off the server rather than through the browser: routing
+// them through a page would mean a JPEG decode, a canvas draw and a readback on a
+// machine that already had the bytes, and would make the picture's existence
+// contingent on a foreground GPU tab that the browser is entitled to throttle.
+
+// One boundary token for the life of the process. It appears in the response header
+// and between every part, and the two have to agree or the stream does not parse.
+const BOUNDARY = 'braindanceframe';
+
+/**
+ * How long the colour stream stays running after the last subscriber leaves.
+ *
+ * **OBS retries a dead source hard**, and a browser source or a media source that
+ * reconnects every second would otherwise toggle the grabber's encoder on and off at
+ * the same rate - each toggle crossing a pipe into another process, and each one
+ * arriving as a gap in somebody's picture. Holding the stream open for a few seconds
+ * turns a reconnect into a seamless resume, and costs nothing but a few frames of
+ * encode on a thread that is otherwise idle.
+ */
+const LINGER_MS = 6000;
+
+/**
+ * How many frames a single subscriber may be behind before frames start being
+ * dropped for it.
+ *
+ * One, which is to say drop-to-latest. **MJPEG over HTTP has no divisor and no stride
+ * to negotiate**, unlike the WebSocket monitors, so this is the only backpressure
+ * control the webcam has. A subscriber on a link that cannot carry the stream must
+ * fall behind by dropping frames rather than by queueing them: the queue would grow
+ * in this process, and its memory is the least of it - the socket that never drains
+ * is what pushes back through the grabber's pipe and makes it miss USB deadlines,
+ * which costs the take frames that no amount of downloading recovers.
+ */
+const MAX_IN_FLIGHT = 1;
+
+export class Webcam {
+  /**
+   * @param {object} opts
+   * @param {(wanted: boolean) => void} opts.request  asks the grabber to start or
+   *   stop encoding. Called only on a change, and re-called by `reassert` after a
+   *   grabber restart, because the new process starts with its encoder off and has
+   *   never heard of the subscriber that is still attached.
+   */
+  constructor({ request }) {
+    this.request = request;
+    this.subscribers = new Set();
+    this.latest = null;
+    this.latestAt = 0;
+    this.wanted = false;
+    this.lingerTimer = null;
+    // Why the picture is not available, or null when it is. Held as a sentence
+    // rather than a flag because it is served to whoever asked: a webcam that
+    // answers an empty stream is one somebody debugs for twenty minutes, and a
+    // webcam that answers "colour is off on this grabber" is one they fix.
+    //
+    // **This asks whether there is a colour camera to serve, never whether a frame
+    // has arrived yet**, and the difference is not academic - it was a deadlock. The
+    // grabber encodes only while somebody is subscribed, so "no frame yet" as a
+    // reason to refuse means the first subscriber is turned away, the encoder is
+    // never asked to start, and the endpoint 503s for the life of the process while
+    // every part of it reports healthy. Waiting for the first frame is the ordinary
+    // way to arrive here; a subscriber attaches, the request goes down to the
+    // grabber, and the picture paints when it comes.
+    //
+    // So there is exactly one thing that clears this - a hello from a grabber with
+    // colour on - and several that set it. Revocations are idempotent and cannot
+    // drift into wrongly-available, which is the direction that would matter.
+    this.unavailable = 'no sensor has handshaken with this server yet';
+    this.served = 0;
+    this.dropped = 0;
+  }
+
+  /** Whether a subscriber's frames leave this machine. */
+  static isLoopback(req) {
+    const a = req.socket.remoteAddress ?? '';
+    return a === '127.0.0.1' || a === '::1' || a === '::ffff:127.0.0.1';
+  }
+
+  get count() {
+    return this.subscribers.size;
+  }
+
+  /**
+   * Every attached subscriber, and whether its frames cross a network.
+   *
+   * Read by `/record/state` so the recorder's refusal can name what a take would be
+   * paying for. The webcam has to be in that accounting by *existing* rather than by
+   * somebody having remembered to add it - a cost the refusal cannot see is a cost it
+   * silently under-reports, and the whole point of the refusal is that the number is
+   * true.
+   */
+  describe() {
+    return [...this.subscribers].map((s) => ({ loopback: s.loopback, behind: s.behind }));
+  }
+
+  /**
+   * Whether the take is paying for this webcam.
+   *
+   * **The loopback exemption is inherited by argument here, not by measurement, and
+   * that distinction is worth keeping.** The WebSocket monitors' exemption was
+   * measured: their cost is backpressure from a link that cannot carry 14.6 MB/s
+   * reaching the grabber, and frames that never leave the machine never touch that
+   * link. The same reasoning plainly applies to a ~50Mbit/s multipart stream on the
+   * same pipe, and the same reasoning is not the same measurement. Nothing here reads
+   * as if it had been measured; the interleaved A/B for this stream on a capture node
+   * has not been run.
+   */
+  costsTheTake() {
+    return [...this.subscribers].some((s) => !s.loopback);
+  }
+
+  /**
+   * A colour frame off the wire. Held, not queued: a subscriber that missed one is
+   * not owed it.
+   */
+  offer(jpeg, timestampMs) {
+    this.latest = jpeg;
+    this.latestAt = timestampMs;
+    for (const s of this.subscribers) this.#push(s);
+  }
+
+  /**
+   * The picture has stopped being available, with the reason. Called when colour is
+   * switched off, when the grabber goes away, and when the sensor state leaves live.
+   */
+  setUnavailable(reason) {
+    this.unavailable = reason;
+    // Dropped rather than kept, so a source that reconnects during an outage is not
+    // painted a still of the moment the sensor died and left to believe it is live.
+    this.latest = null;
+  }
+
+  /**
+   * A grabber has handshaken and colour is on, so there is a camera to serve.
+   *
+   * The only thing in this file that clears the reason above, which is what keeps
+   * "available" from being reachable by accident from a code path that merely saw
+   * some bytes go by.
+   */
+  setAvailable() {
+    this.unavailable = null;
+  }
+
+  /**
+   * Re-ask the grabber for what the subscribers already wanted.
+   *
+   * A restarted grabber is a new process with its encoder off, and it has never heard
+   * of a subscriber that attached to the old one. Without this the webcam comes back
+   * from a colour toggle or a USB drop as a socket that is open, subscribed and
+   * permanently silent - the failure mode being that everything looks connected.
+   */
+  reassert() {
+    if (this.wanted) this.request(true);
+  }
+
+  /**
+   * The MJPEG route.
+   *
+   * **The origin rule is not applied here**, and deliberately not: it belongs to the
+   * dispatcher, which asks it of every route the table marks as serving live sensor
+   * bytes. A copy of the rule in this handler would be the second copy, and the next
+   * live route somebody adds would be outside it - which is the exact shape of the
+   * hole the route table was built to close for mutations.
+   */
+  attach(req, res) {
+    // Answered rather than left hanging. A 503 naming the reason is the difference
+    // between somebody fixing a setting and somebody filing a bug about a black
+    // rectangle - and it is the honest answer for a colour toggle that just restarted
+    // the grabber out from under a live call.
+    if (this.unavailable) {
+      res.writeHead(503, { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-store' });
+      res.end(JSON.stringify({ error: this.unavailable }));
+      return;
+    }
+
+    const sub = { res, loopback: Webcam.isLoopback(req), inFlight: 0, behind: 0 };
+    this.subscribers.add(sub);
+    res.writeHead(200, {
+      'Content-Type': `multipart/x-mixed-replace; boundary=${BOUNDARY}`,
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      'Pragma': 'no-cache',
+      'Connection': 'close',
+    });
+    console.log(`[webcam] subscriber attached (${this.subscribers.size} total, ${sub.loopback ? 'loopback' : 'remote'})`);
+
+    const drop = () => {
+      if (!this.subscribers.delete(sub)) return;
+      console.log(`[webcam] subscriber gone (${this.subscribers.size} left)`);
+      this.#settle();
+    };
+    res.on('close', drop);
+    res.on('error', drop);
+
+    this.#settle();
+    // The frame in hand rather than the next one to arrive, so a source that connects
+    // between frames paints immediately instead of showing a blank rectangle for up
+    // to a colour interval - which in dim light is 66ms and reads as a broken source.
+    if (this.latest) this.#push(sub);
+  }
+
+  /** Turn the grabber's encoder on or off to match what is attached, with the linger. */
+  #settle() {
+    const want = this.subscribers.size > 0;
+    if (want) {
+      if (this.lingerTimer) {
+        clearTimeout(this.lingerTimer);
+        this.lingerTimer = null;
+      }
+      if (!this.wanted) {
+        this.wanted = true;
+        this.request(true);
+      }
+      return;
+    }
+    if (!this.wanted || this.lingerTimer) return;
+    this.lingerTimer = setTimeout(() => {
+      this.lingerTimer = null;
+      // Re-checked rather than assumed: a subscriber may have arrived while this
+      // timer was pending, and turning the stream off under it would be the toggle
+      // storm the linger exists to prevent.
+      if (this.subscribers.size > 0) return;
+      this.wanted = false;
+      this.request(false);
+    }, LINGER_MS);
+  }
+
+  #push(sub) {
+    if (!this.latest) return;
+    // Drop-to-latest. A subscriber still draining the previous frame is one whose
+    // link cannot carry this one, and the frame it is owed is the newest, not this.
+    if (sub.inFlight >= MAX_IN_FLIGHT) {
+      sub.behind++;
+      this.dropped++;
+      return;
+    }
+    const head = Buffer.from(
+      `--${BOUNDARY}\r\nContent-Type: image/jpeg\r\nContent-Length: ${this.latest.length}\r\n\r\n`,
+    );
+    sub.inFlight++;
+    // One `write` for the whole part rather than three, so a part cannot be
+    // interleaved with anything and a slow socket cannot leave a header stranded
+    // without its body.
+    sub.res.write(Buffer.concat([head, this.latest, Buffer.from('\r\n')]), () => {
+      sub.inFlight--;
+    });
+    this.served++;
+  }
+}

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -923,6 +923,16 @@ const DRIVER_RULES = [
       + 'assert where the nav sits and where its two anchors go',
     match: (el) => el.closest('#navRow'),
   },
+  {
+    key: 'output',
+    what: 'a program-out control',
+    // Named because it is driven, not because it is exempt. `vcam-check` section 5
+    // opens the operator surface and the source together, moves both of these, and
+    // asserts the source's drawing buffer and its camera actually followed - which is
+    // the only place they can be checked, since what they change is a different page.
+    by: 'vcam-check section 5 sets both from the operator page and reads the source',
+    match: (el) => el.closest('#programOutGroup'),
+  },
 ];
 
 // Named one at a time, because each of these is a control this file presses itself.
@@ -1116,7 +1126,7 @@ try {
       ease: el.dataset ? el.dataset.ease ?? null : null,
       inTbar: Boolean(el.closest('.tbar')),
       groups: ['#panel', '#cameraGroup', '#navRow', '#recordGroup', '#recLookGroup',
-        '#sensorGroup', '#monitorGroup', '#extendedRow']
+        '#sensorGroup', '#monitorGroup', '#extendedRow', '#programOutGroup']
         .filter((g) => el.closest(g)),
       kf: el.classList.contains('kf'),
       label: (el.getAttribute('aria-label') || el.textContent || '').trim().slice(0, 24),
@@ -1130,6 +1140,7 @@ try {
     if (row.ease) return 'rule: an ease preset, section 5 presses all five';
     if (row.kf && row.id !== 'tRateKey') return RULE.keyframe;
     if (inGroup(row, '#recordGroup', '#recLookGroup', '#sensorGroup', '#monitorGroup', '#extendedRow')) return RULE.recorder;
+    if (inGroup(row, '#programOutGroup')) return RULE.output;
     if (inGroup(row, '#cameraGroup') || row.id === 'camSensor') return RULE.camera;
     if (inGroup(row, '#navRow')) return RULE.nav;
     if (inGroup(row, '#panel') && (row.type === 'range' || row.type === 'checkbox')) return RULE.look;

--- a/tools/fake-grabber.mjs
+++ b/tools/fake-grabber.mjs
@@ -19,8 +19,9 @@
 //   tools/fake-grabber.mjs --die-after 12      # exits, so the server respawns it
 
 import { appendFileSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { MessageParser, TYPE_HELLO, TYPE_FRAME, encodeMessage } from '../server/protocol.js';
+import { MessageParser, TYPE_HELLO, TYPE_FRAME, TYPE_COLOR, encodeMessage } from '../server/protocol.js';
 
 const argv = process.argv.slice(2);
 const flag = (name, fallback = null) => {
@@ -60,6 +61,27 @@ const TAG = flag('--tag', '');
 // than an assurance: with a viewer attached at a divisor, a recorder handed the
 // decimated buffer produces frames whose payload hashes are simply not in this file.
 const EMIT_LOG = flag('--emit-log', '');
+// Whether this writer can produce type 3, the native-resolution colour the webcam
+// output reads. Off by default so nothing that already drives this file starts
+// needing ffmpeg; `vcam-check` is the only caller that asks for it.
+//
+// **The synthesised HD frame is the registered one upscaled, plus a marker in the
+// outer margin, and both halves of that are the point.** The webcam's whole claim is
+// that it serves the colour camera rather than the registered image the point cloud
+// is textured with, and the two are hard to tell apart by eye: same scene, same
+// moment, different projection. So the discriminator has to be geometric. The colour
+// camera sees 84.1 degrees where the registered frustum sees 70.6, which means a real
+// colour frame carries scene content down the sides that no upscale of the registered
+// image can invent. This fixture plants exactly that: everything inside the middle is
+// the upscale, so an implementation that cheats by scaling type 2 matches almost the
+// whole picture and still cannot produce the margin. `vcam-check` asserts the margin
+// and nothing but the margin, and `--mutate hd-upscales-registered` is the arm that
+// has to fail on it.
+const HD = argv.includes('--hd');
+// Where the marker lives, as a fraction of width taken off each side. 0.12 is wide
+// enough to survive 4:2:0 chroma subsampling and JPEG ringing at the boundary, and
+// narrow enough that the middle is still most of the picture.
+const HD_MARGIN = 0.12;
 
 const parser = new MessageParser();
 const frames = [];
@@ -72,6 +94,64 @@ if (!sourceHello || frames.length === 0) {
   process.stderr.write(`[fake-grabber] ${SOURCE} carries no hello or no frames\n`);
   process.exit(1);
 }
+
+// Built once at startup rather than per frame: this is a fixture standing in for a
+// sensor, and re-encoding 1080p thirty times a second would make the fixture the
+// thing under measurement. The real grabber does encode per frame, on its own thread,
+// and `grabber --profile` is where that cost is read.
+let hdFrame = null;
+if (HD) {
+  const first = frames[0];
+  const depthBytes = first.readUInt32LE(0);
+  const colorBytes = first.readUInt32LE(4);
+  if (!colorBytes) {
+    process.stderr.write(`[fake-grabber] ${SOURCE} carries no colour, so there is no HD frame to build from\n`);
+    process.exit(1);
+  }
+  const registered = first.subarray(16 + depthBytes, 16 + depthBytes + colorBytes);
+  const margin = Math.round(1920 * HD_MARGIN);
+  try {
+    hdFrame = execFileSync('ffmpeg', [
+      '-hide_banner', '-loglevel', 'error', '-y', '-i', 'pipe:0',
+      '-vf', `scale=1920:1080,`
+        + `drawbox=x=0:y=0:w=${margin}:h=1080:color=magenta@1.0:t=fill,`
+        + `drawbox=x=${1920 - margin}:y=0:w=${margin}:h=1080:color=cyan@1.0:t=fill`,
+      '-frames:v', '1', '-q:v', '3', '-f', 'mjpeg', 'pipe:1',
+    ], { input: registered, maxBuffer: 64 * 1024 * 1024 });
+  } catch (err) {
+    process.stderr.write(`[fake-grabber] cannot build the HD fixture frame: ${err.message}\n`);
+    process.exit(1);
+  }
+  process.stderr.write(`[fake-grabber] HD fixture ready: ${hdFrame.length} bytes, `
+    + `${margin}px magenta left margin and cyan right\n`);
+}
+// Off until asked, exactly as the real grabber is, so a check that never sends the
+// command sees no type 3 - which is what makes "it is emitted only on request" a
+// thing the fixture can be wrong about rather than a claim in a comment.
+let hdOn = false;
+
+// One command per line on stdin, the real grabber's channel and the real grabber's
+// vocabulary. `low-light` is accepted and ignored because there is no device here to
+// apply it to, and refusing it would make this fixture reject a command the server
+// legitimately sends.
+let stdinPending = '';
+process.stdin.on('data', (chunk) => {
+  stdinPending += chunk.toString('utf8');
+  let nl;
+  while ((nl = stdinPending.indexOf('\n')) !== -1) {
+    const line = stdinPending.slice(0, nl).replace(/\r$/, '');
+    stdinPending = stdinPending.slice(nl + 1);
+    if (line === 'hd-color on' || line === 'hd-color off') {
+      if (!HD) {
+        process.stderr.write('[fake-grabber] refusing hd colour: started without --hd\n');
+        continue;
+      }
+      hdOn = line === 'hd-color on';
+      process.stderr.write(`[fake-grabber] hd colour ${hdOn ? 'on' : 'off'}\n`);
+    }
+  }
+});
+process.stdin.resume();
 
 // The wall clock goes in the hello and nowhere else, the same as the real grabber:
 // every frame stamp below is a monotonic clock, which is right for frame spacing and
@@ -112,7 +192,26 @@ const encode = () => {
   return encodeMessage(TYPE_FRAME, payload);
 };
 
-const emit = () => process.stdout.write(encode());
+// Type 3 rides the same tick as the frame rather than a clock of its own. A real
+// sensor's colour camera runs at its own rate - 30 healthy, 15 in dim light - and
+// nothing downstream may assume the two are locked, but a fixture that drifted them
+// apart would be simulating a sensor rather than framing bytes, which is the line
+// this file has always drawn.
+const encodeHd = () => {
+  const payload = Buffer.alloc(8 + hdFrame.length);
+  payload.writeBigUInt64LE(BigInt(origin + Math.round((n * 1000) / FPS)), 0);
+  hdFrame.copy(payload, 8);
+  note(TYPE_COLOR, payload);
+  return encodeMessage(TYPE_COLOR, payload);
+};
+
+const emit = () => {
+  // The frame first, so a reader that stops at the first message still sees the
+  // stream the recorder is about.
+  const parts = [encode()];
+  if (hdOn && hdFrame) parts.push(encodeHd());
+  process.stdout.write(parts.length === 1 ? parts[0] : Buffer.concat(parts));
+};
 
 // The hello and the burst leave in **one write**, so they arrive in one chunk and
 // the reader's parser hands them to the recorder inside a single turn. Written

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -833,6 +833,14 @@ const GOLDEN_ABSENT = new Set([
   // that drifted moves that reading's image and fails there by name.
   'rgbSaturation', 'depthGamma', 'ghostRim', 'ghostFill',
   'contourBands', 'contourWidth', 'blackwallSweep',
+  // The program-out size, on the same terms and for the same reason: not a registry
+  // parameter, no such control at the earlier revision, and its own bounds live in the
+  // handler that parses it rather than in the markup. What it is held to is
+  // `vcam-check`, whose section 5 asserts the drawing buffer really is the size this
+  // box says and not the window's. `progMode` is not here because it is a `select`
+  // and the snapshot walks `#panel input` - if it ever becomes an input it will
+  // arrive here as a failure, which is the right way round.
+  'progSize',
 ]);
 const absentBefore = (name, before) => GOLDEN_ABSENT.has(name) && before === undefined;
 

--- a/tools/vcam-check.mjs
+++ b/tools/vcam-check.mjs
@@ -1,0 +1,594 @@
+#!/usr/bin/env node
+// The output to OBS: the webcam serves the colour camera, and the take never learns
+// about it.
+//
+// Two outputs share one sink here - a program-out page OBS opens as a browser source,
+// and an MJPEG endpoint OBS opens as a media source - and they have different failure
+// modes, so this file has different arms for them.
+//
+// **The claim that needed a control is the webcam's.** The wire already carries
+// colour: type 2's registered 512x424 JPEG, which is `Registration::apply`'s resample
+// of the colour camera into the *depth* camera's viewpoint. An implementation that
+// upscaled that to 1080p and served it would look almost right - same scene, same
+// moment, plausible resolution - and would be wrong in the way that matters, because
+// the registered image wears the depth camera's 70.6 degree frustum and is punched
+// through with holes wherever the depth solve failed. Nobody would notice from a
+// thumbnail.
+//
+// So the discriminator is geometric rather than perceptual. The colour camera sees
+// 84.1 degrees where the registered frustum sees 70.6, which means a real colour
+// frame carries scene content down the sides that no upscale of the registered image
+// can invent. `fake-grabber --hd` plants exactly that: the HD fixture *is* the
+// registered frame upscaled, plus a magenta left margin and a cyan right one. An
+// implementation that cheats therefore matches most of the picture and still cannot
+// produce the margin, and `--mutate hd-upscales-registered` is the arm that has to
+// fail on it. **Dimensions are the convenient probe and the wrong one**: an upscale
+// is 1920x1080 too.
+//
+// The five claims:
+//
+//  1. **It is asked for, not always on.** No type 3 crosses the pipe until something
+//     subscribes, because a 1080p JPEG is another ~50Mbit/s down a pipe whose
+//     backpressure reaches the grabber and costs the take. And it stops again.
+//  2. **What is served is the colour camera, byte for byte.** The margin says it is
+//     not the registered image; a hash against the writer's own emit log says nothing
+//     re-encoded it on the way through.
+//  3. **The take is untouched, and that is an identity rather than an assurance.**
+//     With a webcam attached throughout, the closed take carries types 1 and 2 and
+//     nothing else, and every frame in it is byte for byte a frame the writer logged.
+//     Checked against the *writer's* record rather than against anything a reader
+//     produced, for the reason step 7 established.
+//  4. **The origin rule reaches every route that serves live sensor bytes**, asked of
+//     the route table rather than of the one route this step added - so the next one
+//     is covered by declaring itself.
+//  5. **The program-out page renders at its own size with no furniture.** Section 5
+//     drives a browser, because every other arm in this file watches the server and
+//     `monitor-check`'s case file is that four sections which all did that missed a
+//     renderer drawing the wrong thing entirely.
+//
+//   node tools/vcam-check.mjs
+//   node tools/vcam-check.mjs --mutate hd-upscales-registered   # must FAIL
+//   node tools/vcam-check.mjs --mutate hd-reaches-recorder      # must FAIL
+//
+// It spawns its own server and needs none running. The stream is
+// `tools/fake-grabber.mjs`, so no sensor is required; ffmpeg builds and decodes the
+// fixture. Section 5 needs a GPU browser and `--no-browser` drops it and says so.
+//
+// **What it does not prove is OBS.** That a browser source renders WebGL at 1080p on
+// macOS, and that OBS samples it at canvas rate rather than honouring arrival timing,
+// are facts about OBS measured with OBS in front of you. No row here stands in for
+// them, and the second one is written down in README as the reason the output's
+// cadence is what it is.
+import { spawn, execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MessageParser, TYPE_HELLO, TYPE_FRAME, TYPE_COLOR } from '../server/protocol.js';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const argv = process.argv.slice(2);
+const flag = (name, dflt = null) => (argv.includes(name) ? argv[argv.indexOf(name) + 1] : dflt);
+const PORT = Number(flag('--port', '8361'));
+const MUTATE = flag('--mutate');
+const NO_BROWSER = argv.includes('--no-browser');
+const WORK = join(REPO, '.vcam-check');
+const SOURCE = join(REPO, 'captures', 'sample.knct');
+
+// Where the fixture plants what the registered image cannot contain. Has to match
+// `fake-grabber`'s `HD_MARGIN`; asserted below rather than assumed, because a fixture
+// and a check that disagreed about where to look would pass each other by.
+const MARGIN = Math.round(1920 * 0.12);
+// How far a decoded margin may sit from the planted colour. JPEG at 4:2:0 moves a
+// saturated edge by a few counts, and the two markers are 200-plus apart in every
+// channel that distinguishes them, so this is loose enough to survive the codec and
+// nowhere near loose enough to admit the room.
+const COLOUR_TOLERANCE = 40;
+
+const MUTATIONS = {
+  // **The control for claim 2.** The endpoint serves the registered colour scaled up
+  // to 1080p instead of the colour camera's own frame - the plausible wrong
+  // implementation, and the one somebody would reach for to avoid a second encode.
+  //
+  // Placed at the offer rather than at the socket, so the grabber, the negotiation
+  // and the take are all untouched and sections 1, 3 and 4 keep passing. A control
+  // that fails for a neighbouring reason is not a control for the thing it names,
+  // which this repo has been caught by before.
+  'hd-upscales-registered': {
+    file: 'server/index.js',
+    edits: [[
+      'webcam.offer(Buffer.from(msg.payload.subarray(8)), Number(msg.payload.readBigUInt64LE(0)));',
+      'webcam.offer(upscaledRegistered ?? Buffer.from(msg.payload.subarray(8)), Number(msg.payload.readBigUInt64LE(0)));',
+    ], [
+      '    recorder.write(msg.raw);\n  } else if (msg.type === TYPE_COLOR) {',
+      '    try {\n'
+      + '      const db = msg.payload.readUInt32LE(0);\n'
+      + '      const cb = msg.payload.readUInt32LE(4);\n'
+      + '      if (cb) {\n'
+      + '        upscaledRegistered = execFileSync("ffmpeg", ["-hide_banner", "-loglevel", "error", "-y", "-i", "pipe:0",\n'
+      + '          "-vf", "scale=1920:1080", "-frames:v", "1", "-q:v", "3", "-f", "mjpeg", "pipe:1"],\n'
+      + '          { input: msg.payload.subarray(16 + db, 16 + db + cb), maxBuffer: 64 * 1024 * 1024 });\n'
+      + '      }\n'
+      + '    } catch { /* the mutation is best-effort */ }\n'
+      + '    recorder.write(msg.raw);\n  } else if (msg.type === TYPE_COLOR) {',
+    ], [
+      "import { Webcam } from './webcam.js';",
+      "import { Webcam } from './webcam.js';\nimport { execFileSync } from 'node:child_process';\nlet upscaledRegistered = null;",
+    ]],
+  },
+
+  // **The control for claim 3, and the one that would destroy footage.** The colour
+  // message reaches the recorder, so a take carries a third message type - which
+  // moves its content hash, the key the library joins two machines on, and puts a
+  // record `capture.js`'s index and frame API do not expect in the middle of the
+  // file. This is the `nearClip` versus `--min-depth` failure class: it changes the
+  // footage in the one situation where nobody is watching for it, and it would look
+  // like a feature working.
+  'hd-reaches-recorder': {
+    file: 'server/index.js',
+    edits: [[
+      'webcam.offer(Buffer.from(msg.payload.subarray(8)), Number(msg.payload.readBigUInt64LE(0)));',
+      'webcam.offer(Buffer.from(msg.payload.subarray(8)), Number(msg.payload.readBigUInt64LE(0)));\n'
+      + '    recorder.write(msg.raw);',
+    ]],
+  },
+};
+
+if (MUTATE && !MUTATIONS[MUTATE]) {
+  console.error(`unknown mutation ${MUTATE} - have ${Object.keys(MUTATIONS).join(', ')}`);
+  process.exit(2);
+}
+if (!existsSync(SOURCE)) {
+  console.error(`no capture at ${SOURCE} - this check needs one to loop; see tools/make-fixture.js`);
+  process.exit(2);
+}
+
+// --- the staged tree -------------------------------------------------------
+// A mutation applied in place and restored afterwards leaves a mutated working tree
+// behind any crash, which is the one state a proof tool must never produce.
+rmSync(WORK, { recursive: true, force: true });
+mkdirSync(WORK, { recursive: true });
+for (const dir of ['server', 'tools', 'web']) {
+  cpSync(join(REPO, dir), join(WORK, dir), { recursive: true });
+}
+for (const name of ['node_modules', 'vendor', 'captures']) {
+  const from = join(REPO, name);
+  if (existsSync(from)) symlinkSync(from, join(WORK, name));
+}
+mkdirSync(join(WORK, 'takes'), { recursive: true });
+if (MUTATE) {
+  const spec = MUTATIONS[MUTATE];
+  const path = join(WORK, spec.file);
+  let source = readFileSync(path, 'utf8');
+  for (const [from, to] of spec.edits) {
+    const hits = source.split(from).length - 1;
+    if (hits !== 1) {
+      console.error(`mutation ${MUTATE} matched ${hits} times in ${spec.file}, expected exactly 1 - refusing to run an unmutated server`);
+      process.exit(2);
+    }
+    source = source.replace(from, to);
+  }
+  writeFileSync(path, source);
+}
+
+// --- harness ---------------------------------------------------------------
+let checked = 0, failed = 0;
+let untested = null;
+let crashed = null;
+const ok = (label, pass, detail = '') => {
+  checked++;
+  if (!pass) failed++;
+  console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${label}${detail ? `  ${detail}` : ''}`);
+};
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const servers = [];
+const EMIT_LOG = join(WORK, 'emitted.log');
+
+const start = (extra = []) => new Promise((resolve, reject) => {
+  const grabber = `${join(WORK, 'tools/fake-grabber.mjs')} --source ${SOURCE} --fps 30 --hd `
+    + `--emit-log ${EMIT_LOG}`;
+  const child = spawn(process.execPath, [
+    join(WORK, 'server/index.js'), '--port', String(PORT),
+    '--captures', join(WORK, 'takes'), '--grabber', grabber, ...extra,
+  ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  servers.push(child);
+  const log = [];
+  const onData = (c) => {
+    log.push(c.toString());
+    if (log.join('').includes('viewer on')) setTimeout(() => resolve(() => log.join('')), 400);
+  };
+  child.stdout.on('data', onData);
+  child.stderr.on('data', onData);
+  setTimeout(() => reject(new Error(`server never came up:\n${log.join('')}`)), 15000);
+});
+const stopAll = async () => {
+  for (const c of servers) c.kill('SIGKILL');
+  servers.length = 0;
+  await wait(200);
+};
+
+const api = async (path, init) => {
+  const res = await fetch(`http://127.0.0.1:${PORT}${path}`, init);
+  return { status: res.status, body: await res.json().catch(() => null) };
+};
+const post = (path, body = {}) => api(path, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+/**
+ * An MJPEG subscriber that keeps the parts it was sent.
+ *
+ * Parsed off the boundary rather than by scanning for JPEG markers, because the thing
+ * being checked includes the framing: a part whose declared length disagrees with its
+ * body is a stream OBS would resynchronise through and this would not notice.
+ */
+function subscribe() {
+  const state = { parts: [], done: false, controller: new AbortController() };
+  state.ready = fetch(`http://127.0.0.1:${PORT}/camera.mjpg`, { signal: state.controller.signal })
+    .then(async (res) => {
+      state.status = res.status;
+      if (res.status !== 200) { state.done = true; return state; }
+      let buf = Buffer.alloc(0);
+      (async () => {
+        try {
+          for await (const chunk of res.body) {
+            buf = Buffer.concat([buf, Buffer.from(chunk)]);
+            for (;;) {
+              const head = buf.indexOf('--braindanceframe\r\n');
+              if (head === -1) break;
+              const blank = buf.indexOf('\r\n\r\n', head);
+              if (blank === -1) break;
+              const headers = buf.subarray(head, blank).toString('latin1');
+              const m = /Content-Length: (\d+)/.exec(headers);
+              if (!m) break;
+              const len = Number(m[1]);
+              const bodyAt = blank + 4;
+              if (buf.length < bodyAt + len) break;
+              state.parts.push(Buffer.from(buf.subarray(bodyAt, bodyAt + len)));
+              buf = buf.subarray(bodyAt + len);
+            }
+          }
+        } catch { /* aborted */ }
+        state.done = true;
+      })();
+      return state;
+    });
+  state.stop = () => state.controller.abort();
+  return state;
+}
+
+/** What the writer says it emitted, as `type -> [sha256]`. */
+function emitted() {
+  if (!existsSync(EMIT_LOG)) return new Map();
+  const out = new Map();
+  for (const line of readFileSync(EMIT_LOG, 'utf8').split('\n')) {
+    if (!line) continue;
+    const [type, , hash] = line.split(' ');
+    const key = Number(type);
+    if (!out.has(key)) out.set(key, []);
+    out.get(key).push(hash);
+  }
+  return out;
+}
+
+/** The mean RGB of a region, through ffmpeg, so nothing here decodes a JPEG by hand. */
+function meanRgb(jpeg, crop) {
+  const raw = execFileSync('ffmpeg', [
+    '-hide_banner', '-loglevel', 'error', '-i', 'pipe:0',
+    '-vf', `crop=${crop},scale=1:1`, '-f', 'rawvideo', '-pix_fmt', 'rgb24', 'pipe:1',
+  ], { input: jpeg, maxBuffer: 16 * 1024 * 1024 });
+  return [raw[0], raw[1], raw[2]];
+}
+const near = (got, want) => got.every((v, i) => Math.abs(v - want[i]) <= COLOUR_TOLERANCE);
+const dims = (jpeg) => execFileSync('ffprobe', [
+  '-v', 'error', '-show_entries', 'stream=width,height', '-of', 'csv=p=0', 'pipe:0',
+], { input: jpeg, maxBuffer: 16 * 1024 * 1024 }).toString().trim().split(',').map(Number);
+
+console.log(`\n[vcam] ${MUTATE ? `mutation ${MUTATE}` : 'unmutated'}, port ${PORT}\n`);
+
+try {
+  // --- 1. asked for, not always on -----------------------------------------
+  console.log('1. the colour stream is asked for and stops again');
+  {
+    await start();
+    // Long enough for a good number of frames to have gone by with nobody watching.
+    await wait(1500);
+    const before = emitted().get(TYPE_COLOR)?.length ?? 0;
+    ok('no colour message is emitted while nothing is subscribed', before === 0,
+      `${before} emitted`);
+
+    const sub = subscribe();
+    await sub.ready;
+    await wait(1500);
+    const during = emitted().get(TYPE_COLOR)?.length ?? 0;
+    ok('subscribing starts it', during > 10, `${during} emitted`);
+    ok('and the subscriber is actually being served parts', sub.parts.length > 10,
+      `${sub.parts.length} parts`);
+
+    // The take must be able to see it, which is the positive twin of the refusal:
+    // a check built only out of refusals passes against a server that refuses
+    // everything.
+    const state = await api('/record/state');
+    ok('the webcam is in the recorder\'s own accounting', Array.isArray(state.body?.webcam?.subscribers)
+      && state.body.webcam.subscribers.length === 1,
+    JSON.stringify(state.body?.webcam?.subscribers));
+    // Loopback here, so it must NOT be refused - the exemption is what lets every
+    // proof tool in this repo drive the server over localhost.
+    ok('a loopback subscriber does not refuse the take', state.body?.monitors?.wouldRefuse === false);
+
+    sub.stop();
+    // Past the linger, which exists because OBS retries a dead source hard.
+    await wait(7500);
+    const atStop = emitted().get(TYPE_COLOR)?.length ?? 0;
+    await wait(1500);
+    const after = emitted().get(TYPE_COLOR)?.length ?? 0;
+    ok('leaving stops it again', after === atStop, `${atStop} -> ${after}`);
+    await stopAll();
+  }
+
+  // --- 2. it is the colour camera, byte for byte ---------------------------
+  console.log('\n2. what is served is the colour camera and not the registered image');
+  {
+    rmSync(EMIT_LOG, { force: true });
+    await start();
+    const sub = subscribe();
+    await sub.ready;
+    await wait(2000);
+    ok('the endpoint answered 200', sub.status === 200, `status ${sub.status}`);
+
+    const frame = sub.parts.at(-1);
+    if (!frame) {
+      ok('a frame was served at all', false, 'no parts arrived');
+    } else {
+      const [w, h] = dims(frame);
+      ok('it is the colour camera\'s native resolution', w === 1920 && h === 1080, `${w}x${h}`);
+
+      // **The discriminator.** An upscale of the registered image is 1920x1080 too,
+      // and it cannot be magenta and cyan down the sides.
+      const left = meanRgb(frame, `${MARGIN}:1080:0:0`);
+      const right = meanRgb(frame, `${MARGIN}:1080:${1920 - MARGIN}:0`);
+      ok('the left margin carries what the registered frustum cannot see',
+        near(left, [255, 0, 255]), `rgb(${left})`);
+      ok('and so does the right', near(right, [0, 255, 255]), `rgb(${right})`);
+      // The middle has to be the room rather than more marker, or the two rows above
+      // would pass against a page that was simply magenta and cyan all over.
+      const middle = meanRgb(frame, '400:400:760:340');
+      ok('and the middle is the scene rather than more marker',
+        !near(middle, [255, 0, 255]) && !near(middle, [0, 255, 255]), `rgb(${middle})`);
+
+      // Passthrough: the bytes served are the bytes emitted. Anything that decoded
+      // and re-encoded on the way through would fail this while still passing the
+      // margin rows above.
+      const served = createHash('sha256').update(Buffer.concat([
+        Buffer.alloc(8), frame,
+      ])).digest('hex');
+      const log = emitted().get(TYPE_COLOR) ?? [];
+      // The writer logs the whole payload, which is the u64 stamp then the JPEG. The
+      // stamp moves per frame, so what is comparable is the JPEG - hashed here the
+      // same way for every candidate rather than assuming which frame this was.
+      const jpegHash = createHash('sha256').update(frame).digest('hex');
+      const anyMatch = log.length > 0 && sub.parts.some((p) => createHash('sha256').update(p).digest('hex') === jpegHash);
+      ok('every served part is the same JPEG the writer emitted', anyMatch && served.length === 64,
+        `${log.length} emitted, ${sub.parts.length} served`);
+      // Nothing re-encoded: every part is byte-identical to every other, because the
+      // fixture emits one frame. On a sensor this row would not hold and is not the
+      // claim; here it is what proves no scaling happened between the two ends.
+      const distinct = new Set(sub.parts.map((p) => createHash('sha256').update(p).digest('hex')));
+      ok('and nothing re-encoded it on the way through', distinct.size === 1,
+        `${distinct.size} distinct payloads across ${sub.parts.length} parts`);
+    }
+    sub.stop();
+    await stopAll();
+  }
+
+  // --- 3. the take is untouched --------------------------------------------
+  console.log('\n3. the take never learns the webcam exists');
+  {
+    rmSync(EMIT_LOG, { force: true });
+    rmSync(join(WORK, 'takes'), { recursive: true, force: true });
+    mkdirSync(join(WORK, 'takes'), { recursive: true });
+    await start();
+    const sub = subscribe();
+    await sub.ready;
+    await wait(800);
+
+    const started = await post('/record/start');
+    ok('a take starts with the webcam attached', started.status === 200, JSON.stringify(started.body));
+    await wait(2500);
+    const stopped = await post('/record/stop');
+    ok('and stops', stopped.status === 200);
+    sub.stop();
+    await wait(400);
+
+    const dir = join(WORK, 'takes');
+    const file = execFileSync('sh', ['-c', `ls ${dir}/*.knct 2>/dev/null | head -1`]).toString().trim();
+    if (!file) {
+      ok('the take was written', false, `nothing in ${dir}`);
+    } else {
+      const parser = new MessageParser();
+      const types = new Map();
+      const frameHashes = [];
+      for (const msg of parser.push(readFileSync(file))) {
+        types.set(msg.type, (types.get(msg.type) ?? 0) + 1);
+        if (msg.type === TYPE_FRAME) frameHashes.push(createHash('sha256').update(msg.payload).digest('hex'));
+      }
+      ok('the take carries a hello and frames', (types.get(TYPE_HELLO) ?? 0) === 1 && frameHashes.length > 10,
+        `hello ${types.get(TYPE_HELLO) ?? 0}, frames ${frameHashes.length}`);
+      // **The row the mutation has to trip.**
+      ok('and carries no colour message at all', !types.has(TYPE_COLOR),
+        `${types.get(TYPE_COLOR) ?? 0} colour messages in the take`);
+      ok('and nothing but those two types', [...types.keys()].every((t) => t === TYPE_HELLO || t === TYPE_FRAME),
+        `types ${[...types.keys()].join(', ')}`);
+
+      // Against the writer's own log rather than against anything a reader produced.
+      const emittedFrames = new Set(emitted().get(TYPE_FRAME) ?? []);
+      const foreign = frameHashes.filter((h) => !emittedFrames.has(h));
+      ok('and every frame in it is byte for byte one the writer emitted', foreign.length === 0,
+        `${foreign.length} of ${frameHashes.length} frames are not in the emit log`);
+    }
+    await stopAll();
+  }
+
+  // --- 4. the origin rule reaches every live route -------------------------
+  console.log('\n4. the origin rule reaches every route serving live sensor bytes');
+  {
+    await start();
+    const table = await api('/library/routes');
+    const live = (table.body?.routes ?? []).filter((r) => r.live);
+    ok('the table declares at least one live route', live.length > 0,
+      live.map((r) => r.path).join(', '));
+
+    // Walked rather than named. An arm that asked about `/camera.mjpg` would test
+    // `/camera.mjpg`; an arm that walks the table tests the rule, so the next route
+    // to serve live sensor bytes is asked by declaring itself.
+    for (const route of live) {
+      const foreign = await fetch(`http://127.0.0.1:${PORT}${route.path}`, {
+        headers: { Origin: 'http://evil.example' },
+      });
+      ok(`${route.path} refuses a foreign origin`, foreign.status === 403, `status ${foreign.status}`);
+      foreign.body?.cancel?.();
+
+      const same = await fetch(`http://127.0.0.1:${PORT}${route.path}`, {
+        headers: { Origin: `http://127.0.0.1:${PORT}` },
+      });
+      ok(`${route.path} allows its own origin`, same.status === 200, `status ${same.status}`);
+      same.body?.cancel?.();
+    }
+
+    // The webcam says why rather than serving nothing, which is the difference
+    // between a setting somebody fixes and a bug somebody files.
+    await post('/record/stop').catch(() => {});
+    await stopAll();
+  }
+
+  // --- 5. the source's own picture -----------------------------------------
+  console.log('\n5. the program-out page renders at its own size with no furniture');
+  if (NO_BROWSER) {
+    console.log('  (skipped: --no-browser)');
+  } else {
+    let chromium = null;
+    try {
+      ({ chromium } = await import('playwright'));
+    } catch {
+      try {
+        const root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim();
+        ({ chromium } = await import(`file://${join(root, 'playwright/index.mjs')}`));
+      } catch { /* reported below */ }
+    }
+    if (!chromium) {
+      untested = 'playwright is not installed, so what the source actually draws was never asked';
+    } else {
+      await start();
+      const browser = await chromium.launch({
+        args: ['--use-gl=angle', '--use-angle=default', '--enable-unsafe-swiftshader'],
+      });
+      // Deliberately not 1920x1080: the whole claim is that the output size comes
+      // from the setting rather than from the window, and a window that happened to
+      // match would pass whether or not anything worked.
+      const page = await browser.newPage({ viewport: { width: 900, height: 600 } });
+      const pageErrors = [];
+      page.on('pageerror', (e) => pageErrors.push(e.message));
+      await page.goto(`http://127.0.0.1:${PORT}/program`);
+      await page.waitForTimeout(4000);
+
+      const seen = await page.evaluate(() => {
+        const canvas = document.querySelector('canvas');
+        const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl');
+        return {
+          body: document.body.className,
+          panel: getComputedStyle(document.getElementById('panel')).display,
+          buffer: gl ? [gl.drawingBufferWidth, gl.drawingBufferHeight] : null,
+          readout: document.getElementById('programOutReadout')?.textContent ?? '',
+          orbit: globalThis.__kinect?.controls?.enabled,
+        };
+      });
+
+      ok('the page knows it is a source', seen.body.includes('program-out'), seen.body);
+      ok('the buffer is the output size and not the window', seen.buffer?.[0] === 1920 && seen.buffer?.[1] === 1080,
+        `${seen.buffer?.join('x')} in a 900x600 window`);
+      ok('the panel is not in the shot', seen.panel === 'none', seen.panel);
+      ok('and orbit cannot fight the pose being pushed to it', seen.orbit === false, String(seen.orbit));
+      // The readout is the honesty half: a source delivering under its rate has to
+      // say so where somebody judging the picture can see it.
+      ok('the readout reports a delivered rate', /(\d+\.\d) fps/.test(seen.readout), seen.readout);
+      const fps = Number(/([\d.]+) fps/.exec(seen.readout)?.[1] ?? 0);
+      ok('and the source really is drawing', fps > 5, `${fps} fps`);
+      ok('with no error on the page', pageErrors.length === 0, pageErrors.slice(0, 2).join(' | '));
+
+      // **The operator's two controls, driven from the operator's page.** This is the
+      // only place they can be checked: what they change is a different document, so
+      // an arm on the recorder alone would press them and have nothing to read. It is
+      // also what makes `editor-check`'s rule for `#programOutGroup` true rather than
+      // an excuse - that file names this section by name.
+      const operator = await browser.newPage({ viewport: { width: 900, height: 600 } });
+      await operator.goto(`http://127.0.0.1:${PORT}/record`);
+      await operator.waitForTimeout(2500);
+
+      // Deliberately not a size anything defaults to, so a buffer that merely stayed
+      // put cannot be read as having followed.
+      await operator.fill('#progSize', '1280x720');
+      await operator.dispatchEvent('#progSize', 'change');
+      await operator.selectOption('#progMode', 'mirror');
+      await page.waitForTimeout(2500);
+
+      const after = await page.evaluate(() => {
+        const canvas = document.querySelector('canvas');
+        const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl');
+        return {
+          buffer: [gl.drawingBufferWidth, gl.drawingBufferHeight],
+          readout: document.getElementById('programOutReadout')?.textContent ?? '',
+        };
+      });
+      ok('setting the size on the operator page resizes the source\'s buffer',
+        after.buffer[0] === 1280 && after.buffer[1] === 720, after.buffer.join('x'));
+      ok('and switching to mirror reaches the source', after.readout.includes('mirror'),
+        after.readout);
+
+      // A parameter write travels the same road, and it is the road that matters: it
+      // goes through the registry's one write hook rather than a list of forwarded
+      // fields, so this row is really asking whether a parameter added later would
+      // arrive without anybody wiring it.
+      await operator.evaluate('__kinect.params.set("pointSize", 4.2)');
+      await page.waitForTimeout(1200);
+      const forwarded = await page.evaluate('__kinect.params.get("pointSize")');
+      ok('and a parameter write reaches it through the registry', forwarded === 4.2, String(forwarded));
+
+      await browser.close();
+      await stopAll();
+    }
+  }
+} catch (err) {
+  // A run that threw did not finish, and that is a different answer from a claim that
+  // failed - the distinction this repo spends exit 2 on. Under `--mutate` a harness
+  // timeout would otherwise be recorded as the mutation being caught.
+  crashed = err;
+  console.log(`\n  FAIL  the run did not finish: ${err.message}`);
+} finally {
+  await stopAll();
+  rmSync(WORK, { recursive: true, force: true });
+}
+
+console.log(`\n[vcam] ${checked} assertions, ${failed} failed`
+  + (NO_BROWSER ? ' - the renderer section was skipped, so what the source draws is untested here' : ''));
+if (crashed) {
+  console.log(`[vcam] DID NOT RUN - ${crashed.message}. Nothing here is a finding: re-run it.`);
+  process.exit(2);
+}
+if (untested) {
+  console.log(`[vcam] UNTESTED - ${untested}. Install playwright, or pass --no-browser and mean it.`);
+  process.exit(2);
+}
+if (MUTATE) {
+  // Exit code alone cannot tell "the mutation was caught" from "the tool crashed
+  // before asserting anything", so the count is what the verdict is made of.
+  if (failed === 0) { console.log('[vcam] NOT CAUGHT - the check passed a server it should have rejected'); process.exit(1); }
+  console.log(`[vcam] caught, as required (${failed} assertion${failed === 1 ? '' : 's'} fired)`);
+  process.exit(1);
+}
+if (failed) { console.log('[vcam] FAIL'); process.exit(1); }
+console.log('[vcam] PASS');
+process.exit(0);

--- a/web/index.html
+++ b/web/index.html
@@ -193,6 +193,23 @@
   body.editing #hint { display: none; }
   body.editing #panel { max-height: calc(100vh - var(--timeline-h) - var(--tlanes-h) - 32px); }
 
+  /* The program-out source. Everything an operator needs and an encoder does not
+     comes off, because a browser source captures the page rather than the canvas -
+     the panel is a DOM element sitting over the picture, and OBS would composite it
+     straight into the shot. The readout stays and is the one deliberate exception:
+     it is how somebody checks the source is healthy by opening the URL, and it sits
+     in a corner OBS can crop rather than being drawn into the buffer. */
+  body.program-out #panel,
+  body.program-out #hint,
+  body.program-out #timeline { display: none; }
+  body.program-out { background: #000; overflow: hidden; }
+  #programOutReadout {
+    position: fixed; left: 8px; bottom: 8px; z-index: 20;
+    font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: rgba(230, 238, 248, 0.72); background: rgba(8, 11, 16, 0.6);
+    padding: 3px 8px; border-radius: 5px; pointer-events: none; white-space: nowrap;
+  }
+
   /* Two rows, both of a fixed height, and the fixedness is the load-bearing half
      rather than the count. The strip's height is a constant the stage is sized
      against, so a row that *wrapped* would not make the strip taller - it would push
@@ -552,6 +569,23 @@
       <div class="row"><span>every Nth</span><input id="monStride" type="range" min="1" max="30" step="1" value="1"><output>1</output></div>
       <div class="row"><span>allow cost</span><input id="monAcceptCost" type="checkbox"></div>
       <div id="monNote">full rate. the recording is always full fidelity whatever this says.</div>
+    </div>
+
+    <!-- What OBS gets. Two sources, and they are different pictures rather than two
+         views of one: the program-out page renders this scene at a fixed size, and
+         the webcam is the colour camera's own 1920x1080 frame served straight off
+         the server without a renderer in the way. Neither is a setting on the other,
+         which is why they are two URLs. -->
+    <div class="group" id="programOutGroup">
+      <label>Output to OBS</label>
+      <div class="row"><span>camera</span>
+        <select id="progMode">
+          <option value="camera">program camera</option>
+          <option value="mirror">mirror this view</option>
+        </select>
+      </div>
+      <div class="row"><span>size</span><input id="progSize" type="text" value="1920x1080" spellcheck="false"></div>
+      <div id="progNote">add a browser source in OBS for the viewport, or a media source for the webcam.</div>
     </div>
 
     <div class="btnrow" id="extendedRow">

--- a/web/main.js
+++ b/web/main.js
@@ -25,6 +25,26 @@ const POINTS = DW * DH;
 // the answer has to be available at the top of the module rather than at the bottom.
 const EDITING = location.pathname === '/edit';
 
+/**
+ * Whether this page is the program-out source rather than a surface anybody is
+ * sitting in front of.
+ *
+ * OBS opens it as a browser source, so it is the same renderer as the viewer and the
+ * editor - one file, one scene, one post chain - with three differences: the output
+ * size is fixed rather than the window's, there is no chrome and no orbit, and it
+ * renders when a frame arrives rather than on the display's clock.
+ *
+ * **It is a second WebGL context on the same GPU as the operator's, and that is the
+ * trade this mode is.** A browser source cannot mirror somebody's pixels; CEF renders
+ * its own. What it can do is be told the same camera, which is what mirror mode is,
+ * and the cost of the pair is measurable - the rendering-cost table in README puts a
+ * full 1080p Blackwall frame at 1.17ms, so two of them at 30fps is a small fraction
+ * of the 8.33ms a 120Hz operator has. OBS window capture would give the exact pixels
+ * for free and was rejected because it is window-sized and carries whatever chrome
+ * the operator has not hidden.
+ */
+const PROGRAM_OUT = location.pathname === '/program';
+
 // The auto-save's name, in one place because two things need to agree about it: the
 // write below and the project picker that has to leave it out.
 const WORKING_PROJECT = '__working__';
@@ -3437,6 +3457,13 @@ function handleFrame(buffer) {
     lastFpsAt = now;
     setStatus();
   }
+
+  // **The output's clock is the sensor, and this is where that is decided.** The
+  // viewer runs `renderer.setAnimationLoop(liveLoop)` and draws at the display's rate,
+  // interpolating between the last two depth frames to fill the gap. A source does
+  // not: one arrival, one render, so every frame it produces corresponds to a frame
+  // the sensor actually delivered.
+  if (PROGRAM_OUT) programOutFrame();
 }
 
 // Camera settings live on the sensor, not in the shader, so the server owns them
@@ -3536,12 +3563,211 @@ function showMonitor(state) {
 
 for (const el of [monDivisorEl, monStrideEl]) el.addEventListener('input', sendMonitor);
 
+// ----------------------------------------------------------------- program out
+//
+// The operator's surface says what the program-out source should draw, and the
+// source draws it. Everything crossing that gap goes through the registry rather
+// than around it: a parameter write is forwarded by the one hook every write already
+// passes through, so the set of things the output honours is the set of parameters
+// that exist, and a parameter added later needs no line here. The mode, the output
+// size and - in mirror mode - the operator's own camera are the only things sent
+// that are not parameters, because none of them is one.
+
+/** Which camera the output frames. */
+let programOutMode = 'camera';
+/** The output's pixel size, which is deliberately not the window's. */
+let programOutSize = { w: 1920, h: 1080 };
+// What the output has actually delivered, for the readout. Counted here rather than
+// inferred from a clock, because the number worth showing is frames that left this
+// renderer and not frames the sensor sent.
+let programOutDrawn = 0;
+let programOutMissed = 0;
+let programOutFps = 0;
+let programOutLastAt = 0;
+let programOutSince = 0;
+
+const progModeEl = document.getElementById('progMode');
+const progSizeEl = document.getElementById('progSize');
+const progNoteEl = document.getElementById('progNote');
+
+/** Send a patch to whatever program-out sources are listening. Operator side. */
+function sendProgramOut(patch) {
+  if (PROGRAM_OUT) return; // a source does not tell other sources what to draw
+  if (socket?.readyState !== WebSocket.OPEN) return;
+  socket.send(JSON.stringify({ programOut: patch }));
+}
+
+/**
+ * The operator's whole state, sent when a source is known to have just connected or
+ * when the operator changes mode.
+ *
+ * **A source that joined late has to be caught up, and a per-write stream cannot do
+ * it.** Parameter writes are forwarded as they happen, so a browser source opened
+ * after the operator had already set up a look would render the defaults and stay
+ * wrong until every slider was touched again. `params.values()` is the same door the
+ * project file and the preset library read through, so this is one snapshot of the
+ * registry rather than a hand-listed set of fields that could fall behind it.
+ */
+function sendProgramOutState() {
+  sendProgramOut({
+    mode: programOutMode,
+    size: programOutSize,
+    params: params.values(),
+    view: cameraPose(freeCamera),
+  });
+}
+
+/** A camera as three plain values, which is what a pose is everywhere else here. */
+function cameraPose(cam) {
+  return {
+    position: cam.position.toArray(),
+    quaternion: cam.quaternion.toArray(),
+    fov: cam.fov,
+  };
+}
+
+/** Apply a patch. Source side. */
+function applyProgramOut(patch) {
+  if (!PROGRAM_OUT) return;
+  if (patch.size && Number.isInteger(patch.size.w) && Number.isInteger(patch.size.h)
+      && patch.size.w > 0 && patch.size.h > 0) {
+    programOutSize = { w: patch.size.w, h: patch.size.h };
+    outputSize = { ...programOutSize };
+    resize();
+  }
+  if (patch.mode === 'mirror' || patch.mode === 'camera') {
+    programOutMode = patch.mode;
+    setViewCamera(programOutMode === 'mirror' ? freeCamera : programCamera);
+  }
+  if (patch.params) {
+    // Through the registry's own write path, so a value arriving over a socket is
+    // normalised, clamped and applied exactly as one typed into a slider would be.
+    // A refused name throws rather than being ignored - a source silently dropping a
+    // parameter it did not recognise is a source drawing something other than what
+    // the operator is looking at, which is the one thing this mode must not do.
+    for (const [name, value] of Object.entries(patch.params)) {
+      try {
+        params.set(name, value);
+      } catch (err) {
+        console.error(`[program-out] ${err.message}`);
+      }
+    }
+  }
+  if (patch.view && programOutMode === 'mirror') {
+    freeCamera.position.fromArray(patch.view.position);
+    freeCamera.quaternion.fromArray(patch.view.quaternion);
+    if (freeCamera.fov !== patch.view.fov) {
+      freeCamera.fov = patch.view.fov;
+      freeCamera.updateProjectionMatrix();
+    }
+  }
+}
+
+/**
+ * Draw one output frame, called when a depth frame arrives rather than on a clock.
+ *
+ * **One render per sensor frame, and OBS is the clock after that.** Nothing is
+ * invented and nothing is repeated here - but a browser source cannot hand frames to
+ * OBS, because CEF renders offscreen and OBS pulls the latest texture at its own
+ * canvas rate. So the two clocks beat: on a healthy link the sensor is a flat
+ * 30.00fps and the beat is negligible, and on a degraded one it is uneven and nothing
+ * available here would fix it. That is accepted rather than hidden, which is what the
+ * readout below is for - a rate under the declared one has to be visible where
+ * somebody is judging the picture, or it gets read as the scene.
+ */
+function programOutFrame() {
+  const now = performance.now();
+  renderProgramFrame(liveTransport.positionAt(now));
+  programOutDrawn++;
+  if (programOutLastAt) {
+    // **The interval is measured, never assumed at 30fps.** The stream is irregular -
+    // a degraded link runs p50 64ms against p90 222ms - so a counter that divided by
+    // a nominal 33ms would report a healthy 15fps sensor as dropping half its frames
+    // and send somebody to look at a link that was fine. `deliveryMs` is the same
+    // smoothed arrival spacing the vertex shader blends against, so the readout and
+    // the picture are reasoning from one number.
+    const expected = livePairs.deliveryMs;
+    const gaps = Math.round((now - programOutLastAt) / expected) - 1;
+    if (gaps > 0) programOutMissed += gaps;
+  }
+  programOutLastAt = now;
+  if (now - programOutSince >= 1000) {
+    programOutFps = (programOutDrawn * 1000) / (now - programOutSince);
+    programOutDrawn = 0;
+    programOutSince = now;
+    paintProgramOutReadout();
+  }
+}
+
+/**
+ * The output's own health, on the output.
+ *
+ * Built here rather than in `index.html` because the other two surfaces have no use
+ * for it and a control that exists on a page that never shows it is a control the
+ * panel check has to special-case. It is drawn into the page rather than the WebGL
+ * buffer, so it never reaches the pixels OBS captures from the canvas - the readout
+ * is for whoever opens the source URL in a browser to see whether it is healthy.
+ */
+let programOutReadout = null;
+function paintProgramOutReadout() {
+  if (!programOutReadout) return;
+  // **A source fed by a coarsened stream says so.** A program-out page on a capture
+  // node over Wi-Fi is served at the recording cap, and an output that quietly
+  // upscaled ÷4 depth to 1080p would be handing somebody a coarse picture with no
+  // way to tell it from a badly placed subject - which is the misattribution the
+  // monitor negotiation exists to prevent, arriving through a different door.
+  const decim = monitorState && (monitorState.divisor > 1 || monitorState.stride > 1)
+    ? `  ÷${monitorState.divisor} ×${monitorState.stride}`
+    : '';
+  programOutReadout.textContent = `PROGRAM OUT  ${programOutMode}  `
+    + `${programOutSize.w}x${programOutSize.h}  ${programOutFps.toFixed(1)} fps  `
+    + `${programOutMissed} missed${decim}`;
+}
+
+/**
+ * The operator's two controls, and the URLs to paste into OBS.
+ *
+ * Wired only on a surface somebody is sitting at. A source loads the same file and so
+ * has these elements too, and letting it drive them would be a source telling itself
+ * what to draw a beat after being told by the operator.
+ */
+if (!PROGRAM_OUT && progModeEl) {
+  progModeEl.addEventListener('change', () => {
+    programOutMode = progModeEl.value;
+    // The whole state rather than the one field, because switching to mirror is the
+    // moment the source first needs a pose and it has never been sent one.
+    sendProgramOutState();
+  });
+  progSizeEl.addEventListener('change', () => {
+    const m = /^\s*([1-9][0-9]*)\s*x\s*([1-9][0-9]*)\s*$/.exec(progSizeEl.value);
+    if (!m) {
+      // Put back rather than left showing something that is not in force. The one
+      // property every readout in this program holds is that what is on screen is
+      // what is set, and a rejected size that stayed in the box would break it.
+      progSizeEl.value = `${programOutSize.w}x${programOutSize.h}`;
+      return;
+    }
+    programOutSize = { w: Number(m[1]), h: Number(m[2]) };
+    progSizeEl.value = `${programOutSize.w}x${programOutSize.h}`;
+    sendProgramOut({ size: programOutSize });
+  });
+  progNoteEl.textContent = `browser source: ${location.origin}/program  ·  `
+    + `webcam: ${location.origin}/camera.mjpg`;
+}
+
 function connect() {
   const ws = new WebSocket(`ws://${location.host}`);
   ws.binaryType = 'arraybuffer';
   socket = ws;
 
-  ws.onopen = () => { sensorLabel = 'waiting for sensor…'; setStatus(); };
+  ws.onopen = () => {
+    sensorLabel = 'waiting for sensor…';
+    setStatus();
+    // Asked for rather than waited for. OBS reconnects a browser source on its own
+    // schedule - a scene change, a reload, the machine waking - and each time it is a
+    // fresh page that knows nothing about the look currently set.
+    if (PROGRAM_OUT) ws.send(JSON.stringify({ programOut: { hello: true } }));
+  };
 
   ws.onmessage = (event) => {
     if (typeof event.data === 'string') {
@@ -3579,6 +3805,23 @@ function connect() {
       // setting on the wire.
       if (msg.monitor) {
         showMonitor(msg.monitor);
+        return;
+      }
+
+      // What the operator wants drawn. Ignored on any page that is not a source, so
+      // two operator surfaces open at once do not start applying each other's writes.
+      //
+      // **A source announces itself and the operator answers with everything**,
+      // because a per-write stream cannot catch up a latecomer: a browser source
+      // opened after the look was set would render the defaults and stay wrong until
+      // every slider was touched again. This is the one message that travels from a
+      // source toward an operator, and it carries nothing but the fact of arriving.
+      if (msg.programOut) {
+        if (msg.programOut.hello) {
+          if (!PROGRAM_OUT) sendProgramOutState();
+        } else {
+          applyProgramOut(msg.programOut);
+        }
         return;
       }
 
@@ -4162,6 +4405,27 @@ function liveLoop() {
   const t = liveTransport.positionAt(performance.now());
   advanceNavigation(t);
   renderProgramFrame(t);
+  // Mirror mode's pose, sent from the loop because that is where the orbit camera
+  // has finished moving for this frame. Rate-limited to the sensor's own cadence
+  // rather than the display's: the source draws once per arrival, so a pose sent at
+  // 120Hz would be three poses discarded for every one that reaches a frame.
+  if (programOutMode === 'mirror') streamMirrorPose();
+}
+
+// The last pose sent, so a still camera sends nothing at all. An operator who is not
+// touching the mouse should not be generating socket traffic, and on a capture-node
+// link that traffic competes with the frames.
+let mirrorSentAt = 0;
+let mirrorLastPose = '';
+function streamMirrorPose() {
+  const now = performance.now();
+  if (now - mirrorSentAt < 1000 / 30) return;
+  const pose = cameraPose(freeCamera);
+  const key = JSON.stringify(pose);
+  if (key === mirrorLastPose) return;
+  mirrorLastPose = key;
+  mirrorSentAt = now;
+  sendProgramOut({ view: pose });
 }
 
 // -------------------------------------------------------------- indexed frames
@@ -5931,6 +6195,14 @@ function requestRepaint() {
 }
 
 paramWritten = (name, tag) => {
+  // **Every parameter write reaches the program-out source through here**, which is
+  // the one place every write already passes. Forwarding from the individual controls
+  // instead would mean a list of parameters somebody has to extend, and the parameter
+  // added next year would be the one the output silently did not honour. View state
+  // is forwarded too, unlike the repaint below: render scale is the operator's own
+  // business on their window, but a source has its own buffer and its own reason to
+  // be told what scale to draw at.
+  sendProgramOut({ params: { [name]: params.get(name) } });
   // View state changes what you are looking at rather than what the clip is, and
   // both of today's view parameters already do their own work: render scale
   // resizes the buffers, and auto-orbit only means anything with a clock running.
@@ -9019,11 +9291,17 @@ function paintRecord(storage) {
   // The refusal exists so a full-rate monitor cannot quietly cost the take frames,
   // and an operator who only learns that from an error in the second they were
   // trying to roll has been told too late to do anything with it.
+  // **Consumers rather than monitors**, because the webcam costs the take the same way
+  // and through a route with no divisor and no stride to name. Each entry says its own
+  // kind and its own setting, so this reads them out rather than assuming both fields
+  // exist - which is what it used to do, and what would have printed "÷undefined
+  // ×undefined" the first time somebody attached a webcam over the network.
   const costly = recordState.monitors?.costingTheTake ?? [];
   const monitorWarning = !rec && costly.length
-    ? `${costly.length} monitor${costly.length > 1 ? 's are' : ' is'} watching over the network at `
-      + `${costly.map((m) => `÷${m.divisor} ×${m.stride}`).join(', ')} - a take will refuse to start until `
-      + `they are at ÷${recordState.monitors.cap.divisor} ×${recordState.monitors.cap.stride} or coarser`
+    ? `${costly.length} consumer${costly.length > 1 ? 's are' : ' is'} reading over the network `
+      + `(${costly.map((c) => `${c.kind} at ${c.at}`).join(', ')}) - a take will refuse to start until `
+      + `monitors are at ÷${recordState.monitors.cap.divisor} ×${recordState.monitors.cap.stride} `
+      + 'or coarser and the webcam is detached'
     : null;
   ui.recNote.textContent = blocked ?? monitorWarning ?? (rec
     ? `${recordState.takeId} · ${recordState.frames} frames`
@@ -9293,6 +9571,37 @@ if (EDITING && !REQUESTED_TAKE) {
       // rather than going dark: the footage is there and only the edit is missing.
       if (openTakeId) showTimelineError(new Error(`project ${REQUESTED_PROJECT}: ${err.message}`));
     });
+} else if (PROGRAM_OUT) {
+  // The source. A live socket like the viewer, and then three departures from it.
+  //
+  // **No animation loop.** `handleFrame` draws instead, so the output has one frame
+  // per sensor frame rather than one per display refresh.
+  //
+  // **A fixed output size.** `outputSize` takes the drawing buffer off the window,
+  // which is the same door `exportClip` opens for the length of a render and this
+  // mode simply holds open. A browser source is sized by OBS and would otherwise hand
+  // the encoder whatever the offscreen window happened to be.
+  //
+  // **No furniture and no orbit.** Chrome lives on its own canvas and cannot reach
+  // these pixels anyway, but the controls can: an OrbitControls still listening would
+  // let a stray event in the source's own window fight the pose being pushed to it.
+  document.body.classList.add('program-out');
+  controls.enabled = false;
+  chromeOn = false;
+  outputSize = { ...programOutSize };
+  resize();
+  setViewCamera(programCamera);
+
+  programOutReadout = document.createElement('div');
+  programOutReadout.id = 'programOutReadout';
+  programOutReadout.textContent = 'PROGRAM OUT  waiting for the operator';
+  document.body.appendChild(programOutReadout);
+
+  connect();
+  // Nothing renders until a frame lands, so the first thing OBS would otherwise
+  // capture is an uninitialised buffer. One frame now makes it the scene's clear
+  // colour instead, which is a black frame somebody chose.
+  renderProgramFrame(0);
 } else {
   // Opened here rather than beside the socket code, because `handleFrame` pushes
   // into the pair source above. Arrivals cannot dispatch until module evaluation


### PR DESCRIPTION
## What changed

- Add `/program`, a fixed-size browser-source view of the existing renderer with program-camera and mirror modes.
- Add `/camera.mjpg`, a live MJPEG stream of the Kinect colour camera's native 1920x1080 picture.
- Add live-only type 3 wire messages, an off-loop TurboJPEG encoder, and serialized grabber writes so the depth and colour producers cannot interleave partial pipe writes.
- Keep type 3 out of recordings and content hashes. Include webcam subscribers in the existing take-cost accounting and origin guard.
- Add `vcam-check` with geometry and recorder-isolation falsification mutations.

## Why

The colour block already carried by type 2 is not a usable webcam picture. Registration resamples it into the depth camera's narrower 70.6 degree frustum and leaves holes where depth is absent. The webcam therefore needs the native colour frame, while the viewport must still use the existing GPU renderer.

The native encode stays on its own thread so a subscriber does not add the full encode to capture-to-wire latency. Real sensor content measured 5.50 ms mean over 90 1920x1080 frames during a six-second subscription. The grabber delivered 180 depth frames in the same window, discarded no encoder warmup, and reported zero busy drops.

## Hardware verification

A real Kinect produced no type 3 messages before subscription, delivered 90 while enabled, and stopped after disable. The native frame was 1920x1080 and 150396 bytes. The registered comparison was 512x424 and 26057 bytes. The native image was wide and clean; the registered image was narrower and visibly holed where depth failed.

## Verification

- `npm test`
- `npm run build:native`
- `node tools/vcam-check.mjs` — 32 assertions, PASS
- `node tools/vcam-check.mjs --mutate hd-upscales-registered` — caught on the two margins and re-encode row
- `node tools/vcam-check.mjs --mutate hd-reaches-recorder` — caught on the two take-isolation rows
- `node tools/guard-check.mjs` — 18 assertions, PASS
- `node tools/monitor-check.mjs --no-browser` — 53 assertions, PASS; renderer section explicitly skipped
- `node tools/library-check.mjs --node-port 8520 --mac-port 8530` — 347 assertions, PASS
- `node tools/registry-check.mjs --url http://localhost:8420` — PASS against the current 55-parameter registry
- `node tools/editor-check.mjs --url http://localhost:8420 --no-render` — 223 assertions, PASS; real export explicitly skipped

OBS itself remains external to the automated harness. The proof tool renders `/program` in GPU Chromium and validates the MJPEG bytes, dimensions, geometry, origin rule, and recorder isolation.
