### PR TITLE
Make world levelling selectable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,8 @@ node tools/level-check.mjs --mutate region-follows-tilt   # ... and must FAIL mu
 node tools/level-check.mjs --mutate sensor-view-ignores-tilt # ... and must FAIL mutated
 node tools/level-check.mjs --mutate level-writes-zero     # ... and must FAIL mutated
 node tools/level-check.mjs --mutate level-order-swapped   # ... and must FAIL mutated
+node tools/level-check.mjs --mutate level-selection-ignores-point # ... and must FAIL mutated
+node tools/level-check.mjs --mutate reset-keeps-roll      # ... and must FAIL mutated
 node tools/vcam-check.mjs                                 # the output to OBS: the colour camera, the take it must not touch, and the source's picture
 node tools/vcam-check.mjs --mutate hd-upscales-registered # ... and must FAIL mutated
 node tools/vcam-check.mjs --mutate hd-reaches-recorder    # ... and must FAIL mutated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ node tools/level-check.mjs --mutate sensor-view-ignores-tilt # ... and must FAIL
 node tools/level-check.mjs --mutate level-writes-zero     # ... and must FAIL mutated
 node tools/level-check.mjs --mutate level-order-swapped   # ... and must FAIL mutated
 node tools/level-check.mjs --mutate level-selection-ignores-point # ... and must FAIL mutated
+node tools/level-check.mjs --mutate pointer-levels-the-centre # ... the press's own position, one link earlier
 node tools/level-check.mjs --mutate reset-keeps-roll      # ... and must FAIL mutated
 node tools/vcam-check.mjs                                 # the output to OBS: the colour camera, the take it must not touch, and the source's picture
 node tools/vcam-check.mjs --mutate hd-upscales-registered # ... and must FAIL mutated

--- a/README.md
+++ b/README.md
@@ -244,11 +244,12 @@ sets of camera intrinsics and no accelerometer, so there is no gravity vector an
 straighten it by. `tilt` and `roll` under Framing rotate the *room* rather than the camera,
 which is what makes it one setting instead of four: the turntable's pole, the top-down inset,
 auto-orbit's axis and the exported frame all come level together, where a camera that merely
-rolled itself would leave the other three canted. Aim a flat surface into the middle of the
-frame and press **level to centre** to have the pair derived from it — a ceiling works as well
-as a floor, since the fit takes whichever of the surface's two normals disagrees less with the
-vertical already in force. Two angles and not three: the third would be yaw about the room's
-vertical, which is what dragging on the picture already does.
+rolled itself would leave the other three canted. Press **select floor**, then click a flat
+floor or ceiling plane in the picture to derive the pair from that surface. The button and
+`Escape` both cancel an armed selection. **Reset rotation** takes both axes back to zero.
+A ceiling levels the same way as a floor, since the fit takes whichever of the surface's two
+normals disagrees less with the vertical already in force. Two angles and not three: the third
+would be yaw about the room's vertical, which is what dragging on the picture already does.
 
 The crop faces and the region stay in sensor metres through all of it. They are tested before
 the model matrix, so a box shrunk onto a subject stays on that subject when the room is levelled

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -291,6 +291,35 @@ curve. The probes were moved onto the knees and onto an eased ramp and the same 
 fails four. Ask what the wrong implementation would agree with, and probe somewhere it
 cannot.
 
+### A probe can be in the right place and still start one link past the break
+
+`level-check` section 5 graded floor selection on a frame with two different planes planted
+in it, pressed each side, and checked the two rotations differed — which is the probe placed
+exactly where its answer is different, and it was still blind to half of what it was named
+for. Every one of those arms called `levelAtStagePoint` directly and passed its own
+coordinate, so all of them began *after* the step that turns a press into a coordinate. The
+sole gesture through the real control pressed the exact centre of a frame carrying one plane,
+and a frame of one plane answers the same whatever point reaches it. So a `pointerdown`
+handler that computed `view` and then handed the middle of the frame to a correct hook passed
+the whole section: measured, on the shipped tool, at 33 assertions and 0 failed.
+
+The existing `level-selection-ignores-point` did not cover it either, and the reason is worth
+keeping. That mutation discards the coordinate *inside* the hook, one link below where the
+arms attach, so they see it; the handler sits one link above them, where nothing was looking.
+**A hook exposed for testing is a seam, and a seam has two sides — arms that all attach on
+the same side of it measure one of them.** The fix drove the split plant through `#camLevel`
+and `#stage` at 0.35 and 0.65 of the stage's own width, graded which plane each press landed,
+and added `pointer-levels-the-centre` as the control: it now reddens 2 of 36 and the run still
+finishes, the left press writing the right plane's `32/45` because the seam between the two
+planted planes falls on the right half.
+
+One row of that set passes under the mutation and is kept anyway. The *right*-side press is
+answered correctly by a centre-passing build, since the centre lands on that plane by
+construction — so the left-side row and the two-presses-differ row are what carry the claim,
+and the right-side row exists to say the gesture works on both ends rather than to catch
+anything. **Ask of a control set which member would still be green under the mutation, and do
+not mistake it for redundancy: it is measuring a different thing.**
+
 ### `nav-at-the-foot` stood in a dead zone and then moved the page it measured
 
 Both flaws at once, in one probe, and both were found by running the mutation and reading

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -173,6 +173,10 @@ rather than a convenience.** It writes analytic planes — `z = c / (u . n)` alo
 own ray — straight into the depth texture, so it knows the normal of every surface it plants
 and can mark the plane fit against the answer. A fixture take would have given it a surface
 nobody knows the normal of, and the fit would then only ever have been asserted against itself.
