### PR TITLE
Specify the .knct format beside it, and check that specification against the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ rather than by reading a config key:
 
 ```
 node tools/syntax-check.mjs                          # every JS file this repo ships parses
+node tools/syntax-check.mjs --mutate spec-drifts     # ... and the .knct decoder specification must FAIL when a constant moves under it
 node tools/release-gate-check.mjs                    # the .npmrc supply-chain gate is actually armed
 node tools/release-gate-check.mjs --mutate wrong-unit # ... and must FAIL (also: no-gate, absent)
 ```

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -142,6 +142,25 @@ machine it fires eight, all of them the intended row. So a throw is now `crashed
 verdict and before `untested`. **Read which assertions fired, not how many** — and a proof
 tool must never count its own crash as a finding in either direction.
 
+### Reverting a probe with `git checkout --` deletes the thing under test when it is uncommitted
+
+Found while mutation-testing the `.knct` specification row in `syntax-check`. The row was new
+and so was the specification it reads, both of them uncommitted, and each probe ended in
+`git checkout -- server/protocol.js` to undo the damage. That restores the file to `HEAD`, which
+in this state means restoring the version with no specification in it at all. So the first probe
+was valid, the revert silently removed the feature, and the two probes after it ran against a
+file that no longer had anything to check — both went red, both for the wrong reason, and both
+would have been recorded as catches by anybody reading only the count. One of them additionally
+reported `Identifier 'MAGIC' has already been declared`, which is the shape of a probe whose
+own edit is malformed rather than a finding, and is the tell that should stop the run.
+
+`git stash` is already forbidden here for a different reason, and the same replacement covers
+this one: **copy the file outside the repository, probe, and restore from the copy**, then
+`diff` the restore against it and re-run the clean arm to confirm it is green again. The rule
+in `CLAUDE.md` about taking a baseline is written for a measurement, and it applies unchanged to
+mutating an instrument you have not committed yet. The cheaper version of the same protection is
+to commit the instrument before probing it, so that a revert has something to revert to.
+
 ### A mutation can erase its own evidence
 
 `plant-open-take` originally appended its foreign bytes through a second file descriptor.

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -219,6 +219,27 @@ is named in `CLAUDE.md`, which is why the invocation list lives there rather tha
 added later is asked by existing, and the falsification control is adding a tool without
 documenting it.
 
+**Its third row is the `.knct` decoder specification**, the page at the top of
+`server/protocol.js` that issue #45 decided is a take's exit from this program instead of a
+point-cloud export. That makes it load-bearing in a way prose here usually is not: it is what
+somebody writes a reader from once nothing in this tree runs, so a constant that moved while it
+did not would send them to a reader that is plausibly shaped and quietly wrong. The row reads the
+specification's number table against the module's exports and fails on any disagreement. Two
+choices in it are the whole of why it means anything. The exports are **enumerated rather than
+listed**, so every numeric export has to appear in the specification and a constant added next
+year is asked by existing rather than added to a second table that drifts. And the values are
+read by **importing** the module rather than by a regex over its source, because
+`MAX_PAYLOAD_BYTES` is `8 * 1024 * 1024` and reads correctly one way and not the other.
+
+The control is `--mutate spec-drifts`, which substitutes `TYPE_COLOR = 3` for `4` and leaves the
+prose where it is. Both arms import through a scratch copy of the file rather than the clean arm
+importing the live path — they have to differ only in the substitution, or the run is comparing
+two mechanisms and calling the difference a catch. An anchor it cannot find and a mutation name it
+does not know both exit 2 rather than running, for the reason the exit-code section above gives.
+Mutation-tested three ways beyond its own control: a numeric export added to `protocol.js` and
+left out of the table reddens it, the specification block deleted reddens it, and a number edited
+in the table while the code stays put reddens it.
+
 **`prof-summary.mjs <profile> [warmup]`** reads `grabber --profile` output and flags any run
 under 29.5fps as contended, because the segment timings from a run that dropped frames are
 noise. That floor belongs to a profiling run that writes nothing — see the gate paragraph in

--- a/server/protocol.js
+++ b/server/protocol.js
@@ -1,6 +1,81 @@
 // Wire format shared by the native grabber, the recorder and the replayer.
 //
-//   [u32 magic 'KNCT'][u32 type][u32 payloadLen][payload]
+// ---- the .knct decoder specification ---------------------------------------
+//
+// **A recorded take is this wire verbatim** - the framing below, written to disk in
+// arrival order, with nothing added and nothing wrapped around it. So this is both the
+// live protocol and the archive format, and it is written out here rather than left
+// implied because the archive outlives the stack that recorded it: a Kinect v2
+// discontinued for years, a libfreenect2 that is minimally maintained, and a depth solve
+// on an OpenCL that Apple has deprecated. Issue #45 asked whether a take's exit from this
+// program should be a point-cloud export or a specification, and settled on this: an
+// export costs a measured 4.10x the take as xyz and does not replace it, since the take
+// is kept anyway for the native JPEG and the sensor stamps, while a page here is enough
+// for somebody to write a reader in an afternoon.
+//
+// The numbers in the table are checked against this module's own exports by
+// `tools/syntax-check.mjs`, which fails when a constant moves and the prose does not, and
+// which enumerates the exports rather than a list so a constant added later is asked by
+// existing. A specification nobody checks is a document that drifts, which is the failure
+// this repository deleted its design document to avoid.
+//
+//   MAGIC              0x4b4e4354   'KNCT' read as a little-endian u32
+//   HEADER_BYTES       12           three u32s: magic, type, payloadLen
+//   TYPE_HELLO         1            the sensor record, once, before any frame
+//   TYPE_FRAME         2            one depth grid and at most one JPEG
+//   TYPE_COLOR         3            live only - the recorder never writes one
+//   MAX_PAYLOAD_BYTES  8388608      a longer declared payload is a desync, not a frame
+//
+// **Container.** Every message is `[u32 magic][u32 type][u32 payloadLen][payload]`, all
+// integers little-endian, `payloadLen` counting the payload alone. A file is one message
+// after another to EOF. A final message whose payload falls short of its declared length
+// is a take that was cut off mid-write rather than a corrupt file, and every frame before
+// it is still good - which is why a reader should stop at a short tail instead of
+// refusing the take.
+//
+// **Type 1, the hello.** UTF-8 JSON, once, ahead of every frame. `fx`, `fy`, `cx`, `cy`
+// are the depth camera's intrinsics *as this device reported them*, and they are what a
+// reader must unproject with rather than any constant: they are per-device, and the
+// viewer's own boot defaults of 366/366/256/212 sit about 45mm from a real sensor's at
+// three metres. `width` and `height` are the depth grid. Not every take carries every
+// key - the list has grown, and one recorded before a key existed simply lacks it.
+//
+// **Type 2, the frame.** `[u32 depthBytes][u32 colorBytes][u64 stampMs][depth][jpeg]`,
+// little-endian again, `stampMs` a wall clock in milliseconds from the recording machine.
+// The depth is `width * height` u16 millimetres, row-major, top row first, so
+// `depthBytes` is `width * height * 2`. `colorBytes` may be zero: the colour camera runs
+// at about half the depth rate, and a frame carrying no JPEG means the previous picture
+// still stands rather than that anything was lost. The JPEG, where present, is the
+// *registered* colour - `Registration::apply`'s resample into the depth camera's
+// viewpoint - so it shares the depth grid pixel for pixel and a per-vertex colour is a
+// direct lookup at the same row and column.
+//
+// **A depth of 0 is not a point.** It is the solve returning no reading along that ray,
+// and a reader that unprojects it anyway puts a vertex at the sensor origin - a wall of
+// geometry that was never in the room. Measured over all 284 frames of the sample take,
+// 76.5% of the 512x424 grid carries a reading: mean 166,148 samples, range 146,129 to
+// 170,134.
+//
+// **Unprojection**, libfreenect2's pinhole model, the same one `Registration::getPointXYZ`
+// and the vertex shader in `web/main.js` use. For the sample at column `col` and row
+// `row` holding `mm` millimetres, in metres, in a right-handed frame with the camera
+// looking down -z:
+//
+//     z = mm / 1000
+//     X =  (col + 0.5 - cx) / fx * z
+//     Y = -(row + 0.5 - cy) / fy * z
+//     Z = -z
+//
+// The half pixel is the sample's centre, and Y is negated because image space grows
+// downward. That is the whole of it: those four lines against the four intrinsics out of
+// the hello turn a take into geometry with none of this program running.
+//
+// **Nothing in the file says which generation of grabber wrote it.** That is issue #44's
+// to fix rather than this specification's, and it is recorded here because a reader that
+// assumes one geometry model across an archive holding more than one gets a silently
+// wrong answer - and here is where somebody writing that reader will be looking.
+//
+// ---- end of the .knct decoder specification --------------------------------
 
 export const MAGIC = 0x4b4e4354;
 export const TYPE_HELLO = 1;

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
-// Parses every JavaScript file this repo ships. Nothing else - no server, no browser,
-// no sensor, no dependencies - which is what makes it the one thing CI can run on a
-// fresh clone and mean it.
+// Parses every JavaScript file this repo ships, and asks the three questions about the
+// tree that need nothing to answer: that every tool is documented, that every cited
+// `docs/` page exists, and that the `.knct` decoder specification still agrees with the
+// module it specifies. No server, no browser, no sensor, no dependencies - which is what
+// makes it the one thing CI can run on a fresh clone and mean it.
 //
 //   node tools/syntax-check.mjs [--root <dir>]
 //
@@ -32,11 +34,32 @@ import { execFileSync } from 'node:child_process';
 import { copyFileSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const argv = process.argv.slice(2);
 const REPO = join(dirname(fileURLToPath(import.meta.url)), '..');
 const ROOT = argv.includes('--root') ? argv[argv.indexOf('--root') + 1] : REPO;
+
+// A literal source substitution in `server/protocol.js`, in the shape the other tools'
+// mutation tables use. It is applied to the copy the specification row actually imports,
+// so that row reads a genuinely moved constant rather than a comparison somebody nudged -
+// and the specification's own prose is left alone, which is the drift being simulated:
+// the code moved and the document did not.
+const MUTATIONS = {
+  'spec-drifts': {
+    from: 'export const TYPE_COLOR = 3;',
+    to: 'export const TYPE_COLOR = 4;',
+  },
+};
+
+// Resolved before anything runs, so a name nobody implemented costs a second rather than
+// a full parse of the tree and a verdict about the wrong thing.
+const mutateAt = argv.indexOf('--mutate');
+const mutation = mutateAt === -1 ? null : argv[mutateAt + 1];
+if (mutateAt !== -1 && !MUTATIONS[mutation]) {
+  console.log(`DID NOT RUN - no mutation named ${mutation ?? '(nothing was given)'}; this tool knows ${Object.keys(MUTATIONS).join(', ')}`);
+  process.exit(2);
+}
 
 // The server, the tools and the browser bundle. Everything else with a .js in it is
 // either vendored, built or a capture, and none of those are ours to parse.
@@ -203,9 +226,95 @@ if (!existsSync(DOC)) {
   }
 }
 
+// **And the `.knct` decoder specification has to agree with the module it specifies.**
+// Same family as the two blocks above - documentation checked against the tree rather than
+// asserted beside it - and here for the same reason they are: this tool needs nothing at
+// all, so the control costs a run of what CI already does.
+//
+// The take is the one irreplaceable artifact in the system, and issue #45 decided its exit
+// from this program is that specification rather than a point-cloud export. That makes the
+// specification load-bearing in a way prose usually is not here: it is the thing somebody
+// writes a reader from once nothing in this tree runs any more, and a constant that moved
+// while it did not would send them to a reader that is plausibly shaped and quietly wrong.
+//
+// **Enumerated from the module, not from a list.** Every numeric export has to appear in
+// the specification with its exact value, so a constant added next year is asked by
+// existing rather than added to a second table that drifts. The values come from importing
+// the module rather than from a regex over its source, because a constant that is computed
+// - `MAX_PAYLOAD_BYTES` is `8 * 1024 * 1024` - reads correctly one way and not the other.
+//
+// **Imported from a scratch copy in both arms, and that is not tidiness.** The clean run
+// and the mutated run have to differ only in the substitution; a row that imported the live
+// path when clean and a copy when mutated would be comparing two mechanisms and calling the
+// difference a catch.
+//
+// The control is `--mutate spec-drifts`, which moves `TYPE_COLOR` and leaves the prose.
+{
+  const SPEC_OPEN = '// ---- the .knct decoder specification';
+  const SPEC_SHUT = '// ---- end of the .knct decoder specification';
+  const rel = 'server/protocol.js';
+  const file = join(ROOT, rel);
+  if (!existsSync(file)) {
+    fail(`${rel} is missing, so the decoder specification has nothing to be checked against`);
+  } else {
+    let src = readFileSync(file, 'utf8');
+    if (mutation) {
+      const { from, to } = MUTATIONS[mutation];
+      // Refused rather than run. A mutation whose anchor has moved does nothing, and a run
+      // that does nothing comes back green - which gets recorded as the control passing.
+      if (!src.includes(from)) {
+        console.log(`DID NOT RUN - the ${mutation} anchor "${from}" is not in ${rel}, so nothing was mutated and this run would prove nothing`);
+        process.exit(2);
+      }
+      src = src.replace(from, to);
+    }
+    const open = src.indexOf(SPEC_OPEN);
+    const shut = src.indexOf(SPEC_SHUT);
+    let mod = null;
+    const scratch = mkdtempSync(join(tmpdir(), 'syntax-check-spec-'));
+    try {
+      // `.mjs` rather than `.js` beside a copied package.json: the parse mode has to be
+      // unambiguous here, and unlike the canary above this row is not trying to prove
+      // anything about how Node decides it.
+      const copy = join(scratch, 'protocol.mjs');
+      writeFileSync(copy, src);
+      mod = await import(pathToFileURL(copy).href);
+    } catch (err) {
+      fail(`${rel} could not be imported, so its exports could not be read: ${err.message}`);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+    const numbers = mod ? Object.entries(mod).filter(([, v]) => typeof v === 'number') : [];
+    if (open === -1 || shut === -1) {
+      fail(`${rel} carries no decoder specification block, so the archive's only written description of its own format is gone`);
+    } else if (numbers.length === 0) {
+      fail(`${rel} exports no numeric constant, so this assertion passed on nothing`);
+    } else {
+      const spec = src.slice(open, shut);
+      const wrong = [];
+      for (const [name, value] of numbers) {
+        const said = spec.match(new RegExp(`^//\\s+${name}\\s+(0x[0-9a-fA-F]+|\\d+)\\b`, 'm'));
+        if (!said) {
+          wrong.push(`${name} is exported as ${value} and the specification never gives it`);
+        } else if (Number(said[1]) !== value) {
+          wrong.push(`the specification says ${name} is ${said[1]} where the module exports ${value}`);
+        }
+      }
+      if (wrong.length) {
+        fail(`the .knct decoder specification disagrees with ${rel}: ${wrong.join('; ')}`);
+      } else {
+        console.log(`  spec/   all ${numbers.length} protocol constants match the .knct decoder specification`);
+      }
+    }
+  }
+}
+
 console.log(`\n${total} JavaScript files, ${failed} failed`);
 // Said out loud because `npm test` runs this, and a green `npm test` that meant "the
