### PR TITLE
Compare the webcam's two ends, and give the refusal a subscriber it applies to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,9 @@ node tools/level-check.mjs --mutate pointer-levels-the-centre # ... the press's 
 node tools/level-check.mjs --mutate reset-keeps-roll      # ... and must FAIL mutated
 node tools/vcam-check.mjs                                 # the output to OBS: the colour camera, the take it must not touch, and the source's picture
 node tools/vcam-check.mjs --mutate hd-upscales-registered # ... and must FAIL mutated
+node tools/vcam-check.mjs --mutate hd-reencodes-in-flight # ... the bytes, where the picture is right
 node tools/vcam-check.mjs --mutate hd-reaches-recorder    # ... and must FAIL mutated
+node tools/vcam-check.mjs --mutate refusal-ignores-webcam # ... what the take is told the stream costs
 node tools/guard-check.mjs                                # the socket's origin rule, the bind, and the rebinding rule
 node tools/guard-check.mjs --mutate upgrade-skips-origin  # ... and must FAIL mutated
 node tools/guard-check.mjs --mutate host-accepts-a-name   # ... and must FAIL mutated

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -26,6 +26,35 @@ growth bound. When you write a proof tool, ask what a broken implementation woul
 to still pass it, and close that. **Every proof tool needs a falsification control**:
 something that must FAIL if the thing under test were not actually doing the work.
 
+### The passthrough row that hashed a served part against the set of served parts
+
+`vcam-check` section 2 claimed "the bytes served are the bytes emitted", with a comment above
+it saying in as many words that anything decoding and re-encoding on the way through would fail
+it. It could not. `frame` was taken off the end of `sub.parts`, `jpegHash` was the hash of
+`frame`, and the row then asked whether anything in `sub.parts` hashed to `jpegHash` — which
+`frame` does, being one of them. The other half of the conjunction was `served.length === 64`,
+true of every sha256 hex digest there has ever been. The whole row reduced to "the emit log is
+not empty", and the log was read and then never compared against anything.
+
+The reason it was written that way was real and was even stated in the comment: the emit log's
+third column hashes the whole payload, which for a colour message is a u64 stamp then the JPEG,
+and the stamp moves per frame, so the logged hash can never equal the hash of a served part.
+Faced with two sides that could not be compared, the row hashed one side against itself. **When
+the two ends of a comparison do not share a quantity, make the writer log one — do not hash
+around the problem.** The fix was a fourth column carrying the sha256 of the part body, passed
+in at the call site because the wire layout belongs there and `note` should not have to know
+that type 3 puts a stamp before its JPEG.
+
+`hd-reencodes-in-flight` is the control, and it was written *before* the fix and run against the
+unfixed row on purpose: `[vcam] 22 assertions, 0 failed`, `NOT CAUGHT`, with every row in
+section 2 green including both of the ones that exist to catch it. That output is the finding.
+Two things it taught that generalise. The mutation has to be memoised, because a synchronous
+1920x1080 re-encode per message starves the stream until `a frame was served at all` reddens
+instead — a control that fires for a neighbouring reason is not a control. And its ffmpeg
+fallback means an ffmpeg that failed to run prints NOT CAUGHT too, so what discriminates a real
+catch is the *pair*: NOT CAUGHT against the old row, `caught, as required` against the new one.
+A single run in either direction would not have said which.
+
 ### An A/B where one arm cleans up after the other measures nothing
 
 The version of that failure worth naming separately, because both arms run, both produce a
@@ -518,6 +547,29 @@ user-facing surface should have at least one arm pointed at that surface.** Sect
 browser; `bind-ignores-grid` and `expand-shifts-by-a-block` are one control each, and the
 second exists because the first reddens every row and a control that fails everything cannot
 say which row carries the claim.
+
+**A fourth, and this time the skipped object was a kind of client no tool had ever created.**
+The recorder refuses to start a take while a webcam subscriber is pulling ~50Mbit/s over the
+same radio the depth packets are competing for, and the rule implementing that refusal had no
+arm anywhere in the suite. Not because anybody excluded it — because every proof tool in this
+repo subscribes over `127.0.0.1` to a server started with no `--host`, so `Webcam.isLoopback`
+was true by construction and the filter picking out costing subscribers ran against the empty
+array in every run of every check. Deleting the rule outright would have changed nothing any of
+them observed, and it had in fact already half-happened: the predicate shipped twice, and the
+copy carrying the whole docstring about the exemption being inherited by argument rather than
+measured had no callers at all.
+
+That is the shape worth taking away. The first three skipped objects were things nobody looked
+at; this one was a *state of the system* nobody could reach, because the way every tool
+connects made one branch unreachable. **Ask what your fixtures make impossible, not only what
+your probes omit** — a constant that every arm happens to share is an exclusion nobody wrote
+down. `guard-check` and `monitor-check` had both already solved it for their own claims, by
+widening the server with `--host 0.0.0.0` and connecting over this machine's own non-internal
+IPv4, so the technique was in the repo and simply had not been pointed here. `vcam-check`
+section 6 does that now, with `refusal-ignores-webcam` as the control and an operator accepting
+the cost as the positive twin, since an arm built only out of refusals passes against a server
+that refuses everything. On a machine with no second address it exits 2 as UNPROVEN rather than
+passing, because the arm cannot mean anything there.
 
 ## Close the class, not the instance — and have the check enumerate it
 

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -101,6 +101,29 @@ rather than pinning jobs to.
 (`--no-browser` drops it and says so). It writes takes into its own staged tree, so it never
 touches `captures/`.
 
