### PR TITLE
One delivery path for a mutated page, and a refusal when it does not arrive

### DIFF
--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -78,14 +78,43 @@ the retime seam, and the refusal is what surfaced that rather than a silent pass
 something a mutation anchors to, re-anchor it in the same commit and say in the message which
 ones moved.
 
-**`library-check` serves a mutated page at the URL the page is reached by, not at its
-filename.** `web/library.html` has no URL of its own — `server/index.js` 404s any `.html`
-under `web/` on purpose, so a page has exactly one address — and it is served at `/gallery`.
-A route interception written as `**/library.html` therefore matches nothing, the unmutated
-page loads, and the run is recorded as the check having missed a bug it was never shown.
-That is the match-exactly-once failure arriving through the *delivery* rather than through
-the anchor, where nothing refuses it, so the interception refuses a page file it has no URL
-for instead.
+**`library-check` delivers every mutation by one mechanism — the staged tree — and then asks
+the server whether it arrived.** Both halves are worth reading before editing that tool,
+because it had two mechanisms for a release and the seam between them was a hazard rather
+than a redundancy.
+
+Server mutations were always staged. Page mutations were fulfilled by a Playwright route
+interception matched on a URL, and that shape has a specific failure: **a page is reached at
+the URL `PAGES` names it by, not at its filename**. `web/library.html` has no URL of its own —
+`server/index.js` 404s any `.html` under `web/` on purpose, so a page has exactly one address —
+and it is served at `/gallery`, so an interception written as `**/library.html` matches
+nothing, the unmutated page loads, and the run is recorded as the check having missed a bug it
+was never shown. That is the match-exactly-once failure arriving through the *delivery* rather
+than through the anchor, where nothing refused it.
+
+Staging everything closed a different hole — `server/library.js` imports `web/format.js` by
+path, so a mutation of it that reached only the page left the server deciding `openable` on the
+unmutated band — and made the interception redundant in the same breath, since `WEB_DIR` is
+`join(ROOT, 'web')` and `web/` is copied into the staged root. Two mechanisms delivering the
+same bytes is not defence in depth; it is the two-gates-that-agree shape `docs/instruments.md`
+records, where no mutation can reach one without the other covering, so neither can be tested
+and one of them is doing all the work.
+
+So there is one delivery path, and `requireMutationDelivered` is the opposite shape from the
+thing it replaced: it fetches the page's own URL before a browser opens anything and requires
+the bytes back to be the ones this run staged. `PAGE_URLS` is unavoidably a second spelling of
+`PAGES` and is *checked rather than trusted* by exactly that fetch, so a page that moved or
+stopped being served fails by name. **It exits 2 rather than failing an assertion**, and the
+direction is the point: a suite that fails one row on a mutation run reads as a catch, so a
+mutation that never arrived has to be the harness declining to run.
+
+Measured when the mechanisms were collapsed: 19 of the 20 page mutations delivered, each
+named with the URL and the byte count, `gallery-has-no-way-back` among them at `/gallery`,
+which is the case the interception existed for. The twentieth is `marks-ignore-retime`, which
+cannot be constructed at all — its anchor matches twice in `web/main.js` and the
+match-exactly-once refusal stops it, a stale anchor that predates this and is tracked in #28.
+The control for the delivery refusal is to stop staging `web/` files and run a page mutation:
+it names the file, the URL and both byte counts, and exits 2 without printing an assertion.
 
 ## What each tool needs
 
@@ -247,14 +276,13 @@ green — both `no-hello-take` rows, `local-clip`'s `dateSource === 'hello'`, an
 generation-zero rows. A mutation that reddened fewer would mean the band had quietly become
 several predicates that agree.
 