+Section 5 also plants different planes on the left and right of one frame, selects each side,
+and checks the two resulting rotations. A full frame of one plane cannot distinguish a selected
+point from a hard-coded centre. The same section drives the reset button and reads both axes and
+both sliders back at neutral.
 
 **Its staged tree deliberately has no `native/`, and that is the reason it works.** A live
 socket wipes a planted frame in well under a second — an arriving frame swaps the two depth

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -988,9 +988,10 @@ const DRIVER_IDS = {
   tExport: 'section 6 asserts it is reachable, section 7 renders with it',
   tExportSave: 'section 7 - the saved copy, against a stubbed picker',
   cropReset: 'section 8 - opens the crop box again and the planes are read back',
-  camLevel: 'level-check section 5 - clicks this element and reads the pair, the slider '
-    + 'and the note back; it drives the button rather than the function behind it, which '
-    + 'is the distinction this whole section exists to enforce',
+  camLevel: 'level-check section 5 - arms this element, clicks the stage and reads the pair, '
+    + 'the slider, the note and the spent mode back; it drives both parts of the gesture '
+    + 'rather than the function behind them, which is the distinction this whole section exists to enforce',
+  camLevelReset: 'level-check section 5 - clicks this element and reads both axes and both sliders at neutral',
 };
 
 // ------------------------------------------------------------------- the page

--- a/tools/level-check.mjs
+++ b/tools/level-check.mjs
@@ -36,13 +36,14 @@
 //     at any cant is the same picture it gives at none. That is what forces the free
 //     camera's up onto the sensor's, which is why navigation's controls are rebuilt
 //     rather than written to - see `setNavigationUp` in `web/main.js`.
-//  5. **"Level to centre" reads the geometry.** Three planted surfaces with three
+//  5. **Floor selection reads the chosen geometry.** Three planted surfaces with three
 //     different normals must produce three different and individually correct
 //     answers. One arm would not do: a button that wrote zeros is right about a
 //     level room, and a button that read the pair in the wrong order is right about
 //     every surface that leans only one way. `level-writes-zero` and
 //     `level-order-swapped` are the two controls, and the third arm leans both ways
-//     precisely so the order has a consequence.
+//     precisely so the order has a consequence. A split frame then makes the selected
+//     point consequential, and the reset control proves the neutral way back.
 //
 // **The frames are planted, so this needs no sensor and no capture.** The depth
 // texture is written directly with an analytic plane - `z = c / (u . n)` along each
@@ -59,6 +60,8 @@
 //   node tools/level-check.mjs --mutate sensor-view-ignores-tilt # must FAIL
 //   node tools/level-check.mjs --mutate level-writes-zero        # must FAIL
 //   node tools/level-check.mjs --mutate level-order-swapped      # must FAIL
+//   node tools/level-check.mjs --mutate level-selection-ignores-point # must FAIL
+//   node tools/level-check.mjs --mutate reset-keeps-roll          # must FAIL
 //
 // It spawns its own server and needs none running. `--port` takes one nothing else
 // holds; the default is not in any other tool's range, but two worktrees running this