+**It also needs this machine to have a non-internal IPv4, and exits 2 when it has none.**
+Section 6 is the only arm in the repo that creates a webcam subscriber which is not on
+loopback, and it makes one the way `guard-check` does: a server widened with `--host 0.0.0.0`
+and a subscriber arriving on this machine's own LAN address. Without a second address there is
+nothing the loopback exemption can be asked about, so the run prints `UNPROVEN` naming the
+missing address rather than passing quietly — `guard-check`'s answer to the same condition,
+not `monitor-check`'s, which turns it into a failed assertion. Both exit-2 reasons carry their
+own remedy now, because the verdict line used to append playwright's advice to whatever it was
+given and would have told an operator missing a LAN address to install a browser.
+
+**Its own server-readiness wait is on the sensor rather than on a constant**, and that was a
+bug rather than a nicety. `viewer on` is printed inside `httpServer.listen`'s callback, which
+is before the grabber has been spawned at all, and this grabber reads a 138MB capture and runs
+a 1080p ffmpeg encode first — measured at 3.8 to 4.7 seconds on a loaded Mac and never under a
+second on an idle one, against the 400ms the tool used to allow. Sections 2, 3 and 4 were all
+questioning a server with no sensor behind it, so the endpoint 503'd, no take gathered a frame,
+and every row read as a finding about the webcam. `start()` now polls `/record/state` until
+`webcam.available`, which is the right flag because `server/webcam.js` only ever clears it on a
+hello with colour on, and reads without subscribing — which section 1 needs, since its first
+row is about what happens while nothing is subscribed. That row was the second casualty: it
+passed on an empty emit log, which is as true of a grabber that never started as of one running
+with colour off.
+
 **Its discriminator is geometry rather than resolution, and that is the whole design of the
 tool.** The webcam's claim is that it serves the colour camera and not the registered 512x424
 image the point cloud is textured with — and an implementation that upscaled the registered
@@ -109,9 +132,49 @@ colour camera sees 84.1° where the registered frustum sees 70.6°, so a real co
 content down the sides that no upscale can invent. `fake-grabber --hd` builds the fixture as
 *the registered frame upscaled* plus a magenta left margin and a cyan right one, so a cheating
 implementation matches most of the picture and still fails on the 12% at each edge. Run
