### PR TITLE
Close five contradictions between the enforced documents and the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,9 @@ change, with a clean control taken on an idle machine.
 
 ## Proof tools
 
-Each takes a running server and exits non-zero on failure. `docs/proof-tools.md` says what
-each one needs.
+Each exits non-zero on failure. What a tool needs before it will run varies — a server already
+listening, one it spawns for itself, or nothing at all — and the notes under the list say which
+is which. `docs/proof-tools.md` says what else each one needs.
 
 ```
 node tools/determinism-check.mjs                    # step 1: same program time, same image
@@ -202,8 +203,17 @@ node tools/jobs-check.mjs --mutate claim-ignores-renderer # ... and must FAIL mu
 ```
 
 `jobs-check` needs a GPU browser and ffprobe and renders one real job through
-`tools/render-worker.mjs`; `--no-render` drops that row. `guard-check`, `library-check`,
-`level-check` and `vcam-check` spawn their own servers. `export-check` needs ffmpeg and ffprobe.
+`tools/render-worker.mjs`; `--no-render` drops that row. **Six spawn their own servers and need
+none running** — `guard-check` on 8321, `jobs-check` on 8231, `level-check` on 8377,
+`monitor-check` on 8341, `vcam-check` on 8361, and `library-check` across the span described
+below — so what each of those needs is a free port rather than a server, and the distinction is
+not bookkeeping: a tool that finds a stranger already listening on its port is answered by the
+stranger, and asserts against whatever fixture that process staged rather than the one this run
+staged, which is a green run proving nothing. `sensor-view-check` does both — it takes `--url`
+against a running server for most of its run and spawns a private one on 8131 for the section
+that needs its own capture. `library-check` is the only one of any of them that asks the kernel
+first and refuses, so everywhere else the `pgrep` below is the check. `export-check` needs
+ffmpeg and ffprobe.
 `level-check` needs neither a sensor nor a capture — it plants analytic planes straight into
 the depth texture, which is what lets it grade the plane fit against a normal it chose.
 

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -34,10 +34,13 @@ so a saturated main thread slows the driver by exactly as much as it slows itsel
 quotient says more about the round trip than about the browser. Counting the page's own
 animation frames over the same drag gave 12.4/s, with a 10.0-18.1 spread across five rounds.
 
-**So install the counter in the page** — `globalThis.__raf` incremented from a
+**So install the counter in the page** — `globalThis.__orbitFrames` incremented from a
 `requestAnimationFrame` chain — and read a delta around the gesture. That is what the editor's
-new section 9 does and why it does it. The rule generalises past rAF: any figure derived from
-how long the driver's own loop took is a measurement of the driver.
+section 9 does and why it does it: `tools/editor-check.mjs` installs the chain before the drag
+and reads the count back beside `navigationRedraws`, so grep that identifier for a working copy
+rather than writing a second chain that competes for the very frames it is there to count. The
+rule generalises past rAF: any figure derived from how long the driver's own loop took is a
+measurement of the driver.
 
 And prefer a counter the page already keeps to a rate you compute. Across three runs of the
 same A/B the frame rate moved with whatever else the machine was doing, while the draft count

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -15,9 +15,10 @@ Counted rather than recalled:
 - **Seven exit non-zero on a catch and say `NOT CAUGHT` when they miss**: `guard-check`,
   `jobs-check`, `editor-check`, `monitor-check`, `sensor-view-check`, `level-check`,
   `vcam-check`.
-- **Three invert it**: `vendor-check`, `registration-check` and `registry-check`, where caught
-  is exit **0** with `caught, as required (N assertions fired)` and exit **1** is `NOT CAUGHT`.
-  Anything gating on "non-zero means caught" reads a genuine miss by these three as a catch.
+- **Four invert it**: `vendor-check`, `registration-check`, `registry-check` and
+  `release-gate-check`, where caught is exit **0** with `caught, as required (N assertions
+  fired)` and exit **1** is `NOT CAUGHT`.
+  Anything gating on "non-zero means caught" reads a genuine miss by these four as a catch.
   `registry-check` joined this group rather than the first deliberately, because all three of
   its outcomes have their own code: it exits **2** with `DID NOT RUN` on a crash, on the same
   reading `registration-check` reserves 2 for. `level-check` and `vcam-check` separate the same
