### PR TITLE
Stabilize temporal grading during navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ node tools/editor-check.mjs --mutate import-saves-before-validating --no-render 
 node tools/editor-check.mjs --mutate panel-row-skips-parameter --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate nav-at-the-foot --no-render       # ... and must FAIL
 node tools/editor-check.mjs --mutate orbit-pumps-on-change --no-render # ... and must FAIL
+node tools/editor-check.mjs --mutate camera-motion-keeps-history --no-render # ... and must FAIL
+node tools/editor-check.mjs --mutate orbit-uses-scrub-draft --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate orbit-arms-into-playback --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate orbit-arms-stale-position --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate release-seeks-past-target --no-render # ... and must FAIL
@@ -260,8 +262,8 @@ than by duration. See `docs/proof-tools.md`.
 `change` on a damped control that moved — so a handler that renders on `change` has asked for
 the next render, and with the playhead parked there is no frame clock to pace it. That shipped:
 one pointer move on a paused orbit cost 34 rebuilds and the drag ran at 12fps while rendering
-190. Arm `draftWanted` and let the animation loop pump it; **nothing may start a redraw except
-the loop**. `editor-check` section 9 counts drafts against animation frames, with
+190. Arm a redraw request and let the animation loop pump it; **nothing may start a redraw except
+the loop**. `editor-check` section 9 counts navigation redraws against animation frames, with
 `--mutate orbit-pumps-on-change` as its control.
 
 

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -2979,15 +2979,71 @@ try {
     // on relative to the loop's.
     check(redraws <= frames + 1, 'and never more than one redraw per frame the display was given',
       `${redraws} navigation redraws against ${frames} frames`);
-    // Forty tile means across the stage rather than one lit count over it, and the
-    // reason is the same one `docs/measurement.md` records for the bloom rebase: a
-    // scalar over the whole frame can come out equal for two genuinely different
-    // pictures, because a cloud that has moved a second along mostly *redistributes*
-    // its brightness rather than changing how much of it there is. A spatial
-    // signature cannot be fooled that way, and the row below needs it to not be.
+    // The largest part of the renderer that nothing is drawn over, established by
+    // what is actually on top rather than by the stage's bounds. The panel is fixed
+    // over the stage and its cost readout changes between a draft and an accurate
+    // seek, so a stage screenshot can distinguish the UI while the renderer agrees.
+    // `elementFromPoint` closes that false-positive path, and the two rows below make
+    // the conditions of every following picture comparison assertions of the tool.
+    const picture = await page.evaluate(`(() => {
+      const canvas = __kinect.renderer.domElement;
+      const r = canvas.getBoundingClientRect();
+      const clean = (rect) => {
+        let covered = 0;
+        const over = new Set();
+        for (let i = 0; i <= 4; i++) {
+          for (let j = 0; j <= 4; j++) {
+            const at = document.elementFromPoint(
+              rect.x + (rect.width * i) / 4, rect.y + (rect.height * j) / 4,
+            );
+            if (at !== canvas) {
+              covered++;
+              over.add(at ? (at.id ? '#' + at.id : at.tagName.toLowerCase()) : 'nothing');
+            }
+          }
+        }
+        return { covered, over: [...over].join(' ') };
+      };
+      let rect = {
+        x: Math.ceil(r.x) + 1, y: Math.ceil(r.y) + 1,
+        width: Math.floor(r.width) - 2, height: Math.floor(r.height) - 2,
+      };
+      let hits = clean(rect);
+      for (let step = 0;
+        step < 40 && hits.covered > 0 && rect.width > 64 && rect.height > 64;
+        step++) {
+        const dx = Math.max(2, Math.round(rect.width * 0.05));
+        const dy = Math.max(2, Math.round(rect.height * 0.05));
+        rect = {
+          x: rect.x + dx, y: rect.y + dy,
+          width: rect.width - 2 * dx, height: rect.height - 2 * dy,
+        };
+        hits = clean(rect);
+      }
+      return {
+        ...rect, covered: hits.covered, over: hits.over,
+        chromeHidden: document.getElementById('chrome')?.hidden === true,
+      };
+    })()`);
+    check(picture.chromeHidden,
+      'the chrome overlay is off, so temporal signatures contain the renderer rather than annotations',
+      '#chrome hidden');
+    check(picture.covered === 0 && picture.width > 200 && picture.height > 200,
+      'and nothing is drawn over the temporal signature region, hit-tested rather than assumed',
+      `${picture.width}x${picture.height} at ${picture.x},${picture.y}, `
+      + `${picture.covered} of 25 probes covered${picture.over ? ` by ${picture.over}` : ''}`);
+
+    // Forty tile means across that renderer-only region rather than one lit count
+    // over it, and the reason is the same one `docs/measurement.md` records for the
+    // bloom rebase: a scalar over the whole frame can come out equal for two genuinely
+    // different pictures, because a cloud that has moved a second along mostly
+    // *redistributes* its brightness rather than changing how much of it there is. A
+    // spatial signature cannot be fooled that way, and the row below needs it to not
+    // be.
     const signature = async () => {
-      const box = await page.locator('#stage').boundingBox();
-      const shot = await page.screenshot({ clip: box });
+      const shot = await page.screenshot({
+        clip: { x: picture.x, y: picture.y, width: picture.width, height: picture.height },
+      });
       return page.evaluate(`(async (dataUrl) => {
         const img = new Image();
         img.src = dataUrl;
@@ -3015,6 +3071,22 @@ try {
     };
     /** The worst of the forty tiles, in 0-255 luma. */
     const apart = (a, b) => Math.max(...a.map((v, k) => Math.abs(v - b[k])));
+
+    // The falsification control for the region itself. The panel's composited pixels
+    // change conspicuously while the renderer does nothing. A screenshot that went
+    // back to the stage's bounds would redden this row even if it kept asserting a
+    // different hit-tested rectangle, which is the exact split that let the panel
+    // contaminate the first version of these signatures.
+    const panelControlBefore = await signature();
+    await page.evaluate("document.getElementById('panel').style.background = '#fff'");
+    await page.evaluate('new Promise(requestAnimationFrame)');
+    const panelControlAfter = await signature();
+    await page.evaluate("document.getElementById('panel').style.background = ''");
+    await page.evaluate('new Promise(requestAnimationFrame)');
+    const panelApart = apart(panelControlBefore, panelControlAfter);
+    check(panelApart < 0.01,
+      'control: changing only the panel changes no temporal signature pixels',
+      `worst tile ${panelApart.toFixed(2)}/255`);
 
     // The picture the release actually left on the stage, read before anything else
     // moves the transport. The rows below ask whether it is the picture an accurate
@@ -3048,7 +3120,7 @@ try {
     // drafts row's does: a signature that could not tell two moments apart would make
     // the comparison below pass on every build there is, including one that released
     // to the wrong second.
-    check(canSee > 2, 'the stage signature can tell this moment from one a second away',
+    check(canSee > 2, 'the renderer signature can tell this moment from one a second away',
       `worst tile ${canSee.toFixed(2)}/255 apart`);
     check(landed < canSee / 4,
       'and the release lands the picture an accurate seek to that moment gives, not merely an accurate seek',

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -54,6 +54,8 @@
 //   node tools/editor-check.mjs --mutate ease-handles-on-flat  --no-render  # must FAIL
 //   node tools/editor-check.mjs --mutate ease-preset-ignored   --no-render  # must FAIL
 //   node tools/editor-check.mjs --mutate scroller-cannot-shrink --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate camera-motion-keeps-history --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate orbit-uses-scrub-draft --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate orbit-arms-stale-position --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate release-seeks-past-target --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate pin-keeps-orbit-armed  --no-render # must FAIL
@@ -258,19 +260,43 @@ const MUTATIONS = {
     ],
   },
 
-  // The control for section 9, and it is one line because the bug was one line: a
-  // finishing draft starts whatever was armed while it ran. For a scrub that is
-  // harmless, since the pointer cannot outrun the display; for an orbit it is the
-  // whole failure, because the draft's own render arms the next position through
-  // `advanceNavigation`. The mutated build renders correct images at forty-five
-  // times the rate anything can show them, which is why the row it must redden is
-  // the count and not the picture.
+  // The control for section 9: a finishing navigation redraw immediately starts
+  // whatever the redraw armed while it ran. The accurate image is still produced,
+  // but OrbitControls damping advances at rebuild rate instead of display rate. The
+  // row it must redden is therefore the page-side count, not the picture.
   'orbit-pumps-on-change': {
     file: 'web/main.js',
     edits: [[
-      '    draftBusy = false;\n  }\n}',
-      '    draftBusy = false;\n    if (orbitRedrawWanted) {\n      orbitRedrawWanted = false;\n'
-      + '      draftWanted = timeline.programSec;\n      pumpDraft();\n    }\n  }\n}',
+      '      .finally(() => { draftBusy = false; });',
+      '      .finally(() => {\n        draftBusy = false;\n'
+      + '        if (orbitRedrawWanted) pumpParkedDraft();\n      });',
+    ]],
+  },
+
+  // The parked orbit goes back through the scrub preview. The pointer still moves
+  // the camera and the release still performs an accurate seek, so a release-only
+  // check passes. The picture sampled while the pointer is held must fail because
+  // the draft deliberately zeros fade, wake and trails.
+  'orbit-uses-scrub-draft': {
+    file: 'web/main.js',
+    edits: [[
+      '    draftBusy = true;\n'
+      + '    timeline.redraw(timeline.programSec)\n'
+      + '      .catch(showTimelineError)\n'
+      + '      .finally(() => { draftBusy = false; });',
+      '    draftWanted = timeline.programSec;\n    pumpDraft();',
+    ]],
+  },
+
+  // The renderer keeps the afterimage produced by the previous camera pose. The
+  // next frame is otherwise valid, which makes this the exact old failure: Three's
+  // component-wise maximum overlays the old projection and raises luminance while
+  // navigation is moving.
+  'camera-motion-keeps-history': {
+    file: 'web/main.js',
+    edits: [[
+      '    if (renderedCameraChanged()) {',
+      '    if (false && renderedCameraChanged()) {',
     ]],
   },
 
@@ -2801,12 +2827,14 @@ try {
 
   // ================ 9. orbiting the parked viewport costs frames, not settles
 
-  console.log('\n[9] orbiting while paused redraws once per frame, not once per rebuild');
+  console.log('\n[9] a parked orbit keeps its temporal look and redraws once per frame');
 
   // The control the editor gives you for looking at the cloud is the drag itself, and
-  // it is the one control in this file whose failure is a *rate* rather than a wrong
-  // answer. Every image it produced was correct; there were just forty-five of them
-  // per pointer move, because `renderProgramFrame` runs `advanceNavigation`, which
+  // it is the one control in this file whose scheduling failure is a *rate* rather
+  // than a wrong answer. The old temporal path also produced a wrong picture while
+  // the pointer was held; the picture rows below keep those two claims separate.
+  // Before the scheduling fix one pointer move could cause dozens of redraws,
+  // because `renderProgramFrame` runs `advanceNavigation`, which
   // calls `controls.update()`, which fires `change` on a damped control that moved -
   // so the render asked for the next render and the damping settle ran at whatever
   // rate the machine could rebuild a frame. Measured before the fix: one pointer move
@@ -2920,7 +2948,7 @@ try {
 
     const poseBefore = await poseOf();
     const before = await page.evaluate(
-      '({ drafts: __kinect.timeline.counters.drafts, frames: globalThis.__orbitFrames })');
+      '({ redraws: __kinect.timeline.counters.navigationRedraws, frames: globalThis.__orbitFrames })');
     await page.mouse.move(stage.x, stage.y);
     await page.mouse.down();
     const MOVES = 24;
@@ -2931,26 +2959,26 @@ try {
     await page.mouse.up();
     await settle();
     const after = await page.evaluate(
-      '({ drafts: __kinect.timeline.counters.drafts, frames: globalThis.__orbitFrames })');
+      '({ redraws: __kinect.timeline.counters.navigationRedraws, frames: globalThis.__orbitFrames })');
     const poseAfter = await poseOf();
 
-    const drafts = after.drafts - before.drafts;
+    const redraws = after.redraws - before.redraws;
     const frames = after.frames - before.frames;
     const travelled = Math.hypot(...poseAfter.map((v, i) => v - poseBefore[i]));
     note(`${MOVES} pointer moves across the stage`,
-      `${drafts} drafts over ${frames} animation frames, camera moved ${travelled.toFixed(3)} m`);
+      `${redraws} navigation redraws over ${frames} animation frames, camera moved ${travelled.toFixed(3)} m`);
 
     // The control for the row below, and it has to come first: a drag that rendered
     // nothing would satisfy any ceiling at all, and so would one that never moved
     // the camera.
-    check(drafts > 0 && travelled > 0.05, 'the drag renders, and it moves the camera',
-      `${drafts} drafts, ${travelled.toFixed(3)} m`);
+    check(redraws > 0 && travelled > 0.05, 'the drag renders, and it moves the camera',
+      `${redraws} navigation redraws, ${travelled.toFixed(3)} m`);
     // The invariant rather than a threshold: the animation loop is the only thing
-    // that starts a draft while the playhead is parked, so it cannot start more than
+    // that starts a redraw while the playhead is parked, so it cannot start more than
     // one per frame. The slack is one frame, for the turn this counter was installed
     // on relative to the loop's.
-    check(drafts <= frames + 1, 'and never more than one redraw per frame the display was given',
-      `${drafts} drafts against ${frames} frames`);
+    check(redraws <= frames + 1, 'and never more than one redraw per frame the display was given',
+      `${redraws} navigation redraws against ${frames} frames`);
     // Forty tile means across the stage rather than one lit count over it, and the
     // reason is the same one `docs/measurement.md` records for the bloom rebase: a
     // scalar over the whole frame can come out equal for two genuinely different
@@ -3025,6 +3053,121 @@ try {
     check(landed < canSee / 4,
       'and the release lands the picture an accurate seek to that moment gives, not merely an accurate seek',
       `worst tile ${landed.toFixed(2)}/255 against the ${canSee.toFixed(2)} a wrong second would cost`);
+
+    // The renderer-level half of the bug, separated from the editor transport. A
+    // camera change is rendered once through the live seam with trails enabled, then
+    // the same pose and source position are rendered after an explicit afterimage
+    // clear. Surface memory and the trails parameter stay untouched in both arms. The
+    // first enabled frame has no legitimate old screen pixel to contribute: after the
+    // camera-history clear it is `max(current, 0)`, so the two pictures must agree.
+    // `camera-motion-keeps-history` removes only that clear. It leaves the camera move,
+    // render and look intact and must redden the picture row below.
+    const historyProbe = await page.evaluate(`(() => {
+      const k = __kinect;
+      const c = k.freeCamera;
+      const t = k.controls.target;
+      return {
+        look: k.params.values(['fade', 'wake', 'trails', 'bloom']),
+        view: { p: c.position.toArray(), q: c.quaternion.toArray(), t: [t.x, t.y, t.z] },
+        clears: k.timeline.counters.navigationHistoryClears,
+      };
+    })()`);
+    await page.evaluate(`__kinect.params.apply({ fade: 0, wake: 0, trails: 0.75, bloom: 0 })`);
+    await settle();
+    await page.evaluate('__kinect.timeline.transport().seek(4.0)');
+    await settle();
+    const cameraBeforeHistoryMove = await poseOf();
+    await page.evaluate(`(() => {
+      const k = __kinect;
+      const c = k.freeCamera;
+      const t = k.controls.target;
+      const offset = c.position.clone().sub(t).applyAxisAngle(c.up, 0.24);
+      c.position.copy(t).add(offset);
+      c.lookAt(t);
+      k.controls.update(0);
+      k.drive.stepTo(4.0);
+    })()`);
+    const movedWithTrails = await signature();
+    const cameraAfterHistoryMove = await poseOf();
+    const historyClears = await page.evaluate(
+      `__kinect.timeline.counters.navigationHistoryClears - ${historyProbe.clears}`);
+    await page.evaluate(`(() => {
+      __kinect.drive.clearAfterimage();
+      __kinect.drive.stepTo(4.0);
+    })()`);
+    const movedWithoutHistory = await signature();
+    const historyTravel = Math.hypot(...cameraAfterHistoryMove.map(
+      (v, i) => v - cameraBeforeHistoryMove[i]));
+    const historyApart = apart(movedWithTrails, movedWithoutHistory);
+    note('the first frame at a new camera pose against the same frame with no old screen history',
+      `worst tile ${historyApart.toFixed(2)}/255 after ${historyTravel.toFixed(3)} m and ${historyClears} history clears`);
+    check(historyTravel > 0.05 && historyClears > 0,
+      'the camera-history probe moves the camera and exercises the clear',
+      `${historyTravel.toFixed(3)} m, ${historyClears} clears`);
+    check(historyApart < 0.5,
+      'and camera motion carries no pixels from the previous view into the new one',
+      `worst tile ${historyApart.toFixed(2)}/255`);
+    await page.evaluate(`(() => {
+      const k = __kinect;
+      const v = ${JSON.stringify(historyProbe.view)};
+      const c = k.freeCamera;
+      c.position.fromArray(v.p);
+      c.quaternion.fromArray(v.q);
+      k.controls.target.set(v.t[0], v.t[1], v.t[2]);
+      k.controls.update(0);
+      k.params.apply(${JSON.stringify(historyProbe.look)});
+    })()`);
+    await settle();
+    await page.evaluate('__kinect.timeline.transport().seek(4.0)');
+    await settle();
+
+    // Now sample the actual editor gesture before release. Damping is disabled for
+    // this one move so the pose is stationary while the two pictures are read; the
+    // rate row above exercises the shipped damped path. The first picture is what the
+    // orbit redraw left while the pointer is still held. The second is an explicit
+    // accurate seek at that unchanged pose. A deliberately requested scrub draft is
+    // the falsification control: it must differ, or this look cannot tell whether the
+    // orbit reused the degraded preview.
+    const orbitLook = await page.evaluate(`(() => ({
+      look: __kinect.params.values(['fade', 'wake', 'trails']),
+      damping: __kinect.controls.enableDamping,
+    }))()`);
+    await page.evaluate('__kinect.params.apply({ fade: 400, wake: 900, trails: 0.5 })');
+    await settle();
+    await page.evaluate('__kinect.timeline.transport().seek(4.0)');
+    await settle();
+    await page.evaluate('__kinect.controls.enableDamping = false');
+    await page.mouse.move(stage.x, stage.y);
+    await page.mouse.down();
+    await page.mouse.move(stage.x + 95, stage.y + 45);
+    await page.evaluate('new Promise(requestAnimationFrame)');
+    await settle();
+    const heldSig = await signature();
+    const heldState = await read();
+    await page.evaluate('__kinect.timeline.transport().seek(4.0)');
+    await settle();
+    const heldAccurateSig = await signature();
+    await page.evaluate('__kinect.timeline.transport().draft(4.0)');
+    await settle();
+    const scrubDraftSig = await signature();
+    await page.evaluate('__kinect.timeline.transport().seek(4.0)');
+    await settle();
+    const heldApart = apart(heldSig, heldAccurateSig);
+    const draftApart = apart(scrubDraftSig, heldAccurateSig);
+    note('the picture while the orbit is held against an accurate seek at its pose',
+      `worst tile ${heldApart.toFixed(2)}/255; a scrub draft differs by ${draftApart.toFixed(2)}`);
+    check(draftApart > 1,
+      'the temporal look can distinguish the scrub draft from the accurate image',
+      `worst tile ${draftApart.toFixed(2)}/255`);
+    check(heldState.drafted === false && heldApart < draftApart / 4,
+      'and the held orbit keeps the accurate temporal look instead of substituting the scrub draft',
+      `drafted ${heldState.drafted}; ${heldApart.toFixed(2)}/255 against ${draftApart.toFixed(2)}`);
+    await page.mouse.up();
+    await page.evaluate(`(() => {
+      __kinect.controls.enableDamping = ${orbitLook.damping};
+      __kinect.params.apply(${JSON.stringify(orbitLook.look)});
+    })()`);
+    await settle();
 
     // An armed position means something only while something will consume it, and
     // hitting play mid-drag is a state where nothing will - the loop's first act is

--- a/tools/timeline-check.mjs
+++ b/tools/timeline-check.mjs
@@ -142,8 +142,11 @@ const MUTATIONS = {
   ]],
   // The accumulators are not cleared before a pre-roll.
   'no-reset': [[
-    'const feedback = [statePrev, stateNext, afterimage._textureComp, afterimage._textureOld];',
-    'const feedback = [];',
+    '  clearFeedback(\n'
+    + '    [statePrev, stateNext, afterimage._textureComp, afterimage._textureOld],\n'
+    + "    'afterimage internals moved: the accumulator reset is no longer complete',\n"
+    + '  );',
+    '  /* mutation: accumulator reset skipped */',
   ]],
   // The surface memory's age ceiling drops back under the longest life the
   // sliders can ask for, so a ray that stops swapping sheds forever. The boot

--- a/web/main.js
+++ b/web/main.js
@@ -4045,6 +4045,7 @@ const noop = () => {};
 // that it did, or it is asserting the claim rather than enforcing it.
 const counters = {
   renders: 0, stateAdvances: 0, resets: 0, drafts: 0, seeks: 0, requests: 0, framesFetched: 0,
+  navigationRedraws: 0, navigationHistoryClears: 0,
   // The lane rebuild is the expensive one - it resizes the drawing buffer - and the
   // reposition is the cheap one. Counted separately because "a drag no longer rebuilds"
   // is a claim about which of the two ran, and a check that timed the drag instead
@@ -4419,31 +4420,74 @@ function advanceSurfaceState(dtSec) {
 
 let lastProgramTime = 0;
 
+// Screen-space history belongs to the camera pose that produced it. Carrying it
+// across a different pose overlays the old view on the new one: Three's afterimage
+// pass takes the component-wise maximum of the current pixel and the damped old
+// pixel, so a pan raises the frame's luminance until the camera stops. The camera
+// used by the render is compared here rather than inferred from OrbitControls
+// events. That covers the program camera, auto-orbit and camera-view switches too,
+// and it leaves one policy at the seam every surface and export already shares.
+let renderedCamera = null;
+const renderedCameraPosition = new THREE.Vector3();
+const renderedCameraQuaternion = new THREE.Quaternion();
+const renderedProjection = new THREE.Matrix4();
+
+function renderedCameraChanged() {
+  const changed = renderedCamera !== null && (
+    renderedCamera !== viewCamera
+    || !renderedCameraPosition.equals(viewCamera.position)
+    || !renderedCameraQuaternion.equals(viewCamera.quaternion)
+    || !renderedProjection.equals(viewCamera.projectionMatrix)
+  );
+  renderedCamera = viewCamera;
+  renderedCameraPosition.copy(viewCamera.position);
+  renderedCameraQuaternion.copy(viewCamera.quaternion);
+  renderedProjection.copy(viewCamera.projectionMatrix);
+  return changed;
+}
+
+function clearFeedback(targets, refusal) {
+  if (!targets.every((target) => target?.isWebGLRenderTarget)) throw new Error(refusal);
+  const color = new THREE.Color();
+  renderer.getClearColor(color);
+  const alpha = renderer.getClearAlpha();
+  renderer.setClearColor(0x000000, 0);
+  try {
+    for (const target of targets) {
+      renderer.setRenderTarget(target);
+      renderer.clear(true, true, true);
+    }
+  } finally {
+    renderer.setRenderTarget(null);
+    renderer.setClearColor(color, alpha);
+  }
+}
+
+function clearAfterimage() {
+  // Three exposes no reset on the afterimage pass, so its two buffers are reached
+  // for directly. They are the whole of its state at 0.185.1, and the check makes an
+  // upstream rename loud instead of clearing the canvas while stale history survives.
+  clearFeedback(
+    [afterimage._textureComp, afterimage._textureOld],
+    'afterimage internals moved: camera history can no longer be cleared safely',
+  );
+}
+
 // Clears both feedback paths. Neither can be walked backwards, so an accurate
 // seek clears them and pre-rolls forward from a known state - and all zeroes is
 // that state, since a zero last-depth reads as invalid and the first frame after
 // it comes through as births rather than as swaps.
 function resetAccumulators() {
   counters.resets++;
-  const color = new THREE.Color();
-  renderer.getClearColor(color);
-  const alpha = renderer.getClearAlpha();
-  renderer.setClearColor(0x000000, 0);
   // Three exposes no reset on the afterimage pass, so its two buffers are reached
   // for directly. They are the whole of its state at 0.185.1, and the check is
   // there because a rename on upgrade would fail silently: setRenderTarget of
   // undefined binds the canvas instead, the clear lands nowhere, and the seek
   // would quietly carry the previous image's trails into its pre-roll.
-  const feedback = [statePrev, stateNext, afterimage._textureComp, afterimage._textureOld];
-  if (!feedback.every((target) => target?.isWebGLRenderTarget)) {
-    throw new Error('afterimage internals moved: the accumulator reset is no longer complete');
-  }
-  for (const target of feedback) {
-    renderer.setRenderTarget(target);
-    renderer.clear(true, true, true);
-  }
-  renderer.setRenderTarget(null);
-  renderer.setClearColor(color, alpha);
+  clearFeedback(
+    [statePrev, stateNext, afterimage._textureComp, afterimage._textureOld],
+    'afterimage internals moved: the accumulator reset is no longer complete',
+  );
   lastProgramTime = 0;
 }
 
@@ -4491,6 +4535,16 @@ function renderProgramFrame(t) {
     // operation. A clip with no keys writes nothing and the registry's own values
     // stand, which is a locked-off camera and a static look.
     evaluateTracks(t);
+
+    // Temporal source history remains valid while the camera is still. A changed
+    // camera is a different projection, so only the screen-space feedback is
+    // discarded; the surface-state texture still describes the same room and must
+    // survive the navigation. This happens after track evaluation because that is
+    // where the program camera moves.
+    if (renderedCameraChanged()) {
+      clearAfterimage();
+      counters.navigationHistoryClears++;
+    }
 
     const dt = Math.max(0, t - lastProgramTime);
     lastProgramTime = t;
@@ -5293,6 +5347,38 @@ class TimelineTransport {
     counters.drafts++;
     this.frame = target;
     this.drafted = true;
+    this.paint();
+    return this.lastCostMs;
+  }
+
+  /**
+   * Rebuilds the parked viewport after navigation without borrowing the scrub
+   * draft's look. With trails active, the accurate image requires a pre-roll at
+   * the new camera pose because screen-space history cannot be reprojected. With
+   * trails off, the already-bound source pair and surface state are sufficient,
+   * so the same frame can be drawn directly unless another draft left incomplete
+   * state behind it.
+   */
+  redraw(programSec) {
+    return this.exclusive(() => this.redrawNow(programSec));
+  }
+
+  async redrawNow(programSec) {
+    counters.navigationRedraws++;
+    const target = this.frameAt(programSec);
+    const t = target / this.outputFps;
+    const source = this.sourceFrameAt(t);
+    if (this.drafted || valueAtProgram('trails', t) > 0
+        || target !== this.frame || this.source.applied !== source + 1) {
+      return this.seekNow(t);
+    }
+
+    const began = performance.now();
+    advanceNavigation(t);
+    renderProgramFrame(t);
+    this.lastCostMs = performance.now() - began;
+    this.frame = target;
+    this.drafted = false;
     this.paint();
     return this.lastCostMs;
   }
@@ -7299,10 +7385,11 @@ ui.fps.addEventListener('change', () => {
   history.commit();
 });
 
-// Orbiting while the playhead is parked has the same shape as scrubbing: a drag
-// wants a cheap frame per pointer move and a true one on release. It differs from
-// scrubbing in the one way that matters, and the difference is why this arms rather
-// than pumps: **the render answers this event**. `renderProgramFrame` runs
+// Orbiting while the playhead is parked differs from scrubbing in two ways that
+// matter. The first is temporal: a scrub draft deliberately zeros fade, wake and
+// trails, while an orbit must keep the grade stable as the camera moves. The second
+// is scheduling, and it is why this arms rather than pumps: **the render answers this
+// event**. `renderProgramFrame` runs
 // `advanceNavigation`, `advanceNavigation` calls `controls.update()`, and a damped
 // control that moved fires `change` - so a handler that rendered here would be a
 // render asking for the next render, with the damping settle running at rebuild rate
@@ -7414,15 +7501,18 @@ function pumpParkedDraft() {
   // never paint over one that is already queued.
   if (orbitRedrawWanted && !draftBusy) {
     orbitRedrawWanted = false;
-    draftWanted = timeline.programSec;
-    pumpDraft();
+    draftBusy = true;
+    timeline.redraw(timeline.programSec)
+      .catch(showTimelineError)
+      .finally(() => { draftBusy = false; });
     return;
   }
   // Nothing armed and nothing in flight, so the controls have stopped moving.
   if (orbitSettling && !draftBusy) {
     orbitSettling = false;
-    // Releasing is what asks for the true image, the same rule the scrubber follows
-    // and for the same reason: a draft is not the picture playback would produce.
+    // The redraws above are already accurate. This last seek closes the race between
+    // the final redraw and the last damping step and makes release an explicit
+    // accuracy boundary, the same rule the scrubber follows.
     timeline.seek(timeline.programSec).catch(showTimelineError);
   }
 }
@@ -10382,6 +10472,8 @@ globalThis.__kinect = {
      * in here ties a picture to a frame number instead.
      */
     injectDepth(depth) { bindDepth(depth); },
+    /** Clears only screen-space history, for a proof arm that keeps surface memory. */
+    clearAfterimage() { clearAfterimage(); },
     reset() {
       pinnedPairs?.rewind();
       resetAccumulators();


### PR DESCRIPTION
## What

- Clear the `AfterimagePass` screen-space history whenever the rendered camera pose or projection changes.
- Give paused orbit navigation an accurate temporal redraw path while preserving requestAnimationFrame pacing.
- Add visual regression coverage and falsification mutations for camera-history clearing, held-orbit grading, and redraw scheduling.

## Why

`AfterimagePass` retained pixels from the previous camera projection through its component-wise maximum. During a pan or orbit, that stale projection raised the image luminance until navigation stopped. The paused editor also routed orbit updates through the scrub-draft path, which intentionally disables fade, wake, and trails, so the held and released images used different grading.

## Impact

- Navigation no longer composites the old projection over the new camera pose.
- Paused editor orbit preserves the accurate temporal grade throughout the gesture.
- Trails-off redraws remain direct; trails-on redraws accurately pre-roll at the new pose.
- Navigation remains paced by the animation loop.

## Verification

- `npm test`: passed; syntax checked 39 JavaScript files and the release-gate checks passed.
- `node tools/editor-check.mjs --url http://127.0.0.1:8181 --take sample --no-render`: 227 assertions, 0 failed.
- Clean camera-history and held-orbit comparisons: worst tile `0.00/255`.
- `--mutate camera-motion-keeps-history`: caught with 2 failed assertions and `65.66/255` visual error.
- `--mutate orbit-uses-scrub-draft`: caught with 2 failed assertions and `47.59/255` visual error.
- `--mutate orbit-pumps-on-change`: caught with 2 failed assertions and 1,003 redraws over 58 animation frames.
- `node tools/determinism-check.mjs --url http://127.0.0.1:8181 --capture temp`: passed.
- In-app browser validation on `/edit?take=sample` and `/record`: applied Blackwall, performed real orbit gestures, confirmed rendered output, and observed no console warnings or errors.

## Known verification limitations

- The affected `timeline-check` renderer sections passed, but the full tool did not complete because its 1.05x rate assertion conflicts with the shipped 1x detent. The same failure reproduces on a clean `main` checkout.
- The required one-attempt Claude review was unavailable because the account had reached its session limit.