-`--mutate hd-upscales-registered` and read which rows fire: the two margin rows and the
-re-encode row, and nothing else. `--mutate hd-reaches-recorder` fires the two rows about the
-take. A control that failed on a neighbouring row would not be a control for the thing it names.
+`--mutate hd-upscales-registered` and read which rows fire: the two margin rows, the
+passthrough row and the re-encode row. `--mutate hd-reaches-recorder` fires the two rows about
+the take, and only those. A control that failed on a neighbouring row would not be a control
+for the thing it names.
+
+**`hd-upscales-registered` reddens neighbouring rows on a contended machine, and that is a
+defect in the control rather than a finding about the code.** It runs a synchronous 1920x1080
+ffmpeg scale on the server's event loop *per colour message*, so the stream starves — measured
+over four runs at load averages 25 to 95, its four named rows fired every time while `and the
+subscriber is actually being served parts` and `the take carries a hello and frames` each fired
+in two of them and neither fired in the other two. Read the four named rows and treat a fifth
+in section 1 or 3 as the harness competing for the machine. Memoising it the way
+`hd-reencodes-in-flight` is memoised would fix the starvation, but not for free: the registered
+image varies across the fixture's 284-frame loop, so a memoised upscale serves one constant
+frame and `and nothing re-encoded it on the way through` would go green — which is a decision
+about what that control is for, not a tidy-up, and it has not been taken here.
+
+**The margins say the picture is right and only the emit log says the bytes are.**
+`--mutate hd-reencodes-in-flight` decodes the colour payload and re-encodes it at the same size
+and a comparable quality, so every geometric row still passes and exactly one fires: `every
+served part is the same JPEG the writer emitted`. It fires because the writer's emit log now
+carries a fourth column, the sha256 of the part body a reader receives, which is what makes
+comparing the two ends possible at all — a colour payload is a u64 stamp then the JPEG, the
+stamp moves per frame, and the row that used to be here hashed a served part against the set of
+served parts and was therefore true whenever a part arrived. Both readers of that log
+destructure positionally and ignore the fourth column, so adding it changed no behaviour; if a
+fifth is ever wanted, that is the moment to give the log a header line instead.
+
+The mutation memoises its re-encode, and that is load-bearing rather than an optimisation: a
+synchronous 1920x1080 re-encode per message starves the stream until `a frame was served at all`
+reddens instead, and a control that fires for a neighbouring reason is not a control. The memo
+costs nothing in fidelity because the fixture's colour payload carries one constant HD frame.
+Its own falsification is the pair: the same mutation printed NOT CAUGHT with 0 failed against
+the row as it stood before, and prints `caught, as required` with 1 failed after — which is
+also what discriminates a real catch from ffmpeg having silently failed, since the mutation
+falls back to the original bytes when it cannot run.
+
+**`--mutate refusal-ignores-webcam`** deletes the webcam clause from
+`consumersCostingTheTake`, leaving the monitors one, and must fire exactly the two section 6
+rows that assert the refusal — never the third, which is the operator accepting the cost, since
+a take that was already permitted stays permitted. Section 1's `a loopback subscriber does not
+refuse the take` is a row that mutation makes *more* true, which is why it could never have
+stood in for the arm that creates a remote one.
 
 **`guard-check`** spawns its own servers and needs none running. It exits 2 when the machine has
 no non-internal IPv4, because "not listening on the network" is only a claim if there is a

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -139,11 +139,12 @@ for the thing it names.
 
 **`hd-upscales-registered` reddens neighbouring rows on a contended machine, and that is a
 defect in the control rather than a finding about the code.** It runs a synchronous 1920x1080
-ffmpeg scale on the server's event loop *per colour message*, so the stream starves — measured
-over four runs at load averages 25 to 95, its four named rows fired every time while `and the
-subscriber is actually being served parts` and `the take carries a hello and frames` each fired
-in two of them and neither fired in the other two. Read the four named rows and treat a fifth
-in section 1 or 3 as the harness competing for the machine. Memoising it the way
+ffmpeg scale on the server's event loop *per colour message*, so the stream starves — over four
+`--no-browser` runs on one Mac spanning one-minute load averages of about 25 to about 95, its
+four named rows fired in all four, `and the subscriber is actually being served parts` fired in
+two, `the take carries a hello and frames` fired in two, and exactly one run showed neither.
+Read the four named rows and treat a fifth in section 1 or 3 as the harness competing for the
+machine. Memoising it the way
 `hd-reencodes-in-flight` is memoised would fix the starvation, but not for free: the registered
 image varies across the fixture's 284-frame loop, so a memoised upscale serves one constant
 frame and `and nothing re-encoded it on the way through` would go green — which is a decision
@@ -175,6 +176,13 @@ rows that assert the refusal — never the third, which is the operator acceptin
 a take that was already permitted stays permitted. Section 1's `a loopback subscriber does not
 refuse the take` is a row that mutation makes *more* true, which is why it could never have
 stood in for the arm that creates a remote one.
+
+**That row is the control for the other direction**, and it was tested rather than reasoned
+about. `Webcam.subscribersCostingTheTake` is written as a filter over `describe()`, so a
+`describe()` that stopped publishing `loopback` would silently make it return every subscriber
+and charge every proof tool in this repo for its own localhost connection. Forcing the rule to
+`return this.describe()` reddens three rows — the section 1 one by name, and the two in section
+3 that need a take to start with a loopback webcam attached.
 
 **`guard-check`** spawns its own servers and needs none running. It exits 2 when the machine has
 no non-internal IPv4, because "not listening on the network" is only a claim if there is a

--- a/server/index.js
+++ b/server/index.js
@@ -1001,12 +1001,18 @@ const shooting = (run) => async (req, res, args, query) => {
  * rather than by somebody remembering this function exists. A cost the refusal cannot
  * see is a cost it silently under-reports, and the only thing the refusal has going
  * for it is that its number is true.
+ *
+ * **Each kind is asked its own rule where that rule is written**, rather than having
+ * it restated here. The webcam's used to be a `!s.loopback` filter on this line, which
+ * left the copy in `server/webcam.js` carrying all of the reasoning and none of the
+ * behaviour - so the interleaved A/B that paragraph is waiting on would have been
+ * acted on in the dead one.
  */
 function consumersCostingTheTake() {
   return [
     ...attachedMonitors().filter(costsTheTake)
       .map((m) => ({ kind: 'monitor', at: `÷${m.divisor} ×${m.stride}` })),
-    ...webcam.describe().filter((s) => !s.loopback)
+    ...webcam.subscribersCostingTheTake()
       .map(() => ({ kind: 'webcam', at: 'the colour camera at full rate' })),
   ];
 }

--- a/server/webcam.js
+++ b/server/webcam.js
@@ -116,7 +116,7 @@ export class Webcam {
   }
 
   /**
-   * Whether the take is paying for this webcam.
+   * The subscribers the take is paying for.
    *
    * **The loopback exemption is inherited by argument here, not by measurement, and
    * that distinction is worth keeping.** The WebSocket monitors' exemption was
@@ -126,9 +126,21 @@ export class Webcam {
    * same pipe, and the same reasoning is not the same measurement. Nothing here reads
    * as if it had been measured; the interleaved A/B for this stream on a capture node
    * has not been run.
+   *
+   * **This is the one place that rule is written**, which is what makes the paragraph
+   * above worth keeping: the recorder's refusal used to repeat the same test inline,
+   * so whoever ran that A/B would have edited the copy carrying the reasoning and
+   * found that nothing happened. It returns the subscribers rather than a boolean so
+   * the refusal can name one consumer per costing subscriber without knowing what
+   * makes one costly.
+   *
+   * Named for the subscribers rather than for the question, because the name that asks
+   * the question outright already belongs to a different rule about a different
+   * consumer - the monitors' divisor and stride test in `server/index.js` - and a
+   * reader should not have to work out which of the two they are looking at.
    */
-  costsTheTake() {
-    return [...this.subscribers].some((s) => !s.loopback);
+  subscribersCostingTheTake() {
+    return this.describe().filter((s) => !s.loopback);
   }
 
   /**

--- a/tools/fake-grabber.mjs
+++ b/tools/fake-grabber.mjs
@@ -177,9 +177,21 @@ process.stderr.write(`[fake-grabber] streaming ${frames.length} looped frames at
 // has logged everything the reader could possibly have received and never less. The
 // other order would let a frame reach the recorder that this file does not vouch
 // for, and the check reading it would report a take carrying a frame nobody emitted.