@@ -26,10 +27,15 @@ Counted rather than recalled:
   That is not hypothetical — two of its four mutations reddened their intended row and *then* died on
   Playwright's `Target page, context or browser has been closed`, and without the crash handler
   each would have exited non-zero having asserted the right thing for the wrong reason.
+  `release-gate-check` is here because its header says it follows `vendor-check` and its code
+  does: it prints the assertion count and exits 0 on a catch, and 1 with `NOT CAUGHT` on a miss.
+  It is the one tool in this census that carries mutations without appearing in the fourteen
+  below, for the reason given there — so an agent who goes looking for it under Mutations and
+  gives up reads it by the majority convention, which is backwards for exactly this tool.
 - **Four have no `NOT CAUGHT` branch at all** and simply exit on their failure count:
   `timeline-check`, `export-check`, `keyframe-check`, `library-check`. **A mutation these four
   fail to catch exits 0**, which reads as a clean pass rather than as the check being blind.
-  That is the same direction as the inverted pair and it is silent rather than merely
+  That is the same direction as the inverting group above and it is silent rather than merely
   confusing, so it is the worse of the two shapes.
 
 Which is why the rule is worded the way it is: count failed assertions, never exit codes — and
@@ -51,11 +57,20 @@ same way. The convention was reached independently several times and it is one r
 `--mutate <name>` serves a deliberately broken `main.js` into the running server, or for the
 two vendoring tools rebuilds a deliberately broken source tree.
 
-**Fourteen tools carry mutations** — editor, export, guard, jobs, keyframe, level, library,
-monitor, registration, registry, sensor-view, timeline, vcam and vendor — and all of them refuse
-a mutation whose text they cannot find exactly once, because a replacement that silently
-matched nothing would run the unmutated page and be recorded as the check having missed a bug
-it was never shown.
+**Fourteen tools carry mutations by one of those two mechanisms** — editor, export, guard, jobs,
+keyframe, level, library, monitor, registration, registry, sensor-view, timeline, vcam and
+vendor — and all of them refuse a mutation whose text they cannot find exactly once, because a
+replacement that silently matched nothing would run the unmutated page and be recorded as the
+check having missed a bug it was never shown.
+
+**That qualifier is load-bearing, because the exit-code census above has fifteen entries and
+this list has fourteen names.** `release-gate-check` is the difference, and it carries three
+mutations — `wrong-unit`, `no-gate` and `absent` — by a third mechanism: each is a whole
+`.npmrc`, written into a scratch directory npm is then asked to resolve a package from, so there
+is no source text to match and nothing for the refusal above to be about. Both numbers are
+right because they count different things, so do not reconcile them — a fifteenth name in this
+list would claim a delivery that tool does not use, and dropping it from the census leaves the
+tool whose convention is easiest to read backwards as the one nothing documents.
 
 **A mutation is a piece of source text, so a mutation stops matching the moment the code it
 names is edited** — three of `timeline-check`'s nine had to be re-anchored when step 5 rewrote
@@ -89,7 +104,11 @@ that into a sentence.
 **`jobs-check`** spawns its own server and renders one real job through
 `tools/render-worker.mjs`, so it needs a GPU browser and ffprobe. `--no-render` drops that row
 and says so - the queue rows are seconds, the render row is a minute. Its mutation runs use
-`--no-render` because all five are queue semantics.
+`--no-render` because every mutation it declares is queue semantics, and none of them needs a
+rendered frame to be caught. Take the names from the tool's own refusal rather than from a count
+written here - this sentence used to carry one and it was wrong, which is what a count in prose
+beside a list that grows does to itself, and enumerating from the refusal is what `sweep-all`
+already does for the same reason.
 
 **The worker reads its renderer class out of the browser it will render in and cannot be told
 one.** `channel: 'chromium'` rather than the bundled headless shell, which has no GPU and falls
