### PR TITLE
Stamp the generation that wrote a take into the take

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FA
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL
 node tools/library-check.mjs --mutate open-take-swallows-library # ... and must FAIL
 node tools/library-check.mjs --mutate one-refusal-for-older-versions # ... and must FAIL
+node tools/library-check.mjs --mutate open-ignores-format          # ... the capture's generation, at all four doors at once
 node tools/editor-check.mjs --url http://localhost:8080   # the editor's controls: that they exist, that pressing them changes something
 node tools/editor-check.mjs --mutate lanes-clear-siblings --no-render  # ... and must FAIL
 node tools/editor-check.mjs --mutate plant-unswept-control --no-render # ... and must FAIL

--- a/README.md
+++ b/README.md
@@ -604,13 +604,37 @@ is byte-identical to what the grabber emits:
 [u32 magic 'KNCT'][u32 type][u32 payloadLen][payload]
 
 type 1  hello  UTF-8 JSON, once, before any frame:
-               { serial, firmware, width, height, fx, fy, cx, cy, color }
+               { format, serial, firmware, width, height, fx, fy, cx, cy,
+                 color, minDepth, maxDepth, lowLight, startedAt }
 type 2  frame  [u32 depthBytes][u32 colorBytes][u64 timestampMs]
                [u16 depth[512*424] millimetres, 0 = no reading]
                [JPEG of the registered 512x424 colour image]
 type 3  colour [u64 timestampMs][JPEG of the native 1920x1080 colour image]
                Live only, and only while something is subscribed.
 ```
+
+**`format` is the generation of the capture format, and a take that carries no `format`
+key at all is generation zero.** Everything shot before the field existed is one, and
+nothing migrates them, because rewriting a capture to add a key is the one operation this
+design will not perform on the artifact that cannot be shot again — so a take declaring
+nothing opens, a take declaring the generation this build reads opens, and a take
+declaring anything else is refused rather than unprojected on assumptions that may not be
+its own. `web/format.js` owns the number and the three bands; `native/grabber.cpp` carries
+the only other spelling of it, and `tools/syntax-check.mjs` requires the two equal and
+requires this key list to be exactly what the grabber emits, in both directions.
+
+**Four of the other keys are load-bearing and were undocumented for a long time**, which
+is worth stating rather than quietly fixing, because the shape of that failure is a second
+producer written against this block. `startedAt` is the only durable capture date a take
+has — the frame stamps are `steady_clock`, monotonic since boot, so two takes recorded a
+day apart on a node that never rebooted are indistinguishable by them — and a writer that
+omits it lands every take in the gallery dated by file modification time, which changes the
+first time the take is copied off the node. The library's ordering silently becomes "when
+it was last copied", and it degrades quietly, because `describeTake` has a legitimate
+fallback for exactly that case and reports `dateSource: 'mtime'` rather than an error.
+`minDepth` and `maxDepth` say how much of the world the file was allowed to contain, and
+the editor paints its preview range from them; `lowLight` says whether the colour camera
+was run long-exposure.
 
 **Type 3 is live-only, so "byte-identical" now means identical to the type 1 and 2
 subsequence.** A capture file is still exactly what the grabber emitted of the stream

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -136,6 +136,59 @@ held, `startServer` throws if its own child exits instead of listening, and it r
 outside the declared span so a section added at `+17` is a failure rather than a hole. Pass
 `--node-port`/`--mac-port` a range nothing else holds.
 
+**Two takes carry the capture format's band, and the second is the one that keeps the archive
+readable.** `future-format-take` declares a generation this build has never read and is
+otherwise an entirely ordinary take — whole frames, a readable hello, intrinsics in range —
+because "nothing here knows what these numbers mean" is a condition with no other symptom.
+`generation-zero-take` declares no `format` key at all, which is what `captures/sample.knct`
+itself is and what every take shot before the field existed is; it is planted under its own name
+rather than left to the takes that are generation zero incidentally, since a band written as
+"refuse anything unfamiliar" passes every row about the first take and shuts the whole existing
+archive out of the editor.
+
+`--mutate open-ignores-format` is the control and it edits one line of `web/format.js`, which is
+the point of it rather than an implementation detail. Four doors decide whether a take may be
+opened — `openable` in `describeTake`, the badge and the dead Open button in the gallery, and
+`openTake` in the editor — and three of them are cheap to satisfy by inlining a comparison, which
+would pass every row here and drift the first time the band gains a member. So the assertion the
+mutation really carries is the *count*: it reddens **6 of 360**, one row per door plus the
+gallery's menu sentence and the editor's editing state, and the takes that must stay green stay
+green — both `no-hello-take` rows, `local-clip`'s `dateSource === 'hello'`, and all four
+generation-zero rows. A mutation that reddened fewer would mean the band had quietly become
+several predicates that agree.
+
+Reaching all four needed one change to the harness. `stageServer` used to write only a `server/`
+mutation into the staged tree, leaving `web/` ones to the browser route interception — which is
+right for `main.js` and `library.js`, since nothing on the Node side imports either. It is wrong
+for `format.js`, which `server/library.js` imports by path: served to the page and not staged, the
+server would have gone on deciding `openable` on the unmutated band and the control would have
+reddened the page's rows only, reading as a partial break in the product rather than a half-broken
+build. Every mutation is written into the staged tree now; both roots there are copies, so nothing
+reaches the subject.
+
+**`syntax-check` also holds the hello to the README and the format constant to the grabber**, in
+both directions and without importing either. The prose block documented nine keys against the
+thirteen emitted for long enough that the four it omitted became the argument for the check:
+`startedAt` is the only durable capture date a take has, so a second producer written against the
+documented nine writes takes the library dates by file modification time, which changes the first
+time a take is copied off the node and degrades quietly, because that fallback is legitimate and
+reports `dateSource: 'mtime'` rather than failing. The README side is cut to the `type 1 hello`
+stanza and stops at `type 2`, the grabber side to the one `snprintf` that builds the hello, and an
+empty extraction from either fails — zero keys means the anchor moved and the comparison ran on
+nothing. `CAPTURE_FORMAT` is read textually out of `web/format.js` and `native/grabber.cpp` and
+required equal, because this tool takes `--root` and an import would bind the assertion to this
+checkout while claiming to have checked another tree.
+
+Its three controls are run by hand, in the idiom the `tools/` and `docs/` blocks already use,
+because this tool carries no `--mutate` harness. Add a key to the grabber literal and not to the
+README; add one to the README the grabber does not emit; bump the constant in one language. Each
+must fail naming what it found — measured, in that order: `the grabber's hello emits exposure and
+README.md's type 1 hello does not document it`, `README.md's type 1 hello documents exposure and
+the grabber does not emit it`, and `CAPTURE_FORMAT is 2 in web/format.js and 1 in
+native/grabber.cpp`. The first of those three is worth doing carefully: the obvious `perl -pi`
+one-liner silently matches nothing against a C++ string literal full of escaped quotes, and a
+mutation that did not apply reads exactly like a check that missed one.
+
 **`editor-check` enumerates rather than lists, and it exists because the suite tested the model
 and never the control.** The clip in/out markers were detached from the document during boot
 for the whole life of the feature — `rebuildLanes` cleared `#tBeds` of every child that was

