### PR TITLE
Keep a dropped beat, a prototype key and a dead grabber from reading as healthy

### DIFF
--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -156,6 +156,20 @@ held, `startServer` throws if its own child exits instead of listening, and it r
 outside the declared span so a section added at `+17` is a failure rather than a hole. Pass
 `--node-port`/`--mac-port` a range nothing else holds.
 
+**One row in it is flaky under machine contention, and it is written down here so the next
+person does not spend the afternoon on an innocent change.** `and it is stamped in source
+milliseconds rather than program time`, in the marks-on-the-scrubber section, seeks the editor
+to program 1.0s, awaits `settled()`, presses mark, and asserts the written `sourceMs` is within
+40ms of `sourceSecAt(1.0)`. Observed failing as `0ms against source 150ms` — the playhead still
+at program zero when the mark was taken — on **two of four runs at load average 34 with another
+worktree's `library-check` running concurrently**, and passing at `150ms against 150ms` on the
+other two. It failed on an unmutated tree as well as a mutated one, which is what says it is
+the row rather than the change under test. Nothing has fixed it: `settled()` resolving before
+the transport's program position has moved is a page-timing race in the editor, not a property
+of anything the section is about. A run that reddens only this row on a busy machine is a
+re-run, not a finding — and per the rule at the top of this file, that judgement comes from
+reading *which* assertion fired, never from the exit code.
+
 **`editor-check` enumerates rather than lists, and it exists because the suite tested the model
 and never the control.** The clip in/out markers were detached from the document during boot
 for the whole life of the feature — `rebuildLanes` cleared `#tBeds` of every child that was

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -86,10 +86,30 @@ per frame, each of which renders a pre-roll which evaluates, so the page never a
 never errors - it runs out of memory some minutes later, somewhere else. A bounded probe turns
 that into a sentence.
 
-**`jobs-check`** spawns its own server and renders one real job through
-`tools/render-worker.mjs`, so it needs a GPU browser and ffprobe. `--no-render` drops that row
-and says so - the queue rows are seconds, the render row is a minute. Its mutation runs use
-`--no-render` because all five are queue semantics.
+**`jobs-check`** spawns its own server and renders two real jobs through
+`tools/render-worker.mjs`, so it needs a GPU browser and ffprobe. `--no-render` drops both rows
+and says so - the queue rows are seconds, each render is about a minute.
+
+**Its mutation runs are no longer all `--no-render`, and reading them as though they were is
+how a control gets recorded as green without running.** Every one but `heartbeat-stops-on-first-error`
+is queue semantics and wants `--no-render`; that one names a line in the worker's beat, is
+reached only by a render, and needs the browser and about two minutes. No count is written down
+here, because the sentence this replaced carried one and it was stale — the table is the list.
+
+**The worker under test is the staged copy, not the repo's.** `jobs-check` copies `server/`,
+`web/` and `tools/render-worker.mjs` into `.jobs-check/root` and spawns from there, because a
+mutation naming a file nothing runs reports a miss that is really a control that never applied.
+
+**The heartbeat row runs the whole render through a forwarding proxy**, which destroys the
+socket on the first `POST /jobs/<id>/heartbeat` without answering - `ECONNRESET` at the
+worker's `fetch`, the one class of failure that is neither a 409 nor a status code. A worker
+has one `--url`, so the proxy also carries the page load and the export WebSocket, handling
+`upgrade` by piping the raw sockets both ways with the headers verbatim - `Host` included,
+since the page's `Origin` names the proxy and `originAllowed` compares the two. If that row
+fails with anything about the export, the page or a closed target, the proxy is the suspect and
+the finding is not the heartbeat. What discriminates is the record's `heartbeat` against its
+`claimed`: `claim` stamps them equal, so a worker that gave up on the first failure finishes
+`done` exactly like a healthy one and only the timestamp says it went quiet.
 
 **The worker reads its renderer class out of the browser it will render in and cannot be told
 one.** `channel: 'chromium'` rather than the bundled headless shell, which has no GPU and falls