@@ -230,10 +249,11 @@ report milliseconds from an arm that lost frames.
 
 **`sweep-all` says "every mutation of every tool" and drives four of the fourteen that carry
 mutations.** Its `TOOLS` is `['library', 'timeline', 'keyframe', 'export']`, so editor, guard,
-jobs, monitor, registration, registry, sensor-view, vcam and vendor are outside the sweep a merge waits on -
-and the file's own header is an argument against exactly this shape, since it takes each tool's
-mutation *names* from that tool's refusal specifically so no list has to agree with anything.
-The names are enumerated and the tools are not. The nine that are missing each need something
+jobs, level, monitor, registration, registry, sensor-view, vcam and vendor are outside the sweep
+a merge waits on - and the file's own header is an argument against exactly this shape, since it
+takes each tool's mutation *names* from that tool's refusal specifically so no list has to agree
+with anything. The names are enumerated and the tools are not. The ten that are missing each
+need something
 the sweep does not currently arrange - a private server, a GPU browser, a built prefix - so
 wiring them is real work rather than a longer array.
 


### PR DESCRIPTION
Closes #47.

Five contradictions between `CLAUDE.md`, `docs/proof-tools.md` and `docs/measurement.md` and the code they describe, all confirmed against the tree before editing. Both drift checks in the issue came back empty and HEAD was exactly `907b87f`, so every line reference in the issue was live.

Prose only — the three in-scope documents and nothing else. `git diff --name-only 907b87f..HEAD` is exactly `CLAUDE.md`, `docs/measurement.md`, `docs/proof-tools.md`.

**One departure from the issue, and it is the interesting one: the self-spawning list is six, not five.** The issue named five and I took the list from the code rather than from the issue. `monitor-check` accepts no `--url` at all, defaults `--port` to 8341, and spawns `server/index.js` at `tools/monitor-check.mjs:255` — the same shape as guard, level and vcam, and its documented invocation is a bare `node tools/monitor-check.mjs`. Writing "five" would have shipped a fresh false universal into the one file this issue exists to de-drift. `sensor-view-check` turned up as a seventh case of a different kind and is named separately: it takes `--url` against a running server for most of its run and spawns a private one on 8131 for the section needing its own capture.

```
grep -n -B2 "server/index.js'" tools/*-check.mjs | grep spawn   # library, guard, vcam, level, jobs, sensor-view, monitor
grep -n "flag('--url'" tools/*-check.mjs                        # sensor-view is in both lists; monitor is in neither
```

## What changed, and what each one cost

**`CLAUDE.md`: the self-spawning census is now a census.** The section opener claimed each tool takes a running server, which is false for ten of the eighteen and dangerous for six. `jobs-check` was outside the self-spawning list entirely, so a leaked listener on 8231 goes unlooked-for, and `startServer`'s readiness poll returns as soon as *anything* answers `GET /library/takes` — the stale process's jobs directory then answers every assertion and the run is green having proved nothing. All six are now named with their default ports (`guard-check` 8321, `jobs-check` 8231, `level-check` 8377, `monitor-check` 8341, `vcam-check` 8361, `library-check` across its declared span), and the sentence says only `library-check` asks the kernel first, which is what makes the `pgrep` line below it the check everywhere else.

The ten is enumerated rather than recalled: eighteen proof tools, of which six spawn a server, four need none at all (`vendor`, `registration`, `syntax`, `release-gate`), and the remaining eight take one on `--url`.

**`docs/proof-tools.md`: `release-gate-check` joins the exit-code census.** It was in none of the three buckets, while its own header follows `vendor-check` — a catch is exit 0 with the assertion count, exit 1 is `NOT CAUGHT` — so an agent who looked it up and gave up fell back on the majority reading, which turns a genuine miss into a recorded catch for exactly this tool. The split now reads 7/4/4. Two consequential edits came with it: "these three" became "these four", and "the inverted pair", left over from when that group was two, became "the inverting group".

**The fifteen-versus-fourteen gap is explained rather than left open.** The census now covers fifteen tools while the Mutations section says fourteen, and an unexplained discrepancy between two adjacent numbers is what invites the next reader to "fix" the correct one. The added paragraph names the mechanism: the fourteen counts mutations delivered as a served page or a rebuilt tree, and `release-gate-check`'s three arrive as a whole `.npmrc` written into a scratch directory npm is then asked to resolve from, so there is no source text to match and nothing for the match-exactly-once refusal to be about. It says explicitly not to reconcile the two numbers, and why closing it either way loses something.