-const note = (type, payload) => {
+// The fourth column is the hash of the *body* a reader downstream receives, which for
+// a colour message is the JPEG without the stamp in front of it. It exists because the
+// payload hash cannot serve that purpose: the stamp moves per frame, so a check
+// comparing what the webcam served against what this file logged would never find a
+// match and had been hashing served parts against each other instead - an assertion
+// whose two sides came out of the same object, true whenever a part arrived at all.
+//
+// Passed in by the caller rather than sliced out of `payload` here, because the wire
+// layout belongs at the call site: `note` would otherwise have to know that type 3
+// puts a u64 before its JPEG and type 2 does not. Callers with no separate body write
+// a `-`, which has no space in it, so both readers' positional destructuring holds.
+const note = (type, payload, body = null) => {
   if (!EMIT_LOG) return;
-  appendFileSync(EMIT_LOG, `${type} ${payload.length} ${createHash('sha256').update(payload).digest('hex')}\n`);
+  const sha = (b) => createHash('sha256').update(b).digest('hex');
+  appendFileSync(EMIT_LOG, `${type} ${payload.length} ${sha(payload)} ${body ? sha(body) : '-'}\n`);
 };
 
 const encode = () => {
@@ -201,7 +213,9 @@ const encodeHd = () => {
   const payload = Buffer.alloc(8 + hdFrame.length);
   payload.writeBigUInt64LE(BigInt(origin + Math.round((n * 1000) / FPS)), 0);
   hdFrame.copy(payload, 8);
-  note(TYPE_COLOR, payload);
+  // The JPEG on its own as well as the payload, because the JPEG is what the webcam
+  // hands a subscriber and so the only thing the two ends can be compared on.
+  note(TYPE_COLOR, payload, hdFrame);
   return encodeMessage(TYPE_COLOR, payload);
 };
 

--- a/tools/vcam-check.mjs
+++ b/tools/vcam-check.mjs
@@ -25,7 +25,7 @@
 // fail on it. **Dimensions are the convenient probe and the wrong one**: an upscale
 // is 1920x1080 too.
 //
-// The five claims:
+// The six claims:
 //
 //  1. **It is asked for, not always on.** No type 3 crosses the pipe until something
 //     subscribes, because a 1080p JPEG is another ~50Mbit/s down a pipe whose
@@ -45,14 +45,23 @@
 //     drives a browser, because every other arm in this file watches the server and
 //     `monitor-check`'s case file is that four sections which all did that missed a
 //     renderer drawing the wrong thing entirely.
+//  6. **A subscriber whose frames leave the machine is charged to the take**, and one
+//     on loopback is not. Section 6 is the only arm in this repo that creates the
+//     first kind, which is why the rule deciding it had never been tested by anything:
+//     every other check subscribes over `127.0.0.1`, so the filter ran on an empty set
+//     and deleting it would have changed nothing anybody could see.
 //
 //   node tools/vcam-check.mjs
 //   node tools/vcam-check.mjs --mutate hd-upscales-registered   # must FAIL
+//   node tools/vcam-check.mjs --mutate hd-reencodes-in-flight   # must FAIL
 //   node tools/vcam-check.mjs --mutate hd-reaches-recorder      # must FAIL
+//   node tools/vcam-check.mjs --mutate refusal-ignores-webcam   # must FAIL
 //
 // It spawns its own server and needs none running. The stream is
 // `tools/fake-grabber.mjs`, so no sensor is required; ffmpeg builds and decodes the
 // fixture. Section 5 needs a GPU browser and `--no-browser` drops it and says so.
+// Section 6 needs this machine to have a non-internal IPv4, and exits 2 as UNPROVEN
+// rather than passing quietly on one that has none.
 //
 // **What it does not prove is OBS.** That a browser source renders WebGL at 1080p on
 // macOS, and that OBS samples it at canvas rate rather than honouring arrival timing,
@@ -62,6 +71,7 @@
 import { spawn, execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { networkInterfaces } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MessageParser, TYPE_HELLO, TYPE_FRAME, TYPE_COLOR } from '../server/protocol.js';
@@ -85,6 +95,14 @@ const MARGIN = Math.round(1920 * 0.12);
 // channel that distinguishes them, so this is loose enough to survive the codec and
 // nowhere near loose enough to admit the room.
 const COLOUR_TOLERANCE = 40;
+
+// This machine's own address on the network, which is the only way to create a webcam
+// subscriber that is not on loopback - and therefore the only way section 6 can ask
+// the refusal anything. Discovered the way `guard-check` discovers it, and null on a
+// machine that has none, which section 6 turns into an UNPROVEN verdict rather than a
+// quiet pass.
+const LAN = Object.values(networkInterfaces()).flat()
+  .find((i) => i && i.family === 'IPv4' && !i.internal)?.address ?? null;
 
 const MUTATIONS = {
   // **The control for claim 2.** The endpoint serves the registered colour scaled up
@@ -118,6 +136,49 @@ const MUTATIONS = {
     ]],
   },
 
+  // **The other control for claim 2, and the one the section was missing.** The
+  // margins say the picture is the colour camera's; nothing said the *bytes* were.
+  // This mutation decodes the colour payload and re-encodes it at the same size and a
+  // comparable quality, so every geometric row above still passes - same scene, same
+  // frustum, same magenta and cyan down the sides - and only the bytes differ. That is
+  // precisely the implementation `server/webcam.js` says it does not have, and until
+  // this arm existed the passthrough row hashed a served part against the set of
+  // served parts and was true whenever a part arrived at all.
+  //
+  // **Memoised, and the memo is not what is under test.** A synchronous 1920x1080
+  // re-encode per message starves the stream until `a frame was served at all` or `and
+  // the subscriber is actually being served parts` reddens instead, and a control that
+  // fails for a neighbouring reason is not a control for the thing it names. The memo
+  // costs nothing in fidelity here because the fixture's colour payload carries one
+  // constant HD frame, so re-encoding the first is re-encoding every one of them - and
+  // it is what keeps `and nothing re-encoded it on the way through` green, which is how
+  // the reddened row is shown to be the row doing the work.
+  //
+  // Placed at the offer, so the grabber, the negotiation and the recorder are all
+  // untouched and sections 1, 3 and 4 keep passing. If ffmpeg is missing the memo
+  // holds the original bytes, the mutation becomes a no-op and the run says NOT
+  // CAUGHT - loud, which is the only acceptable way for a control to fail to run.
+  'hd-reencodes-in-flight': {
+    file: 'server/index.js',
+    edits: [[
+      'webcam.offer(Buffer.from(msg.payload.subarray(8)), Number(msg.payload.readBigUInt64LE(0)));',
+      'webcam.offer(reencodedColour(Buffer.from(msg.payload.subarray(8))), Number(msg.payload.readBigUInt64LE(0)));',
+    ], [
+      "import { Webcam } from './webcam.js';",
+      "import { Webcam } from './webcam.js';\nimport { execFileSync } from 'node:child_process';\n"
+      + 'let reencodedOnce = null;\n'
+      + 'function reencodedColour(jpeg) {\n'
+      + '  if (reencodedOnce) return reencodedOnce;\n'
+      + '  try {\n'
+      + '    reencodedOnce = execFileSync("ffmpeg", ["-hide_banner", "-loglevel", "error", "-y", "-i", "pipe:0",\n'
+      + '      "-frames:v", "1", "-q:v", "2", "-f", "mjpeg", "pipe:1"],\n'
+      + '      { input: jpeg, maxBuffer: 64 * 1024 * 1024 });\n'
+      + '  } catch { reencodedOnce = jpeg; }\n'
+      + '  return reencodedOnce;\n'
+      + '}',
+    ]],
+  },
+
   // **The control for claim 3, and the one that would destroy footage.** The colour
   // message reaches the recorder, so a take carries a third message type - which
   // moves its content hash, the key the library joins two machines on, and puts a
@@ -131,6 +192,24 @@ const MUTATIONS = {
       'webcam.offer(Buffer.from(msg.payload.subarray(8)), Number(msg.payload.readBigUInt64LE(0)));',
       'webcam.offer(Buffer.from(msg.payload.subarray(8)), Number(msg.payload.readBigUInt64LE(0)));\n'
       + '    recorder.write(msg.raw);',
+    ]],
+  },
+
+  // **The control for claim 6.** The refusal keeps its monitors clause and loses its
+  // webcam one, so a take starts while somebody is pulling ~50Mbit/s of MJPEG over the
+  // same radio the depth packets are competing for - which is the whole cost the
+  // refusal exists to state, going unstated.
+  //
+  // It has to be reddened by section 6 and by nothing else. Sections 2, 3 and 4 never
+  // ask the recorder what a take would cost, and section 1's `a loopback subscriber
+  // does not refuse the take` is a row this mutation makes *more* true rather than
+  // less - which is exactly why that row could never have stood in for this one.
+  'refusal-ignores-webcam': {
+    file: 'server/index.js',
+    edits: [[
+      "\n    ...webcam.subscribersCostingTheTake()\n"
+      + "      .map(() => ({ kind: 'webcam', at: 'the colour camera at full rate' })),",
+      '',
     ]],
   },
 };