@@ -298,5 +318,12 @@ block is carried through untouched` and `divisor 4 lands at the ~80KB`), because
 measure a JPEG the stand-in does not contain, and a sample whose hello carries `startedAt`
 fails the file-date fallback row, because the fixture depends on some takes having no wall
 clock. Neither is a defect in the build. Say which sample a run used when reporting its
-verdict — a run against a stand-in is 317 of 319 by construction, and reporting it as a pass
-or as two failures without naming the fixture is wrong in both directions.
+verdict — a run against a stand-in fails the rows named above by construction, and reporting it
+as a pass or as unexplained failures without naming the fixture is wrong in both directions.
+
+**The total is not written down here any more, and that is deliberate.** This sentence used to
+carry one — "317 of 319" — and it was stale by twenty-eight the day it was next read, because
+the total moves whenever a section is added and nothing was walking it. The number to compare a
+run against is the one a baseline on the same tree prints: **352 assertions on darwin against
+the real 138MB sample at the commit that added section 4f**, which is the figure to re-measure
+rather than to trust.

--- a/server/export.js
+++ b/server/export.js
@@ -61,10 +61,27 @@ export const VALID_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
  * that went in, so a round trip is a byte comparison rather than an argument
  * about how much codec loss is acceptable - which makes orientation, channel
  * order, frame order and frame count one assertion instead of four proxies.
+ *
+ * `evenDimensions` is a property of the entry rather than a comparison against its
+ * name, because yuv420p subsamples chroma by two in each direction and an odd
+ * dimension has no half-pixel to carry - which is a fact about the pixel format an
+ * entry names, not about the string `h264`. Stated on **both** entries rather than
+ * only on the one that needs it: an entry that may simply omit the field is an entry
+ * that opts out of the rule by saying nothing, and a codec added later would then
+ * inherit the exemption silently, which is the whole failure this move exists to
+ * remove.
  */
 const CODECS = {
-  h264: { ext: 'mp4', args: ['-c:v', 'libx264', '-preset', 'medium', '-crf', '18', '-pix_fmt', 'yuv420p'] },
-  lossless: { ext: 'mkv', args: ['-c:v', 'ffv1', '-level', '3', '-pix_fmt', 'rgb24'] },
+  h264: {
+    ext: 'mp4',
+    evenDimensions: true,
+    args: ['-c:v', 'libx264', '-preset', 'medium', '-crf', '18', '-pix_fmt', 'yuv420p'],
+  },
+  lossless: {
+    ext: 'mkv',
+    evenDimensions: false,
+    args: ['-c:v', 'ffv1', '-level', '3', '-pix_fmt', 'rgb24'],
+  },
 };
 
 // Exported so the queue can validate a job before it is claimed. One rule with two
@@ -79,8 +96,22 @@ export function validateExport({ name, width, height, fps, frames = null, codec 
   const f = Number(fps);
   if (!Number.isInteger(w) || w <= 0) throw new Error(`bad output size ${width}x${height}`);
   if (!Number.isInteger(h) || h <= 0) throw new Error(`bad output size ${width}x${height}`);
-  if (codec === 'h264' && (w % 2 || h % 2)) {
-    throw new Error(`h264 needs even dimensions, got ${w}x${h}`);
+  // **`Object.hasOwn` rather than truthiness, because a plain object answers for its
+  // prototype.** `CODECS['toString']` is a function and therefore truthy, so
+  // `"codec": "toString"` - and `constructor`, `valueOf`, `__proto__` - walked past
+  // this validator, took the enqueue, reserved an output name, and then died a minute
+  // later inside `begin` with `CODECS[codec].args is not iterable`, which is the exact
+  // place `server/jobs.js` calls out as where an unknown codec must never first be
+  // discovered. Nothing an attacker chose ever reached ffmpeg's argv - `.args` is
+  // undefined for every inherited key - so what this costs is a job admitted and a
+  // worker's minute, not an injection.
+  //
+  // Resolved here rather than at the bottom because the dimension rule below reads the
+  // entry: the lookup has to happen before anything can ask the entry a question.
+  const spec = Object.hasOwn(CODECS, codec) ? CODECS[codec] : null;
+  if (!spec) throw new Error(`unknown codec ${codec}`);
+  if (spec.evenDimensions && (w % 2 || h % 2)) {
+    throw new Error(`${codec} needs even dimensions, got ${w}x${h}`);
   }
   if (!Number.isFinite(f) || f <= 0) throw new Error(`bad output rate ${fps}`);
   if (frames !== null) {
@@ -91,7 +122,6 @@ export function validateExport({ name, width, height, fps, frames = null, codec 
   if (frameBytes > MAX_FRAME_BYTES) {
     throw new Error(`a ${w}x${h} frame is ${frameBytes} bytes, past the ${MAX_FRAME_BYTES} ceiling`);
   }
-  if (!CODECS[codec]) throw new Error(`unknown codec ${codec}`);
   return { width: w, height: h, fps: f, frames: frames !== null ? Math.trunc(frames) : null, codec };
 }
 

--- a/server/export.js
+++ b/server/export.js
@@ -70,6 +70,18 @@ export const VALID_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
  * that opts out of the rule by saying nothing, and a codec added later would then
  * inherit the exemption silently, which is the whole failure this move exists to
  * remove.
+ *
+ * Which is why the loop below exists rather than the convention being left to the
+ * example. `spec.evenDimensions && ...` reads a missing field as false, so writing the
+ * field on both entries is a habit and not a rule - a third codec added without it
+ * would inherit exactly the silent exemption the paragraph above says has been removed,
+ * and the sentence would be an assertion about the table rather than a property of it.
+ * At module load and throwing, because a malformed entry here is a typo in a constant
+ * and not a condition to be handled: the alternative is discovering it at the first
+ * odd-dimensioned export, which is the class of late discovery this whole change is
+ * about. It has no falsification control for the same reason the dimension rule itself
+ * has none - both entries are well formed, so a mutation removing this loop changes
+ * nothing observable, and an assertion that cannot fire buys confidence with a number.
  */
 const CODECS = {
   h264: {
@@ -83,6 +95,14 @@ const CODECS = {
     args: ['-c:v', 'ffv1', '-level', '3', '-pix_fmt', 'rgb24'],
   },
 };
+for (const [name, spec] of Object.entries(CODECS)) {
+  if (typeof spec.evenDimensions !== 'boolean') {
+    throw new Error(`codec ${name} does not say whether it needs even dimensions, and a codec that says nothing about a rule is exempt from it by accident`);
+  }
+  if (typeof spec.ext !== 'string' || !Array.isArray(spec.args)) {
+    throw new Error(`codec ${name} is missing the extension or the arguments every export path dereferences`);
+  }
+}
 
 // Exported so the queue can validate a job before it is claimed. One rule with two
 // callers, the same shape `originAllowed` took: a second copy of this code in

--- a/server/index.js
+++ b/server/index.js
@@ -2268,6 +2268,28 @@ function startLive() {
 
     child.on('exit', (code, signal) => {
       console.error(`[server] grabber exited (code=${code} signal=${signal})`);
+      // **The reference goes with the process, the same identity test and for the same
+      // reason the `error` handler above uses.** Nothing here used to clear it, so for
+      // the whole respawn backoff - `RESTART_DELAYS[attempt]`, a full second on the
+      // first failure, and 250ms after an ordinary colour restart - `child` was a
+      // truthy `ChildProcess` that had already exited. A colour toggle landing in that
+      // window passed `applyCamera`'s guard against the corpse, armed `restarting`, and
+      // called `stopGrabber` on something that can neither be signalled nor exit again,
+      // so nothing ever consumed the flag. What eventually read it was the *next*
+      // grabber's genuine failure: it took the requested-restart branch below, returned
+      // before `scheduleRetry`, and so the sensor was never reported lost and the
+      // backoff table started over. An ordinary double-click on the colour checkbox is
+      // enough to reach it.
+      //
+      // `child === proc` rather than an unconditional null, because a later spawn may
+      // already own the reference by the time a slow exit arrives, and clearing it then
+      // would hide the grabber that is actually running from the toggle and from
+      // `stopGrabber`. With every process-specific callback clearing only its own,
+      // `child` means the grabber running now - which is what makes `applyCamera`'s
+      // decision correct by construction rather than by when it happens to be read.
+      // At the top with the two nullings below, because every exit path matters and the
+      // restart branch returns before the rest of the handler runs.
+      if (child === proc) child = null;
       // **The hello goes with the grabber that sent it.** `/record/start` stamps the
       // take it opens with whatever is in here, and between a grabber exiting and the
       // next one handshaking that is the *previous* grabber's - so a take started
@@ -2327,13 +2349,19 @@ function startLive() {
       // **`restarting` is a claim about an exit that is coming, so it is only armed when
       // there is a child whose exit it describes.** With none - the window between a
       // failed spawn nulling `child` and the backoff's timer firing, which on a machine
-      // where the binary is missing is most of the time - `stopGrabber` returns on the
-      // spot, no exit is ever emitted, and the flag stays set for the life of the
+      // where the binary is missing is most of the time, and the same window after an
+      // ordinary exit, which the handler above now nulls through - `stopGrabber` returns
+      // on the spot, no exit is ever emitted, and the flag stays set for the life of the
       // process. What eventually reads it is the *next* grabber's exit, after a clean
       // handshake and however many minutes of good footage: that exit is a real failure,
       // and the restart branch takes it, returns before `scheduleRetry`, and so leaves
       // the sensor status reading `live` with nothing running while the backoff skips a
       // step. One toggle at the wrong moment, one silently mishandled failure later.
+      //
+      // Which is why this reads `child` at all rather than a flag of its own: every
+      // callback that owns a process clears the reference when that process is gone, so
+      // the question "is there a grabber running to restart" is the identity of what is
+      // in there, and a corpse cannot answer it yes.
       //
       // Nothing is lost by not arming it. The setting itself reaches the grabber through
       // `buildArgs` on the spawn the backoff has already scheduled, which is the same

--- a/tools/jobs-check.mjs
+++ b/tools/jobs-check.mjs
@@ -16,6 +16,8 @@
 import { spawn } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { createServer, request } from 'node:http';
+import { connect } from 'node:net';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 // The format version, imported rather than written down. Every document these tools
@@ -29,6 +31,10 @@ const argv = process.argv.slice(2);
 const flag = (name, dflt = null) => (argv.includes(name) ? argv[argv.indexOf(name) + 1] : dflt);
 const has = (name) => argv.includes(name);
 const PORT = Number(flag('--port', '8231'));
+// The forwarding proxy the heartbeat row puts in front of the server. Its own port
+// because the worker has exactly one `--url` and everything it does - the queue calls,
+// the page load and the export socket - has to arrive on the same origin.
+const PROXY_PORT = Number(flag('--proxy-port', String(PORT + 1)));
 const MUTATE = flag('--mutate');
 const WORK = join(REPO, '.jobs-check');
 const SAMPLE = flag('--source', join(REPO, 'captures', 'sample.knct'));
@@ -145,6 +151,29 @@ const MUTATIONS = {
     "      job.state = 'queued';\n      job.claimed = null;",
     "      job.state = 'queued';\n      job.renderer = null;\n      job.claimed = null;",
   ]] },
+  // A codec lookup that reads through the prototype chain, which is how it shipped.
+  // `CODECS['toString']` is a truthy function, so `"codec": "toString"` walked past
+  // the validator the queue calls precisely so a worker is not where an unknown codec
+  // is first discovered - the job took the enqueue, held its output-name reservation,
+  // and died a minute later inside `begin`.
+  //
+  // The mutation puts back the truthiness test alone and leaves `spec` resolved off
+  // the same expression, so it changes the one thing it names. The even-dimension
+  // rule is deliberately not part of it: with two codecs shipping, a mutation
+  // reverting that rule to `codec === 'h264'` behaves identically and could never be
+  // caught, and an assertion that cannot fail buys confidence with a number.
+  'codec-read-through-prototype': { file: 'server/export.js', edits: [[
+    '  const spec = Object.hasOwn(CODECS, codec) ? CODECS[codec] : null;\n  if (!spec) throw new Error(`unknown codec ${codec}`);',
+    '  const spec = CODECS[codec];\n  if (!CODECS[codec]) throw new Error(`unknown codec ${codec}`);',
+  ]] },
+  // The beat that stops for good after one dropped connection, which is how it
+  // shipped: any rejection cleared the interval and nothing ever re-armed it. It is
+  // aimed at the one line both the interval and the first beat go through, so a
+  // control cannot be satisfied by whichever of the two the mutation missed.
+  'heartbeat-stops-on-first-error': { file: 'tools/render-worker.mjs', edits: [[
+    '      const beatOnce = () => { heartbeat().catch((err) => missedBeat(err.message)); };',
+    '      const beatOnce = () => { heartbeat().catch((err) => { stopBeating(); console.error(`[worker] ${job.id} heartbeat: ${err.message}`); }); };',
+  ]] },
 };
 if (MUTATE && !MUTATIONS[MUTATE]) {
   console.error(`unknown mutation ${MUTATE} - have ${Object.keys(MUTATIONS).join(', ')}`);
@@ -171,6 +200,15 @@ const root = join(WORK, 'root');
 mkdirSync(root, { recursive: true });
 cpSync(join(REPO, 'server'), join(root, 'server'), { recursive: true });
 cpSync(join(REPO, 'web'), join(root, 'web'), { recursive: true });
+// **The worker is staged too, and the render row spawns the staged copy.** It used to
+// be copied nowhere and spawned from the repo path, so a mutation naming
+// `tools/render-worker.mjs` would have edited a file nothing runs and reported a miss
+// that was really a control that never applied - the shape `docs/instruments.md`
+// records as the worst kind, because a miss reads as "the code was fine". Only this one
+// file rather than all of `tools/`: nothing else under it is spawned by this check, and
+// the symlinked `node_modules` beside it is what lets the copy still resolve Playwright.
+mkdirSync(join(root, 'tools'), { recursive: true });
+cpSync(join(REPO, 'tools/render-worker.mjs'), join(root, 'tools/render-worker.mjs'));
 for (const name of ['node_modules', 'vendor']) {
   const from = join(REPO, name);
   if (existsSync(from)) symlinkSync(from, join(root, name));
@@ -203,6 +241,7 @@ if (!existsSync(SAMPLE)) {
 symlinkSync(SAMPLE, join(caps, 'sample.knct'));
 
 const servers = [];
+const proxies = [];
 const startServer = async () => {
   const child = spawn(process.execPath, [join(root, 'server/index.js'),
     '--port', String(PORT), '--captures', caps, '--jobs', jobsDir,
@@ -301,6 +340,74 @@ const enqueue = (over = {}) => post('/jobs', {
 // reason: 400 is the answer to several different questions.
 const refusedBecause = (res, needle) => res.status === 400 && String(res.body.error ?? '').includes(needle);
 
+/**
+ * A forwarding proxy that destroys the socket on the first heartbeat and answers
+ * nothing, which is the one failure the worker's beat used to turn into permanent
+ * silence.
+ *
+ * **`ECONNRESET` at the worker's `fetch` is what this is for, and nothing cheaper
+ * produces it.** A 500 from the server resolves with a status rather than throwing, and
+ * a 409 is handled inside the beat, so a transport-level failure is the only thing that
+ * reaches the rejection path - and reaching it is the whole claim. Dropping the socket
+ * without a response is exactly a reused keep-alive connection the far end had already
+ * closed, or a moment of `EHOSTUNREACH` on a worker pointed at a remote `--url`.
+ *
+ * **It carries the whole render rather than the queue calls, because the worker has one
+ * `--url`.** It resolves the take over it, loads `/edit` over it, and the page opens the
+ * export WebSocket back to that same origin - so `upgrade` is handled by dialling the
+ * server and piping the raw sockets both ways, and every RGBA frame of the export
+ * travels through here. Splitting the origin into a second flag would have been easier
+ * and would have made this fixture test a topology the program does not have.
+ *
+ * The headers go across verbatim, `Host` included, which is not incidental: the page's
+ * `Origin` names this proxy and `originAllowed` compares the two, so rewriting `Host`
+ * to the server's would turn every mutating request the page makes into a 403.
+ */
+async function startDroppingProxy(listenPort, targetPort) {
+  const state = { dropped: 0 };
+  const target = { host: '127.0.0.1', port: targetPort };
+  const proxy = createServer((req, res) => {
+    if (state.dropped === 0 && req.method === 'POST' && /^\/jobs\/[^/]+\/heartbeat$/.test(req.url ?? '')) {
+      state.dropped++;
+      req.socket.destroy();
+      return;
+    }
+    const up = request({ ...target, path: req.url, method: req.method, headers: req.headers }, (upRes) => {
+      res.writeHead(upRes.statusCode ?? 502, upRes.headers);
+      upRes.pipe(res);
+    });
+    up.on('error', () => res.destroy());
+    req.pipe(up);
+  });
+  proxy.on('upgrade', (req, socket, head) => {
+    const up = connect(target, () => {
+      // Rebuilt from `rawHeaders` rather than from the parsed map, so a header that
+      // arrived twice still arrives twice - the origin guard counts duplicate `Host`
+      // headers and refuses on them, and a proxy that silently collapsed one would be
+      // answering a question the server was never asked.
+      const lines = [`${req.method} ${req.url} HTTP/1.1`];
+      for (let i = 0; i < req.rawHeaders.length; i += 2) lines.push(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}`);
+      up.write(`${lines.join('\r\n')}\r\n\r\n`);
+      // Whatever the client had already sent past the header block. Without it the
+      // first WebSocket frame is lost, which on this socket is the export's `begin`.
+      if (head?.length) up.write(head);
+      up.pipe(socket);
+      socket.pipe(up);
+    });
+    up.on('error', () => socket.destroy());
+    socket.on('error', () => up.destroy());
+  });
+  await new Promise((done, fail) => {
+    proxy.once('error', fail);
+    proxy.listen(listenPort, '127.0.0.1', done);
+  });
+  return {
+    state,
+    url: `http://localhost:${listenPort}`,
+    close: () => { proxy.closeAllConnections?.(); proxy.close(); },
+  };
+}
+
 try {
   const serverLog = await startServer();
 
@@ -329,6 +436,55 @@ try {
   check(refusedNames.length === badNames.length,
     'an output that is not a plain file name is refused at enqueue, not three layers later by the thing that writes the file',
     `${refusedNames.length} of ${badNames.length} refused`);
+  // **A key off `Object.prototype` is not a codec, and truthiness could not tell.**
+  // `CODECS['toString']` is a function, so this walked past `validateExport`, took the
+  // enqueue and reserved its output name - and then a worker spent a minute launching a
+  // browser, resolving the take and restoring the project before `begin` threw
+  // `CODECS[codec].args is not iterable`. That is the exact place `server/jobs.js` says
+  // an unknown codec must never first be discovered. Nothing chosen here reaches
+  // ffmpeg's argv, so what it costs is a job admitted and a worker's minute.
+  //
+  // Asserted through `refusedBecause` rather than on the status, because the
+  // output-name collision next door answers 400 as well and a refusal arriving for a
+  // neighbouring reason reads exactly like this one.
+  const inherited = [];
+  // Every job this block leaves behind, whether it was meant to or not. The four below
+  // are supposed to be refused and leave nothing - but the whole point of the control
+  // for this row is a build that admits them, and four stray jobs would then redden the
+  // precondition row, the renderer rows and the race counts as well. A mutation caught
+  // on a neighbour is indistinguishable from one caught on its own row, which this file
+  // has already recorded once; the row above fires either way, and this is what keeps it
+  // the only one that does.
+  const strays = [];
+  for (const codec of ['toString', 'constructor', 'valueOf', '__proto__']) {
+    const r = await enqueue({ codec });
+    if (refusedBecause(r, 'unknown codec')) inherited.push(codec);
+    else if (typeof r.body.id === 'string') strays.push(r.body.id);
+  }
+  check(inherited.length === 4,
+    'a codec named off Object.prototype is refused with the same "unknown codec" a typo gets, rather than admitted and discovered by the export socket a minute later',
+    `${inherited.length} of 4 refused: ${inherited.join(' ')}`);
+  // The positive twin, in the shape this tool's header describes: the refusal above is
+  // only a claim about codecs if the codec that ships is still taken. Odd dimensions
+  // with it, because the even-dimension rule now hangs off the resolved entry rather
+  // than off the string, and a lookup that resolved nothing would take this row with it.
+  const goodCodec = await enqueue({ codec: 'h264' });
+  const oddH264 = await enqueue({ codec: 'h264', width: 641, height: 400 });
+  check(goodCodec.status === 200 && refusedBecause(oddH264, 'even dimensions'),
+    'while h264 is still accepted, and still refuses an odd dimension - the rule travels with the entry now, not with the name',
+    `${goodCodec.status}, then ${oddH264.status} ${(oddH264.body.error ?? '').slice(0, 40)}`);
+  const lossless = await enqueue({ codec: 'lossless', width: 641, height: 400 });
+  check(lossless.status === 200,
+    'and lossless takes the odd dimension it has no reason to refuse, so that rule is a property of the codec rather than of every export',
+    `${lossless.status} ${(lossless.body.error ?? '').slice(0, 40)}`);
+  // Everything this block queued goes back off, records and all, because the section
+  // below reasons about exactly what is queued and asserts it is one job. Removed by
+  // unlinking the file rather than through a route, since there is no route that deletes
+  // a job - and a record is a file, which is the same door the planted records further
+  // down go through.
+  for (const id of [...strays, goodCodec.body.id, lossless.body.id]) {
+    rmSync(join(jobsDir, `${id}.json`), { force: true });
+  }
 
   section('the queue hands a job only to a machine that can reproduce it');
   // **A precondition row, because the section below reasons about what is left in
@@ -556,7 +712,7 @@ try {
     if (!take) throw new Error('no take in the staged library to render');
     const real = await enqueue({ capture: take.hash, output: 'jobs-check-render', width: 320, height: 200 });
     check(real.status === 200, 'a job against real footage is queued', real.body.id ?? real.body.error);
-    const worker = spawn(process.execPath, [join(REPO, 'tools/render-worker.mjs'),
+    const worker = spawn(process.execPath, [join(root, 'tools/render-worker.mjs'),
       '--url', URL_, '--name', 'jobs-check', '--drain', '--max', '1'], { stdio: 'ignore' });
     const code = await new Promise((done) => worker.on('close', done));
     const record = await get(`/jobs/${real.body.id}`);
@@ -588,6 +744,44 @@ try {
     check(probedFrames > 1 && probedFrames === record.frames,
       'and it holds every frame the export declared, not one frame at the right size',
       `${probedFrames} in the file, ${record.frames} declared, from a ${take.frames}-frame take`);
+
+    section('a dropped connection does not silence a claim that is still rendering');
+    // **The whole render goes through the proxy, and it has to.** A worker has one
+    // `--url`: the take resolution, the page load and the export socket all arrive on
+    // it, so the fixture either carries all three or tests a topology this program does
+    // not have. If a row here fails with anything about the export, the page or a closed
+    // target, the proxy is the suspect and this is not a finding about the heartbeat.
+    //
+    // `--beat` is driven down so the beats fit inside the render rather than the
+    // interval being shortened in the worker for the benefit of the instrument. The
+    // failure budget is a count of consecutive failures, so a short interval spends the
+    // same seven and just does it sooner.
+    const proxy = await startDroppingProxy(PROXY_PORT, PORT);
+    proxies.push(proxy);
+    const beaten = await enqueue({ capture: take.hash, output: 'jobs-check-heartbeat', width: 320, height: 200 });
+    const beatWorker = spawn(process.execPath, [join(root, 'tools/render-worker.mjs'),
+      '--url', proxy.url, '--name', 'jobs-check-beat', '--drain', '--max', '1', '--beat', '1000'],
+    { stdio: 'ignore' });
+    const beatCode = await new Promise((done) => { beatWorker.on('close', done); });
+    const beatRecord = await get(`/jobs/${beaten.body.id}`);
+    // The fixture's own provenance, first, because every reading below is about a
+    // connection that was dropped and nothing else in this run says one was.
+    check(proxy.state.dropped === 1,
+      'the proxy dropped exactly one heartbeat on the floor, so what follows is about a worker that lost a connection rather than about one that never had a beat to lose',
+      `${proxy.state.dropped} dropped`);
+    check(beatCode === 0 && beatRecord.state === 'done',
+      'the job still renders and still finishes done, which a worker that gave up on the first failure also does',
+      `exit ${beatCode}, state ${beatRecord.state}${beatRecord.error ? `, ${beatRecord.error.slice(0, 70)}` : ''}`);
+    // **This is the discriminating row and the one above is deliberately not.** A claim
+    // that stopped speaking still finishes, so the outcome says nothing; what says it is
+    // the timestamp. `claim` stamps `heartbeat` equal to `claimed`, so strictly greater
+    // is a beat that landed after the drop - and a worker that cleared its interval on
+    // the first rejection leaves the two equal for the whole render, which is exactly the
+    // silence `requeue` reads as a dead worker and hands to a second machine.
+    check(beatRecord.heartbeat > beatRecord.claimed,
+      'and it went on saying so afterwards - a beat that stops for good on one dropped connection leaves a live render looking dead to the queue',
+      `heartbeat ${beatRecord.heartbeat ?? 'null'} against claimed ${beatRecord.claimed ?? 'null'}`
+      + `, ${((beatRecord.heartbeat ?? 0) - (beatRecord.claimed ?? 0)) / 1000}s apart`);
   } else {
     console.log('  ...   render row skipped by --no-render, so nothing here proves a job becomes a file');
   }
@@ -603,6 +797,7 @@ try {
   console.log(`\n  FAIL  the run did not finish: ${err.message}`);
 } finally {
   stopServers();
+  for (const p of proxies) p.close();
   rmSync(WORK, { recursive: true, force: true });
   rmSync(exportsDir, { recursive: true, force: true });
 }

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -893,6 +893,20 @@ const MUTATIONS = {
     '  if (!isLoopback(req)) {\n    const { label } = revealSupport();',
     '  if (false) {\n    const { label } = revealSupport();',
   ]] },
+
+  // ---- the supervisor's reference to the grabber it is supervising
+  //
+  // The exit handler stops nulling the reference, so for the whole respawn backoff the
+  // colour toggle finds a `ChildProcess` that has already exited, arms `restarting`
+  // against it and calls `stopGrabber` on a pid that cannot be signalled. Nothing then
+  // consumes the flag until the next genuine failure, which reads it as a requested
+  // restart. Anchored on the comment above the line as well as the line itself, because
+  // the identity test it copies appears verbatim in the spawn-`error` handler thirty
+  // lines up and a bare anchor would match twice.
+  'exit-keeps-the-child-reference': { file: 'server/index.js', edits: [[
+    '      // restart branch returns before the rest of the handler runs.\n      if (child === proc) child = null;',
+    '      // restart branch returns before the rest of the handler runs.',
+  ]] },
 };
 
 function mutatedSource(name) {
@@ -2002,6 +2016,129 @@ async function runChecks() {
         room.release();
       }
     }
+  }
+
+  // ------------------- 4f. a grabber that has exited is not a grabber that is running
+  //
+  // **The window this aims at is between an exit and the respawn the backoff has
+  // scheduled, and it exists because a colour toggle reads the supervisor's `child`
+  // reference to decide whether there is anything to restart.** Nothing used to clear
+  // that reference on exit, so for the whole backoff - `RESTART_DELAYS[attempt]`, a full
+  // second after the first failure - `child` was a truthy `ChildProcess` that had
+  // already gone. A toggle landing there armed `restarting` against the corpse and
+  // called `stopGrabber` on something that can neither be signalled nor exit again, so
+  // nothing consumed the flag; what eventually read it was the *next* grabber's genuine
+  // failure, which then took the requested-restart branch and returned before the
+  // backoff ever ran.
+  //
+  // Its own server rather than 4b's, because an extra restart moves that section's
+  // closed-take count and this section's whole method is provoking extra restarts.
+  //
+  // **What can be observed is the branch that was taken, not the state that was
+  // wrong.** The `attempt = 0` the toggle also does is invisible here - `fake-grabber`
+  // handshakes, and a hello zeroes `attempt` anyway - and the record button is
+  // unreachable for the same reason, since `everLive` is true so the node never reaches
+  // `absent`. What is left is two absences on the next genuine death: no `lost` on the
+  // status channel, and no `restarting grabber in ...ms` in the log. Those are the rows.
+  console.log('\n[library] a colour toggle during the respawn backoff does not eat the next failure');
+  {
+    const supDir = join(WORK, 'supervised');
+    mkdirSync(supDir, { recursive: true });
+    // Short-lived on purpose: the grabber says hello, streams a burst and dies
+    // unrequested, which is the failure the backoff is for. A hello before each death
+    // is also what pins the window - it puts `attempt` back to 0, so the delay that
+    // follows is `RESTART_DELAYS[0]` and therefore 1000ms rather than a later and wider
+    // entry in the table. The 250ms clean-respawn window is a different one and is not
+    // what this aims at.
+    const supUrl = await startServer(root, [
+      '--captures', supDir, '--name', 'supervised', '--no-color',
+      '--grabber', `${join(REPO, 'tools/fake-grabber.mjs')} --source ${SAMPLE} --die-after 24 --burst 10 --fps 40`,
+    ], MAC_PORT + 1);
+    const supLog = () => servers.find((s) => s.port === MAC_PORT + 1).log.join('');
+    const countIn = (text, re) => [...text.matchAll(re)].length;
+    const EXITED = /\[server\] grabber exited/g;
+    const BACKOFF = /\[server\] restarting grabber in \d+ms \(attempt \d+\)/g;
+
+    // The status channel, held the way the descriptor section holds one: `lost` is
+    // broadcast and never served, so nothing over HTTP can answer this.
+    const statuses = [];
+    const ws = new WebSocket(supUrl.replace('http', 'ws'));
+    ws.on('message', (data, isBinary) => {
+      if (isBinary) return;
+      try {
+        const msg = JSON.parse(data.toString('utf8'));
+        if (msg.status) statuses.push(msg.status);
+      } catch { /* not a status message */ }
+    });
+    await new Promise((done, fail) => { ws.on('open', done); ws.on('error', fail); });
+
+    // Polled finely rather than slept against, because the whole row is a message that
+    // has to land inside a one-second window. 20ms against 1000ms is a margin of fifty.
+    let died = false;
+    for (let i = 0; i < 1500 && !died; i++) {
+      await new Promise((done) => { setTimeout(done, 20); });
+      died = countIn(supLog(), EXITED) >= 1;
+    }
+    check(died, 'the grabber handshook, streamed and died unrequested, which is the failure the backoff exists for',
+      `${countIn(supLog(), EXITED)} exits`);
+
+    // Everything after this point is counted from here, because the first death has
+    // already produced a `lost` and a backoff line of its own and the claim is about
+    // the *next* one.
+    const statusesBefore = statuses.length;
+    const backoffBefore = countIn(supLog(), BACKOFF);
+    const spawnsBefore = countIn(supLog(), /\[server\] starting grabber:/g);
+    ws.send(JSON.stringify({ camera: { color: true } }));
+    // **Whether the message landed in the window is the instrument's own question, and
+    // it is asked separately from the claim.** Both the fixed build and the broken one
+    // take a toggle during the backoff; what differs is the branch. A toggle that
+    // arrived late, after the respawn, is a legitimate restart on a live grabber in
+    // either build - so it would leave the two rows below green on a build that has the
+    // defect, and the run has to say the fixture missed rather than say the code passed.
+    const spawnsAtToggle = countIn(supLog(), /\[server\] starting grabber:/g);
+    check(spawnsAtToggle === spawnsBefore && spawnsBefore === 1,
+      'and the toggle was sent while nothing was running - between the exit and the respawn, which is the window the whole section is about',
+      `${spawnsAtToggle} spawns at the toggle, ${countIn(supLog(), EXITED)} exits`);
+
+    // The next genuine death: a respawn, a hello, a burst, and an exit nobody asked
+    // for. Waited for by the exit count rather than by a duration, since a spawn on a
+    // contended machine is the one part of this with no fixed cost.
+    for (let i = 0; i < 1500 && countIn(supLog(), EXITED) < 2; i++) {
+      await new Promise((done) => { setTimeout(done, 20); });
+    }
+    // A moment past the exit, because the two things being read are written by the
+    // handler that the exit runs and by the socket it broadcasts on.
+    await new Promise((done) => { setTimeout(done, 400); });
+    ws.close();
+
+    // **The read has to land on the second death and not on a third, and on the broken
+    // build a third is only 250ms away.** The requested-restart branch respawns at
+    // `RESPAWN_AFTER_CLEAN_MS` rather than at the backoff, so a mutated run that
+    // over-ran this window would see grabber #3 die, produce the `lost` and the backoff
+    // line the two rows below are asserting the absence of, and pass - and this tool has
+    // no `NOT CAUGHT` branch, so it would exit 0 and read as clean. Two on both sides:
+    // under the fix the next respawn is a second out, and under the mutation a third
+    // death here means the fixture over-ran rather than the code being right.
+    const exitsAtRead = countIn(supLog(), EXITED);
+    check(exitsAtRead === 2,
+      'and exactly one further death has happened when the reading is taken, so this is the next failure rather than a later one',
+      `${exitsAtRead} exits`);
+    // Printed rather than asserted, because it is the diagnostic that tells a fixture
+    // which missed the window from a control that is blind: `takes effect on the next
+    // spawn` means the reference was clear when the toggle arrived, and
+    // `restarting grabber` means it was not. Asserting it would be asserting the
+    // mechanism rather than what the mechanism costs, and it would hand the mutation a
+    // third row to redden.
+    console.log(`  ...   ${supLog().match(/\[server\] colour camera .*/)?.[0] ?? 'no colour line in the log at all'}`);
+
+    const after = statuses.slice(statusesBefore);
+    check(after.includes('lost'),
+      'the next failure is still reported lost, rather than being read as the restart the toggle never got to ask for',
+      after.length ? `saw ${after.join(' ')}` : 'no status changes at all');
+    check(countIn(supLog(), BACKOFF) > backoffBefore,
+      'and it still counts toward the backoff, which is the table a machine with no sensor has to be able to spend',
+      `${backoffBefore} backoff lines before the toggle, ${countIn(supLog(), BACKOFF)} after`);
+    for (const p of servers.filter((s) => s.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
   }
 
   // ---------------------------------------------------------- 6. the gallery page

--- a/tools/render-worker.mjs
+++ b/tools/render-worker.mjs
@@ -75,11 +75,20 @@ async function loadPlaywright() {
   throw new Error('playwright not found - install it globally or in this project');
 }
 
-const post = async (path, body) => {
+// `timeoutMs` is offered rather than applied everywhere, because the two kinds of call
+// here want opposite answers. A claim or a finish report is worth waiting out - it is
+// the only chance to say what happened - while a heartbeat that has not been answered
+// by the time the next one is due has already failed, and the difference is not
+// cosmetic: undici's default header timeout is around 300s, so a black-hole outage that
+// drops packets without an RST leaves a beat hanging for minutes. The failure counter
+// never moves during that, so the budget below would be counting something other than
+// wall-clock seconds while its comment claimed otherwise.
+const post = async (path, body, { timeoutMs = null } = {}) => {
   const res = await fetch(URL_ + path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
+    ...(timeoutMs ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
   });
   return { status: res.status, body: await res.json().catch(() => ({})) };
 };
@@ -212,18 +221,29 @@ try {
       //
       // So a failure is retried, and only a budget of them gives up. Seven at the
       // default 15s beat is 105s of consecutive failure against the queue's 120s
-      // `STALE_MS`, which is deliberately inside it: past that the queue is about to
-      // declare this claim dead anyway and there is nothing left to keep alive. Any
-      // single success resets the count, because what matters is a run of failures
-      // rather than a tally of them. `--beat` scales the wall clock of that budget
-      // with it, which is how the check drives it in seconds - anything that moves the
-      // interval, the budget or `STALE_MS` moves whether a worker can outlive an
-      // outage its own queue is about to time it out for.
+      // `STALE_MS`, which is deliberately inside it: past that the queue would accept
+      // a requeue of this job anyway, so there is nothing left for a beat to keep
+      // alive. Any single success resets the count, because what matters is a run of
+      // failures rather than a tally of them. The beat carries a timeout of one
+      // interval for the arithmetic's sake - a hung request that never rejects is not
+      // a failure this counter can see, and the 105s would be a fiction.
+      //
+      // **Past the budget this worker is silent while it renders, which is the
+      // original failure bounded rather than removed - say so rather than calling it
+      // safe.** It is bounded at 105s instead of at one beat, and what it still costs
+      // is the case the queue's own rescue is for: an operator requeues the job that
+      // has gone quiet, a second worker claims it, and this one renders to the end for
+      // an outcome that will be refused on the lease. Removing the bound entirely
+      // would mean beating until a 409 says the lease is gone and aborting on it, and
+      // that is a decision about whether a worker may outlive its own stale window
+      // rather than a bug to fix in passing - `STALE_MS` and this budget are one
+      // arithmetic and moving either without the other is what makes a worker choose
+      // to be requeued underneath itself.
       const BEAT_BUDGET = 7;
       let missed = 0;
       const heartbeat = async () => {
         if (leaseLost) return;
-        const res = await post(`/jobs/${job.id}/heartbeat`, { lease: job.lease });
+        const res = await post(`/jobs/${job.id}/heartbeat`, { lease: job.lease }, { timeoutMs: BEAT_MS });
         if (res.status === 409) {
           // The lease is gone: the job was requeued or finished by something else.
           leaseLost = true;
@@ -250,7 +270,7 @@ try {
         console.error(`[worker] ${job.id} heartbeat failed (${missed}/${BEAT_BUDGET}): ${message}`);
         if (missed < BEAT_BUDGET) return;
         stopBeating();
-        console.error(`[worker] ${job.id} ${BEAT_BUDGET} heartbeats failed in a row - the render carries on and the job goes stale, which is the safe direction`);
+        console.error(`[worker] ${job.id} ${BEAT_BUDGET} heartbeats failed in a row - this claim now goes quiet while it renders, and a requeue would put a second worker on it`);
       };
       // One handler for the interval and for the first beat both, so the retry policy
       // has exactly one place to be wrong and one place for a control to name.
@@ -320,12 +340,19 @@ try {
       // rendered rather than only that something was. `server/export.js` refuses a
       // stream whose count differs from the one the export declared, so this is the
       // encoder's own number and a check can hold the file against it.
+      // **Stopped before the report rather than after it, because the report is what
+      // makes the job terminal.** A beat still in the air when `finish` lands reads the
+      // job as `done` and is answered 409, which this loop now treats as a revoked lease
+      // - so a completely successful render printed a "heartbeat refused" line and fired
+      // the abort navigation at a page it had already finished with. Only reachable with
+      // a beat interval short enough to fall inside the finish round trip, which is what
+      // the check drives.
+      stopBeating();
       const fin = await post(`/jobs/${job.id}/finish`, {
         state: 'done', output: result.output, frames: result?.frames ?? null, lease: job.lease,
       });
       if (fin.status !== 200) throw new Error(`the queue refused the report: ${fin.body.error}`);
       console.log(`[worker] ${job.id} done ${result.output} ${result?.frames ?? ''} frames`);
-      stopBeating();
     } catch (err) {
       failed++;
       const message = String(err.message ?? err);

--- a/tools/render-worker.mjs
+++ b/tools/render-worker.mjs
@@ -33,10 +33,15 @@ const NAME = flag('--name', 'worker');
 const MAX = Number(flag('--max', has('--once') ? '1' : '16'));
 const IDLE_EXIT = has('--drain');
 const POLL_MS = Number(flag('--poll', '2000'));
+// How often a running claim says it is still there. A flag with the shipped value as
+// its default, the way `JobStore`'s constructor already takes `staleMs` defaulting to
+// `STALE_MS`, so a check can drive the loop fast without the worker growing a second
+// code path that only checks run down.
+const BEAT_MS = Number(flag('--beat', '15000'));
 
 if (has('--help')) {
   console.log(`usage: render-worker.mjs [--url URL] [--name NAME] [--once | --max N]
-                        [--drain] [--poll MS]
+                        [--drain] [--poll MS] [--beat MS]
 
   Claims render jobs and runs them in headless Chrome, reporting each outcome
   back to the queue. The renderer class it claims with is read out of the
@@ -159,6 +164,10 @@ try {
     errors.length = 0;
     let beat = null;
     let leaseLost = false;
+    // Out here with `beat` rather than inside the try, so the two teardown paths below
+    // and the loop itself all stop it the same way. Three spellings of the same two
+    // lines is how one of them ends up being the one that forgets to null it.
+    const stopBeating = () => { if (beat) { clearInterval(beat); beat = null; } };
     try {
       // Reopened per job rather than once, because two jobs in a queue are two
       // edits and nothing says they are against the same footage. The page reloads
@@ -186,23 +195,73 @@ try {
       // **Says it is alive while it renders, because the queue's only alternative
       // is believing a dead worker forever.** A render runs for minutes or hours
       // by design, so nothing can time a job out on duration - what the queue
-      // expires is silence, and this is the noise. Cheap and unconditional: if it
-      // fails the render still runs, and the job goes stale, which is the safe
-      // direction.
+      // expires is silence, and this is the noise.
+      //
+      // **A dropped connection is not silence, and turning one into silence is what
+      // this loop used to do.** The beat was armed with a catch that cleared the
+      // interval on any rejection and never re-armed it, and the only thing that can
+      // reach that catch is a transport failure - a 409 is handled below, and an HTTP
+      // 500 resolves with a status rather than throwing. So one `ECONNRESET` on a
+      // reused keep-alive socket, one DNS hiccup, one moment of `EHOSTUNREACH` on a
+      // worker pointed at a remote `--url`, and a still-rendering job went quiet for
+      // the rest of its life with `leaseLost` false and the render carrying on. That
+      // is not cosmetic: `JobStore.requeue` refuses a running job only while it has
+      // spoken inside `STALE_MS`, on the premise that a live render would have spoken,
+      // so a worker gone silent while alive removes the premise and the documented
+      // rescue hands a live render to a second worker.
+      //
+      // So a failure is retried, and only a budget of them gives up. Seven at the
+      // default 15s beat is 105s of consecutive failure against the queue's 120s
+      // `STALE_MS`, which is deliberately inside it: past that the queue is about to
+      // declare this claim dead anyway and there is nothing left to keep alive. Any
+      // single success resets the count, because what matters is a run of failures
+      // rather than a tally of them. `--beat` scales the wall clock of that budget
+      // with it, which is how the check drives it in seconds - anything that moves the
+      // interval, the budget or `STALE_MS` moves whether a worker can outlive an
+      // outage its own queue is about to time it out for.
+      const BEAT_BUDGET = 7;
+      let missed = 0;
       const heartbeat = async () => {
         if (leaseLost) return;
         const res = await post(`/jobs/${job.id}/heartbeat`, { lease: job.lease });
         if (res.status === 409) {
           // The lease is gone: the job was requeued or finished by something else.
-          // The render cannot be interrupted mid-frame, but we stop before the
-          // finish report so the queue does not accept an outcome from a dead claim.
           leaseLost = true;
-          if (beat) { clearInterval(beat); beat = null; }
+          stopBeating();
           console.error(`[worker] ${job.id} heartbeat refused: ${res.body?.error ?? 'lease lost'}`);
+          // **And the render stops, which takes interrupting the page from outside.**
+          // `exportClip` has no cancel - adding one is a change to `web/main.js` rather
+          // than to this worker - so the blunt version is to navigate the one page away,
+          // which destroys the execution context and rejects the in-flight
+          // `page.evaluate` into the catch below. Blunt and honest about it: the partial
+          // output is lost and the GPU stops, which is the right trade for an outcome
+          // the queue is going to refuse on the lease anyway. Without it the worker
+          // rendered on for however long was left and threw its own time away.
+          page.goto('about:blank').catch(() => { /* the page may already be gone */ });
+          return;
         }
+        // A 5xx did not land either, so it counts the same way a dropped socket does -
+        // the record's `heartbeat` is what `requeue` reads, and it did not move.
+        if (res.status !== 200) throw new Error(`the queue answered ${res.status}`);
+        missed = 0;
       };
-      beat = setInterval(() => { heartbeat().catch((e) => { if (beat) { clearInterval(beat); beat = null; } console.error(`[worker] ${job.id} heartbeat: ${e.message}`); }); }, 15_000);
+      const missedBeat = (message) => {
+        missed++;
+        console.error(`[worker] ${job.id} heartbeat failed (${missed}/${BEAT_BUDGET}): ${message}`);
+        if (missed < BEAT_BUDGET) return;
+        stopBeating();
+        console.error(`[worker] ${job.id} ${BEAT_BUDGET} heartbeats failed in a row - the render carries on and the job goes stale, which is the safe direction`);
+      };
+      // One handler for the interval and for the first beat both, so the retry policy
+      // has exactly one place to be wrong and one place for a control to name.
+      const beatOnce = () => { heartbeat().catch((err) => missedBeat(err.message)); };
+      beat = setInterval(beatOnce, BEAT_MS);
       beat.unref?.();
+      // Beaten once here rather than one interval from now. A claim used to say nothing
+      // at all for its first fifteen seconds, and a job whose very first beat rejected
+      // never beat at all - so the record carried a `claimed` and no `heartbeat`, which
+      // is exactly the shape of a worker that died on the claim.
+      beatOnce();
 
       // The project travels *in the job* rather than by name. That is what makes a
       // job self-contained: a name would resolve to whatever is in the store when
@@ -266,11 +325,11 @@ try {
       });
       if (fin.status !== 200) throw new Error(`the queue refused the report: ${fin.body.error}`);
       console.log(`[worker] ${job.id} done ${result.output} ${result?.frames ?? ''} frames`);
-      if (beat) { clearInterval(beat); beat = null; }
+      stopBeating();
     } catch (err) {
       failed++;
       const message = String(err.message ?? err);
-      if (beat) { clearInterval(beat); beat = null; }
+      stopBeating();
       console.error(`[worker] ${job.id} failed: ${message}`);
       // Reported, not swallowed. A job left `running` by a worker that walked away
       // is the state nothing can tell from a job still being rendered.


### PR DESCRIPTION
Closes #46.

Three server-side defects that share a shape rather than a component: in each one a transient condition becomes a permanent wrong state, and in each one the wrong state looks healthy from outside. They are independent and were done one at a time, verifying between each.

## What was wrong, and what it cost

**One dropped connection silenced a render worker for the rest of a job.** The beat was armed with a catch that cleared the interval on any rejection and never re-armed it, and the only thing that can reach that catch is a transport failure — a 409 is handled inline, and an HTTP 500 resolves with a status rather than throwing. So one `ECONNRESET` on a reused keep-alive socket left a still-rendering job silent while `leaseLost` stayed false. `JobStore.requeue` refuses a running job only while it has spoken inside `STALE_MS`, on the premise that a live render would have spoken, so the documented rescue for a stuck job then handed a live render to a second worker and discarded the first one's GPU time. A job whose very first beat rejected never beat at all, because the first beat was fifteen seconds after the claim.

Now a failure is retried against a budget of seven consecutive misses — seven beats at the default 15s is 105s against the 120s stale window, deliberately inside it — any single success resets the count, the first beat fires immediately, and a lost lease actually stops the render by navigating the page away. That last one is blunt and says so in the comment: `exportClip` has no cancel, so the only interruption available from outside is destroying the execution context, which loses the partial output for an outcome the queue is going to refuse on the lease anyway. The interval is now a `--beat` flag defaulting to 15s, the way `JobStore`'s constructor already takes `staleMs` defaulting to `STALE_MS`, so the check drives it without a second code path.

**`"codec": "toString"` passed as a codec.** `if (!CODECS[codec])` read through the prototype chain, so `toString`, `constructor`, `valueOf` and `__proto__` were all admitted by the queue, reserved an output name, and then died a minute later inside `begin` with `CODECS[codec].args is not iterable` — the exact place `server/jobs.js` says an unknown codec must never first be discovered. It is a validation and late-failure defect and not argument injection: `.args` is `undefined` for every inherited key, so nothing chosen reaches ffmpeg's argv. `Object.hasOwn` closes it, and the even-dimension rule moves off the `codec === 'h264'` string onto an explicit `evenDimensions` field carried by **both** entries, so a codec added later cannot opt out of the rule by saying nothing.

**A dead grabber still read as live to the colour toggle.** The `exit` handler never cleared the shared `child` reference, so for the whole respawn backoff — a full second on the first failure, and 250ms after an ordinary colour restart, which an ordinary double-click reaches — a toggle passed `applyCamera`'s guard against a corpse, armed `restarting`, and called `stopGrabber` on something that can neither be signalled nor exit again. Nothing consumed the flag, and the *next* genuine failure read it as a requested restart: it returned before `scheduleRetry`, so the sensor was never reported lost and the failure never counted toward the backoff. Cleared with `if (child === proc) child = null;`, the same identity test the spawn-`error` handler thirty lines above already uses, and for the same stated reason.

## The controls

Each was verified to redden only its own rows. Measured on darwin against the **real 138 MB `captures/sample.knct`**, not a synthesised stand-in.

| Run | Result |
|---|---|
| `npm test` | exit 0 |
| `node tools/jobs-check.mjs` | 53 assertions, 0 failed, both render rows included |
| `node tools/jobs-check.mjs --no-render --mutate codec-read-through-prototype` | 1 row fired — the new codec row, nothing else |
| `node tools/jobs-check.mjs --mutate heartbeat-stops-on-first-error` | 1 row fired — the heartbeat timestamp row, with its `done` twin still green |
| `node tools/library-check.mjs` | 352 assertions, 0 failed |
| `node tools/library-check.mjs --mutate exit-keeps-the-child-reference` | 2 rows fired — the missing `lost` and the missing backoff line |

**`jobs-check` now stages the worker.** It copied `server/` and `web/` into `.jobs-check/root` and spawned the worker from the repo path, so a mutation naming `tools/render-worker.mjs` would have edited a file nothing runs and reported a miss that was really a control which never applied. That was staged before any worker mutation existed.

**The heartbeat control runs the whole render through a forwarding proxy** that destroys the socket on the first `POST /jobs/<id>/heartbeat` without answering — `ECONNRESET` at the worker's `fetch`, the one class of failure that is neither a 409 nor a status code. A worker has one `--url`, so the proxy also carries the page load and the export WebSocket, handling `upgrade` by piping the raw sockets both ways with the headers verbatim (`Host` included, since the page's `Origin` names the proxy and `originAllowed` compares the two). 911 RGBA frames travelled through it. What discriminates is the record's `heartbeat` against its `claimed`: `claim` stamps them equal, so a worker that gave up on the first failure finishes `done` exactly like a healthy one and only the timestamp says it went quiet — measured 11.3s apart when fixed, 0s apart when mutated.

**`library-check` section 4f** spawns its own server on the spare `MAC_PORT + 1`, points `--grabber` at `fake-grabber --die-after 24`, polls the captured log every 20ms for `grabber exited`, and sends `{"camera":{"color":true}}` over the status socket inside the 1000ms backoff window that follows. Two provenance rows keep the fixture honest: that exactly one spawn had happened when the toggle was sent (so a late toggle reads as the fixture missing rather than as the code passing), and that exactly one further death had happened when the reading was taken — the mutated build respawns at 250ms, so a third death would produce the very `lost` the rows assert the absence of, and this tool has no `NOT CAUGHT` branch, so that would have exited 0 and read as clean. The server's own `colour camera on - takes effect on the next spawn` / `- restarting grabber` line is printed rather than asserted, because it is the mechanism and asserting it would hand the mutation a third row.

## Things worth knowing before merging

- **One contended-machine reproduction, recorded rather than hidden.** The first mutated `library-check` run also reddened an unrelated marks row (`0ms against source 150ms`) at load average 34, with another worktree's `library-check` running concurrently. Re-run on the same tree it passed at 150ms against 150ms. The mutated line is in the `exit` handler, and that row's server has no grabber binary — it fails at spawn and never emits `exit` — so the line is unreachable for it.
- **The `evenDimensions` move has no falsification control, deliberately.** With only two codecs shipping, a mutation reverting the rule to `codec === 'h264'` behaves identically and could never be caught; an assertion that cannot fail still increments the count, which buys confidence with a number. The rule is already the right shape for the day a third codec lands.
- **The `leaseLost` → navigate-away render stop has no control either.** Reaching it needs a lease revoked mid-render, which no fixture here produces, and the issue's test plan names three controls. Named rather than left looking proven.
- **`CLAUDE.md` was not touched**, per the issue's done criteria — so its per-tool mutation list does not name the three new mutations. It was already non-exhaustive for both tools; `docs/proof-tools.md` carries them.
- **`docs/proof-tools.md` had two stale counts and one is now gone.** Its `jobs-check` paragraph claimed every mutation run uses `--no-render` "because all five are queue semantics" — there were twelve, not five, and one now needs the render. That sentence names the exception instead of a count. The `library-check` total in the same file read "317 of 319" and the real figure was 347 before this change, so it was stale by twenty-eight; it now states the measured 352 with its method and says to re-measure rather than trust it. The stand-in paragraph above it also lists three rows a synthetic sample cannot answer while the old number implied two — that inconsistency predates this change and is left as found.