-// suite passed" would be the most expensive wrong impression in the repo. Nothing here
-// executes a line of what it parsed.
+// suite passed" would be the most expensive wrong impression in the repo. **One thing here
+// executes rather than parses**, and it is named rather than buried: the specification row
+// imports a copy of `server/protocol.js`, which is a module of constants with no imports of
+// its own, and reads its exported values. Nothing is called and no behaviour is exercised.
+// Everything else is `node --check` and nothing runs.
 console.log('syntax only - no proof tool ran here; see CLAUDE.md "Proof tools" for the suite and what each of them needs');
 process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Closes #55. #45 is already closed, by the decision recorded in its thread rather than by this diff.

## What this is

#45 asked whether a take's exit from this program should be an interchange format or archival
insurance, and the [decision](https://github.com/totally-tim/braindance/issues/45#issuecomment-5166712759)
settled it: archival, and it does not need a separate export. This is the branch that answer
opened — the `.knct` decoder specification, beside the format in `server/protocol.js`, with the
row that keeps it true.

## The measurement that decided it

Over the sample take, all 284 frames — the whole file rather than a window, no warmup and none
applicable, because the count is a deterministic function of the file's bytes. The machine was
**not** idle, load average 89.15, which moved the wall clock and not the number.

**76.5% of the 512x424 grid carries a reading**: mean 166,148 samples per frame, range 146,129 to
170,134, p05–p95 164,504–169,370.

| Row | Bytes/frame | vs source | Basis |
|---|---|---|---|
| Source `.knct`, all in | 486,000 | 1.00x | measured (README, real capture) |
| PLY xyz, full grid | 2,605,056 | 5.36x | arithmetic |
| PLY xyz + rgb, full grid | 3,256,320 | 6.70x | arithmetic |
| PLY xyz, **populated only** | 1,993,776 | **4.10x** | measured count × arithmetic size |
| PLY xyz + rgb, **populated only** | 2,492,220 | **5.13x** | measured count × arithmetic size |

The estimate #45 carried was 5.36x/6.70x over the full grid, so it ran about 31% high. That is
why the count came before the arithmetic.

## Why the cheap version died

#45's cheapness rested on *"a PLY writer is that loop with a different sink"*. That loop —
`drawPlanCloud` — rejects on `nearClip`, `farClip` and all four crop faces, then rotates through
`worldTilt`. All seven are `tag: 'look'` registry entries: keyframeable, since `laneRows` gives a
lane to any of `params.names('look')` carrying keys, and written into the project document by
`serialiseProjectBody`.

So a cloud written through that loop is the crop somebody chose in the frame somebody levelled,
and the crop can animate across the take — the same criticism #45 makes of the `.mp4`, one
representation later. An archival writer has to skip all seven, and a writer that skips them is
not that loop any more. **The branch that is cheap is not archival, and the branch that is
archival is not cheap.** On top of that the export is additive rather than replacing: a
registered-colour cloud drops the native JPEG and the sensor stamps, so the `.knct` is kept
anyway.

## What the control covers, and what it does not

Worth stating plainly rather than letting "checked against the code" read as covering the page.

**Covered.** The six numeric constants — `MAGIC`, `HEADER_BYTES`, `TYPE_HELLO`, `TYPE_FRAME`,
`TYPE_COLOR`, `MAX_PAYLOAD_BYTES`. Enumerated from the module's exports rather than from a list,
so a constant added next year is asked by existing, and read by **importing** the module rather
than by regex, because `MAX_PAYLOAD_BYTES` is `8 * 1024 * 1024` and reads correctly one way and
not the other.

**Not covered.** The unprojection formula and the frame payload's field offsets — which is most
of what a reader in ten years actually needs, and where a wrong sign on Y or a wrong prefix
length produces exactly the plausibly-shaped-and-quietly-wrong reader this whole branch exists to
prevent. #45's Test plan named the numbers row as this branch's control and that is what is
built, but the gap is real and is named here rather than left to a justification nobody looks
past. The cheap next step is `server/capture.js`, whose `DEPTH_W`/`DEPTH_H` are numeric and would
fall to the same enumeration.

## Mutation results

Each read by its failed-assertion count and by which assertion fired, not by the exit code.

| Run | Result |
|---|---|
| `--mutate spec-drifts` | **1 failed**, naming `TYPE_COLOR` 3 vs 4. Every other row stayed green. |
| probe: numeric export added, table not told | **1 failed**, naming it — the close-the-class claim |
| probe: specification block deleted | **1 failed** |
| probe: `MAX_PAYLOAD_BYTES` edited in the table only | **1 failed** — the arm proving the import reads the computed value |
| `--mutate nonsense`, bare `--mutate`, unmatched anchor | **exit 2** each — a mutation that did nothing must not read green |
| baseline restored | green, file byte-identical to the copy held outside the repo |

Both arms import through a scratch copy rather than the clean arm importing the live path, so
they differ only in the substitution instead of in mechanism.

## Two things a reviewer will look for

**The mutation-carrying tool count in `docs/proof-tools.md` is deliberately untouched.** It
counts a delivery mechanism rather than tools, #47 owns correcting the prose around it, and that
issue warns in as many words that the next reader will "fix" the fourteen the wrong way. Adding
`syntax-check` to it here would have been exactly that.

**`syntax-check` now executes one thing rather than nothing**, and both comments that claimed
otherwise are corrected in this diff — the header and the closing note. The specification row
imports a copy of `server/protocol.js`, a module of constants with no imports of its own, and
reads its exported values; nothing is called and no behaviour is exercised. The printed
`syntax only - no proof tool ran here` line is still accurate.

## Verification

- `npm test` exits 0.
- `node tools/syntax-check.mjs` exits 0, "0 failed", with the new `spec/` row visible.
- `node tools/syntax-check.mjs --mutate spec-drifts` fails with one assertion.
- No `docs/*.md` file added and no new design document; the `tools/` arithmetic in `CLAUDE.md` is
  unchanged, because no file was added to `tools/`.

`docs/instruments.md` gains the lesson this work cost: reverting a probe with `git checkout --`
deletes the thing under test when it is uncommitted, which invalidated two probes here before
they were re-run against a copy held outside the repository.