@@ -132,6 +135,22 @@ const MUTATIONS = {
   'level-writes-zero': { file: 'web/main.js', edits: [[
     '  writeFromControl(\'roll\', roll);\n  writeFromControl(\'tilt\', tilt);',
     '  writeFromControl(\'roll\', 0);\n  writeFromControl(\'tilt\', 0);',
+  ]] },
+  // The mode and cursor work, but the click coordinate is discarded and both sides
+  // of a frame containing different planes level on the same centre patch. The split
+  // plant in section 5 is what gives this a visible consequence.
+  'level-selection-ignores-point': { file: 'web/main.js', edits: [[
+    '      const d = Math.hypot(\n'
+    + '        (levelVec.x * 0.5 + 0.5) * size.w - stageX,\n'
+    + '        (0.5 - levelVec.y * 0.5) * size.h - stageY,\n'
+    + '      );',
+    '      const d = Math.hypot(levelVec.x * 0.5 * size.w, levelVec.y * 0.5 * size.h);',
+  ]] },
+  // The button takes tilt back to neutral and leaves roll behind. Reading both
+  // parameters and both sliders through the real control catches the half-reset.
+  'reset-keeps-roll': { file: 'web/main.js', edits: [[
+    '  return writeWorldRotation(0, 0);',
+    '  return writeWorldRotation(0, params.get(\'roll\'));',
   ]] },
   // The region is read after the model rotation instead of on the undisplaced
   // sensor-space position, so a region placed on a subject slides off it the moment
@@ -292,14 +311,14 @@ try {
   await page.evaluate(() => { document.getElementById('panel').style.display = 'none'; });
 
   /**
-   * Plants an analytic plane over the whole depth image and settles the picture.
+   * Plants one analytic plane over the depth image, or a different one on each half.
    *
    * The look is flattened first and that is not tidiness. Fade, wake and noise are
    * temporal, so a picture compared against another picture would be comparing two
    * moments of an accumulator rather than two geometries, and the identity in section
    * 2 would be false for a reason that has nothing to do with levelling.
    */
-  const plant = (surface) => page.evaluate(([n0, zc]) => {
+  const plant = (surface, rightSurface = null) => page.evaluate((surfaceSpecs) => {
     const k = globalThis.__kinect;
     for (const [name, value] of Object.entries({
       fade: 0, wake: 0, noise: 0, additive: false, spin: false, denoise: false,
@@ -310,15 +329,18 @@ try {
     const fy = k.uniforms.focal.value.y;
     const cx = k.uniforms.center.value.x;
     const cy = k.uniforms.center.value.y;
-    const len = Math.hypot(n0[0], n0[1], n0[2]);
-    const n = n0.map((v) => v / len);
-    // `c` is fixed by where the centre ray is wanted, so every surface lands at a
-    // sane depth whatever way it leans.
-    const c = zc * -n[2];
+    const planes = surfaceSpecs.filter(Boolean).map(({ n: n0, z: zc }) => {
+      const len = Math.hypot(n0[0], n0[1], n0[2]);
+      const n = n0.map((v) => v / len);
+      // `c` is fixed by where the centre ray is wanted, so every surface lands at a
+      // sane depth whatever way it leans.
+      return { n, c: zc * -n[2] };
+    });
     const data = k.uniforms.depthCurr.value.image.data;
     data.fill(0);
     for (let row = 0; row < DH; row++) {
       for (let col = 0; col < DW; col++) {
+        const { n, c } = planes.length > 1 && col >= DW / 2 ? planes[1] : planes[0];
         const ux = (col + 0.5 - cx) / fx;
         const uy = -(row + 0.5 - cy) / fy;
         const den = ux * n[0] + uy * n[1] - n[2];
@@ -332,8 +354,8 @@ try {
     }
     k.uniforms.depthCurr.value.needsUpdate = true;
     k.resetAccumulators();
-    return n;
-  }, [surface.n, surface.z]);
+    return planes.map(({ n }) => n);
+  }, [surface, rightSurface]).then((normals) => (rightSurface ? normals : normals[0]));
 
   /**
    * Whether the planted frame is still the one the page is drawing.
@@ -372,6 +394,19 @@ try {
     k.params.set('roll', r);
     return { tilt: k.params.get('tilt'), roll: k.params.get('roll'), q: k.worldTilt() };
   }, [tilt, roll]);
+
+  const levelAt = (x, y = 0.5) => page.evaluate(([xFraction, yFraction]) => {
+    const k = globalThis.__kinect;
+    const stage = k.renderer.domElement.getBoundingClientRect();
+    return k.levelAtStagePoint(stage.width * xFraction, stage.height * yFraction);
+  }, [x, y]);
+
+  const landNormal = (normal) => page.evaluate((n) => {
+    const k = globalThis.__kinect;
+    const v = k.freeCamera.position.clone().fromArray(n);
+    const q = k.freeCamera.quaternion.clone().fromArray(k.worldTilt());
+    return v.applyQuaternion(q).toArray();
+  }, normal);
 
   /**
    * The rendered frame, and only the rendered frame.
@@ -554,7 +589,7 @@ try {
   // previous section left the room and the crosshair is looking at nothing.
   await setTilt(0, 0);
   await plant(SURFACES[1]);
-  const level = await page.evaluate(() => globalThis.__kinect.levelToCentre());
+  const level = await levelAt(0.5);
   ok('the planted surface can be levelled on', level.ok === true, level.reason ?? '');
   if (level.ok) {
     const flatPlan = await planExtent();
@@ -617,13 +652,13 @@ try {
     Math.abs(restored.afterLevelling[1] - 1) < 1e-9,
     restored.afterLevelling.map((v) => v.toFixed(3)).join(', '));
 
-  // --- 5. level to centre reads the geometry --------------------------------
-  console.log('\n5. level to centre derives the pair from the surface');
+  // --- 5. selecting a floor reads the chosen geometry ------------------------
+  console.log('\n5. floor selection derives the pair from the chosen surface');
   const answers = [];
   for (const surface of SURFACES) {
     await setTilt(0, 0);
     const planted = await plant(surface);
-    const result = await page.evaluate(() => globalThis.__kinect.levelToCentre());
+    const result = await levelAt(0.5);
     if (!result.ok) {
       ok(`surface ${surface.name} could be levelled on`, false, result.reason);
       continue;
@@ -632,12 +667,7 @@ try {
     // the quaternion the page is carrying rather than recomposed here from the two
     // angles - recomposing would agree with the implementation by construction and
     // could never see the order being read backwards.
-    const landed = await page.evaluate((n) => {
-      const k = globalThis.__kinect;
-      const v = k.freeCamera.position.clone().fromArray(n);
-      const q = k.freeCamera.quaternion.clone().fromArray(k.worldTilt());
-      return v.applyQuaternion(q).toArray();
-    }, planted);
+    const landed = await landNormal(planted);
     answers.push({ surface, result, landed });
     ok(`surface ${surface.name}: the pair it wrote carries that surface's normal onto the vertical`,
       Math.hypot(landed[0], landed[2]) < LEVEL_TOLERANCE,
@@ -652,8 +682,30 @@ try {
     answers.every((a) => Number.isFinite(a.result.rms) && a.result.samples >= 32),
     answers.map((a) => `${a.result.samples} samples at ${(a.result.rms * 1000).toFixed(2)}mm`).join(', '));
 
-  // **Through the button and not through the hook**, and that is the whole reason this
-  // row exists rather than being one more call like the three above. `editor-check`
+  // Two surfaces in one picture make the selected coordinate load-bearing. A full
+  // frame of one plane proves the normal fit but cannot distinguish a selected point
+  // from the old hard-coded centre, however many different full frames are tried.
+  const [leftNormal, rightNormal] = await plant(SURFACES[0], SURFACES[2]);
+  const selected = [];
+  for (const [side, x, normal] of [['left', 0.35, leftNormal], ['right', 0.65, rightNormal]]) {
+    await setTilt(0, 0);
+    await page.evaluate(() => globalThis.__kinect.sensorView());
+    const result = await levelAt(x);
+    const landed = result.ok ? await landNormal(normal) : [Infinity, Infinity, Infinity];
+    selected.push(result);
+    ok(`selecting the ${side} side reads the plane on that side`,
+      result.ok && Math.hypot(landed[0], landed[2]) < LEVEL_TOLERANCE,
+      result.ok
+        ? `lands at ${landed.map((v) => v.toFixed(4)).join(', ')}, wrote ${result.tilt}/${result.roll}`
+        : result.reason);
+  }
+  ok('and the two selected points produce different rotations',
+    selected.every((result) => result.ok)
+      && `${selected[0].tilt}/${selected[0].roll}` !== `${selected[1].tilt}/${selected[1].roll}`,
+    selected.map((result) => (result.ok ? `${result.tilt}/${result.roll}` : result.reason)).join(', '));
+
+  // **Through the two-step control and not through the hook**, and that is the whole
+  // reason these rows exist rather than being one more call like the arms above. `editor-check`
   // names this tool as `camLevel`'s driver, and a driver that reached past the control
   // into the function behind it would be the exact failure that file was written
   // about: the suite testing the model while the control it is named after was never
@@ -663,6 +715,18 @@ try {
   await plant(SURFACES[1]);
   await page.evaluate(() => { document.getElementById('panel').style.display = ''; });
   await page.locator('#camLevel').click();
+  const armed = await page.evaluate(() => ({
+    active: globalThis.__kinect.levelSelection(),
+    pressed: document.getElementById('camLevel').getAttribute('aria-pressed'),
+    label: document.getElementById('camLevel').textContent,
+    note: document.getElementById('levelNote').textContent,
+    rotation: [globalThis.__kinect.params.get('tilt'), globalThis.__kinect.params.get('roll')],
+  }));
+  ok('pressing select floor visibly arms one selection without changing the room',
+    armed.active && armed.pressed === 'true' && /cancel/.test(armed.label)
+      && armed.rotation[0] === 0 && armed.rotation[1] === 0,
+    `${armed.label}, rotation ${armed.rotation.join('/')}; ${armed.note}`);
+  await page.locator('#stage').click({ position: { x: 550, y: 380 } });
   const pressed = await page.evaluate(() => {
     const k = globalThis.__kinect;
     const state = {
@@ -670,16 +734,40 @@ try {
       roll: k.params.get('roll'),
       note: document.getElementById('levelNote').textContent,
       slider: document.getElementById('tilt').value,
+      active: k.levelSelection(),
+      pressed: document.getElementById('camLevel').getAttribute('aria-pressed'),
     };
-    document.getElementById('panel').style.display = 'none';
     return state;
   });
-  ok('pressing the control itself levels the room, not only calling what it calls',
-    pressed.tilt !== 0 || pressed.roll !== 0, `tilt ${pressed.tilt} roll ${pressed.roll}`);
+  ok('clicking the picture through the armed control levels the room and spends the mode',
+    (pressed.tilt !== 0 || pressed.roll !== 0) && !pressed.active && pressed.pressed === 'false',
+    `tilt ${pressed.tilt} roll ${pressed.roll}, armed ${pressed.active}`);
   ok('and the slider beside it follows, because the panel is a view on the registry',
     Number(pressed.slider) === pressed.tilt, `slider reads ${pressed.slider}`);
-  ok('and the press says what it read rather than only that it worked',
+  ok('and the selection says what it read rather than only that it worked',
     /samples/.test(pressed.note), pressed.note);
+
+  await page.locator('#camLevel').click();
+  await page.keyboard.press('Escape');
+  const cancelled = await page.evaluate(() => ({
+    active: globalThis.__kinect.levelSelection(),
+    note: document.getElementById('levelNote').textContent,
+  }));
+  ok('Escape leaves a selection mode without spending it',
+    !cancelled.active && /cancelled/.test(cancelled.note), cancelled.note);
+
+  await setTilt(12.5, -6);
+  await page.locator('#camLevelReset').click();
+  const reset = await page.evaluate(() => ({
+    tilt: globalThis.__kinect.params.get('tilt'),
+    roll: globalThis.__kinect.params.get('roll'),
+    sliders: [document.getElementById('tilt').value, document.getElementById('roll').value],
+    note: document.getElementById('levelNote').textContent,
+  }));
+  ok('reset rotation takes both axes and both sliders back to neutral',
+    reset.tilt === 0 && reset.roll === 0 && reset.sliders.every((value) => Number(value) === 0),
+    `rotation ${reset.tilt}/${reset.roll}, sliders ${reset.sliders.join('/')}; ${reset.note}`);
+  await page.evaluate(() => { document.getElementById('panel').style.display = 'none'; });
 
   // --- 6. which side of the document boundary it falls on --------------------
   console.log('\n6. the cant is the take\'s and the pole is the viewer\'s');

--- a/tools/level-check.mjs
+++ b/tools/level-check.mjs
@@ -146,6 +146,18 @@ const MUTATIONS = {
     + '      );',
     '      const d = Math.hypot(levelVec.x * 0.5 * size.w, levelVec.y * 0.5 * size.h);',
   ]] },
+  // The same discarded coordinate one link earlier, in the handler rather than in the
+  // function behind it. `levelAtStagePoint` still reads the point it is handed and
+  // still fits the plane under it correctly; what is lost is the press's own position
+  // on the way in. That distinction is the whole reason this mutation exists beside the
+  // one above: every arm that calls the hook directly passes its own coordinate and so
+  // cannot see the handler at all, and a single-plane frame answers the same whatever
+  // point reaches it. Only an off-centre press on the split plant, driven through
+  // `#camLevel` and `#stage`, has an answer that differs here.
+  'pointer-levels-the-centre': { file: 'web/main.js', edits: [[
+    '  const result = levelAtStagePoint(view.x, view.y);',
+    '  const result = levelAtStagePoint(stageSize().w / 2, stageSize().h / 2);',
+  ]] },
   // The button takes tilt back to neutral and leaves roll behind. Reading both
   // parameters and both sliders through the real control catches the half-reset.
   'reset-keeps-roll': { file: 'web/main.js', edits: [[
@@ -711,8 +723,18 @@ try {
   // about: the suite testing the model while the control it is named after was never
   // pressed, which is how the in and out markers spent their whole life detached from
   // the document with every proof tool green.
+  // **And the press has to be off the centre, on the split plant.** A frame of one plane
+  // answers the same whatever point reaches the fit, so a gesture on one only ever proves
+  // that pressing did *something* - the handler could drop `view.x`/`view.y` on the floor
+  // and hand the middle of the frame to an otherwise correct hook, and a single-plane
+  // press could not tell. The arms above cannot see it either, because each one passes its
+  // own coordinate straight to `levelAtStagePoint` and so starts one link past the thing
+  // that would be broken. Two planes and a named side is what gives the coordinate a
+  // consequence: `pointer-levels-the-centre` is the control, and it presses the seam
+  // between the two planted planes, where the answer belongs to neither side.
   await setTilt(0, 0);
-  await plant(SURFACES[1]);
+  const [pressLeftNormal, pressRightNormal] = await plant(SURFACES[0], SURFACES[2]);
+  await page.evaluate(() => globalThis.__kinect.sensorView());
   await page.evaluate(() => { document.getElementById('panel').style.display = ''; });
   await page.locator('#camLevel').click();
   const armed = await page.evaluate(() => ({
@@ -726,19 +748,27 @@ try {
     armed.active && armed.pressed === 'true' && /cancel/.test(armed.label)
       && armed.rotation[0] === 0 && armed.rotation[1] === 0,
     `${armed.label}, rotation ${armed.rotation.join('/')}; ${armed.note}`);
-  await page.locator('#stage').click({ position: { x: 550, y: 380 } });
-  const pressed = await page.evaluate(() => {
-    const k = globalThis.__kinect;
-    const state = {
-      tilt: k.params.get('tilt'),
-      roll: k.params.get('roll'),
-      note: document.getElementById('levelNote').textContent,
-      slider: document.getElementById('tilt').value,
-      active: k.levelSelection(),
-      pressed: document.getElementById('camLevel').getAttribute('aria-pressed'),
-    };
-    return state;
-  });
+  // Taken from the element rather than written down, because `#stage` is letterboxed to
+  // the export aspect and a hard-coded pixel would silently stop naming a side the day
+  // that aspect changes.
+  const stageBox = await page.locator('#stage').boundingBox();
+  const pressSide = async (xFraction) => {
+    await page.locator('#stage').click({
+      position: { x: stageBox.width * xFraction, y: stageBox.height * 0.5 },
+    });
+    return page.evaluate(() => {
+      const k = globalThis.__kinect;
+      return {
+        tilt: k.params.get('tilt'),
+        roll: k.params.get('roll'),
+        note: document.getElementById('levelNote').textContent,
+        slider: document.getElementById('tilt').value,
+        active: k.levelSelection(),
+        pressed: document.getElementById('camLevel').getAttribute('aria-pressed'),
+      };
+    });
+  };
+  const pressed = await pressSide(0.35);
   ok('clicking the picture through the armed control levels the room and spends the mode',
     (pressed.tilt !== 0 || pressed.roll !== 0) && !pressed.active && pressed.pressed === 'false',
     `tilt ${pressed.tilt} roll ${pressed.roll}, armed ${pressed.active}`);
@@ -746,6 +776,26 @@ try {
     Number(pressed.slider) === pressed.tilt, `slider reads ${pressed.slider}`);
   ok('and the selection says what it read rather than only that it worked',
     /samples/.test(pressed.note), pressed.note);
+  // Graded against the plane that was actually under the press, and read before the next
+  // `setTilt` moves the rotation this is measured through.
+  const pressedLeftLanded = await landNormal(pressLeftNormal);
+  ok('and the press read the plane under the point pressed, not the middle of the frame',
+    Math.hypot(pressedLeftLanded[0], pressedLeftLanded[2]) < LEVEL_TOLERANCE,
+    `lands at ${pressedLeftLanded.map((v) => v.toFixed(4)).join(', ')}, wrote ${pressed.tilt}/${pressed.roll}`);
+
+  await setTilt(0, 0);
+  await page.locator('#camLevel').click();
+  const pressedRight = await pressSide(0.65);
+  const pressedRightLanded = await landNormal(pressRightNormal);
+  ok('and pressing the other side of the same frame reads the other plane',
+    !pressedRight.active && Math.hypot(pressedRightLanded[0], pressedRightLanded[2]) < LEVEL_TOLERANCE,
+    `lands at ${pressedRightLanded.map((v) => v.toFixed(4)).join(', ')}, wrote ${pressedRight.tilt}/${pressedRight.roll}`);
+  // The two rows above could both pass on a build that levelled correctly on whichever
+  // single plane it always picked, if the two planted normals happened to be close. This
+  // is the row that says the two presses were answered differently at all.
+  ok('so two presses through one control are two rotations, and the coordinate reached the fit',
+    `${pressed.tilt}/${pressed.roll}` !== `${pressedRight.tilt}/${pressedRight.roll}`,
+    `${pressed.tilt}/${pressed.roll} then ${pressedRight.tilt}/${pressedRight.roll}`);
 
   await page.locator('#camLevel').click();
   await page.keyboard.press('Escape');

--- a/web/index.html
+++ b/web/index.html
@@ -45,6 +45,7 @@
      boundary is invisible - which makes it a guide nobody can use. An outline rather
      than a border because it must not enter the layout the letterbox just computed. */
   #stage { outline: 1px solid rgba(120, 220, 210, 0.28); }
+  body.selecting-level #stage { cursor: crosshair; outline-color: var(--accent); }
 
   /* Two boxes rather than one scrolling box, and the split is what makes the way out
      of this surface reachable. The panel fills the window's height and its content is

--- a/web/main.js
+++ b/web/main.js
@@ -1725,14 +1725,13 @@ const PANEL_GROUPS = [
     // to the take, so it rotates the room and not the camera, and the top-down,
     // auto-orbit and the exported frame come level with the picture.
     before: () => [
-      panelButtonRow('camSensor', 'sensor view'),
-      panelButtonRow('camLevel', 'level to centre'),
-      panelNote('levelNote', 'Aim a flat surface into the middle of the frame and press. '
-        + 'A ceiling levels the same way a floor does; if it picks the wrong surface, press '
-        + 'again somewhere flatter or nudge tilt and roll below.'),
+      panelButtonRow(['camSensor', 'sensor view']),
+      panelButtonRow(['camLevel', 'select floor'], ['camLevelReset', 'reset rotation']),
+      panelNote('levelNote', 'Select floor, then click a flat floor or ceiling plane in the picture. '
+        + 'The selection levels the room; tilt and roll below remain available for small corrections.'),
     ],
     after: () => [
-      panelButtonRow('cropReset', 'open the box'),
+      panelButtonRow(['cropReset', 'open the box']),
       panelNote('cropNote', 'The top-down draws this box in x and z. It has no y, so the '
         + 'bottom and top faces do not show there — judge those in the picture.'),
       panelNote('recRange', 'preview only'),
@@ -1799,8 +1798,8 @@ const PARAMS = {
   // The ranges are the whole of what the plane fit can ever produce and not a
   // judgement about how far a bracket can lean: `roll` comes out of an `atan2` over
   // the full turn, and `tilt` out of an `atan2` against a non-negative horizontal
-  // component, so it cannot leave the quarter turn either side. That means "level to
-  // centre" can never write a value its own slider would clamp, which would otherwise
+  // component, so it cannot leave the quarter turn either side. That means selecting
+  // a floor can never write a value its own slider would clamp, which would otherwise
   // be a silent disagreement between the button and the panel.
   tilt: { def: 0, min: -90, max: 90, step: 0.5, kind: 'scalar', tag: 'look',
     group: 'framing', label: 'tilt',
@@ -2391,12 +2390,14 @@ const panelNode = (tag, className, text) => {
   return el;
 };
 
-const panelButtonRow = (id, text) => {
+const panelButtonRow = (...buttons) => {
   const row = panelNode('div', 'btnrow');
-  const button = panelNode('button', null, text);
-  button.type = 'button';
-  button.id = id;
-  row.append(button);
+  for (const [id, text] of buttons) {
+    const button = panelNode('button', null, text);
+    button.type = 'button';
+    button.id = id;
+    row.append(button);
+  }
   return row;
 };
 
@@ -5866,6 +5867,7 @@ const ui = {
   camView: document.getElementById('camView'),
   camSensor: document.getElementById('camSensor'),
   camLevel: document.getElementById('camLevel'),
+  camLevelReset: document.getElementById('camLevelReset'),
   levelNote: document.getElementById('levelNote'),
   cropReset: document.getElementById('cropReset'),
   exportSize: buildExportMenu(document.getElementById('tExportSize')),
@@ -8986,6 +8988,46 @@ function viewUnder(clientX, clientY) {
   return { plan, x, y };
 }
 
+// Floor selection is a one-shot mode because its first press is in the panel and the
+// point it names is in the picture. The state is visible on both ends of that gap: the
+// button changes face and the frame gets a crosshair cursor. `Escape` and pressing the
+// button again are explicit ways out, so hiding the panel or deciding not to select a
+// surface cannot strand the next orbit inside a mode the user forgot was armed.
+let levelSelectionArmed = false;
+
+function setLevelSelection(on, note) {
+  levelSelectionArmed = on;
+  ui.camLevel.setAttribute('aria-pressed', String(on));
+  ui.camLevel.textContent = on ? 'cancel selection' : 'select floor';
+  document.body.classList.toggle('selecting-level', on);
+  if (note) ui.levelNote.textContent = note;
+}
+
+// On the window and in capture phase for the same reason the node drag below lives
+// there: OrbitControls owns pointerdown on the canvas. The selecting press must reach
+// exactly one owner or the room levels while the camera begins orbiting underneath it.
+// Registered before the node handler, with stopImmediatePropagation, because the
+// editor's camera nodes are drawn over the same picture and floor selection wins while
+// it is visibly armed.
+addEventListener('pointerdown', (e) => {
+  if (!levelSelectionArmed || e.target !== renderer.domElement || e.button !== 0) return;
+  e.preventDefault();
+  e.stopImmediatePropagation();
+  const view = viewUnder(e.clientX, e.clientY);
+  if (!view) return;
+  if (chromeOn && view.plan) {
+    ui.levelNote.textContent = 'Select the floor in the main picture, outside the top-down inset.';
+    return;
+  }
+  const result = levelAtStagePoint(view.x, view.y);
+  if (!result.ok) {
+    ui.levelNote.textContent = `${result.reason}. Choose another point or press Escape to cancel.`;
+    return;
+  }
+  setLevelSelection(false,
+    `levelled on ${result.samples} samples, ${(result.rms * 1000).toFixed(1)}mm from flat`);
+}, true);
+
 function nodeUnder(view) {
   let best = null;
   cameraKeys().forEach((key, i) => {
@@ -9185,16 +9227,16 @@ ui.camSensor.addEventListener('click', () => { sensorView(); });
 // wide enough that the fit is reading a surface rather than the depth quantisation,
 // narrow enough that a headliner does not take the windscreen in with it.
 const LEVEL_PATCH = 12;
-// How close to the middle of the frame a sample has to land to be a candidate, in
-// stage pixels. Generous, because the gesture is "the surface I have framed" and
-// asking for sub-pixel aim on a cloud full of holes would make the button feel broken.
+// How close to the selected point a sample has to land to be a candidate, in stage
+// pixels. Generous, because asking for sub-pixel aim on a cloud full of holes would
+// make a visible surface answer as though there were nothing under the pointer.
 const LEVEL_PICK_PX = 60;
-// The grid is walked at this stride hunting for the centre sample - two rather than
+// The grid is walked at this stride hunting for the selected sample - two rather than
 // the plan view's four, because this decides which surface gets levelled and a miss
 // here is a wrong answer rather than a coarse drawing.
 const LEVEL_PICK_STRIDE = 2;
 // Below this many valid samples in the patch there is no plane to speak of. This is
-// the only thing that refuses: see `levelToCentre` on why the flatness is reported
+// the only thing that refuses: see `levelAtStagePoint` on why the flatness is reported
 // rather than judged.
 const LEVEL_MIN_SAMPLES = 32;
 
@@ -9258,7 +9300,7 @@ function fitPatchNormal(col0, row0, depth, fx, fy, cx, cy, near, far) {
   if (levelNormal.lengthSq() === 0) return null;
   levelNormal.normalize();
   // How far the patch actually is from the plane it was given, in metres. Reported
-  // rather than used, for the reason `levelToCentre` gives.
+  // rather than used, for the reason `levelAtStagePoint` gives.
   let sq = 0;
   for (let i = 0; i < n; i++) {
     const d = (xs[i] - mx) * levelNormal.x + (ys[i] - my) * levelNormal.y + (zs[i] - mz) * levelNormal.z;
@@ -9268,21 +9310,35 @@ function fitPatchNormal(col0, row0, depth, fx, fy, cx, cy, near, far) {
 }
 
 /**
- * Levels the room on whatever surface is in the middle of the frame.
+ * Writes both world-rotation controls as one interaction.
+ *
+ * This is the door used by both the plane selection and reset. Keeping them on the
+ * same `writeFromControl` path matters when either angle is keyed: a direct registry
+ * reset would be overwritten on the next evaluated frame while its button and sliders
+ * briefly claimed it had succeeded.
+ */
+function writeWorldRotation(tilt, roll) {
+  writeFromControl('roll', roll);
+  writeFromControl('tilt', tilt);
+  history.commit();
+  requestRepaint();
+  return { tilt: params.get('tilt'), roll: params.get('roll') };
+}
+
+function resetWorldRotation() {
+  return writeWorldRotation(0, 0);
+}
+
+/**
+ * Levels the room on the surface selected at one point in the rendered picture.
  *
  * The button exists because the two sliders are two numbers nobody can guess: the
  * angle a bracket ended up at is not a thing anybody knows to half a degree, and
  * hunting for it by eye on a cloud is slow enough that people would rather work
- * canted. Aiming a flat surface into the middle and pressing once is the gesture, and
- * it writes the same two parameters the sliders do - so it is a way of *saying* the
- * value rather than a second place the value lives, which is what keeps this one
- * implementation and lets you nudge afterwards.
- *
- * **The middle of the frame rather than under the pointer**, and that is a design
- * decision rather than a shortcut. At the moment a button is pressed the pointer is on
- * the button, so "under the pointer" needs the press to arm a mode and a second click
- * to spend it - a mode with a cursor state, an escape path and a way to be left in.
- * A crosshair costs an orbit and no mode at all.
+ * canted. Selecting the floor names the surface directly, and it writes the same two
+ * parameters the sliders do - so it is a way of *saying* the value rather than a
+ * second place the value lives, which is what keeps this one implementation and lets
+ * the user nudge afterwards.
  *
  * **A surface has two normals and both of them make it level.** Picking the one that
  * disagrees least with the vertical already in force is what stops levelling on a
@@ -9295,7 +9351,7 @@ function fitPatchNormal(col0, row0, depth, fx, fy, cx, cy, near, far) {
  * taken across the gap between two seats and press again somewhere better. The one
  * refusal is an empty patch, which is an impossibility rather than an opinion.
  */
-function levelToCentre() {
+function levelAtStagePoint(stageX, stageY) {
   const depth = depthCurr.image.data;
   const fx = uniforms.focal.value.x;
   const fy = uniforms.focal.value.y;
@@ -9304,6 +9360,10 @@ function levelToCentre() {
   const near = uniforms.nearClip.value;
   const far = uniforms.farClip.value;
   const size = stageSize();
+  if (!Number.isFinite(stageX) || !Number.isFinite(stageY)
+      || stageX < 0 || stageY < 0 || stageX > size.w || stageY > size.h) {
+    return { ok: false, reason: 'the selected point is outside the picture' };
+  }
   viewCamera.updateMatrixWorld(true);
 
   // Candidates are projected through the camera that is actually drawing rather than
@@ -9324,7 +9384,10 @@ function levelToCentre() {
       if (levelVec.y < uniforms.cropB.value || levelVec.y > uniforms.cropT.value) continue;
       levelVec.applyQuaternion(worldTilt).project(viewCamera);
       if (levelVec.z < -1 || levelVec.z > 1) continue;
-      const d = Math.hypot(levelVec.x * 0.5 * size.w, levelVec.y * 0.5 * size.h);
+      const d = Math.hypot(
+        (levelVec.x * 0.5 + 0.5) * size.w - stageX,
+        (0.5 - levelVec.y * 0.5) * size.h - stageY,
+      );
       if (d > LEVEL_PICK_PX) continue;
       // Nearest to the camera among the candidates rather than nearest to the
       // crosshair: this footage is full of holes, and a hole in the surface being
@@ -9333,10 +9396,10 @@ function levelToCentre() {
       if (!best || levelVec.z < best.ndcZ) best = { col, row, ndcZ: levelVec.z };
     }
   }
-  if (!best) return { ok: false, reason: 'nothing in the middle of the frame to level on' };
+  if (!best) return { ok: false, reason: 'nothing near the selected point to level on' };
 
   const fit = fitPatchNormal(best.col, best.row, depth, fx, fy, cx, cy, near, far);
-  if (!fit) return { ok: false, reason: 'too few samples around the middle of the frame to fit a surface' };
+  if (!fit) return { ok: false, reason: 'too few samples around the selected point to fit a surface' };
 
   levelUp.set(0, 1, 0).applyQuaternion(levelInverse.copy(worldTilt).invert());
   if (fit.normal.dot(levelUp) < 0) fit.normal.negate();
@@ -9349,23 +9412,12 @@ function levelToCentre() {
   const horizontal = Math.hypot(fit.normal.x, fit.normal.y);
   const roll = THREE.MathUtils.radToDeg(Math.atan2(fit.normal.x, fit.normal.y));
   const tilt = THREE.MathUtils.radToDeg(Math.atan2(-fit.normal.z, horizontal));
-  // Through the control door rather than `params.set`, because these two are keyable
-  // and a bare write to a keyed parameter is the one thing the evaluator undoes: it
-  // rewrites every keyed parameter on the very next render, so the button would report
-  // an angle it had computed correctly while the image and the sliders sprang back to
-  // the old track, and the committed project would still hold the old keys. This is
-  // the same rule a dragged slider keeps, and it is kept here for the same reason -
-  // there is one write path for a parameter that might be keyed, not two.
-  writeFromControl('roll', roll);
-  writeFromControl('tilt', tilt);
-  history.commit();
-  requestRepaint();
+  const written = writeWorldRotation(tilt, roll);
   return {
     ok: true,
     // Read back rather than returned as computed, so the answer is the value the
     // registry holds after snapping to the slider's step and not the one before it.
-    tilt: params.get('tilt'),
-    roll: params.get('roll'),
+    ...written,
     normal: fit.normal.toArray(),
     samples: fit.samples,
     rms: fit.rms,
@@ -9374,11 +9426,29 @@ function levelToCentre() {
 }
 
 ui.camLevel.addEventListener('click', () => {
-  const result = levelToCentre();
-  ui.levelNote.textContent = result.ok
-    ? `levelled on ${result.samples} samples, ${(result.rms * 1000).toFixed(1)}mm from flat`
-    : result.reason;
+  if (levelSelectionArmed) {
+    setLevelSelection(false, 'Floor selection cancelled.');
+    return;
+  }
+  // The second press names a pixel in the picture, so the camera cannot keep coasting
+  // between arming and selection. Finish the orbit here, while there is still a frame
+  // before the user can click the surface, rather than moving it underneath that click.
+  finishOrbitDrift();
+  setLevelSelection(true, 'Click a flat floor or ceiling plane in the picture. Press Escape to cancel.');
 });
+
+ui.camLevelReset.addEventListener('click', () => {
+  setLevelSelection(false);
+  resetWorldRotation();
+  ui.levelNote.textContent = 'World rotation reset to 0° tilt and 0° roll.';
+});
+
+addEventListener('keydown', (e) => {
+  if (!levelSelectionArmed || e.key !== 'Escape') return;
+  e.preventDefault();
+  setLevelSelection(false, 'Floor selection cancelled.');
+});
+setLevelSelection(false);
 
 // Four planes back to their defaults, which are their bounds. Cropping is easy to do
 // by accident and hard to undo by hand once all four have moved - and a box closed
@@ -10104,7 +10174,8 @@ globalThis.__kinect = {
   // would work on screen while every assertion read the corpse.
   get controls() { return controls; },
 
-  // Levelling: the rotation the room is carrying, and the button that derives it.
+  // Levelling: the rotation the room is carrying, the selected-plane fit that derives
+  // it, and the neutral-state action that uses the same control write path.
   //
   // Read off **the cloud** rather than off the quaternion the parameters compose into,
   // and the difference is the whole value of the row. `registry-check` calls this the
@@ -10113,7 +10184,9 @@ globalThis.__kinect = {
   // been computed correctly and never applied, which is one edit away at all times and
   // is exactly what `level-check --mutate tilt-ignored` does.
   worldTilt: () => cloud.quaternion.toArray(),
-  levelToCentre,
+  levelAtStagePoint,
+  levelSelection: () => levelSelectionArmed,
+  resetWorldRotation,
 
   // The sensor's own view, and the numbers it derived. Returned rather than left to
   // be read off the camera because the containment rule is the claim worth checking


### PR DESCRIPTION
## Summary

- replace fixed-centre levelling with a one-shot floor or ceiling selection mode
- add visible armed and cancel states, suppress orbit interaction during selection, and add an explicit world-rotation reset
- extend the analytic levelling proof with split-plane point selection and targeted falsification controls

## Why

The old action only sampled a fixed patch at the frame centre. Operators had to reframe the camera before levelling and had no direct path back to neutral, which made world rotation indirect and brittle.

## Validation

- `npm test`
- `node tools/level-check.mjs --port 8377` — 33/33 assertions passed
- `node tools/level-check.mjs --port 8378 --mutate level-selection-ignores-point` — 2 intended assertions fired
- `node tools/level-check.mjs --port 8379 --mutate reset-keeps-roll` — 1 intended assertion fired
- browser QA at `/record`: armed state, empty-selection retry, Escape cancellation, and rotation reset; no console warnings or errors

## Remaining validation

A live Kinect plane-selection run was not possible because `captures/sample.knct` is absent. The successful selection path was verified with planted analytic planes, which need no sensor or capture.