-Reaching all four needed one change to the harness. `stageServer` used to write only a `server/`
-mutation into the staged tree, leaving `web/` ones to the browser route interception — which is
-right for `main.js` and `library.js`, since nothing on the Node side imports either. It is wrong
-for `format.js`, which `server/library.js` imports by path: served to the page and not staged, the
-server would have gone on deciding `openable` on the unmutated band and the control would have
-reddened the page's rows only, reading as a partial break in the product rather than a half-broken
-build. Every mutation is written into the staged tree now; both roots there are copies, so nothing
-reaches the subject.
+Reaching all four needed the harness to stage `web/` mutations rather than leaving them to the
+browser route interception, because `server/library.js` imports `format.js` by path: served to
+the page and not staged, the server would have gone on deciding `openable` on the unmutated band
+and the control would have reddened the page's rows only, reading as a partial break in the
+product rather than a half-broken build. That is what put the tool briefly on two delivery
+mechanisms and is why it is now on one — see the Mutations section above for the collapse and for
+what `requireMutationDelivered` asserts.
 
 **`syntax-check` also holds the hello to the README and the format constant to the grabber**, in
 both directions and without importing either. The prose block documented nine keys against the

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -125,11 +125,14 @@ const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 // would run the unmutated build and be recorded as this tool having missed a bug it
 // was never shown.
 //
-// Server files and page files both appear here, in one table. The server ones are
-// possible because this check spawns its own servers out of a copied tree; the page
-// ones are served into the browser by route. One namespace, because the safety
-// property is the refusal and splitting it would make it possible to have two rules
-// about it.
+// Server files and page files both appear here, in one table, and they are delivered the
+// same single way: `stageServer` writes the mutated file into the copied tree, and the
+// server spawned out of that tree is what serves it. Page files were once fulfilled
+// separately, by a Playwright route interception, and that second mechanism is gone
+// rather than dormant - see `stageServer` for why two paths delivering the same bytes was
+// a hazard, and `requireMutationDelivered` for the refusal that replaced it. One
+// namespace, because the safety property is the refusal and splitting it would make it
+// possible to have two rules about it.
 
 // **The reveal mutation has to break the branch this platform actually runs.** It
 // edited the Darwin entry only, so on Linux or Windows the staged server kept its own
@@ -935,10 +938,17 @@ const pageMutation = mutation && mutation.file.startsWith('web/') ? mutation : n
 //
 // This is unavoidably a second spelling of that table, and it is **checked rather than
 // trusted**: `requireMutationDelivered` fetches this URL and requires the bytes back to
-// be the ones this run staged, so a page that moved, gained a second address or stopped
-// being served fails the run by name instead of loading unmutated. That is the whole
-// difference from the mechanism this replaced, which could match nothing and say so to
-// nobody.
+// be the ones this run staged, so a page that moved or stopped being served fails the run
+// by name instead of loading unmutated. That is the whole difference from the mechanism
+// this replaced, which could match nothing and say so to nobody.
+//
+// Moved or removed, and **not a second address gained**, which one fetch of one URL
+// cannot see: `/gallery` would go on answering with the staged bytes and this would pass.
+// The narrower claim is the true one and it is also the sufficient one, because every
+// navigation in this file reaches the gallery through `galleryPage`, so the address this
+// checks is the address under test - an alias nothing opens delivers nothing. Written out
+// because the wider claim was here first, and a comment promising a guarantee its check
+// does not make is the failure this file exists to refuse.
 const PAGE_URLS = { 'library.html': '/gallery' };
 const urlForPageFile = (file) => PAGE_URLS[file] ?? `/${file}`;
 const serverMutation = mutation && mutation.file.startsWith('server/') ? mutation : null;
@@ -1272,6 +1282,19 @@ function stopServers() {
   for (const { child } of servers) child.kill('SIGKILL');
 }
 