@@ -174,7 +253,12 @@ if (MUTATE) {
 
 // --- harness ---------------------------------------------------------------
 let checked = 0, failed = 0;
-let untested = null;
+// Claims this machine could not be asked, each carrying its own remedy. A list rather
+// than one string because two different absences reach here now - no browser and no
+// second address - and the verdict line used to append playwright's advice to
+// whatever it was given, which would have told an operator missing a LAN address to
+// go and install playwright.
+const untested = [];
 let crashed = null;
 const ok = (label, pass, detail = '') => {
   checked++;
@@ -183,26 +267,67 @@ const ok = (label, pass, detail = '') => {
 };
 
 const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (cond, ms, what = 'condition') => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    if (await cond()) return true;
+    await wait(50);
+  }
+  throw new Error(`timed out after ${ms}ms waiting for ${what}`);
+};
 const servers = [];
 const EMIT_LOG = join(WORK, 'emitted.log');
 
-const start = (extra = []) => new Promise((resolve, reject) => {
-  const grabber = `${join(WORK, 'tools/fake-grabber.mjs')} --source ${SOURCE} --fps 30 --hd `
-    + `--emit-log ${EMIT_LOG}`;
-  const child = spawn(process.execPath, [
-    join(WORK, 'server/index.js'), '--port', String(PORT),
-    '--captures', join(WORK, 'takes'), '--grabber', grabber, ...extra,
-  ], { stdio: ['ignore', 'pipe', 'pipe'] });
-  servers.push(child);
-  const log = [];
-  const onData = (c) => {
-    log.push(c.toString());
-    if (log.join('').includes('viewer on')) setTimeout(() => resolve(() => log.join('')), 400);
-  };
-  child.stdout.on('data', onData);
-  child.stderr.on('data', onData);
-  setTimeout(() => reject(new Error(`server never came up:\n${log.join('')}`)), 15000);
-});
+/**
+ * Bring a server up and wait until there is a sensor behind it.
+ *
+ * **The wait is on the resource rather than on a constant, and that is a fix rather
+ * than a tidy-up.** `viewer on` is printed inside `httpServer.listen`'s callback,
+ * which is *before* `startLive` has spawned the grabber - and this grabber reads a
+ * 138MB capture and runs a 1080p ffmpeg encode before its hello arrives, measured at
+ * 3.8 to 4.7 seconds on a loaded machine and never under a second on an idle one. The
+ * constant this replaced was 400ms, so sections 2, 3 and 4 were all asking their
+ * questions of a server that had no sensor yet: the endpoint answered 503, no take
+ * gathered a frame, and every row read as a finding about the webcam.
+ *
+ * `webcam.available` is the right predicate because of what `server/webcam.js` spends
+ * a paragraph on: `unavailable` asks whether there is a colour camera to serve and
+ * never whether a frame has arrived, so a hello with colour on clears it once and it
+ * stays clear. It is also readable without subscribing, which section 1 needs, since
+ * its first row is about what happens while nothing is subscribed.
+ *
+ * That row is the other thing this closes. It used to pass whenever the emit log was
+ * empty, which is just as true of a grabber that had not started as of one that was
+ * running with colour off - the right answer and the wrong one setting the same flag.
+ * Behind this gate the grabber is provably up, so "no colour message" is provably a
+ * decision rather than an absence.
+ *
+ * A timeout throws, which lands in the catch below and exits 2 as DID NOT RUN. Under
+ * `--mutate` that distinction is the whole point: a harness that never got a sensor
+ * would otherwise be written down as the mutation being caught.
+ */
+const start = async (extra = []) => {
+  const log = await new Promise((resolve, reject) => {
+    const grabber = `${join(WORK, 'tools/fake-grabber.mjs')} --source ${SOURCE} --fps 30 --hd `
+      + `--emit-log ${EMIT_LOG}`;
+    const child = spawn(process.execPath, [
+      join(WORK, 'server/index.js'), '--port', String(PORT),
+      '--captures', join(WORK, 'takes'), '--grabber', grabber, ...extra,
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    servers.push(child);
+    const lines = [];
+    const onData = (c) => {
+      lines.push(c.toString());
+      if (lines.join('').includes('viewer on')) resolve(() => lines.join(''));
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    setTimeout(() => reject(new Error(`server never came up:\n${lines.join('')}`)), 15000);
+  });
+  await waitFor(async () => (await api('/record/state')).body?.webcam?.available === true,
+    25000, 'the grabber to handshake and offer a colour camera');
+  return log;
+};
 const stopAll = async () => {
   for (const c of servers) c.kill('SIGKILL');
   servers.length = 0;
@@ -226,9 +351,9 @@ const post = (path, body = {}) => api(path, {
  * being checked includes the framing: a part whose declared length disagrees with its
  * body is a stream OBS would resynchronise through and this would not notice.
  */
-function subscribe() {
+function subscribe(host = '127.0.0.1') {
   const state = { parts: [], done: false, controller: new AbortController() };
-  state.ready = fetch(`http://127.0.0.1:${PORT}/camera.mjpg`, { signal: state.controller.signal })
+  state.ready = fetch(`http://${host}:${PORT}/camera.mjpg`, { signal: state.controller.signal })
     .then(async (res) => {
       state.status = res.status;
       if (res.status !== 200) { state.done = true; return state; }
@@ -261,16 +386,24 @@ function subscribe() {
   return state;
 }
 
-/** What the writer says it emitted, as `type -> [sha256]`. */
+/**
+ * What the writer says it emitted, as `type -> [{ hash, body }]`.
+ *
+ * `hash` is the whole payload; `body` is the part body a reader downstream receives, or
+ * null where the two are the same thing. The distinction is the reason this returns
+ * records rather than the bare payload hashes it used to: a colour payload is the u64
+ * stamp then the JPEG, the stamp moves per frame, and the JPEG is the only part of it
+ * that ever reaches a subscriber.
+ */
 function emitted() {
   if (!existsSync(EMIT_LOG)) return new Map();
   const out = new Map();
   for (const line of readFileSync(EMIT_LOG, 'utf8').split('\n')) {
     if (!line) continue;
-    const [type, , hash] = line.split(' ');
+    const [type, , hash, body] = line.split(' ');
     const key = Number(type);
     if (!out.has(key)) out.set(key, []);
-    out.get(key).push(hash);
+    out.get(key).push({ hash, body: body && body !== '-' ? body : null });
   }
   return out;
 }
@@ -363,17 +496,21 @@ try {
       // Passthrough: the bytes served are the bytes emitted. Anything that decoded
       // and re-encoded on the way through would fail this while still passing the
       // margin rows above.
-      const served = createHash('sha256').update(Buffer.concat([
-        Buffer.alloc(8), frame,
-      ])).digest('hex');
-      const log = emitted().get(TYPE_COLOR) ?? [];
-      // The writer logs the whole payload, which is the u64 stamp then the JPEG. The
-      // stamp moves per frame, so what is comparable is the JPEG - hashed here the
-      // same way for every candidate rather than assuming which frame this was.
-      const jpegHash = createHash('sha256').update(frame).digest('hex');
-      const anyMatch = log.length > 0 && sub.parts.some((p) => createHash('sha256').update(p).digest('hex') === jpegHash);
-      ok('every served part is the same JPEG the writer emitted', anyMatch && served.length === 64,
-        `${log.length} emitted, ${sub.parts.length} served`);
+      //
+      // **Against the writer's own log rather than against the other served parts.**
+      // The version this replaced hashed a part taken off `sub.parts` and then asked
+      // whether anything in `sub.parts` hashed to it, so it was satisfied by that part
+      // itself and reduced to "a part arrived" - and `--mutate hd-reencodes-in-flight`
+      // sailed through the whole section. The writer now logs each colour message's
+      // JPEG on its own, which is what makes the comparison possible at all: the
+      // payload carries a u64 stamp that moves per frame, so the payload hash can
+      // never equal the hash of anything a subscriber received.
+      const emittedBodies = new Set((emitted().get(TYPE_COLOR) ?? []).map((e) => e.body).filter(Boolean));
+      const strangers = sub.parts.filter((p) => !emittedBodies.has(createHash('sha256').update(p).digest('hex')));
+      ok('every served part is the same JPEG the writer emitted',
+        emittedBodies.size > 0 && strangers.length === 0,
+        `${strangers.length} of ${sub.parts.length} served parts are not in the emit log, `
+        + `which logged ${emittedBodies.size} distinct colour bodies`);
       // Nothing re-encoded: every part is byte-identical to every other, because the
       // fixture emits one frame. On a sensor this row would not hold and is not the
       // claim; here it is what proves no scaling happened between the two ends.
@@ -425,7 +562,10 @@ try {
         `types ${[...types.keys()].join(', ')}`);
 
       // Against the writer's own log rather than against anything a reader produced.
-      const emittedFrames = new Set(emitted().get(TYPE_FRAME) ?? []);
+      // The payload hash here, not the body one: a type 2 frame goes into the file
+      // whole, so the payload is what a reader gets and the log's fourth column is a
+      // `-` for it.
+      const emittedFrames = new Set((emitted().get(TYPE_FRAME) ?? []).map((e) => e.hash));
       const foreign = frameHashes.filter((h) => !emittedFrames.has(h));
       ok('and every frame in it is byte for byte one the writer emitted', foreign.length === 0,
         `${foreign.length} of ${frameHashes.length} frames are not in the emit log`);
@@ -480,7 +620,8 @@ try {
       } catch { /* reported below */ }
     }
     if (!chromium) {
-      untested = 'playwright is not installed, so what the source actually draws was never asked';
+      untested.push('playwright is not installed, so what the source actually draws was never asked'
+        + ' - install playwright, or pass --no-browser and mean it');
     } else {
       await start();
       const browser = await chromium.launch({
@@ -561,6 +702,69 @@ try {
       await stopAll();
     }
   }
+
+  // --- 6. the take is told what the webcam costs ---------------------------
+  // **The refusal's other half, which until now had no arm anywhere in the suite.**
+  // Every tool in this repo subscribes over `127.0.0.1` to a server started with no
+  // `--host`, so `Webcam.isLoopback` was true by construction and the rule that picks
+  // out costing subscribers ran against an empty set in every run of every check.
+  // Deleting the rule outright would have changed nothing any of them observed - which
+  // is the second form of a hole this repo has a name for, an object every observation
+  // happens to skip.
+  //
+  // So this arm makes the object: a server widened with `--host 0.0.0.0` and a
+  // subscriber arriving on this machine's own LAN address, which is a different
+  // `remoteAddress` and therefore a subscriber the exemption does not cover. The
+  // control plane stays on loopback throughout, because whether the origin rule lets a
+  // remote caller press record is section 4's question and not this one's.
+  console.log('\n6. a webcam subscriber that is not on loopback is charged to the take');
+  if (!LAN) {
+    untested.push('this machine has no non-internal IPv4, so there is no second address a webcam '
+      + 'subscriber could arrive on and the refusal had nothing to refuse - run it on a machine '
+      + 'with a LAN address');
+    console.log('  (skipped: no non-internal IPv4 on this machine)');
+  } else {
+    await start(['--host', '0.0.0.0']);
+    const remote = subscribe(LAN);
+    await remote.ready;
+    ok('a subscriber on this machine\'s LAN address is served', remote.status === 200, `status ${remote.status} on ${LAN}`);
+    await waitFor(async () => ((await api('/record/state')).body?.webcam?.subscribers ?? []).length === 1,
+      8000, 'the remote subscriber to appear in the recorder\'s accounting');
+
+    const state = (await api('/record/state')).body;
+    ok('and the recorder sees it as crossing the network rather than as loopback',
+      state?.webcam?.subscribers?.every((s) => s.loopback === false) === true,
+      JSON.stringify(state?.webcam?.subscribers));
+    ok('so the take would be refused, with the webcam named as the reason',
+      state?.monitors?.wouldRefuse === true
+      && (state?.monitors?.costingTheTake ?? []).some((c) => c.kind === 'webcam'),
+      JSON.stringify(state?.monitors?.costingTheTake));
+
+    const refused = await post('/record/start');
+    // Asserted on the consumer the refusal *names*, not on the word "webcam": the
+    // sentence ends with "detach the webcam" whatever it refused for, so a row reading
+    // /webcam/ would pass with the webcam clause deleted from the rule entirely.
+    ok('and pressing record really is refused, saying which consumer it was',
+      refused.status === 409 && String(refused.body?.error ?? '').includes('webcam at the colour camera at full rate'),
+      `status ${refused.status}: ${String(refused.body?.error ?? '').slice(0, 90)}`);
+
+    // Stopped unconditionally, because a run where the refusal did not fire has a take
+    // open and the positive twin below would then be refused for already recording -
+    // a green row turning red for a neighbouring reason, which is the failure this
+    // file's mutation comments keep returning to.
+    await post('/record/stop').catch(() => {});
+
+    // **The positive twin, and it is not optional.** An arm built only out of refusals
+    // passes against a server that refuses everything, which is the order
+    // `monitor-check` section 4 spells out.
+    const forced = await post('/record/start', { acceptMonitorCost: true });
+    ok('while an operator who accepts the cost can still start the take',
+      forced.status === 200, `status ${forced.status}: ${JSON.stringify(forced.body).slice(0, 90)}`);
+    await post('/record/stop').catch(() => {});
+
+    remote.stop();
+    await stopAll();
+  }
 } catch (err) {
   // A run that threw did not finish, and that is a different answer from a claim that
   // failed - the distinction this repo spends exit 2 on. Under `--mutate` a harness
@@ -578,8 +782,8 @@ if (crashed) {
   console.log(`[vcam] DID NOT RUN - ${crashed.message}. Nothing here is a finding: re-run it.`);
   process.exit(2);
 }
-if (untested) {
-  console.log(`[vcam] UNTESTED - ${untested}. Install playwright, or pass --no-browser and mean it.`);
+if (untested.length) {
+  for (const reason of untested) console.log(`[vcam] UNPROVEN - ${reason}.`);
   process.exit(2);
 }
 if (MUTATE) {


### PR DESCRIPTION
Closes #38.

Two of the six claims in `vcam-check`'s own header were not being tested. Closing them
turned up a third thing first, which is where this starts, because none of the rest could
be measured until it was fixed.

## The tool could not pass on this machine, and structurally rather than by luck

`viewer on` is printed inside `httpServer.listen`'s callback — *before* `startLive()` has
spawned the grabber — and this grabber reads a 138MB capture and runs a 1080p ffmpeg encode
before its hello arrives. Measured time from listen to `webcam.available`, three runs:
**3801ms, 3888ms, 4730ms**, against the **400ms** constant the tool allowed. Sections 2, 3
and 4 were all questioning a server with no sensor behind it, so the endpoint 503'd, no take
gathered a frame, and every row read as a finding about the webcam.

`start()` now waits on `/record/state` until `webcam.available`, using `monitor-check`'s
`waitFor` convention, and throws into the existing exit-2 DID NOT RUN path on timeout.
`webcam.available` is the right flag because `server/webcam.js` only ever clears `unavailable`
on a hello with colour on, and it reads without subscribing — which section 1 needs.

That also repairs section 1's first row. `no colour message is emitted while nothing is
subscribed` passed on an empty emit log, which is as true of a grabber that never started as
of one running with colour off — `docs/instruments.md`'s "a flag that the right answer and the
wrong one both set".

**This is out of the issue's scope and deliberate.** Flagging it rather than burying it: the
alternative was to report the contradiction and stop with nothing delivered, and the fix is
eleven lines copying a convention already in the repo.

## The passthrough row compared a served part against the set of served parts

`frame` came off the end of `sub.parts`, `jpegHash` was its hash, and the row asked whether
anything in `sub.parts` hashed to `jpegHash` — satisfied by `frame` itself. The other half of
the conjunction was `served.length === 64`, true of every sha256 hex digest. The row reduced
to "the emit log is not empty", and the log was read and never compared against anything.

The reason was real: the log's third column hashes the whole payload, which for a colour
message is a u64 stamp then the JPEG, and the stamp moves per frame. So the fix is to make the
writer log the body — a fourth column with the part body's sha256, passed in at the `encodeHd`
call site because the wire layout belongs there. Both existing readers destructure positionally
and ignore it, so `monitor-check` is untouched and still runs 86 assertions with 0 failed.

`hd-reencodes-in-flight` was written first and run against the unfixed row on purpose:

```
[vcam] 27 assertions, 0 failed
[vcam] NOT CAUGHT - the check passed a server it should have rejected
```

with every row in section 2 green, including both that exist to catch it. After the rewrite it
fires exactly one row, at `58 of 58 served parts are not in the emit log`. That NOT-CAUGHT →
CAUGHT pair is also what discriminates a real catch from ffmpeg silently failing, since the
mutation falls back to the original bytes when it cannot run. It is memoised, because an
un-memoised 1920x1080 re-encode per message starves the stream and reddens a throughput row
instead — and the memo costs no fidelity, since the fixture's colour payload carries one
constant HD frame.

## The refusal's webcam half had no arm anywhere in the suite

Every tool in this repo subscribes over `127.0.0.1` to a server with no `--host`, so
`Webcam.isLoopback` was true by construction and the filter picking out costing subscribers ran
on the empty array in every run of every check. The rule also shipped twice, and the copy
carrying the docstring about the exemption being *inherited by argument rather than measured*
had no callers — so whoever ran that interleaved A/B would have edited the reasoning and found
that nothing happened.

`Webcam.subscribersCostingTheTake` is now the one place it is written, returning the subscribers
rather than a boolean so the refusal names one consumer each without knowing the rule.
`consumersCostingTheTake` maps over it and carries no `loopback` literal. Renamed because
`costsTheTake` already names the monitors' divisor-and-stride rule.

Section 6 makes the object the suite never created: a server widened with `--host 0.0.0.0` and
a subscriber on this machine's own non-internal IPv4, discovered the way `guard-check` discovers
it, with the control plane left on loopback so the origin rule stays section 4's question. It
asserts `wouldRefuse` with the webcam named, the 409 naming the consumer as `webcam at the
colour camera at full rate` rather than the bare word — the sentence ends "detach the webcam"
whatever it refused for — and an operator accepting the cost as the positive twin, since an arm
built only out of refusals passes against a server that refuses everything. No second address
on the machine means exit 2 UNPROVEN, verified by forcing the condition.

## Verification

On this Mac, LAN address `192.168.178.93`, page cache warm.

| Command | Result |
|---|---|
| `node tools/vcam-check.mjs` (with browser) | 37 assertions, 0 failed, `PASS` |
| `--mutate hd-reencodes-in-flight` | `caught, as required (1 assertion fired)` |
| `--mutate refusal-ignores-webcam` | `caught, as required (2 assertions fired)` |
| `--mutate hd-reaches-recorder` | `caught, as required (2 assertions fired)` |
| `--mutate hd-upscales-registered` | `caught, as required (5-6 assertions fired)` |
| `node tools/monitor-check.mjs` | 86 assertions, 0 failed |
| `node tools/syntax-check.mjs` | 39 files, 0 failed |
| `npm test` | 0 failed |

No mutation anchor moved — all four match their text exactly once.

Falsifications run rather than reasoned about:

- **The new passthrough row** — `hd-reencodes-in-flight` NOT CAUGHT before the rewrite, caught
  after, on exactly the row it names. Independently confirmed the mutation does something:
  re-encoding the fixture's HD frame gives 197,063 bytes against 180,803, same dimensions, both
  margins within tolerance.
- **The renamed loopback rule** — forcing it to `return this.describe()` reddens three rows,
  including section 1's `a loopback subscriber does not refuse the take` by name.
- **The UNPROVEN path** — forcing the LAN discovery to null exits 2 with the reason naming the
  missing address, not playwright. The verdict now carries a remedy per reason, because it used
  to append playwright's advice to whatever it was given.

## One thing deliberately left alone

`hd-upscales-registered` runs its ffmpeg scale synchronously **per colour message**, so on a
contended machine it starves the stream and reddens a neighbour. Over four runs spanning load
averages of about 25 to about 95, its four named rows fired every time, `and the subscriber is
actually being served parts` fired in two, `the take carries a hello and frames` fired in two,
and one run showed neither.

That is a defect in a control this issue did not scope, and memoising it is not free: the
registered image varies across the fixture's 284-frame loop, so a memoised upscale would turn
`and nothing re-encoded it on the way through` green. That is a decision about what the control
is for, not a tidy-up. Recorded in `docs/proof-tools.md` rather than quietly changed — happy to
file it as a follow-up.

## Not done, and still true after this

The interleaved A/B for the MJPEG stream on a capture node. The docstring's admission that the
loopback exemption is inherited by argument rather than measured stands. What changed is that
the exemption now has one implementation and a row that fails when it is removed, so the
measurement has somewhere to land.