**The sweep paragraph counted nine against thirteen.** Four driven plus nine outside is thirteen, not fourteen — the lost name was `level`, so nothing in the repository said `level-check` was outside the sweep a merge waits on. Added in place, nine is now ten, and the paragraph's closing argument is untouched because it is right.

**`jobs-check`'s "all five are queue semantics" was twelve.** The reasoning survived intact, so the number is gone rather than corrected to twelve, which would be wrong again at the next mutation — the sentence was already wrong once for exactly that reason. It now says to take the names from the tool's own refusal, which is what `sweep-all` already does for the same reason. What the stale count bought was seven falsification controls left unrun by somebody who believed it.

**`docs/measurement.md` named a counter that does not exist.** `globalThis.__raf` appears nowhere in the repository; the identifier `editor-check` installs is `globalThis.__orbitFrames`, at `tools/editor-check.mjs:2856` and read back at 2952 and 2963 beside `navigationRedraws`. Somebody reusing the recipe greps, finds nothing, and does one of the two things the surrounding paragraph exists to forbid — a second `requestAnimationFrame` chain competing for the frames it is counting, or the 4-frames-a-second measurement of the driver that the paragraph above already warns about.

## Verification

`npm install` and `npm test` both exit 0. `node tools/syntax-check.mjs` prints `0 failed`, `tools/  all 28 named in CLAUDE.md` and `docs/   all 3 cited pages exist`.

**The falsification control, run in the trap-guarded form:**

```
bash -c 'trap "mv -f docs/.instruments.md.aside docs/instruments.md 2>/dev/null" EXIT INT TERM
         mv docs/instruments.md docs/.instruments.md.aside && node tools/syntax-check.mjs'
```

Exit 1 with **exactly one** failed assertion — `FAIL  docs/instruments.md is cited but does not exist` — the `docs/   all N cited pages exist` row absent, and the parse rows plus `tools/  all 28 named in CLAUDE.md` still green. One failed assertion and a non-zero exit is a catch rather than a crash, which is the reading the rule asks for. Restore checked rather than assumed: `git status --short docs/instruments.md` empty, `ls docs/.instruments.md.aside` fails, plain `syntax-check` green again.

Identifier check, the one correction machine-checkable without a new instrument: `grep -rn "__raf" tools/ web/ server/ docs/` returns nothing and exits 1; `__orbitFrames` hits in both `docs/measurement.md` and `tools/editor-check.mjs`.

**What that proves and what it does not.** The control proves the three documents are reachable and cited. It says nothing about whether a sentence inside one of them is true, which is why these five could contradict the code across a merge without anything noticing — and why the sixth self-spawning tool went unrecorded in a list that had been read many times. No mutation was written for the other four, because a mutation that plants a wrong number and asserts a `grep` finds it is an instrument testing its own fixture.

## One thing found in passing, not fixed

`tools/release-gate-check.mjs:70` says its mutations are "served from a copy of the repo". The code writes a scratch directory holding nothing but the `.npmrc` under test, and only asks from the repo itself when unmutated. The new paragraph in `docs/proof-tools.md` describes what the code does rather than what that comment says. The tool is out of scope here and correct as it stands — the comment is a one-line correction for whoever next edits that file.

## Deferred, and named in the issue

- `sweep-all` deriving `TOOLS` from the directory the way it already derives mutation names, with `--mutate tool-outside-the-list` as its control. Same class as #20.
- `jobs-check` gaining `library-check`'s up-front port refusal, by lifting `portHeld`/`reservePorts` into something both call. Documenting the port narrows that window; it does not close it. `monitor-check`, `level-check`, `guard-check` and `vcam-check` want the same thing, which is now five callers for one implementation rather than four.

The category stays open until something enforces a documented count against the code it counts — and the sixth tool this PR found is the argument for that follow-up, since the list was wrong in the issue that set out to correct it.