+// **The backstop for every way out that does not reach the `finally`.** A spawned server
+// is not killed by its parent leaving - it is reparented and goes on holding the port -
+// and this suite is the one thing that cannot survive that, because `reservePorts` asks
+// the kernel and refuses, so one orphan turns every later run in every worktree into an
+// exit 2 naming a port nobody can find the owner of. The `finally` at the foot covers the
+// checks; it does not cover the refusal in `requireMutationDelivered`, a `startServer`
+// that throws with the node server already up, or a `chromium.launch` that fails before
+// the `try` is entered. Registered here rather than at each of those, because the list is
+// the wrong thing to maintain - the next exit added below is covered by existing.
+// Synchronous, which `exit` requires, and killing an already-dead child is a no-op, so it
+// costs nothing on the path that did run the `finally`.
+process.on('exit', stopServers);
+
 /**
  * Refuses the run when a page mutation did not reach the browser, and it is exit 2
  * rather than a failed assertion.
@@ -1305,13 +1328,19 @@ async function requireMutationDelivered(base) {
     served = null;
     status = err.message;
   }
+  // `Buffer.byteLength` and not `.length`, because a JavaScript string is counted in
+  // UTF-16 code units and every page here is served as UTF-8: `library.html` is 25,206
+  // bytes and 25,187 units, so the shorter number printed under the word *bytes* is one
+  // nothing on the wire ever measured. The comparison above stays a string compare - the
+  // round trip through UTF-8 is exact, so it already answers the question - and it is only
+  // the evidence that had to stop mislabelling itself.
   if (served === pageMutation.body) {
-    console.log(`[library] ${MUTATE} delivered: ${url} serves the mutated ${file} (${served.length} bytes)`);
+    console.log(`[library] ${MUTATE} delivered: ${url} serves the mutated ${file} (${Buffer.byteLength(served)} bytes)`);
     return;
   }
   console.error(`[library] refusing to run: ${MUTATE} edits web/${file} and ${url} did not answer with it.`);
-  console.error(`[library] the server answered ${status} with ${served === null ? 'nothing' : `${served.length} bytes`}, `
-    + `where the staged file is ${pageMutation.body.length}.`);
+  console.error(`[library] the server answered ${status} with ${served === null ? 'nothing' : `${Buffer.byteLength(served)} bytes`}, `
+    + `where the staged file is ${Buffer.byteLength(pageMutation.body)}.`);
   console.error('[library] a page mutation that does not arrive leaves the unmutated page under test and every row '
     + 'passing, which reads as this tool having missed a bug it was never shown - so the run stops here rather than '
     + 'reporting one. Either the page moved to a URL PAGE_URLS does not name, or the server stopped serving it.');

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -928,6 +928,19 @@ function mutatedSource(name) {
 
 const mutation = MUTATE ? mutatedSource(MUTATE) : null;
 const pageMutation = mutation && mutation.file.startsWith('web/') ? mutation : null;
+// The URL a page file is served at, which is not its filename. `server/index.js` 404s
+// any `.html` under `web/` on purpose - a page has exactly one address - so
+// `library.html` is reachable only at the `/gallery` its `PAGES` table names, while the
+// modules beside it are served by name.
+//
+// This is unavoidably a second spelling of that table, and it is **checked rather than
+// trusted**: `requireMutationDelivered` fetches this URL and requires the bytes back to
+// be the ones this run staged, so a page that moved, gained a second address or stopped
+// being served fails the run by name instead of loading unmutated. That is the whole
+// difference from the mechanism this replaced, which could match nothing and say so to
+// nobody.
+const PAGE_URLS = { 'library.html': '/gallery' };
+const urlForPageFile = (file) => PAGE_URLS[file] ?? `/${file}`;
 const serverMutation = mutation && mutation.file.startsWith('server/') ? mutation : null;
 
 // ----------------------------------------------------------------- the fixtures
@@ -1156,30 +1169,34 @@ function stageServer() {
     const from = join(REPO, name);
     if (existsSync(from) && !existsSync(join(root, name))) symlinkSync(from, join(root, name));
   }
-  // **Every mutation is written into the staged tree, not only the server ones**, and
-  // it was `server/` only until the capture format's band needed breaking.
+  // **This is the one place a mutation is delivered, whichever side of the wire it is
+  // on**, and it is worth saying how it got here because the two halves arrived a
+  // release apart and the seam between them was a hazard rather than a redundancy.
   //
-  // `web/format.js` is the file that made the old arrangement wrong. `server/library.js`
-  // imports it by path - which is the entire reason the constant lives under `web/`,
-  // since the browser can only reach what the server serves and Node has no such
-  // constraint - so a mutation of it delivered to the page and not staged left the
-  // server deciding `openable` on the unmutated band. The control would then redden the
-  // page's rows and leave the server's green, which reads as a check having found a
-  // partial break in the product rather than as the harness having broken half the
-  // build. Both roots here are copies, so this writes into the scratch tree and never
-  // into the subject.
+  // Server mutations were always staged. Page mutations were fulfilled by a Playwright
+  // route interception in `openPage`, matched on a URL. `web/format.js` is what made
+  // that untenable: `server/library.js` imports it by path - which is the entire reason
+  // the constant lives under `web/`, since the browser can only reach what the server
+  // serves and Node has no such constraint - so a mutation of it reached the page and
+  // not the server, which went on deciding `openable` on the unmutated band. That
+  // control reddened the page's rows and left the server's green, reading as a check
+  // having found a partial break in the product rather than as the harness having broken
+  // half the build.
   //
-  // **This is now also the delivery path for a page file**, and saying so matters
-  // because the comment here used to claim the route interception in `openPage` was the
-  // whole of it. `WEB_DIR` is `join(ROOT, 'web')` and `web/` is copied into the staged
-  // root, so a mutated page file staged here is what the server serves - the
-  // interception in `openPage` fulfils first and wins the race, but it is answering with
-  // the same `mutation.body` this wrote, so the two cannot disagree about what is under
-  // test. What the interception still does uniquely is map `library.html` onto `/gallery`
-  // and refuse a page file it has no URL for. Collapsing the two into one mechanism is
-  // worth doing and is deliberately not done here: it would put six page mutations this
-  // issue never touched through a new delivery path, and re-proving each of them for its
-  // own stated reason is a piece of work rather than a line.
+  // Staging everything fixed that and made the interception redundant in the same
+  // breath, which is the state this replaces: `WEB_DIR` is `join(ROOT, 'web')` and
+  // `web/` is copied here, so the staged file *is* what the server serves. Two
+  // mechanisms delivering the same bytes is not defence in depth - it is a rule with
+  // nothing measuring it, since no mutation can reach one without the other covering,
+  // and the interception's own failure mode was silence: matched on a URL, it could
+  // match nothing, load the unmutated page, and be recorded as this tool having missed a
+  // bug it was never shown. `requireMutationDelivered` replaces it with the opposite
+  // shape - it asks the server what it serves and stops the run when the answer is not
+  // this file.
+  //
+  // Both roots here are copies, so this writes into the scratch tree and never into the
+  // subject - the reason a mutation is a file in a staged tree rather than an edit
+  // restored afterwards, which would leave a mutated working tree behind any crash.
   if (mutation) {
     writeFileSync(join(root, mutation.file), mutation.body);
   }
@@ -1253,6 +1270,52 @@ async function startServer(root, args, port) {
 
 function stopServers() {
   for (const { child } of servers) child.kill('SIGKILL');
+}
+
+/**
+ * Refuses the run when a page mutation did not reach the browser, and it is exit 2
+ * rather than a failed assertion.
+ *
+ * **The direction matters more than the check.** A mutation that never arrived leaves
+ * the unmutated page under test, every row passes, and the run is recorded as this tool
+ * having missed a bug it was never shown - which is the same silence
+ * `mutatedSource`'s match-exactly-once refusal exists to break one layer up, arriving
+ * through the delivery instead of through the anchor. Counted as a failed assertion it
+ * would be worse than nothing, because a suite that fails one row on a mutation run
+ * reads as a catch. So this is the harness declining to run, which is what 2 means
+ * everywhere else in the suite.
+ *
+ * Asked of the server over HTTP rather than of the staged file on disk, because the
+ * disk is the half already known to be true - `stageServer` just wrote it - and the
+ * question is whether that file is what a browser asking for this page receives. The
+ * two come apart exactly where the URL is not the filename, which is the case that
+ * produced this paragraph.
+ */
+async function requireMutationDelivered(base) {
+  if (!pageMutation) return;
+  const file = pageMutation.file.slice('web/'.length);
+  const url = `${base}${urlForPageFile(file)}`;
+  let served = null;
+  let status = null;
+  try {
+    const res = await fetch(url);
+    status = res.status;
+    served = await res.text();
+  } catch (err) {
+    served = null;
+    status = err.message;
+  }
+  if (served === pageMutation.body) {
+    console.log(`[library] ${MUTATE} delivered: ${url} serves the mutated ${file} (${served.length} bytes)`);
+    return;
+  }
+  console.error(`[library] refusing to run: ${MUTATE} edits web/${file} and ${url} did not answer with it.`);
+  console.error(`[library] the server answered ${status} with ${served === null ? 'nothing' : `${served.length} bytes`}, `
+    + `where the staged file is ${pageMutation.body.length}.`);
+  console.error('[library] a page mutation that does not arrive leaves the unmutated page under test and every row '
+    + 'passing, which reads as this tool having missed a bug it was never shown - so the run stops here rather than '
+    + 'reporting one. Either the page moved to a URL PAGE_URLS does not name, or the server stopped serving it.');
+  process.exit(2);
 }
 
 /**
@@ -1461,25 +1524,6 @@ async function openPage(browser, url, viewport = { width: 1100, height: 760 }) {
   const errors = [];
   page.on('pageerror', (err) => errors.push(String(err)));
   page.on('console', (msg) => { if (msg.type() === 'error') errors.push(msg.text()); });
-  if (pageMutation) {
-    // **A page is reached at the URL `PAGES` names it by, not at its filename**, which
-    // is a rule `server/index.js` enforces by 404ing any `.html` under `web/` - so a
-    // mutation of `library.html` intercepted at `**/library.html` would match nothing,
-    // the unmutated page would load, and the run would be recorded as the check having
-    // missed a bug it was never shown. That is the failure the match-exactly-once rule
-    // exists for one layer up, arriving through the delivery instead of the anchor.
-    const file = pageMutation.file.slice('web/'.length);
-    const html = file.endsWith('.html');
-    const target = html ? '/gallery' : `/${file}`;
-    await page.route(`**${target}`, (route) => route.fulfill({
-      status: 200,
-      contentType: html ? 'text/html; charset=utf-8' : 'text/javascript; charset=utf-8',
-      body: pageMutation.body,
-    }));
-    if (html && file !== 'library.html') {
-      throw new Error(`no URL is known for web/${file}: only library.html is served, at /gallery`);
-    }
-  }
   await page.goto(url, { waitUntil: 'domcontentloaded' });
   return { page, errors };
 }
@@ -1503,6 +1547,12 @@ const macUrl = await startServer(root, ['--captures', macCaps, '--name', 'mac',
   '--node', nodeUrl, '--node-name', 'pi-01',
   '--presets', join(WORK, 'presets'), '--projects', join(WORK, 'projects'),
   '--builtin-presets', join(WORK, 'builtin-presets')], MAC_PORT);
+
+// Before a browser opens anything, so a mutation that cannot arrive costs a server spawn
+// rather than a full run ending in a verdict about the wrong build. One server answers
+// for all of them: every server this suite spawns is spawned out of `root`, which is the
+// tree `stageServer` wrote the mutation into.
+await requireMutationDelivered(macUrl);
 
 const { chromium } = await loadPlaywright();
 const browser = await chromium.launch({ headless: !HEADED, args: ['--use-gl=angle', '--use-angle=default'] });


### PR DESCRIPTION
Follow-up to #54, which named this and deliberately left it: *"Collapsing the two into one mechanism is worth doing and is deliberately not done here."*

#54 had to stage `web/` mutations as well as `server/` ones, because `server/library.js` imports `web/format.js` by path and a mutation reaching only the page left the server deciding `openable` on the unmutated band. That fixed the hole and made the Playwright route interception redundant in the same breath — `WEB_DIR` is `join(ROOT, 'web')` and `web/` is copied into the staged root, so the staged file already *is* what the server serves.

**Two mechanisms delivering the same bytes is not defence in depth.** It is the two-gates-that-agree shape `docs/instruments.md` already records — no mutation can reach one without the other covering, so neither can be tested and one of them is doing all the work. And the interception's own failure mode was silence: matched on a URL, it could match nothing, load the unmutated page, and be recorded as this tool having missed a bug it was never shown. Its comment documented that hazard and could not close it.

So the interception is gone, and `requireMutationDelivered` is the opposite shape. Before a browser opens anything it fetches the page's own URL and requires the bytes back to be the ones this run staged. `PAGE_URLS` is unavoidably a second spelling of the server's `PAGES` — `library.html` has no URL of its own, since `server/index.js` 404s any `.html` under `web/` so a page has exactly one address — and it is **checked rather than trusted** by exactly that fetch, so a page that moved or stopped being served fails by name instead of loading unmutated.

**It exits 2 rather than failing an assertion, and the direction is the whole point.** A suite that fails one row on a mutation run reads as a catch, so a mutation that never arrived has to be the harness declining to run rather than a claim failing — which is what 2 means everywhere else in the suite.

## Delivery, for every page mutation the tool declares

19 of 20 arrive, each named with its URL and byte count. **`gallery-has-no-way-back` is among them, at `/gallery`** — the case the interception existed for and the one a filename-matched rule gets wrong:

```
OK   web/library.html  gallery-has-no-way-back   http://localhost:8311/gallery serves the mutated library.html (25185 bytes)
OK   web/format.js     open-ignores-format       .../format.js serves the mutated format.js (13493 bytes)
OK   web/main.js       accept-any-version        .../main.js serves the mutated main.js (508603 bytes)
OK   web/library.js    tile-height-follows-content  .../library.js serves the mutated library.js (94845 bytes)
...  16 more
```

The twentieth is **`marks-ignore-retime`, which cannot be constructed at all** — its anchor matches twice in `web/main.js` and the match-exactly-once refusal stops it before delivery is reached. That is a stale anchor, it predates this work (already duplicated at `907b87f`), and it is tracked in #28, whose title is exactly this failure.

## Catching, so the collapse costs no mutation its rows

One full suite per page file, plus a server mutation to show that path is unregressed:

| Run | Mutated file | Result |
|---|---|---|
| clean | — | **360 assertions, none failed** |
| `open-ignores-format` | `web/format.js` | 6 failed — the same six as before this change |
| `gallery-has-no-way-back` | `web/library.html` | 4 failed |
| `tile-height-follows-content` | `web/library.js` | 4 failed |
| `accept-any-version` | `web/main.js` | 6 failed |
| `reconcile-by-filename` | `server/library.js` | 7 failed at 118 assertions |

**`reconcile-by-filename` ends its run early, and it did so before this change too.** Against a pristine `origin/main` tree extracted with `git archive`: 118 assertions, 7 failed, the same seven rows in the same order. Checked rather than reasoned about, because a mutation that ends a run early is precisely what `docs/instruments.md` says not to read as a catch — though delivery could not have moved it, since it is a server mutation on an untouched path.

The first attempt at that baseline came back `3 assertions, 1 failed` with `the run did not finish: fetch failed` — a crash wearing a failure count, which is the `fails=1` shape the same document warns about. Re-run on a settled machine with the span confirmed free, it reproduced the branch exactly.

## The new refusal's own control

Stop staging `web/` files and run a page mutation. It names the file, the URL and both byte counts, and exits **2** having printed **no assertion at all**:

```
[library] refusing to run: open-ignores-format edits web/format.js and http://localhost:8311/format.js did not answer with it.
[library] the server answered 200 with 13457 bytes, where the staged file is 13493.
```

## One correction carried in

The comment this replaces said **six** page mutations. There are **twenty**. That number came out of a review note in #54 and I repeated it without counting; it is corrected here rather than left, since a count in a comment beside a list that grows is how the tools list rotted the first time.

## Not in scope

`web/menu.html`'s refusal sentence and the `openable`/`cannotOpen` duplication are **#49**'s — that issue already names `web/menu.html` and owns the move to a keyed reason list on the server. Touching either here would collide with it.

**A note on the method, since two of my own verification sweeps measured nothing before they measured anything.** The first delivery sweep reported all 20 undelivered because `timeout` does not exist on this machine, so not one run started; the second reported one result because zsh does not word-split an unquoted variable, so the loop ran once with all twenty names as a single mutation. Both looked exactly like a finding. The numbers above are from the third form, which polls the run's own output and kills it once the delivery line appears.