--- a/native/grabber.cpp
+++ b/native/grabber.cpp
@@ -45,6 +45,20 @@ static const uint32_t TYPE_COLOR = 3;
 static const int CW = 1920;
 static const int CH = 1080;
 
+// What generation of this format the hello below declares. A magic says which reader
+// to use and a message type says which record this is; neither says what the numbers
+// inside it mean, and that is what changes: move the depth quantisation or the
+// registration path and every take written afterwards is structurally identical to
+// every take written before, so one geometry model runs over two archives and the
+// older half is silently reprojected wrong.
+//
+// **This is unavoidably a second spelling of a JavaScript number**, since the browser
+// cannot import a C++ constant and Node reads `web/format.js` by path. That file owns
+// the meaning - the three bands and what each opens - and `tools/syntax-check.mjs`
+// reads both values textually and requires them equal, which is what stops the two
+// drifting apart in the one direction nothing else would notice.
+static const uint32_t CAPTURE_FORMAT = 1;
+
 // A corpus is deliberately not KNCT: the wire format carries u16 millimetre depth
 // and a JPEG, which are both lossy relative to what Registration::apply actually
 // consumes. Its own magic keeps the two from ever being read by the wrong reader.
@@ -569,6 +583,11 @@ int main(int argc, char **argv) {
 
   // The browser needs the real intrinsics to unproject; hardcoded values skew the cloud.
   //
+  // format leads the record because it is what says how to read the rest of it. Every
+  // other key here is a measurement whose meaning depends on the generation that took
+  // it, so a reader that has not yet decided whether it can interpret this take at all
+  // has no business acting on its focal length.
+  //
   // startedAt is the wall clock, and it is here rather than in the server because
   // this is the only place that knows when the stream actually began. Every frame
   // timestamp below is steady_clock - monotonic since boot, which is exactly right
@@ -580,10 +599,10 @@ int main(int argc, char **argv) {
     std::chrono::system_clock::now().time_since_epoch()).count();
   char hello[512];
   int helloLen = std::snprintf(hello, sizeof(hello),
-    "{\"serial\":\"%s\",\"firmware\":\"%s\",\"width\":%d,\"height\":%d,"
+    "{\"format\":%u,\"serial\":\"%s\",\"firmware\":\"%s\",\"width\":%d,\"height\":%d,"
     "\"fx\":%.6f,\"fy\":%.6f,\"cx\":%.6f,\"cy\":%.6f,\"color\":%s,"
     "\"minDepth\":%.3f,\"maxDepth\":%.3f,\"lowLight\":%s,\"startedAt\":%lld}",
-    serial.c_str(), dev->getFirmwareVersion().c_str(), DW, DH,
+    CAPTURE_FORMAT, serial.c_str(), dev->getFirmwareVersion().c_str(), DW, DH,
     ir.fx, ir.fy, ir.cx, ir.cy, wantColor ? "true" : "false",
     minDepth, maxDepth, (wantColor && lowLight) ? "true" : "false", startedAt);
   // snprintf truncates silently, and a truncated hello is not JSON - so every take

--- a/server/library.js
+++ b/server/library.js
@@ -49,10 +49,15 @@ export { VALID_ID };
 // function asserts.
 export const VALID_HASH = /^sha256:[0-9a-f]{64}$/;
 
-// Two constants, shared with the page rather than restated here. See web/format.js
-// for what version 1 means and why it is a version rather than an authored buffer
-// height; re-exported so callers on this side have one import to reach for.
-import { PROJECT_VERSION, VALID_ID } from '../web/format.js';
+// Two constants and one predicate, shared with the page rather than restated here. See
+// web/format.js for what version 1 means and why it is a version rather than an authored
+// buffer height; re-exported so callers on this side have one import to reach for.
+//
+// `captureFormatRefusal` is imported rather than the number it compares against, and
+// that is the whole point of it: four doors decide whether a take may be opened and this
+// is one of them, so what travels between them is the decision rather than a constant
+// each is free to compare its own way.
+import { PROJECT_VERSION, VALID_ID, captureFormatRefusal } from '../web/format.js';
 
 export { PROJECT_VERSION };
 
@@ -189,6 +194,10 @@ async function describeTake(dir, file, recording) {
       dateSource: 'mtime',
       truncated: false,
       hasHello: null,
+      // Null with the rest of them, and for the same reason: the hello is at the head
+      // of a file this is deliberately not reading, so a take mid-write has no answer
+      // here rather than an answer that happens to be the current generation.
+      format: null,
       hello: null,
       openable: false,
       recording: true,
@@ -212,6 +221,15 @@ async function describeTake(dir, file, recording) {
   // own modification time, and says which it used rather than presenting a guess
   // as a record.
   const fromHello = Number.isFinite(hello?.startedAt) && hello.startedAt > 0;
+  // What generation of the format wrote this take, carried up to the gallery as it was
+  // found rather than coerced into a number. A hello saying `"format": "banana"` is a
+  // writer this build has no idea about, and reporting that as null would file it with
+  // the takes that honestly declare nothing - which is the one band that opens.
+  const format = hello?.format ?? null;
+  // The band, asked once here and answered for every door on this side. It is a
+  // sentence rather than a boolean so the page can say *which* generation it found
+  // without deriving the refusal a second time.
+  const formatRefusal = captureFormatRefusal(`take ${id}`, format);
   return {
     id,
     file,
@@ -232,14 +250,21 @@ async function describeTake(dir, file, recording) {
     // screen can show. The tile has to say that rather than offering an Open
     // button that throws.
     hasHello: Boolean(index.hello),
+    // Beside `hasHello` and `dateSource` rather than inside the four-value `hello`
+    // subset below, because it is a fact about the file and not one of the intrinsics -
+    // and because that subset carries its own argument for shipping four values and no
+    // more, which this would quietly widen.
+    format,
     // The intrinsics, so a poster can unproject the take rather than draw a picture
     // of the sensor's grid. Only these four: a gallery has no use for the serial or
     // the firmware, and shipping a node's whole hello to every browser that lists a
     // directory is more of that node's record than the listing needs.
     hello: hello ? { fx: hello.fx, fy: hello.fy, cx: hello.cx, cy: hello.cy } : null,
     // Two frames is the floor for a pair source, so a shorter take lists and
-    // refuses to open. Named here rather than discovered in the editor.
-    openable: Boolean(index.hello) && stamps.length >= 2,
+    // refuses to open. Named here rather than discovered in the editor - and the
+    // format band joins the same expression rather than becoming a second one, so a
+    // gallery that offers Open and an editor that throws on it cannot come apart.
+    openable: Boolean(index.hello) && stamps.length >= 2 && formatRefusal === '',
     recording: false,
     marks,
   };

--- a/tools/fake-grabber.mjs
+++ b/tools/fake-grabber.mjs
@@ -22,6 +22,12 @@ import { appendFileSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { MessageParser, TYPE_HELLO, TYPE_FRAME, TYPE_COLOR, encodeMessage } from '../server/protocol.js';
+// The capture format's generation, read from where the band that reads it lives rather
+// than copied. This file is a second producer of the record `native/grabber.cpp` writes,
+// and a second producer with its own literal is the drift the number exists to catch -
+// it would go on stamping last year's generation into every take the suite plants while
+// the check reading them was updated.
+import { CAPTURE_FORMAT } from '../web/format.js';
 
 const argv = process.argv.slice(2);
 const flag = (name, fallback = null) => {
@@ -156,8 +162,15 @@ process.stdin.resume();
 // The wall clock goes in the hello and nowhere else, the same as the real grabber:
 // every frame stamp below is a monotonic clock, which is right for frame spacing and
 // useless for sorting a library.
+//
+// The format number is stamped for the same reason and in the same place. The sample
+// this loops its depth out of predates both fields, so a hello copied through unedited
+// would make every take the suite records generation zero - which is a real shape and
+// the wrong one to write here, because a *writer* that declares nothing is exactly the
+// second producer this repo's own README nearly taught somebody to build.
 const hello = Buffer.from(JSON.stringify({
   ...sourceHello,
+  format: CAPTURE_FORMAT,
   startedAt: Date.now(),
   ...(TAG ? { tag: TAG } : {}),
 }));

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -74,7 +74,7 @@ import { REVEAL } from '../server/library.js';
 // construct or assert on has to carry the one this build writes, and a literal here
 // is a second copy of it - which is exactly what had to be hand-swept when the
 // readings dissolved the mode and the version moved from 3 to 4.
-import { PROJECT_VERSION } from '../web/format.js';
+import { PROJECT_VERSION, CAPTURE_FORMAT } from '../web/format.js';
 
 const argv = process.argv.slice(2);
 const flag = (name, fallback = null) => {
@@ -257,6 +257,23 @@ const MUTATIONS = {
   'accept-any-version': { file: 'web/main.js', edits: [[
     '  if (project.version !== PROJECT_VERSION) {',
     '  if (false) {',
+  ]] },
+  // **The capture format's band comes off.** A take whose hello declares a generation
+  // this build has never read is opened on this build's assumptions instead of being
+  // refused - which is the whole of the failure the format number exists to prevent,
+  // arrived at from the inside: one geometry model applied to two archives, silently.
+  //
+  // The edit is the accepting branch rather than the sentence, so the refusal below it
+  // survives as unreachable code and the mutated build still parses. It is in
+  // `web/format.js` because that is where the one predicate lives, and the interesting
+  // half of that is what it reaches: this file is imported by `server/library.js` on
+  // Node *and* served to both pages, so a single edit here reddens the server's
+  // `openable`, the gallery's badge and dead Open button, and the editor's own throw
+  // together. If it reddened only some of them, the band would have stopped being one
+  // predicate and become three that agree - which is what this control is for.
+  'open-ignores-format': { file: 'web/format.js', edits: [[
+    "  if (format === CAPTURE_FORMAT) return '';",
+    "  return ''; /* mutation: every generation opens on this build's assumptions */",
   ]] },
   // The retime guard comes off the file door. This is the door step 5 named and
   // left open, and a descending region does not merely fail - it can pass the
@@ -940,15 +957,28 @@ const SRC = sampleMessages();
  * `truncated` flag has something to report - the flag has been computed since step
  * 2 and read by nothing until this gallery.
  */
-function writeTake(dir, id, { frames = 8, withHello = true, truncate = false, startedAt = null } = {}) {
+function writeTake(dir, id, { frames = 8, withHello = true, truncate = false, startedAt = null, format = null } = {}) {
   const parts = [];
   if (withHello) {
     // The wall-clock capture date, which the frame stamps cannot supply: they are
     // `steady_clock`, monotonic since boot, right for frame spacing and useless for
-    // sorting a library.
-    const hello = startedAt === null
+    // sorting a library. And the capture format's generation, which is the same shape
+    // of field for the same reason - the sample predates both, so a hello carried
+    // through untouched is honestly a take from before either existed, which is the
+    // shape most of this fixture wants and one the gallery has to keep opening.
+    //
+    // Re-serialised only when something was asked for, and the asked-for keys land in
+    // this order, so a call that names neither writes the sample's own bytes back. The
+    // takes both machines hold are compared by content hash, and a helper that
+    // re-serialised unconditionally would leave that resting on `JSON.stringify` being
+    // stable rather than on the two files being the same file.
+    const stamped = {
+      ...(startedAt === null ? {} : { startedAt }),
+      ...(format === null ? {} : { format }),
+    };
+    const hello = Object.keys(stamped).length === 0
       ? SRC.hello
-      : Buffer.from(JSON.stringify({ ...JSON.parse(SRC.hello.toString('utf8')), startedAt }));
+      : Buffer.from(JSON.stringify({ ...JSON.parse(SRC.hello.toString('utf8')), ...stamped }));
     parts.push(encodeMessage(TYPE_HELLO, hello));
   }
   for (let i = 0; i < frames; i++) parts.push(SRC.frames[i % SRC.frames.length]);
@@ -1050,6 +1080,23 @@ function buildFixture() {
   // quantity cannot measure it however many of them there are.
   writeTake(macCaps, 'three-warning-take', { frames: 1, withHello: false, truncate: true });
 
+  // **Both ends of the capture format's band, and the second one is why there are two.**
+  //
+  // The first declares a generation this build has never read. Everything about it is a
+  // perfectly ordinary take - whole frames, a readable hello, intrinsics in range - and
+  // the only thing wrong with it is that nothing here knows what its numbers mean, which
+  // is exactly the case that has no other symptom.
+  //
+  // The second declares nothing at all, which is what `sample.knct` itself is and what
+  // every take shot before the field existed is. It is planted under its own name rather
+  // than left to the takes that happen to be generation zero for other reasons, because
+  // it is a claim in its own right and a claim wants a row that names it: a band written
+  // as "refuse anything unfamiliar" passes every assertion about the take above and
+  // condemns the entire existing archive, and a control that refused both would be
+  // proving only that the gallery can say no.
+  writeTake(macCaps, 'future-format-take', { frames: 6, format: CAPTURE_FORMAT + 1 });
+  writeTake(macCaps, 'generation-zero-take', { frames: 6 });
+
   // Mark counts the tile renders differently: none, exactly one, and several - plus
   // a mark at source zero and a mark past the end of the footage, which are the two
   // positions a fraction can get wrong without any of the middle ones noticing.
@@ -1109,8 +1156,32 @@ function stageServer() {
     const from = join(REPO, name);
     if (existsSync(from) && !existsSync(join(root, name))) symlinkSync(from, join(root, name));
   }
-  if (serverMutation) {
-    writeFileSync(join(root, serverMutation.file), serverMutation.body);
+  // **Every mutation is written into the staged tree, not only the server ones**, and
+  // it was `server/` only until the capture format's band needed breaking.
+  //
+  // `web/format.js` is the file that made the old arrangement wrong. `server/library.js`
+  // imports it by path - which is the entire reason the constant lives under `web/`,
+  // since the browser can only reach what the server serves and Node has no such
+  // constraint - so a mutation of it delivered to the page and not staged left the
+  // server deciding `openable` on the unmutated band. The control would then redden the
+  // page's rows and leave the server's green, which reads as a check having found a
+  // partial break in the product rather than as the harness having broken half the
+  // build. Both roots here are copies, so this writes into the scratch tree and never
+  // into the subject.
+  //
+  // **This is now also the delivery path for a page file**, and saying so matters
+  // because the comment here used to claim the route interception in `openPage` was the
+  // whole of it. `WEB_DIR` is `join(ROOT, 'web')` and `web/` is copied into the staged
+  // root, so a mutated page file staged here is what the server serves - the
+  // interception in `openPage` fulfils first and wins the race, but it is answering with
+  // the same `mutation.body` this wrote, so the two cannot disagree about what is under
+  // test. What the interception still does uniquely is map `library.html` onto `/gallery`
+  // and refuse a page file it has no URL for. Collapsing the two into one mechanism is
+  // worth doing and is deliberately not done here: it would put six page mutations this
+  // issue never touched through a new delivery path, and re-proving each of them for its
+  // own stated reason is a piece of work rather than a line.
+  if (mutation) {
+    writeFileSync(join(root, mutation.file), mutation.body);
   }
   return root;
 }
@@ -1521,6 +1592,21 @@ async function runChecks() {
     check(byId['one-frame-take'].frames === 1 && byId['one-frame-take'].openable === false,
       'a one-frame take lists, and says it cannot be bracketed');
     check(byId['local-clip'].openable === true, 'and an ordinary take is openable');
+    // The band, at the door the other three read. `format` is reported as the listing
+    // found it rather than as a boolean, because the refusal has to be able to name the
+    // generation - "unknown format" with no number is a sentence nobody can act on.
+    check(byId['future-format-take'].format === CAPTURE_FORMAT + 1
+      && byId['future-format-take'].openable === false,
+      'a take from a format this build does not read lists, says which generation wrote it, and says it cannot be opened',
+      `format ${JSON.stringify(byId['future-format-take'].format)}, openable ${byId['future-format-take'].openable}`);
+    // The half that stops the band from being "refuse anything unfamiliar", which would
+    // pass the row above while shutting every take on disk today out of the editor.
+    check(byId['generation-zero-take'].format === null
+      && byId['generation-zero-take'].openable === true,
+      'while a take whose hello declares no format at all is generation zero and opens, which is the whole existing archive',
+      `format ${JSON.stringify(byId['generation-zero-take'].format)}, openable ${byId['generation-zero-take'].openable}`);
+    check(byId['local-clip'].format === null && byId['no-hello-take'].format === null,
+      'and the field is null rather than absent on a take that carries no answer, so the page has one thing to read');
     check(byId['local-clip'].dateSource === 'hello'
       && Math.abs(byId['local-clip'].capturedAt - Date.UTC(2026, 6, 15, 18, 5)) < 1,
       'the wall-clock capture date comes off the hello where the take carries one');
@@ -2036,6 +2122,13 @@ async function runChecks() {
       'the Open on a take with no hello is disabled rather than a throw waiting to happen');
     check(one('local-clip').acts.find((a) => a.label === 'Open')?.disabled === false,
       'and an ordinary take opens');
+    // The same pair for the format band. Both, because a page that greyed every Open
+    // would pass the first of these on its own and the second is the one that says the
+    // refusal is about this take rather than about the button.
+    check(one('future-format-take').acts.find((a) => a.label === 'Open')?.disabled === true,
+      'the Open on a take from a format this build cannot read is disabled the same way');
+    check(one('generation-zero-take').acts.find((a) => a.label === 'Open')?.disabled === false,
+      'while a take that declares no format at all still opens');
 
     // Marks on the tile's scrub bar, at their source fraction. The two that a
     // fraction gets wrong on its own are checked by name: source zero has to land
@@ -2330,6 +2423,24 @@ async function runChecks() {
     check(warnTile.flags.includes('short') && /no frames/.test(warnMenu.note.match(/^.*no frames.*$/m)?.[0] ?? ''),
       'and a take with no whole frame says so rather than saying it has fewer than two',
       warnMenu.note.split('\n').find((l) => /frame/.test(l)) ?? '');
+    // The format band's badge and the sentence behind it, read the same way. The
+    // sentence is asserted to carry the generation it found rather than merely to
+    // mention a format, because the number is the only part of it an operator can do
+    // anything with - and it is built from the constant rather than written down, so
+    // this row moves with the band instead of having to be swept when it does.
+    const fmtTile = one('future-format-take');
+    const fmtMenu = await page.evaluate(`globalThis.__library.openMenu(${JSON.stringify(fmtTile.hash)})`);
+    check(fmtTile.flags.includes('format'),
+      'a take from a format this build cannot read carries a badge over its poster', fmtTile.flags.join(' ') || 'no badges');
+    check(new RegExp(`capture format ${CAPTURE_FORMAT + 1}\\b`).test(fmtMenu.note)
+      && new RegExp(`reads format ${CAPTURE_FORMAT}\\b`).test(fmtMenu.note),
+      'and the sentence in the menu names the generation it found and the one this build reads',
+      fmtMenu.note.replace(/\n/g, ' | ').slice(0, 130) || 'the menu says nothing');
+    const zeroTile = one('generation-zero-take');
+    check(!zeroTile.flags.includes('format'),
+      'while a take that declares no format carries no such badge, so the badge is about the generation and not about the key being absent',
+      zeroTile.flags.join(' ') || 'no badges');
+    await page.mouse.click(4, 4);
     const oneFrameTile = one('one-frame-take');
     check(oneFrameTile.flags.includes('short'),
       'while the one-frame take still carries the badge, so the row above is about the wording rather than about the badge going away',
@@ -2615,6 +2726,58 @@ async function runChecks() {
 
     check(errors.length === 0, 'the gallery raises no page errors', errors.slice(0, 2).join(' | '));
     await page.close();
+  }
+
+  // ------------------------------------------- 6f. the fourth door, in the editor
+  //
+  // **The gallery greying a button is not the take being refused.** Three of the four
+  // doors that read this band are on the listing - `openable` on the server, the badge
+  // and the dead Open on the page - and all three can be satisfied without the editor
+  // knowing anything, because a take is also reachable by typing its id into the URL,
+  // by a stale bookmark and by the menu's resume. So the row that matters is the one
+  // driven the way somebody arrives, and what it asserts is that the page did not enter
+  // the editing state rather than that it said something: `showTimelineError` writes to
+  // a note that a later message overwrites, and a take that opened *and* complained
+  // would pass a row reading only the note.
+  //
+  // Both takes through the same door, because a build that refused every take would
+  // pass the first of these and fail nobody's notice.
+  console.log('\n[library] the capture format band at the door the editor opens');
+  {
+    const refusedAt = editorPage(macUrl, 'future-format-take');
+    const { page: refused, errors: refusedErrors } = await openPage(browser, refusedAt, { width: 640, height: 400 });
+    // Taken at the moment it matches rather than read again afterwards, for the reason
+    // the preset rows below give: the note is one line and every later message
+    // overwrites it.
+    const held = await refused.waitForFunction(
+      '(() => { const t = document.getElementById("tNote")?.textContent ?? ""; return t.includes("capture format") ? t : null; })()',
+      null, { timeout: 30000 },
+    ).catch(() => null);
+    const note = held ? String(await held.jsonValue())
+      : await refused.evaluate('document.getElementById("tNote")?.textContent ?? ""');
+    check(new RegExp(`capture format ${CAPTURE_FORMAT + 1}\\b`).test(note),
+      'an editor handed a take from a format this build does not read says which generation it found',
+      note.slice(0, 140) || 'the note is empty');
+    check(await refused.evaluate("document.body.classList.contains('editing')") === false,
+      'and it does not open the take - the refusal is a door rather than a message beside an opened clip');
+    // The throw is what this page is about, so counting it as a finding would be
+    // asserting the scenario did not happen. Anything else still is one.
+    const strayed = refusedErrors.filter((e) => !/capture format/.test(e) && !/Failed to load resource/.test(e));
+    check(strayed.length === 0, 'and refusing it raises no page error beyond the refusal itself',
+      strayed.slice(0, 2).join(' | ') || 'none beyond the refusal');
+    await refused.close();
+
+    const { page: opened, errors: openedErrors } = await openPage(
+      browser, editorPage(macUrl, 'generation-zero-take'), { width: 640, height: 400 },
+    );
+    const editing = await opened.waitForFunction("document.body.classList.contains('editing')", null, { timeout: 30000 })
+      .then(() => true, () => false);
+    check(editing === true,
+      'while a take whose hello declares no format at all opens in the same editor, which is every take shot before the field existed',
+      editing ? 'editing' : await opened.evaluate('document.getElementById("tNote")?.textContent ?? "(no note)"'));
+    check(openedErrors.filter((e) => !/Failed to load resource/.test(e)).length === 0,
+      'and it opens without a page error', openedErrors.slice(0, 2).join(' | ') || 'none');
+    await opened.close();
   }
 
   // A library with no takes at all.

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -203,6 +203,105 @@ if (!existsSync(DOC)) {
   }
 }
 
+// **The hello the grabber emits and the hello the README documents have to be the same
+// set of keys, and the constant saying which generation wrote it has to be the same
+// number in both languages.**
+//
+// The prose block was nine keys against the thirteen actually emitted for long enough
+// that the four it omitted became the argument for this: `startedAt` is the only durable
+// capture date a take has, and somebody implementing a second producer against the
+// documented nine writes takes the library dates by file modification time instead - which
+// changes the first time a take is copied off the node, and degrades *quietly*, because
+// the fallback is legitimate and says `dateSource: 'mtime'` rather than failing.
+//
+// Three details decide whether this is an instrument or a green light wired to nothing,
+// and all three are the same rule as the two blocks above.
+//
+// **Both directions.** A key emitted and not documented is the failure that already
+// happened; a key documented and not emitted is somebody writing against a promise the
+// grabber does not keep, which is the same reader misled by the opposite mistake.
+//
+// **Scoped anchors, and an empty extraction is a failure rather than a pass.** A bare
+// `readme.includes('width')` is true of the word appearing anywhere in a 700-line file,
+// so the README side is cut to the `type 1 hello` stanza and stops at `type 2`, and the
+// grabber side to the one `snprintf` that builds the hello. Zero keys from either side
+// means the anchor moved and the comparison ran on nothing, which is exactly the shape
+// this tool's own header is about.
+//
+// **Read textually, never imported.** This tool takes `--root`, so an `import` would bind
+// the assertion to this checkout while claiming to have checked another tree - and the C++
+// constant could not be imported at all, which is the whole reason it needs watching: it
+// is unavoidably a second spelling of a JavaScript number, and nothing else in the repo
+// would notice the two drifting.
+//
+// The controls are run by hand, in the idiom the two blocks above use, because this tool
+// carries no `--mutate` harness: add a key to the grabber literal and not to the README,
+// then the other way round, then bump the constant in one language, and require a named
+// failure each time.
+{
+  const grabberPath = join(ROOT, 'native/grabber.cpp');
+  const readmePath = join(ROOT, 'README.md');
+  if (!existsSync(grabberPath) || !existsSync(readmePath)) {
+    fail('native/grabber.cpp or README.md is missing, so the hello the format claims to have cannot be tested against the one it emits');
+  } else {
+    const grabber = readFileSync(grabberPath, 'utf8');
+    const readme = readFileSync(readmePath, 'utf8');
+
+    // The literal that builds the hello, from the call to its closing paren. Anchored on
+    // the call rather than on the opening brace of the JSON, because the brace is a
+    // character that appears everywhere and the call appears once.
+    const callAt = grabber.indexOf('std::snprintf(hello, sizeof(hello),');
+    const literal = callAt === -1 ? '' : grabber.slice(callAt, grabber.indexOf(');', callAt));
+    // `\"name\":` as it is spelled in C++ source. The `%s` values between them cannot
+    // match, because a conversion specifier does not start with a letter.
+    const emitted = new Set([...literal.matchAll(/\\"([A-Za-z][A-Za-z0-9]*)\\":/g)].map((m) => m[1]));
+
+    // The stanza, and only the stanza: from the type 1 line to the type 2 line, then the
+    // braced list inside it. Splitting a brace on commas rather than scanning for words
+    // keeps the prose around it - "UTF-8 JSON, once, before any frame" - out of the set.
+    const stanzaAt = readme.indexOf('type 1  hello');
+    const stanza = stanzaAt === -1 ? '' : readme.slice(stanzaAt, readme.indexOf('type 2', stanzaAt));
+    const braced = stanza.match(/\{([^}]*)\}/);
+    const documented = new Set((braced?.[1] ?? '').split(',').map((k) => k.trim()).filter(Boolean));
+
+    if (emitted.size === 0) {
+      fail('no hello keys found in native/grabber.cpp - the snprintf anchor moved, so this comparison would have passed on nothing');
+    } else if (documented.size === 0) {
+      fail("no hello keys found in README.md's type 1 hello stanza - the anchor moved, so this comparison would have passed on nothing");
+    } else {
+      const undocumented = [...emitted].filter((k) => !documented.has(k)).sort();
+      const unemitted = [...documented].filter((k) => !emitted.has(k)).sort();
+      // Two failures rather than one, because which direction it broke in is the whole
+      // diagnosis: one is a writer that grew a key nobody was told about, the other is a
+      // reader promised a key that never arrives.
+      if (undocumented.length) {
+        fail(`the grabber's hello emits ${undocumented.join(', ')} and README.md's type 1 hello does not document ${undocumented.length === 1 ? 'it' : 'them'}`);
+      }
+      if (unemitted.length) {
+        fail(`README.md's type 1 hello documents ${unemitted.join(', ')} and the grabber does not emit ${unemitted.length === 1 ? 'it' : 'them'}`);
+      }
+      if (!undocumented.length && !unemitted.length) {
+        console.log(`  hello/  all ${emitted.size} keys emitted are documented, and back`);
+      }
+    }
+
+    // The format generation, in the two languages that have to agree about it. Anchored
+    // on the declaration in each rather than on any mention, so a comment naming the
+    // constant is not a second reading of its value.
+    const inJs = readFileSync(join(ROOT, 'web/format.js'), 'utf8').match(/^export const CAPTURE_FORMAT = (\d+);/m);
+    const inCpp = grabber.match(/^static const uint32_t CAPTURE_FORMAT = (\d+);/m);
+    if (!inJs || !inCpp) {
+      fail(`CAPTURE_FORMAT is not declared where this looked: ${inJs ? '' : 'web/format.js '}${inCpp ? '' : 'native/grabber.cpp'}`.trim()
+        + ' - one of the two declarations moved, and an undeclared constant cannot be compared with anything');
+    } else if (inJs[1] !== inCpp[1]) {
+      fail(`CAPTURE_FORMAT is ${inJs[1]} in web/format.js and ${inCpp[1]} in native/grabber.cpp - `
+        + 'the grabber would stamp a generation the band that reads it refuses, on every take shot after this');
+    } else {
+      console.log(`  format/ CAPTURE_FORMAT is ${inJs[1]} in both languages`);
+    }
+  }
+}
+
 console.log(`\n${total} JavaScript files, ${failed} failed`);
 // Said out loud because `npm test` runs this, and a green `npm test` that meant "the
 // suite passed" would be the most expensive wrong impression in the repo. Nothing here

--- a/web/format.js
+++ b/web/format.js
@@ -96,6 +96,99 @@ export function versionRefusal(what, version) {
 }
 
 /**
+ * The generation of the capture format this build writes and reads, in one place for
+ * the same reason the document's version is - except that the artifact it stamps
+ * cannot be re-authored.
+ *
+ * A project can be rebuilt from a look somebody still remembers and an index can be
+ * rebuilt from the capture it indexes. The capture is the shoot: whatever the room
+ * was doing at that moment exists as those bytes and nowhere else. So the argument
+ * `PROJECT_VERSION` makes - a build that cannot faithfully interpret a file refuses
+ * it rather than rendering somebody else's meaning silently - is the same argument
+ * here with the stakes moved, because a document read wrong can be read again and a
+ * take reprojected wrong is a take nobody will ever notice was reprojected wrong.
+ *
+ * The failure this exists for needs no adversary. Change the depth quantisation, or
+ * move `registration.undistortDepth` on the no-colour path, and every take written
+ * afterwards is byte-indistinguishable in *structure* from every take written before:
+ * same magic, same two message types, same hello keys. One geometry model then runs
+ * over two populations and the older half of the archive is quietly wrong, with
+ * nothing on screen to attribute it to.
+ *
+ * ---
+ *
+ * **Version 1 is the format as it settled**: u16 millimetre depth on the sensor's own
+ * 512x424 grid, colour registered into that grid, and the intrinsics in the hello. It
+ * is `1` rather than a larger number because nothing has moved the depth quantisation
+ * or the registration path since the format settled - a version field that lies is
+ * worse than none, so if a geometry change ever turns out to already be in the
+ * archive, this number is wrong and saying so is the only honest repair.
+ *
+ * **Three bands, and the first is the one that keeps the existing archive readable.**
+ *
+ * A hello carrying no `format` key at all is honestly generation zero and opens.
+ * Every take on disk today is one, the field cannot be added to them retroactively -
+ * nothing in this program rewrites a capture, deliberately - and `describeTake`
+ * already reads `startedAt` by exactly this presence-sniff for exactly this reason.
+ * Presence-sniffing works once, which is what this field is for: it is the last time
+ * an absent key has to mean anything.
+ *
+ * A hello carrying `CAPTURE_FORMAT` opens, because this build wrote it.
+ *
+ * Anything else is refused - a later number, or a `format` that is not a number at
+ * all. Refused rather than unprojected on this build's assumptions, and naming what
+ * it found, because a take from a generation this build has never heard of is
+ * geometry nobody can check, which is the same case the no-hello refusal covers one
+ * band earlier.
+ *
+ * **Bumping this number is a decision about every earlier one, and the comparison below
+ * is deliberately strict so that it cannot be made by default.** `format === CAPTURE_FORMAT`
+ * means the day this becomes 2, every generation-1 take is refused unless the same commit
+ * says what happens to them - an accept set, or a refusal somebody chose. That is the
+ * right way round for the one artifact that cannot be made again: locking the archive out
+ * should be something a person wrote down, never something that fell out of an increment.
+ */
+export const CAPTURE_FORMAT = 1;
+
+/**
+ * The sentence a take from a format this build cannot read gets, and the predicate
+ * behind it: empty when the take may be opened, the reason when it may not.
+ *
+ * One function rather than a comparison at each door, and `versionRefusal` above is
+ * the precedent - two doors saying different things about one file is how one of them
+ * ends up false. There are four doors here rather than two. `describeTake` decides
+ * `openable`, the gallery's badge says why, its dead Open button says why, and
+ * `openTake` refuses in the editor; the first three are cheap to satisfy by inlining
+ * a comparison, and an inlined comparison drifts the first time the band gains a
+ * member. It will gain one: recording HD colour into takes is a third message type,
+ * which is a format change by any reading.
+ *
+ * `what` is a noun phrase the caller owns, because the gallery is talking about a
+ * tile the reader is looking at and the editor is talking about an id in a URL.
+ */
+export function captureFormatRefusal(what, format) {
+  // **Absent and an explicit null are one answer, and that is a choice rather than a
+  // constraint.** JSON distinguishes them perfectly well and `'format' in hello` would
+  // read the difference, so the honest statement is what the difference would cost and
+  // buy. Costs: a second channel through the listing, since `describeTake` ships a value
+  // and not the key's presence, so the browser would need a declared-flag or a sentinel
+  // beside it. Buys: protection against a writer broken twice over - one that learned
+  // the field, stamps a literal null instead of a number, *and* moved the geometry. A
+  // null-stamping writer whose geometry is unchanged is opened on this build's
+  // assumptions, which is exactly what generation zero gets anyway.
+  //
+  // Refusing the literal null is the defensible other reading and costs no take on disk
+  // today, since none of them carry the key at all. It is written down here rather than
+  // settled because the wire cost is real and the hazard needs both failures at once.
+  if (format === null || format === undefined) return '';
+  if (format === CAPTURE_FORMAT) return '';
+  return `${what} was written in capture format ${JSON.stringify(format)} and this build reads `
+    + `format ${CAPTURE_FORMAT}: nothing here knows what geometry that generation recorded, and a `
+    + 'take is the one thing in this program that cannot be made again, so it is refused rather '
+    + 'than unprojected on assumptions that may not be its own';
+}
+
+/**
  * What may be a take id, a document name, or anything else this program joins to a
  * path - and it is here, beside the version, for the same delivery reason.
  *

--- a/web/library.js
+++ b/web/library.js
@@ -47,7 +47,7 @@
 // over the picture where they cost no height. See `library.html` for each of those in
 // the place it is enforced.
 
-import { VALID_ID } from '/format.js';
+import { VALID_ID, captureFormatRefusal } from '/format.js';
 
 const DEPTH_W = 512;
 const DEPTH_H = 424;
@@ -151,6 +151,31 @@ function warningsOf(take) {
       why: 'this take carries no sensor hello, so its intrinsics are unknown and it cannot be unprojected',
     });
   }
+  // The band immediately after the one above, because it is the same fact one step
+  // further along: a take with no hello has intrinsics nobody knows, and a take from a
+  // generation nobody knows has intrinsics whose *meaning* nobody knows. The sentence
+  // comes from `format.js` rather than being spelled here, so this badge and the dead
+  // Open button below it and the editor's own throw are one statement in three places.
+  // The `short` stays local, because what fits over a 228px poster is this file's
+  // concern and nothing else's.
+  //
+  // **The tile under this badge still draws, and that is decided rather than left over.**
+  // The skim unprojects the take's depth on this build's intrinsics, which is the very
+  // thing the refusal calls geometry nobody can check - so a badged tile is showing a
+  // picture whose shape may not be the room's. It draws anyway, because the poster's job
+  // here is recognition and not measurement: a gallery is where somebody goes to find
+  // which take this is, a blank tile answers that worse than an approximate one, and the
+  // badge over it says the picture is not to be trusted. Nothing bakes: the take cannot
+  // be opened, and `render-worker` reaches a take through `/edit?take=` - the same door
+  // `openTake` refuses at - so no export can be made from one of these.
+  const wrongFormat = captureFormatRefusal('this take', take.format ?? null);
+  if (wrongFormat) {
+    out.push({
+      key: 'format',
+      short: 'unknown format',
+      why: wrongFormat,
+    });
+  }
   if (take.frames !== null && take.frames < 2) {
     // Zero and one are different facts and the badge says which. A take cut before
     // its first whole frame has no picture to show at all - which is why the skim
@@ -172,6 +197,12 @@ function warningsOf(take) {
 const cannotOpen = (take) => {
   if (take.recording === true) return warningsOf(take)[0].why;
   if (take.hasHello === false) return 'this take carries no sensor hello, so its intrinsics are unknown';
+  // Taken from `format.js` rather than shortened here the way its two neighbours are.
+  // Those two say one thing each and a reader can be told the rest by the badge; this
+  // one has to name the generation it found, because "unknown format" without the
+  // number is a refusal nobody can act on.
+  const wrongFormat = captureFormatRefusal('this take', take.format ?? null);
+  if (wrongFormat) return wrongFormat;
   if (take.frames !== null && take.frames < 2) return 'a take needs two frames to bracket a position';
   return '';
 };

--- a/web/main.js
+++ b/web/main.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { PROJECT_VERSION, versionRefusal } from './format.js';
+import { PROJECT_VERSION, versionRefusal, captureFormatRefusal } from './format.js';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
@@ -9951,6 +9951,19 @@ async function openTake(id) {
     );
   }
   const hello = await res.json();
+  // **Which generation wrote this, before anything reads a field out of it.** Ahead of
+  // the bounds check below rather than beside it, because the two questions nest: that
+  // check asks whether these numbers are usable *as this build understands the record*,
+  // and a take from a format this build has never seen is one whose fields could be
+  // perfectly in range and mean something else. A gallery listing the same take has
+  // already greyed its Open button off this same sentence, and the two agreeing is the
+  // whole reason it is one function rather than two comparisons.
+  //
+  // Here rather than on the live socket, for the reason the paragraph above gives about
+  // the intrinsics: a live preview bakes nothing, and the file is where a record that
+  // cannot be trusted has already become permanent.
+  const wrongFormat = captureFormatRefusal(`take ${id}`, hello.format ?? null);
+  if (wrongFormat) throw new Error(wrongFormat);
   // Positive rather than finite, and inside the frame rather than merely a number.
   // `Number.isFinite(0)` is true, so a hello carrying `fx: 0` - the shape a writer
   // that recorded a field it never filled produces - passed a refusal written to

--- a/web/menu.html
+++ b/web/menu.html
@@ -195,7 +195,15 @@ async function resolveResume() {
   // gallery's job rather than something to do on the way past.
   if (take.state === 'remote') return gallery(`${take.id} is only on the node`);
   if (take.recording === true) return gallery(`${take.id} is still being recorded`);
-  if (!take.openable) return gallery(`${take.id} cannot be opened: no sensor hello, or under two frames`);
+  // **The predicate is the server's and the sentence is not this page's to write.**
+  // This used to name the two reasons it knew - no sensor hello, or under two frames -
+  // and that stopped being the whole list the moment the capture format grew a band,
+  // which is a third way for `openable` to be false and one neither of those sentences
+  // describes. Enumerating again here would put this page back in the same position one
+  // member later, and the band is expected to gain another when a third message type
+  // lands. So the gate stays on the one predicate and the reason comes from the gallery,
+  // which carries a sentence per band and a badge to go with it.
+  if (!take.openable) return gallery(`${take.id} cannot be opened - the gallery says why`);
 
   // Built a value at a time rather than by interpolation, because a project name is
   // whatever somebody typed and an ampersand in it would otherwise start a second


### PR DESCRIPTION
Closes #44.

A `.knct` file had a magic and a message type and nothing saying what generation of grabber produced it, and it is the only artifact in this system that cannot be made again — a project can be re-authored and an index rebuilt from the capture, but the capture is the shoot. Change the depth quantisation, or move `registration.undistortDepth` on the no-colour path, and every take written afterwards is byte-indistinguishable in *structure* from every take written before, so one geometry model runs over two populations and the older half of the archive is quietly wrong with nothing on screen to attribute it to.

`CAPTURE_FORMAT = 1` now lives in `web/format.js` beside `PROJECT_VERSION`, with **one predicate** behind it: `captureFormatRefusal(what, format)` returns the empty string when a take may be opened and the sentence when it may not. Three bands — a hello carrying no `format` key is honestly generation zero and opens, which is every take on disk today; a hello carrying `CAPTURE_FORMAT` opens; anything else is refused, naming what it found. The grabber carries the only other spelling of the number, unavoidably, since the browser cannot import a C++ constant.

## What the falsification control measures

The thing worth scrutinising is whether the band is genuinely one predicate rather than four comparisons that agree, so the control is aimed at exactly that. `--mutate open-ignores-format` edits **one line** of `web/format.js` and reddens **6 of 360** assertions — one row per door, plus the gallery menu's sentence and the editor's editing state:

```
FAIL  a take from a format this build does not read ... says it cannot be opened  format 2, openable true
FAIL  the Open on a take from a format this build cannot read is disabled the same way
FAIL  a take from a format this build cannot read carries a badge over its poster  no badges
FAIL  and the sentence in the menu names the generation it found and the one this build reads
FAIL  an editor handed a take from a format this build does not read says which generation it found  the note is empty
FAIL  and it does not open the take - the refusal is a door rather than a message beside an opened clip
```

A mutation reddening fewer would mean the band had stopped being one predicate. Every control row stays green: both `no-hello-take` rows, `local-clip`'s `dateSource === 'hello'`, and all four generation-zero rows — a band written as "refuse anything unfamiliar" would pass every row about the future-format take and condemn the entire existing archive, so `generation-zero-take` is planted under its own name rather than left to the takes that are generation zero incidentally.

Clean suite: **360 assertions, none failed** (`--node-port 8310 --mac-port 8311`, idle machine, span free).

## The three parity controls, run by hand

`syntax-check` gained a block reading hello key names out of the grabber's `snprintf` and out of the README's `type 1 hello` stanza, compared as sets in **both directions**, plus `CAPTURE_FORMAT` read textually out of both languages — textually rather than by import because that tool takes `--root`, so an import would bind the assertion to this checkout while claiming to have checked another tree. It carries no `--mutate` harness, so its controls are manual. All three fired, each on its own named assertion:

| Control | Assertion it fired on |
|---|---|
| a 15th key in the grabber literal, not in the README | `the grabber's hello emits exposure and README.md's type 1 hello does not document it` |
| a key in the README the grabber does not emit | `README.md's type 1 hello documents exposure and the grabber does not emit it` |
| `CAPTURE_FORMAT` bumped in `web/format.js` alone | `CAPTURE_FORMAT is 2 in web/format.js and 1 in native/grabber.cpp` |

All three reverted; `git diff` confirmed clean afterwards. **Worth recording for whoever runs these next:** the obvious `perl -pi` one-liner for the first control silently matches nothing against a C++ literal full of escaped quotes. The first attempt did exactly that and reported a clean pass — a mutation that never applied, reading precisely like a check that missed one. It was re-done with an anchor asserted to match exactly once.

## The STOP condition: the content hash does not move

Proved rather than believed. `captures/sample.knct` hashes `sha256:de2b17bd9b8ec2fc…` before building the new grabber and `sha256:de2b17bd9b8ec2fc…` after — read both by `shasum` and by `buildIndex`, which is the scan `server/library.js` joins two machines on. Nothing rewrites a file on disk, so only takes recorded *after* this hash differently. **That is the boundary #9 crosses and this one does not**: a third message type moves every take's content hash, the format key moves none.

The hello literal was also lifted out and compiled under `-Werror=format`: 239 bytes of the 512-byte buffer, parses as JSON, fourteen keys, `format` is the number `1`. `build-native.mjs` exits 0, which includes running the binary it built.

## Two things to look at, reported rather than folded in

**`web/menu.html` is outside the issue's scope list and is changed anyway.** The issue named four doors; there is a fifth. Its *gate* was already correct — it reads `take.openable`, the one predicate — but its *sentence* enumerated `"no sensor hello, or under two frames"`, which stopped being the whole list the moment the band existed, so it would have told an operator two things about a take neither of which was true. I removed the enumeration rather than extending it to three reasons, because extending it puts the page back in the same position one member later and the band is expected to gain one at #9. The done-criterion "no file outside the in-scope list is modified" and "no false sentence ships" cannot both hold here, because the scope list missed a door — **flagging it for the reviewer to bless or to send back as its own issue.**

**`library-check`'s `stageServer` now writes every mutation into the staged tree**, not only `server/` ones. This was needed and is not cosmetic: `server/library.js` imports `web/format.js` by path, so a mutation of it delivered only by the browser route interception left the server deciding `openable` on the unmutated band — the control would have reddened the page's rows and left the server's green, which reads as a partial break in the product rather than a half-broken build. Both staged roots are copies, so nothing touches the subject. A side effect worth naming: since `WEB_DIR` is `join(ROOT, 'web')`, staging is now *also* a delivery path for page files, so the route interception is redundant for delivery (it wins the race and answers with the same body, so they cannot disagree) and its one remaining unique job is the `library.html` → `/gallery` mapping. **Collapsing the two into one mechanism is worth doing and is deliberately not done here** — it would put six page mutations this issue never touched through a new delivery path, and re-proving each for its own stated reason is a piece of work rather than a line.

## One flaky row, and it is not this change

Two of seven runs on this branch failed `and it is stamped in source milliseconds rather than program time` (`0ms against source 150ms at program 1.0s`), a seek/settle race in the mark row. Rather than assert it was unrelated, it was measured: three **interleaved** A/B rounds against a pristine `907b87f` tree extracted with `git archive`, both arms running concurrently on separate port spans so the contention is shared. The baseline failed that identical row with the identical detail line in round 1; this branch ran clean all three rounds. Pre-existing, and nothing here touches the timeline, retime or mark paths.

## Deliberately not done

Nothing migrates an existing capture and no tool is added to do so. A converter over captures is a program whose whole purpose is to rewrite the one artifact that cannot be regenerated. `server/capture.js` and `server/recorder.js` are untouched — the recorder writes the grabber's hello bytes through unchanged, and a recorder that re-serialised it to add a key would be a second producer of the same record. `tools/make-fixture.js` is untouched too: a fixture looped from a generation-zero sample *is* a generation-zero take, and stamping a number onto it would be the harness manufacturing the thing under test.
