### PR TITLE
Honour the colour flags in the fake grabber, and make every mutation anchor checkable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ node tools/monitor-check.mjs                              # step 9: the monitor'
 node tools/monitor-check.mjs --mutate decimate-reaches-recorder  # ... and must FAIL mutated
 node tools/monitor-check.mjs --mutate bind-ignores-grid          # ... and must FAIL mutated
 node tools/monitor-check.mjs --mutate expand-shifts-by-a-block   # ... and must FAIL mutated
+node tools/monitor-check.mjs --mutate colour-off-keeps-the-texture # ... the cloud stops wearing the last JPEG
 node tools/sensor-view-check.mjs                          # the intrinsics a take was shot with, against a build that assumes them
 node tools/sensor-view-check.mjs --mutate fov-hardcoded   # ... and must FAIL mutated
 node tools/sensor-view-check.mjs --mutate no-repaint      # ... and must FAIL mutated

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -281,6 +281,24 @@ control over it at all: `markTicks()` only ever reads the ruler strip, so that s
 could stop going through the retime curve entirely and every row in the suite would stay
 green. Two sites doing one conversion is what made this anchor stale in the first place.
 
+**And reading a table by importing the tool's prefix made this row need what the tool needs,
+which CI found and a developer's machine cannot.** The cut ran from the top of the file so that a
+table referencing a const beside it would still resolve, and it dragged two things with it: the
+tool's own `import ... from 'ws'`, which CI has not installed because this tool is documented as
+needing nothing at all, and the tool's top-level *work* - `export-check` and `registry-check` both
+resolve a commit with `git log -S` while their module body runs, so reading their tables walked the
+whole history of `web/main.js` and threw outright in a tree extracted without its `.git`. Four
+tables went unread on CI, at 137 anchors against 248 here.
+
+The row was loud about it, four FAIL lines and the fallen count, which is why the count is in the
+summary line at all - but the summary still read `all 137 ... match once`, true of what it read and
+indistinguishable from a clean row. **A count is only honest beside what it could not count**, so
+an unread table is now named in that same sentence. The cut itself is the declaration alone, which
+reads fifteen of the sixteen with no imports and no side effects at all, falling back to the
+package-stripped prefix for the one table that references a neighbouring const. Verified where it
+failed: a tree extracted with neither `node_modules` nor `.git` reads all 248 in 14 tables, in 5.7s
+against minutes.
+
 **And the shape inference was wrong within days, which is the argument for normalising rather
 than for a better guess.** A bare `{ from, to }` had a single declarer, `registry-check`, which
 edits the browser bundle - so the resolver read the shape as meaning `web/main.js`. Then

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -142,6 +142,64 @@ machine it fires eight, all of them the intended row. So a throw is now `crashed
 verdict and before `untested`. **Read which assertions fired, not how many** — and a proof
 tool must never count its own crash as a finding in either direction.
 
+### A mutation is source text, and nothing was checking that the text still existed
+
+Three declared controls could not run at all, and had not been able to for a long time.
+`editor-check --mutate space-unbound` anchored on `if (timeline.playing) timeline.pause();`
+where the branch now reads `pauseTransport()` — renamed in `51c7c9d`, sixty commits before
+this was found. `keyframe-check --mutate undo-on-input` anchored on a listener whose local
+was renamed `el` to `input`; one word killed the control that proves a slider drag is one
+undo step rather than two hundred. `library-check --mutate marks-ignore-retime` anchored on
+the line converting a mark through the retime curve, which had been *copied* to the minimap,
+so it matched twice and the tool refused it.
+
+**The two shapes of refusal disagree, and the disagreement runs the dangerous way.**
+`editor-check` resolves its mutation inside a `try` and reports `DID NOT RUN` with exit 2,
+which is the honest answer. `keyframe-check` and `library-check` call `mutatedSource` at
+module top level with nothing catching it, so a run prints a stack trace and exits 1 with no
+`FAIL` row, no assertion count and no verdict line — which is indistinguishable from a caught
+mutation to anything reading exit codes, and `keyframe-check`'s throw happens after
+`chromium.launch`, so it leaves a browser behind as well.
+
+**Neither is the real lesson.** `timeline.pause()` had not vanished from the tree; it moved
+off the line the mutation cared about, and still exists elsewhere in `web/main.js`. Nothing
+casual would have spotted any of the three. The class is that every anchor in this suite is
+one rename away from the same silence, and the only thing that would have noticed was
+`sweep-all`, which needs a server, a browser and hours — the right verdict at the wrong
+latency, since it is what a merge waits on rather than what tells you your control is dead
+while you are leaning on it.
+
+**This had already happened once and was closed as an instance.** The comment above
+`undo-includes-view` in `tools/keyframe-check.mjs` records a previous re-anchoring in these
+words: the line it named moved, "so the old text matched nothing and the tool refused the
+mutation - correctly, and silently as far as anything reading only the exit code was
+concerned." That instance was fixed and the class was left open, and three more went stale
+behind it.
+
+So `syntax-check` now walks every tool's `MUTATIONS` table and asserts each anchor matches
+its target file **exactly once**. It costs nothing, needs no server and runs in CI. The table
+is read without executing the tool, by cutting the source at the end of the declaration,
+appending an export and importing that prefix from inside `tools/` so the tool's own relative
+imports still resolve; a prefix that does not import fails the row rather than being read as
+"this tool has no table". Targets resolve by the entry's *shape*, never by the tool's name,
+and an unrecognised seventh shape fails naming the tool instead of being skipped. Measured at
+`907b87f`: 239 anchors across 13 tables, of 15 declared.
+
+**A duplicate is as stale as a miss, and that is the half a naive row drops.** The real defect
+here was `marks-ignore-retime` matching *two* sites, so a row asking "does this text appear"
+rather than "exactly once" sails straight past the thing that prompted the work while looking
+thorough. Both controls exist for that reason: `anchor-matches-twice` duplicates an anchored
+line into its target file, and `anchor-goes-stale` changes one character inside a `from`
+string. Each must redden the anchor row **and nothing else** — a control that reddens the
+whole tool says nothing about which question the tool was asking.
+
+**One thing this does not close.** `library-check`'s `reveal-drops-the-path` resolves its edit
+through `process.platform`, so a macOS developer and a Linux CI run check different strings
+and neither checks the third. And the minimap's copy of the mark conversion still has no
+control over it at all: `markTicks()` only ever reads the ruler strip, so that second site
+could stop going through the retime curve entirely and every row in the suite would stay
+green. Two sites doing one conversion is what made this anchor stale in the first place.
+
 ### A mutation can erase its own evidence
 
 `plant-open-take` originally appended its foreign bytes through a second file descriptor.

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -276,6 +276,32 @@ than 30.** So size fixtures by *frame count*, not duration: five minutes of its 
 rewritten monotonic stamps — real depth and real JPEGs, only the u64 at payload offset 8 moves.
 Say so whenever a number rests on one.
 
+**`fake-grabber` honours `--no-color` and `--no-low-light`, and reports any argument it does
+not know.** It ignored both for its whole life, which mattered because they are not the
+operator's flags — the server appends them to the grabber's argv out of `camera`, so eight of
+`library-check`'s servers were running colour-off and being answered with a `"color":true`
+hello over frames still carrying full JPEGs. That is a stream the real sensor cannot produce
+under the arguments it was given, and the mirror image of it — a hello claiming colour over a
+take with no JPEG — is a state the server treats as corruption. Under `--no-color` the hello
+now says `"color":false`, and `"lowLight":false` with it: `native/grabber.cpp` reports
+`lowLight` as the **conjunction**, so colour off makes it false whatever the second flag said,
+and a fixture watching only for `--no-low-light` reproduces the same defect one field over
+while looking fixed. Every payload is rewritten once at load — the `colorBytes` u32 at offset
+4 zeroed and the payload truncated to `16 + depthBytes` — because `server/capture.js` refuses
+a frame whose two declared lengths do not describe it, so both edits are needed or nothing
+parses.
+
+**The depth it emits is real recorded sensor depth under both flags**, which is the whole
+value of this fixture. What it still deliberately does not do is simulate a sensor: the
+cadence is a flag, colour is dropped rather than re-shot, and `--pipeline`, `--log`,
+`--quality`, `--min-depth` and `--max-depth` are accepted and ignored because there is no
+device here to apply them to. Anything else in argv gets one line on stderr naming it and the
+stream runs on — **reported, never refused**, because `buildArgs` appends `--pipeline` on a
+server that was given one and a fixture that rejected a legitimate spawn would break that
+path. That line proves the fixture noticed a flag, never that it acted on one; the behavioural
+claims belong to `monitor-check`'s colour-off section, which watches the wire and the page
+separately.
+
 The registration corpus is gitignored like every other capture. Regenerate it with the sensor
 attached, and vary the scene while it runs - a hand near the lens, a person against a far wall,
 something occluding something further - because the occlusion filter only does work at depth

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -713,11 +713,17 @@ const MUTATIONS = {
   // The space bar stops reaching the transport. Everything else about the keyboard
   // stays, so this reddens the transport rows and leaves the stepping and range rows
   // alone - which is what makes it diagnostic of its own term.
+  //
+  // Re-anchored: the pause half of this branch became `pauseTransport()` in `51c7c9d`,
+  // and `timeline.pause()` did not vanish from the tree, it moved off the line this
+  // mutation cared about - so nothing casual would have spotted it while the control sat
+  // dead for sixty commits. `syntax-check`'s anchor row is what now asks the question
+  // cheaply; see `docs/instruments.md`.
   'space-unbound': {
     file: 'web/main.js',
     edits: [[
       '      // Or the page scrolls under the strip.\n      e.preventDefault();\n'
-      + '      if (timeline.playing) timeline.pause();\n'
+      + '      if (timeline.playing) pauseTransport();\n'
       + '      else timeline.play().catch(showTimelineError);\n      return;',
       '      // Or the page scrolls under the strip.\n      e.preventDefault();\n      return;',
     ]],

--- a/tools/fake-grabber.mjs
+++ b/tools/fake-grabber.mjs
@@ -24,10 +24,81 @@ import { createHash } from 'node:crypto';
 import { MessageParser, TYPE_HELLO, TYPE_FRAME, TYPE_COLOR, encodeMessage } from '../server/protocol.js';
 
 const argv = process.argv.slice(2);
+
+// **One table of every argument this fixture knows, and the only enumeration of them.**
+// `--no-color` was dropped in silence for the whole life of this file, because `flag()`
+// scanned argv for the names it happened to care about and nothing anywhere said an
+// argument had gone unread. The server hands it over a two-hop chain - `--no-color` on a
+// server's command line initialises `camera.color` false, and `buildArgs` appends
+// `--no-color` to the grabber's argv from that - so eight servers were running in a
+// colour-off configuration and being answered with full JPEGs under a hello declaring
+// `"color":true`, which is a stream the real sensor cannot produce under the arguments it
+// was given. The server treats the mirror image of that state, a hello claiming colour
+// over a take carrying no JPEG, as corruption worth nulling a hello for.
+//
+// Whether an entry takes a following value lives here too, so `--pipeline gl` reads as an
+// argument and its value rather than as a flag followed by an unknown token.
+//
+// `ignored` marks an argument this fixture reads and deliberately does nothing with, in
+// the register of the `low-light` note on the stdin handler below: there is no device here
+// to apply it to, and refusing it would make this fixture reject a spawn the server
+// legitimately performs.
+const ARGUMENTS = {
+  '--source': { value: true },
+  '--fps': { value: true },
+  '--die-after': { value: true },
+  '--burst': { value: true },
+  '--frames': { value: true },
+  '--tag': { value: true },
+  '--emit-log': { value: true },
+  '--hd': { value: false },
+  // The two the server appends out of `camera`, and the reason this table exists.
+  '--no-color': { value: false },
+  '--no-low-light': { value: false },
+  // `buildArgs` appends this whenever the server was given a pipeline, so it arrives on a
+  // perfectly legitimate spawn. There is no depth processor here to pick.
+  '--pipeline': { value: true, ignored: true },
+  // These four reach a real grabber only through the operator's own `--grabber` string,
+  // which for this fixture is always this fixture's own flags. They are named for that
+  // reason and for no other - not because anything here could honour them.
+  '--log': { value: true, ignored: true },
+  '--quality': { value: true, ignored: true },
+  '--min-depth': { value: true, ignored: true },
+  '--max-depth': { value: true, ignored: true },
+};
+
+// Both readers go through the table rather than beside it, so this file holds one list of
+// arguments and a second one cannot drift out of step with it. A name absent from the
+// table is a mistake in this file rather than in the argv, so it throws.
+const argument = (name) => {
+  if (!Object.hasOwn(ARGUMENTS, name)) throw new Error(`[fake-grabber] ${name} is read but missing from ARGUMENTS`);
+  return ARGUMENTS[name];
+};
 const flag = (name, fallback = null) => {
+  argument(name);
   const i = argv.indexOf(name);
   return i >= 0 && i + 1 < argv.length ? argv[i + 1] : fallback;
 };
+const given = (name) => { argument(name); return argv.includes(name); };
+
+// **Reported, never refused**, and that direction is the whole of the decision. `buildArgs`
+// appends `--pipeline` on a server that was given one, so a fixture that rejected an
+// argument it did not recognise would break a spawn the server is entitled to make; but an
+// argument silently dropped is how the colour-off half of the live path stayed unreachable
+// by every proof tool in this repo. So it says so and streams on.
+//
+// This closes the class rather than the instance: a third flag added to `buildArgs` next
+// year is reported by existing, instead of being swallowed the way `--no-color` was. It is
+// a report and not a driver - it proves this fixture noticed a flag, never that it acted on
+// one, and the behavioural claims belong to the rows that watch the stream.
+for (let i = 0; i < argv.length; i++) {
+  const known = Object.hasOwn(ARGUMENTS, argv[i]) ? ARGUMENTS[argv[i]] : null;
+  if (!known) {
+    process.stderr.write(`[fake-grabber] ignoring ${argv[i]}, which this fixture does not know\n`);
+    continue;
+  }
+  if (known.value) i++;
+}
 
 const SOURCE = flag('--source', 'captures/sample.knct');
 const FPS = Number(flag('--fps', '60'));
@@ -77,7 +148,13 @@ const EMIT_LOG = flag('--emit-log', '');
 // whole picture and still cannot produce the margin. `vcam-check` asserts the margin
 // and nothing but the margin, and `--mutate hd-upscales-registered` is the arm that
 // has to fail on it.
-const HD = argv.includes('--hd');
+const HD = given('--hd');
+// **The colour camera, which the server switches off at boot with `--no-color` and mid-shoot
+// from the editor's checkbox.** A real grabber parses both of these off argv and reports both
+// in its handshake, so a fixture that ignored them answered a colour-off configuration with a
+// stream no sensor could have produced.
+const COLOR = !given('--no-color');
+const LOW_LIGHT = !given('--no-low-light');
 // Where the marker lives, as a fraction of width taken off each side. 0.12 is wide
 // enough to survive 4:2:0 chroma subsampling and JPEG ringing at the boundary, and
 // narrow enough that the middle is still most of the picture.
@@ -125,6 +202,34 @@ if (HD) {
   process.stderr.write(`[fake-grabber] HD fixture ready: ${hdFrame.length} bytes, `
     + `${margin}px magenta left margin and cyan right\n`);
 }
+
+// **Colour comes off the frames themselves, once, here.** A hello saying `"color":false`
+// over payloads still carrying JPEGs would be the same lie one layer down, and it is the
+// lie the viewer cannot detect: `handleFrame` only reaches `pumpColorDecode` when a frame
+// declares `colorBytes > 0`, so the frames are what decide whether the colour path runs at
+// all.
+//
+// Both edits are needed or nothing parses - `server/capture.js` refuses a frame whose two
+// declared lengths do not describe it - so the count is zeroed *and* the bytes are dropped.
+//
+// **The depth stays real recorded sensor depth**, which is the whole value of this fixture:
+// synthesising depth to make the flag easy would trade away the one property that makes a
+// browser-driven suite worth running at all.
+//
+// After the HD build and before anything emits, in that order and no other. The build above
+// reads the source's colour block and exits 1 when the first frame carries none, and
+// `encode()` below has to read the truncated array.
+if (!COLOR) {
+  for (let i = 0; i < frames.length; i++) {
+    const payload = frames[i];
+    const depthBytes = payload.readUInt32LE(0);
+    const trimmed = Buffer.from(payload.subarray(0, 16 + depthBytes));
+    trimmed.writeUInt32LE(0, 4);
+    frames[i] = trimmed;
+  }
+  process.stderr.write(`[fake-grabber] colour off: ${frames.length} frames carry depth only, `
+    + `${frames[0].length} bytes each\n`);
+}
 // Off until asked, exactly as the real grabber is, so a check that never sends the
 // command sees no type 3 - which is what makes "it is emitted only on request" a
 // thing the fixture can be wrong about rather than a claim in a comment.
@@ -142,6 +247,16 @@ process.stdin.on('data', (chunk) => {
     const line = stdinPending.slice(0, nl).replace(/\r$/, '');
     stdinPending = stdinPending.slice(nl + 1);
     if (line === 'hd-color on' || line === 'hd-color off') {
+      // Mirrors `requestHdColor`, which returns early whenever `camera.color` is false and
+      // so never sends either command to a colour-off grabber. Refused here as well rather
+      // than trusted, because type 3 is the *colour camera's* own picture and a colour-off
+      // grabber has no colour camera to photograph with - a fixture that answered anyway
+      // would be manufacturing the one thing this flag is supposed to remove. Both
+      // directions, because the server gates both.
+      if (!COLOR) {
+        process.stderr.write('[fake-grabber] refusing hd colour: colour is off on this grabber\n');
+        continue;
+      }
       if (!HD) {
         process.stderr.write('[fake-grabber] refusing hd colour: started without --hd\n');
         continue;
@@ -156,8 +271,25 @@ process.stdin.resume();
 // The wall clock goes in the hello and nowhere else, the same as the real grabber:
 // every frame stamp below is a monotonic clock, which is right for frame spacing and
 // useless for sorting a library.
+//
+// **`lowLight` is the conjunction, not the negation of its own flag**, which is the half of
+// this that is easy to get backwards. `native/grabber.cpp` reports
+// `(wantColor && lowLight) ? "true" : "false"`, so a grabber given `--no-color` alone - which
+// is exactly what the server produces, since `camera.lowLight` stays true and
+// `--no-low-light` is therefore never appended - says `"lowLight":false`. A fixture that
+// only watched for `--no-low-light` would still say `true`, reproducing this same defect one
+// field over while looking fixed.
+//
+// **It is written only when something settles it**, because the sample's hello carries nine
+// keys and `lowLight` is not among them: it predates the field. Adding a tenth key to a
+// colour-on hello would move every take's content hash - the key the library joins two
+// machines on - across eight servers this change is not about, so the colour-on stream stays
+// byte-identical to what it was.
+const lowLightSettled = !COLOR || !LOW_LIGHT || 'lowLight' in sourceHello;
 const hello = Buffer.from(JSON.stringify({
   ...sourceHello,
+  ...(COLOR ? {} : { color: false }),
+  ...(lowLightSettled ? { lowLight: COLOR && LOW_LIGHT && (sourceHello.lowLight ?? true) } : {}),
   startedAt: Date.now(),
   ...(TAG ? { tag: TAG } : {}),
 }));

--- a/tools/keyframe-check.mjs
+++ b/tools/keyframe-check.mjs
@@ -178,9 +178,14 @@ const MUTATIONS = {
   ]],
   // Undo pushes on every input event rather than on the end of the interaction, so
   // one slider drag is two hundred levels.
+  // Re-anchored: the listener's local was renamed `el` to `input`, and a one-word rename
+  // is enough to kill a control outright - this one proves that a slider drag is a single
+  // undo step, and it had stopped running while reading as though it had. Caught by
+  // `syntax-check`'s anchor row rather than by anybody noticing; `docs/instruments.md`
+  // carries the case file.
   'undo-on-input': [[
-    "    el.addEventListener('input', () => writeFromControl(name, Number(el.value)));",
-    "    el.addEventListener('input', () => { writeFromControl(name, Number(el.value)); history.commit(); });",
+    "      input.addEventListener('input', () => writeFromControl(name, Number(input.value)));",
+    "      input.addEventListener('input', () => { writeFromControl(name, Number(input.value)); history.commit(); });",
   ]],
   // A seek plans its span once and never looks again, which is what the code did
   // before a curve could move under it. The hazard is older than step 5 - the speed

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -319,9 +319,21 @@ const MUTATIONS = {
   ]] },
   // Marks are drawn at their source fraction rather than through the retime curve,
   // which is identical at rate 1 with no keys and wrong everywhere else.
+  //
+  // **It reaches the ruler strip, and that is the only site it could usefully reach.**
+  // The rows below read `markTicks()`, which reads `#tMarks .tmk` - the strip `paintMarks`
+  // fills - so the minimap's copy of this same conversion has no assertion over it and a
+  // mutation landing there would redden nothing while looking identical from outside.
+  //
+  // Re-anchored: the conversion was copied to the minimap, so the bare line matched twice
+  // and `mutatedSource` threw at module top level - a stack trace, exit 1 and no assertion
+  // count at all, which is the failure shape that reads as a catch. It now carries the
+  // following line, because the two sites differ only in indentation and the four-space
+  // form is a substring of the six-space one. Two sites doing one conversion is the reason
+  // this went stale; see `docs/instruments.md`.
   'marks-ignore-retime': { file: 'web/main.js', edits: [[
-    '    const program = retime.programSecAt(mark.sourceMs / 1000);',
-    '    const program = mark.sourceMs / 1000;',
+    "    const program = retime.programSecAt(mark.sourceMs / 1000);\n    const el = document.createElement('span');",
+    "    const program = mark.sourceMs / 1000;\n    const el = document.createElement('span');",
   ]] },
   // The gallery skims a remote take at full resolution, promising a smoothness the
   // link does not have.

--- a/tools/monitor-check.mjs
+++ b/tools/monitor-check.mjs
@@ -198,6 +198,26 @@ const MUTATIONS = {
     'for (let col = 0; col < DW; col++) dst[to + col] = src[from + ((col / grid.k) | 0)];',
     'for (let col = 0; col < DW; col++) dst[to + col] = src[from + Math.min(grid.w - 1, (((col / grid.k) | 0) + 1))];',
   ]] },
+  // **The control for section 6.** The viewer stops noticing that a hello said colour is
+  // off, so `hasColor` keeps whatever value the last decoded JPEG left it at - and the
+  // shader keeps sampling `colorPrev`/`colorCurr`, which nothing is refreshing any more.
+  // Live, that is a cloud textured with a frozen still of the moment colour was switched
+  // off, for the rest of the session, on a viewer that otherwise looks completely healthy.
+  //
+  // It reddens the `hasColor` row after the toggle and nothing else. The fixture rows in
+  // the same section stay green by construction - the hello still says `"color":false` and
+  // the frames still declare `colorBytes === 0`, because this edit is in the page and the
+  // stream never knew about it - and that separation is the point: a control that reddened
+  // the fixture rows as well would have failed for a neighbouring reason and would say
+  // nothing about the viewer, which is the shape `decimate-reaches-recorder` above already
+  // records this tool being caught by.
+  //
+  // Replaced with a comment rather than deleted, so the branch keeps its shape and only the
+  // statement under test goes away.
+  'colour-off-keeps-the-texture': { file: 'web/main.js', edits: [[
+    '        if (!msg.color) uniforms.hasColor.value = 0;',
+    '        // the hello said colour is off, and this build does nothing about it',
+  ]] },
 };
 if (MUTATE && !MUTATIONS[MUTATE]) {
   console.error(`unknown mutation ${MUTATE} - have ${Object.keys(MUTATIONS).join(', ')}`);
@@ -988,6 +1008,132 @@ try {
         rounds.map((r) => `÷4 left ${r[4].sentinel}`).join(', '));
       ok('and the page reported no error while doing any of it', pageErrors.length === 0,
         pageErrors.slice(0, 2).join(' | '));
+
+      // ------------------------------ 6. the colour camera, switched off mid-shoot
+      //
+      // **The colour-off half of the live path, which nothing in this repo could reach
+      // until the fixture learned to produce it.** The colour camera comes off at boot
+      // with `--no-color` or mid-shoot from the editor's checkbox, and `tools/fake-grabber.mjs`
+      // ignored both for its whole life - so eight of `library-check`'s servers ran in a
+      // colour-off configuration and were answered with a `"color":true` hello over frames
+      // still carrying full JPEGs. The viewer's one statement that handles the real thing
+      // was therefore untested in the strongest sense available: deleting it left the whole
+      // suite green.
+      //
+      // What it costs live is a cloud wearing a frozen still of the moment colour went off,
+      // for the rest of the session, on a page that looks completely healthy. `webcam.js`
+      // already closes this exact hole on its own side - `setUnavailable` throws the held
+      // frame away rather than keeping it, so "a source that reconnects during an outage is
+      // not painted a still of the moment the sensor died" - and the point cloud did not.
+      //
+      // **Two rows on two different objects, so a red row says which half is at fault.**
+      // One reads the wire: what the respawned grabber actually handshook and what its
+      // frames declare. One reads the page: whether the viewer stopped sampling a colour it
+      // is no longer being sent. The fixture could be honest and the viewer wrong, which is
+      // the defect; or the fixture could be lying, which would make the viewer row
+      // meaningless - and a single row could not tell those apart.
+      //
+      // Its own server and its own captures directory, deliberately away from the
+      // take-identity section: the toggle takes the grabber down and a respawn splits a
+      // take, so running this beside `caps-3` and the emit log would corrupt the one
+      // section whose whole claim is that a take is byte-for-byte what the writer emitted.
+      await stopAll();
+      console.log('\n[monitor] the colour camera goes off, and the cloud stops wearing the last JPEG');
+      mkdirSync(join(WORK, 'caps-6'), { recursive: true });
+      await start([...streamer(), '--captures', join(WORK, 'caps-6'), '--name', 'colouroff',
+        '--projects', join(WORK, 'p6'), '--presets', join(WORK, 'q6')]);
+
+      // Read off the wire rather than off the page, for the reason above. Helloes are
+      // recognised on the grabber's own fields, the same discriminator `main.js` uses,
+      // because the payload goes into a take verbatim and carries no type tag.
+      const streamed = { helloes: [], colorBytes: [] };
+      const observer = new WebSocket(`ws://127.0.0.1:${PORT}/`);
+      observer.on('message', (data, isBinary) => {
+        if (isBinary) { streamed.colorBytes.push(data.readUInt32LE(4)); return; }
+        const msg = JSON.parse(data.toString('utf8'));
+        if (typeof msg.serial === 'string' && Number.isFinite(msg.fx)) streamed.helloes.push(msg);
+      });
+      await new Promise((resolve, reject) => {
+        observer.on('open', resolve);
+        observer.on('error', reject);
+      });
+
+      await page.goto(RECORDER_URL, { waitUntil: 'load' });
+
+      // **The precondition is asserted, never waited out.** `hasColor` reaching 1 is the
+      // proof that a JPEG really decoded and bound, since `bindColor` is the only thing
+      // that ever sets it - so if it never arrives, everything below is measuring nothing
+      // and has to say so. A fixed wait here would turn "no colour ever decoded" into a
+      // silent pass on the row that matters most.
+      const hasColor = () => page.evaluate('globalThis.__kinect.uniforms.hasColor.value');
+      let bound = false;
+      try {
+        await waitFor(async () => (await hasColor()) === 1, 20000, 'a colour frame to decode and bind');
+        bound = true;
+      } catch { /* the row below is the report, and the rows after it are skipped */ }
+      ok('a colour-on grabber paints the cloud with a real decoded JPEG, which is what the toggle is measured against',
+        bound, bound ? '' : 'hasColor never reached 1, so no colour ever bound and nothing below would have measured the toggle');
+
+      // Counted before the press, because the restart can be under way by the time the
+      // click resolves and a hello read after the fact could be the one already on file.
+      const helloesBefore = streamed.helloes.length;
+      // **The real control, pressed the way an operator presses it.** The page's own
+      // `change` handler is what puts `{camera: {color: false}}` on the socket, so this
+      // exercises the wire the product uses rather than a function this tool reached past
+      // it for - which would prove the server's half while leaving the control untested.
+      await page.click('#colorCam');
+
+      // Waited on the *respawned* grabber's handshake rather than on a duration, because
+      // the toggle drops the child and the backoff spawns a replacement with the new argv.
+      // A fixed sleep here would make the row about how fast this machine is.
+      let respawned = null;
+      try {
+        await waitFor(() => streamed.helloes.length > helloesBefore, 25000, 'the respawned grabber to hand shake');
+        respawned = streamed.helloes.at(-1);
+      } catch { /* reported by the row below */ }
+      ok('the toggle takes the grabber down and the replacement hands shake again',
+        respawned !== null, respawned ? '' : 'no second hello arrived, so nothing restarted');
+      // **Both fields, and the second is the one that is easy to get wrong.**
+      // `native/grabber.cpp` reports `lowLight` as the *conjunction*, so a grabber given
+      // `--no-color` alone - which is exactly what the server produces here, since
+      // `camera.lowLight` stays true and `--no-low-light` is never appended - says
+      // `"lowLight":false`. A fixture watching only for `--no-low-light` would still say
+      // `true`, reproducing this same defect one field over while looking fixed.
+      ok('and it handshakes the configuration it was actually given: colour off, and low light off with it',
+        respawned?.color === false && respawned?.lowLight === false,
+        `hello says color=${respawned?.color}, lowLight=${respawned?.lowLight}`);
+
+      // Frames from before the new hello are dropped rather than counted, so one still in
+      // flight under the previous grabber cannot read as the new one failing to drop its
+      // colour.
+      streamed.colorBytes.length = 0;
+      let streaming = false;
+      try {
+        await waitFor(() => streamed.colorBytes.length >= 5, 15000, 'frames from the respawned grabber');
+        streaming = true;
+      } catch { /* reported by the row below */ }
+      const carried = streamed.colorBytes.filter((c) => c !== 0).length;
+      ok('and every frame it sends declares no colour block at all, which is what the viewer reads to decide whether to decode one',
+        streaming && carried === 0,
+        streaming ? `${carried} of ${streamed.colorBytes.length} frames still declared colour` : 'no frames arrived after the respawn');
+
+      // **The row this section exists for**, and the one `colour-off-keeps-the-texture`
+      // has to redden on its own. Skipped rather than asserted when no colour ever bound,
+      // because `hasColor` is 0 at boot: asserting it against a page that never reached 1
+      // would pass by agreeing with the initial value and record the strongest row in this
+      // file as green on a run that tested nothing.
+      if (bound) {
+        let zeroed = false;
+        try {
+          await waitFor(async () => (await hasColor()) === 0, 15000, 'the viewer to stop sampling a colour it is no longer sent');
+          zeroed = true;
+        } catch { /* reported by the row below */ }
+        ok('the viewer stops texturing the cloud the moment the hello says there is no colour',
+          zeroed, zeroed ? '' : `hasColor is still ${await hasColor()}, so the cloud is wearing a frozen still of the moment colour went off`);
+      } else {
+        console.log('  ....  the viewer row did not run: no colour ever bound, so there was nothing for the toggle to take away');
+      }
+      observer.terminate();
 
       await browser.close();
     }

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -470,6 +470,33 @@ if (!existsSync(DOC)) {
   // than letting it sit in `tools/` looking like something this repo ships.
   const PROBE = join(ROOT, 'tools', '.mutation-table-probe.mjs');
 
+  // **The declaration alone, and the whole prefix only when the declaration will not stand
+  // up on its own.** Taking the prefix from the top of the file was the obvious cut and it
+  // was wrong twice over, both of them found by running this somewhere other than a
+  // developer's machine.
+  //
+  // It made the row need what the *tool* needs. This tool is documented as needing nothing
+  // at all, and CI installs no dependencies, so `import ... from 'ws'` in the prefix meant
+  // four tables could not be read there while all sixteen read here - 137 anchors against
+  // 248. The row said so, four FAIL lines and the fallen count, which is the loud direction
+  // and is why the count is in the summary line at all.
+  //
+  // Worse, it *executed* the tool's top-level work. `export-check` and `registry-check` both
+  // resolve a commit with `git log -S` while their module body runs, so reading their tables
+  // shelled out to git over the whole history of `web/main.js` - a walk this row has no
+  // business doing, and one that throws outright in a tree extracted without its `.git`.
+  //
+  // So the declaration is cut on its own, which reads fifteen of the sixteen with no imports
+  // and no side effects. The sixteenth is `library-check`, whose table references a
+  // `REVEAL_EDIT` const beside it; that one falls back to the prefix with installed-package
+  // imports struck out, because a `node:` builtin and a relative path both resolve in a tree
+  // nobody ran `npm install` in and a bare package name does not. A table is data, so a
+  // package is the one thing it can never legitimately need.
+  const withoutPackages = (prefix) => prefix.replace(
+    /^import\s[^;]*?from\s+'([^']+)';$/gm,
+    (line, spec) => (/^[./]|^node:/.test(spec) ? line : ''),
+  );
+
   /** What a single entry anchors on, or why it anchors on nothing, or null for unknown. */
   const shapeOf = (spec) => {
     if (Array.isArray(spec)) {
@@ -506,7 +533,7 @@ if (!existsSync(DOC)) {
     return targets.get(path);
   };
 
-  let tablesDeclared = 0, tablesWithAnchors = 0, anchorsChecked = 0, stale = 0;
+  let tablesDeclared = 0, tablesWithAnchors = 0, anchorsChecked = 0, stale = 0, unreadable = 0;
   const anchorless = [];
   for (const name of readdirSync(join(ROOT, 'tools')).filter((f) => PARSES.test(f)).sort()) {
     const source = readFileSync(join(ROOT, 'tools', name), 'utf8');
@@ -519,17 +546,32 @@ if (!existsSync(DOC)) {
       continue;
     }
     let table = null;
-    try {
-      writeFileSync(PROBE, `${source.slice(0, end + 3)}\nexport { MUTATIONS };\n`);
-      // Cache-busted, because fifteen tools are imported through one filename and Node
-      // would otherwise hand back the first tool's table fourteen more times - which
-      // would read as every anchor matching and is the quietest possible way for this
-      // row to pass on nothing.
-      ({ MUTATIONS: table } = await import(`file://${PROBE}?tool=${encodeURIComponent(name)}`));
-    } catch (err) {
-      fail(`${name}: its MUTATIONS table could not be read - ${String(err.message).split('\n')[0]}`);
-    } finally {
-      rmSync(PROBE, { force: true });
+    // The declaration on its own first, then the prefix behind it. Both attempts are the
+    // same mechanism reading the same table, and only the first failing puts the tool's own
+    // module body on the path - so a tool that grows a top-level `git log` or a package
+    // import costs this row nothing until its table also starts needing a neighbour.
+    const cuts = [
+      source.slice(declared.index, end + 3),
+      withoutPackages(source.slice(0, end + 3)),
+    ];
+    for (const [attempt, cut] of cuts.entries()) {
+      try {
+        writeFileSync(PROBE, `${cut}\nexport { MUTATIONS };\n`);
+        // Cache-busted, because sixteen tools are imported through one filename and Node
+        // would otherwise hand back the first tool's table fifteen more times - which
+        // would read as every anchor matching and is the quietest possible way for this
+        // row to pass on nothing. The attempt is in the key as well, so a fallback is not
+        // answered by the cached failure of the cut it is falling back from.
+        ({ MUTATIONS: table } = await import(`file://${PROBE}?tool=${encodeURIComponent(name)}&cut=${attempt}`));
+        break;
+      } catch (err) {
+        if (attempt === cuts.length - 1) {
+          unreadable++;
+          fail(`${name}: its MUTATIONS table could not be read - ${String(err.message).split('\n')[0]}`);
+        }
+      } finally {
+        rmSync(PROBE, { force: true });
+      }
     }
     if (!table) continue;
 
@@ -570,11 +612,19 @@ if (!existsSync(DOC)) {
   }
   if (anchorsChecked === 0) {
     fail('no mutation anchors were checked at all, so this assertion passed on nothing - the tables moved or this scan is looking in the wrong place');
-  } else if (stale) {
+  } else if (stale || unreadable) {
     // Counted separately from the total rather than folded into it, because "239
     // checked" beside three FAIL lines is the number a reader needs and "all 239 match"
     // over the top of them would be this row asserting the very thing it just disproved.
-    console.log(`  anchors/ ${anchorsChecked} checked in ${tablesWithAnchors} tables of ${tablesDeclared} declared, ${stale} not matching exactly once`);
+    //
+    // A table that could not be read at all belongs in the same sentence, and it took a
+    // control to notice that it was not there: with `library-check` unreadable the line
+    // above still said "all 174 match once", which is true of what it read and reads as a
+    // clean row over a FAIL. The number that is missing is the point - it was 248.
+    const parts = [];
+    if (stale) parts.push(`${stale} not matching exactly once`);
+    if (unreadable) parts.push(`${unreadable} table${unreadable === 1 ? '' : 's'} unread, so this count is short by however many ${unreadable === 1 ? 'it' : 'they'} held`);
+    console.log(`  anchors/ ${anchorsChecked} checked in ${tablesWithAnchors} tables of ${tablesDeclared} declared, ${parts.join(', ')}`);
   } else {
     console.log(`  anchors/ all ${anchorsChecked} in ${tablesWithAnchors} tables match once, of ${tablesDeclared} declared`);
   }

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -203,6 +203,158 @@ if (!existsSync(DOC)) {
   }
 }
 
+// **A mutation is a piece of source text, and until this row nothing checked that the
+// text still existed.** Every claim this suite makes about the tree is proved by running
+// a mutation and reading which assertions fired, so a mutation whose anchor no longer
+// matches proves nothing at all - and it fails in the direction that reads as success.
+// Of the three found when this row was written, two threw at module top level: a stack
+// trace, a non-zero exit and **zero failed assertions**, which is precisely what a caught
+// mutation looks like to anything reading exit codes instead of counting failures. The
+// third refused politely with exit 2. `docs/instruments.md` carries the case file, and
+// the previous instance of this same drift was closed at `keyframe-check`'s
+// `undo-includes-view` without closing the class - which is how three more went stale.
+//
+// **A duplicate is as stale as a miss**, and that is the half a naive row drops. The
+// defect that prompted this was an anchor matching *two* sites, because one conversion
+// had been copied to a second place, and a row asking "does this text appear" rather than
+// "exactly once" sails straight past it while looking thorough.
+//
+// Nothing here executes a tool. The table is read by cutting the tool's source at the end
+// of the declaration, appending an export, and importing that prefix from inside `tools/`
+// so the tool's own relative imports still resolve. Two properties of that cut were
+// measured rather than assumed: no tool that declares a table does side-effectful
+// top-level work above the declaration, and the terminator is the first `};` at column
+// zero, because no table body contains a line starting there. The second is an invariant
+// rather than a guarantee, so a prefix that does not import fails the row instead of being
+// quietly read as "this tool has no table".
+//
+// The target file is resolved from each entry's *shape* rather than from the tool's name,
+// because a hardcoded list of tools is the exact failure `sweep-all`'s header records from
+// its own shell ancestor: four arrays that would have run 59 of 78 mutations and printed
+// "all caught". There are six shapes, which is five more than there should be - and the
+// honest fix is normalising them onto `{ file, edits }`, which this row is the regression
+// test for. A seventh fails naming the tool rather than being skipped, because a
+// deliberate exclusion arrives with a justification that stops anybody looking twice.
+//
+// Last of the three rows on purpose: it is the only one that writes a file into `tools/`,
+// so a crash that leaks the prefix cannot make the same run's documentation row fail for a
+// reason that has nothing to do with the tree.
+{
+  const DECLARATION = /^const MUTATIONS = \{$/m;
+  // Where a shape that does not carry its own target points. Both are facts about the
+  // shape rather than about any tool: a bare `[from, to]` pair is only ever the C++
+  // registration mutation, and the three JavaScript shapes all edit the browser bundle.
+  const MAIN = 'web/main.js';
+  const REGISTRATION = 'third_party/libfreenect2/src/registration.cpp';
+  // One name reused for every extraction, so a crash can leak at most one file, and
+  // dotted-and-suffixed so the documentation row above catches it on the next run rather
+  // than letting it sit in `tools/` looking like something this repo ships.
+  const PROBE = join(ROOT, 'tools', '.mutation-table-probe.mjs');
+
+  /** What a single entry anchors on, or why it anchors on nothing, or null for unknown. */
+  const shapeOf = (spec) => {
+    if (Array.isArray(spec)) {
+      // Both array shapes are pairs, so `Array.isArray` alone cannot tell them apart -
+      // it is the first element that says which. Read it wrong and every registration
+      // anchor reports hundreds of hits, which is loud and still wrong.
+      if (typeof spec[0] === 'string') return { file: REGISTRATION, from: [spec[0]] };
+      if (Array.isArray(spec[0])) return { file: MAIN, from: spec.map(([from]) => from) };
+      return null;
+    }
+    if (typeof spec === 'function') return { anchorless: 'functions that redirect the oracle' };
+    if (spec === null || typeof spec === 'string') return { anchorless: 'whole replacement file bodies' };
+    if (typeof spec === 'object') {
+      if (typeof spec.file === 'string' && Array.isArray(spec.edits)) {
+        return { file: spec.file, from: spec.edits.map(([from]) => from) };
+      }
+      if (typeof spec.from === 'string') return { file: MAIN, from: [spec.from] };
+    }
+    return null;
+  };
+
+  const targets = new Map();
+  const targetSource = (path) => {
+    if (!targets.has(path)) {
+      const full = join(ROOT, path);
+      targets.set(path, existsSync(full) ? readFileSync(full, 'utf8') : null);
+    }
+    return targets.get(path);
+  };
+
+  let tablesDeclared = 0, tablesWithAnchors = 0, anchorsChecked = 0, stale = 0;
+  const anchorless = [];
+  for (const name of readdirSync(join(ROOT, 'tools')).filter((f) => PARSES.test(f)).sort()) {
+    const source = readFileSync(join(ROOT, 'tools', name), 'utf8');
+    const declared = DECLARATION.exec(source);
+    if (!declared) continue;
+    tablesDeclared++;
+    const end = source.indexOf('\n};', declared.index);
+    if (end === -1) {
+      fail(`${name} declares a MUTATIONS table with no terminator at column zero, so its anchors cannot be read`);
+      continue;
+    }
+    let table = null;
+    try {
+      writeFileSync(PROBE, `${source.slice(0, end + 3)}\nexport { MUTATIONS };\n`);
+      // Cache-busted, because fifteen tools are imported through one filename and Node
+      // would otherwise hand back the first tool's table fourteen more times - which
+      // would read as every anchor matching and is the quietest possible way for this
+      // row to pass on nothing.
+      ({ MUTATIONS: table } = await import(`file://${PROBE}?tool=${encodeURIComponent(name)}`));
+    } catch (err) {
+      fail(`${name}: its MUTATIONS table could not be read - ${String(err.message).split('\n')[0]}`);
+    } finally {
+      rmSync(PROBE, { force: true });
+    }
+    if (!table) continue;
+
+    let carriesAnchors = false;
+    for (const [mutation, spec] of Object.entries(table)) {
+      const shape = shapeOf(spec);
+      if (!shape) {
+        fail(`${name}/${mutation} declares a MUTATIONS shape this row does not recognise, and a shape nobody checks is a control nobody proved`);
+        continue;
+      }
+      if (shape.anchorless) {
+        if (!anchorless.some((a) => a.name === name)) anchorless.push({ name, why: shape.anchorless });
+        continue;
+      }
+      const body = targetSource(shape.file);
+      if (body === null) {
+        fail(`${name}/${mutation} anchors into ${shape.file}, which does not exist`);
+        continue;
+      }
+      for (const from of shape.from) {
+        carriesAnchors = true;
+        anchorsChecked++;
+        const hits = body.split(from).length - 1;
+        if (hits !== 1) {
+          stale++;
+          fail(`${name}/${mutation} matches ${hits} times in ${shape.file}, expected exactly 1`
+            + ` - ${hits === 0 ? 'the text it anchors on has moved, so this control cannot run' : 'the text it anchors on appears more than once, so the tool refuses it'}`);
+        }
+      }
+    }
+    if (carriesAnchors) tablesWithAnchors++;
+  }
+
+  // Printed rather than absorbed: a table with nothing to check is a real answer, and one
+  // the count would otherwise hide behind a total that looks complete.
+  for (const { name, why } of anchorless) {
+    console.log(`  anchors/ ${name} declares ${why} rather than source anchors, so it has none to check`);
+  }
+  if (anchorsChecked === 0) {
+    fail('no mutation anchors were checked at all, so this assertion passed on nothing - the tables moved or this scan is looking in the wrong place');
+  } else if (stale) {
+    // Counted separately from the total rather than folded into it, because "239
+    // checked" beside three FAIL lines is the number a reader needs and "all 239 match"
+    // over the top of them would be this row asserting the very thing it just disproved.
+    console.log(`  anchors/ ${anchorsChecked} checked in ${tablesWithAnchors} tables of ${tablesDeclared} declared, ${stale} not matching exactly once`);
+  } else {
+    console.log(`  anchors/ all ${anchorsChecked} in ${tablesWithAnchors} tables match once, of ${tablesDeclared} declared`);
+  }
+}
+
 console.log(`\n${total} JavaScript files, ${failed} failed`);
 // Said out loud because `npm test` runs this, and a green `npm test` that meant "the
 // suite passed" would be the most expensive wrong impression in the repo. Nothing here


### PR DESCRIPTION
Closes #42. Closes #28.

#42 declares `Depends on #28`, and #28 was still open, so both are here — #28 first, because
its new `syntax-check` row is what proves the anchor #42 adds actually matches.

## #28 — a mutation is source text, and nothing checked the text still existed

Three declared controls could not run. `editor-check --mutate space-unbound` anchored on
`if (timeline.playing) timeline.pause();` where the branch has read `pauseTransport()` since
`51c7c9d` — sixty commits. `keyframe-check --mutate undo-on-input` anchored on a listener
whose local was renamed `el` to `input`. `library-check --mutate marks-ignore-retime` anchored
on the retime conversion, which had been copied to the minimap, so it matched twice.

The refusals disagree and the disagreement runs the dangerous way: `editor-check` reports
`DID NOT RUN` with exit 2, while the other two throw at module top level and exit 1 with **no
FAIL row and no assertion count** — indistinguishable from a caught mutation to anything
reading exit codes.

`syntax-check` now walks every tool's `MUTATIONS` table and asserts each anchor matches its
target **exactly once**. Tables are read without executing the tool: cut the source at the end
of the declaration, append an export, import that prefix from inside `tools/` so relative
imports resolve, remove it in a `finally`. Targets resolve by the entry's *shape*, never by
the tool's name. An unrecognised seventh shape fails naming the tool rather than being skipped.

Measured on darwin at `907b87f`: **239 anchors across 13 tables, of 15 declared**, exactly
three not matching once — the three above. On the merged tree it reads **248 anchors in 14
tables of 16 declared, all matching exactly once**; the two control transcripts below were
taken at `907b87f` and their counts are that tree's.

### The two controls, in full

`anchor-matches-twice` — a second copy of `reconcile-by-filename`'s anchor appended to
`server/library.js`:

```
  server/  9 files parsed
  tools/  27 files parsed
  web/  3 files parsed
  tools/  all 28 named in CLAUDE.md
  docs/   all 3 cited pages exist
  FAIL  library-check.mjs/reconcile-by-filename matches 2 times in server/library.js, expected exactly 1 - the text it anchors on appears more than once, so the tool refuses it
  anchors/ release-gate-check.mjs declares whole replacement file bodies rather than source anchors, so it has none to check
  anchors/ vendor-check.mjs declares functions that redirect the oracle rather than source anchors, so it has none to check
  anchors/ 239 checked in 13 tables of 15 declared, 1 not matching exactly once

39 JavaScript files, 1 failed
```

`anchor-goes-stale` — one character changed inside that entry's `from` string:

```
  server/  9 files parsed
  tools/  27 files parsed
  web/  3 files parsed
  tools/  all 28 named in CLAUDE.md
  docs/   all 3 cited pages exist
  FAIL  library-check.mjs/reconcile-by-filename matches 0 times in server/library.js, expected exactly 1 - the text it anchors on has moved, so this control cannot run
  anchors/ release-gate-check.mjs declares whole replacement file bodies rather than source anchors, so it has none to check
  anchors/ vendor-check.mjs declares functions that redirect the oracle rather than source anchors, so it has none to check
  anchors/ 239 checked in 13 tables of 15 declared, 1 not matching exactly once

39 JavaScript files, 1 failed
```

Re-run on the merged tree, both reddened the identical row, on `monitor-check`'s
`colour-off-keeps-the-texture` this time, at 248 checked with 1 not matching once. They have to
run in the real repository rather than in an extracted copy: two tools shell out to `git log -S`
while their tables are read, so a tree with no `.git` reddens two rows that have nothing to do
with the control and drops the count to 223. The pristine `web/main.js` was copied outside the
repository and restored from the copy, never with `git stash`.

Both redden the anchor row **and nothing else** — the parse counts, the CLAUDE.md
documentation row and the `docs/` citation row stay green in both. A third control rewrote one
`vcam-check` entry into an unrecognised shape:

```
  FAIL  vcam-check.mjs/unrecognised-seventh-shape declares a MUTATIONS shape this row does not recognise, and a shape nobody checks is a control nobody proved
```

One note on method: the first `anchor-goes-stale` attempt used a `perl -0pi` substitution that
silently did not apply, and the run came back green. That green was a mutation that did
nothing, not a missed catch — confirmed by `grep` before it was read either way.

### The three re-anchored mutations, each demonstrated to run and catch

- `editor-check --mutate space-unbound --no-render` — runs (no `DID NOT RUN`), **1 assertion**:
  `space starts playback  false -> false`. The transport row and nothing else, which is what
  the entry's comment claims makes it diagnostic of its own term.
- `keyframe-check --mutate undo-on-input` — runs (no top-level throw), **3 assertions**. Two
  are the claim: `a slider drag pushes one snapshot, at the end of the interaction  5 levels
  for five input events` and `and nothing at all while the drag is still running  3 levels`.
  The third is `and the animation loop is still being driven afterwards  0 frames rendered
  after`, which is **not** attributable to the mutation — it fails in the unmutated baseline
  too, and identically on a pristine checkout of `907b87f` against the same server. It is a
  render-throughput row on a machine running sixteen concurrent check processes. Reading which
  assertions fired rather than how many is what separates the two.
- `library-check --mutate marks-ignore-retime` — runs (no top-level throw), **1 assertion of
  347**, and it is the tick-position row:

  ```
    FAIL  and each tick sits where the curve puts it rather than where the fraction would  0.0s -> 0.0% (want 0.0%); 1.2s -> 16.3% (want 63.4%); 3.4s -> 46.2% (want 96.5%); 900.0s -> 100.0% (want 100.0%)
  ```

  `every mark draws a tick on the ruler` and `a mark at source zero ticks at the left edge`
  stay green, exactly as #28 predicts — a wrong conversion still produces the right number of
  ticks and still puts source zero at zero. And it reddened at all, which is the check that it
  landed on the ruler rather than the minimap: a re-anchoring onto `7982` would have come back
  clean and looked identical to a passing tool from the outside.

`marks-ignore-retime` now carries the following line as well, because the two sites differ
only in indentation and the four-space form is a substring of the six-space one. It reaches
the ruler strip, which is the only site it could usefully reach: the rows read `markTicks()`,
which reads `#tMarks .tmk`. The minimap's copy has no control over it at all — recorded in
`docs/instruments.md` rather than fixed here.

## #42 — the fake grabber now honours the colour flags

These are not the operator's flags. `--no-color` on a server's command line initialises
`camera.color` false, and `buildArgs` appends `--no-color` to the grabber's argv from that — so
eight of `library-check`'s servers were running colour-off and being answered with a
`"color":true` hello over frames still carrying full JPEGs.

Under `--no-color` the hello now says `"color":false` and `"lowLight":false` with it
(`native/grabber.cpp:588` reports lowLight as the **conjunction**), and every payload is
rewritten once at load — `colorBytes` zeroed at offset 4, payload truncated to
`16 + depthBytes` — because `server/capture.js` refuses a frame whose declared lengths do not
describe it.

Measured against `captures/sample.knct`, 8 frames each:

| | stdout bytes | per frame |
|---|---|---|
| colour on (before and after — byte-identical) | 3,918,215 | 485,869–492,860 |
| colour off | 3,473,839 | 434,192 = 16 + 434,176 |

Both figures are from `907b87f`. After the merges the same 8 frames come to **3,918,226** and
**3,473,850**, eleven bytes larger each because main's hello grew a `format` key — so the
number to compare against is main's, never the one above. Measured that way, with the wall
clock and each frame's monotonic stamp zeroed since they are the only fields a rerun may move:
this tree against a pristine `9121217`, same byte count, same message count, the hello's ten
keys in the same order with the same values, and every frame matching type, length and content.
The control on that comparison is a colour-off stream from the same build, which comes out a
different size with a different key set — so the rows can tell two streams apart rather than
agreeing with themselves.

Every emitted frame parses with `16 + depthBytes + colorBytes` equal to its payload length.
The colour-off hello:

```
{"serial":"258741134347",...,"color":false,"lowLight":false,"startedAt":...}
```

### The falsification control

`monitor-check`'s section 6 arm, unmutated — waits for `hasColor` to reach 1 (proof a JPEG
really decoded and bound), presses `#colorCam` so the page's own handler puts
`{camera:{color:false}}` on the socket, waits for the respawned grabber's hello, asserts:

```
  PASS  a colour-on grabber paints the cloud with a real decoded JPEG, which is what the toggle is measured against
  PASS  the toggle takes the grabber down and the replacement hands shake again
  PASS  and it handshakes the configuration it was actually given: colour off, and low light off with it  hello says color=false, lowLight=false
  PASS  and every frame it sends declares no colour block at all  0 of 5 frames still declared colour
  PASS  the viewer stops texturing the cloud the moment the hello says there is no colour
  PASS  and the page reported no error while doing any of it
  6 assertions, 0 failed
```

And with `colour-off-keeps-the-texture` applied to `web/main.js`:

```
  PASS  a colour-on grabber paints the cloud with a real decoded JPEG, which is what the toggle is measured against
  PASS  the toggle takes the grabber down and the replacement hands shake again
  PASS  and it handshakes the configuration it was actually given: colour off, and low light off with it  hello says color=false, lowLight=false
  PASS  and every frame it sends declares no colour block at all  0 of 5 frames still declared colour
  FAIL  the viewer stops texturing the cloud the moment the hello says there is no colour  hasColor is still 1
  PASS  and the page reported no error while doing any of it
  6 assertions, 1 failed
```

**The viewer row alone reddens**, with both fixture rows staying green — which is the
separation the control needs: a run that reddened the fixture rows too would have failed for a
neighbouring reason and said nothing about the viewer.

`decimate-reaches-recorder` still catches, so the new section did not disturb the existing
control — 3 assertions at 53 checked, all three the take-identity rows:

```
  FAIL  every frame on disk is byte for byte a frame the grabber emitted, with a monitor watching decimated throughout  43 of 43 frames are not in the writer's log; first declares 27136 depth bytes where a full frame declares 434176
  FAIL  and every one of them carries the full depth grid rather than a decimated one  depth 27136 against 434176
  FAIL  the take is in order and contiguous in the writer's log, so this is the stream rather than a lucky subset  43 frames
```

## The three merges

`main` moved three times while this branch was open, and each hop is its own commit.

**`tools/fake-grabber.mjs` and `tools/syntax-check.mjs`.** Both sides added to the same
insertion point rather than disagreeing about anything. The fixture builds one hello and both
wanted a field in it: `format` goes first, exactly where main put it, and the two colour
spreads follow — the order is the byte order, and the byte order is the take's content hash.
`syntax-check` gained a block from each side and both are kept whole, with the anchor row
staying last because it is the only one that writes a probe into `tools/`.

**`docs/instruments.md`.** A case file appended at the same point from each side, both kept.

**And the merge produced a real finding, in `syntax-check`'s own new `spec-drifts` control.**
The anchor row resolves a target from the entry's *shape*, and a bare `{ from, to }` had a
single declarer until now — `registry-check`, which edits `web/main.js` — so the shape was
being read as "the browser bundle". `spec-drifts` is that shape against `server/protocol.js`,
so the row went looking for `export const TYPE_COLOR = 3;` in the bundle, found none, and
reported a working control as a stale anchor. It is a false positive rather than a missed
defect, which is the cheap direction of the mistake, and the fix is the entry declaring its own
target rather than the resolver learning a second tool's name — a resolver that knows which
tool is asking is the hardcoded list the row exists to replace. `spec-drifts` is now
`{ file, edits }`. `--mutate spec-drifts` still reddens the specification row and nothing else.

### And CI found the anchor row reading four fewer tables than it does here

The row read a table by importing the tool's *prefix*, from the top of the file down to the end
of the declaration, so a table referencing a const beside it would still resolve. That cut
carried two things it had no business carrying. It brought the tool's own
`import ... from 'ws'` into a tree that installs no dependencies — and `syntax-check` is
documented as needing nothing at all, which is the only reason CI can run it — so four tables
went unread there, at **137 anchors against 248**. And it *executed* the tool's module body:
`export-check` and `registry-check` each resolve a commit with `git log -S` at top level, so
reading their tables walked the whole history of `web/main.js`, and threw outright in a tree
extracted without its `.git`. That was also the minutes this row was costing on a loaded
machine.

The cut is now the declaration alone, which reads every table but `library-check` with no
imports and no side effects at all; that one refers to a `REVEAL_EDIT` const beside it and
falls back to the prefix with installed-package imports struck out. A `node:` builtin and a
relative path both resolve without `npm install` and a bare package name does not, and a table
is data, so a package is the one thing it can never legitimately need.

The summary line was the other half of it. With a table unread it still printed
`all 137 ... match once` — true of what it read, and indistinguishable from a clean row sitting
directly above a FAIL. An unread table is now named in that same sentence.

Measured where it failed, in a tree extracted with neither `node_modules` nor `.git`: **all 248
anchors in 14 tables of 16 declared, 39 files parsed, 0 failed, 5.7s** against minutes. In the
repo, the same 248 in 4.3s, and CI green on all four jobs. Three controls, each reddening the
anchor row and nothing else — an anchor moved off its line reports 0 matches, an anchor copied
to a second site reports 2, and a table neither cut can read reports the tool by name and
shortens the count out loud. One more, since sixteen tools are imported through one filename:
two tools read in sequence come back with their own tables and the first one re-read comes back
unchanged, so the cache key is not handing one tool another's anchors.

## Two departures from the issues, both measured

**1. `lowLight` is written only when something settles it.** #42 step 1 says to set it to the
conjunction. Done — but only when colour is off, when `--no-low-light` was given, or when the
source hello already carried it. The sample's hello carries **nine keys and `lowLight` is not
among them**; writing it unconditionally would add a tenth key to a colour-on hello and move
every take's content hash — the key the library joins two machines on — across eight servers
this change is not about. Colour-on helloes are byte-identical to before.

**2. The unknown-argument done-criterion cannot hold as written.** It expects
`... --nonsense 2>&1 >/dev/null | wc -l` to print `1`. It prints **2**, because
`[fake-grabber] streaming N looped frames at Xfps` already went to stderr before this change —
measured at `907b87f`, where the same command prints `1` with no unknown argument at all:

```
[fake-grabber] ignoring --nonsense, which this fixture does not know
[fake-grabber] streaming 284 looped frames at 60fps
```

The behavioural requirement — one line, naming the argument, stream runs on — holds: the
companion criterion prints 3,918,215 bytes, well over the 3,000,000 floor. (Note both
criteria must be run under `bash`; zsh's MULTIOS makes `2>&1 >/dev/null` duplicate the binary
stdout into the count, which reads as 57,781 lines.)

## Findings out of scope — two pre-existing faults in `monitor-check`

Both reproduce **identically on a pristine checkout of `907b87f`** with the same sample, so
neither is introduced here. They are why the stock tool could not be run end to end.

**A cold sidecar loses a race in section 2.** `start()` resolves 200 ms after `viewer on`, but
`captureAliases.set(captureIdFor(REPLAY), …)` only runs after `openCapture` has indexed the
138 MB sample. The fetch then lands first and gets `unknown capture` — 15 bytes, which
`viaHttp[4].readBigUInt64LE(8)` turns into `The value of "offset" is out of range … Received 8`,
so the run dies with **0 failed assertions and exit 2**. Building `captures/sample.idx` once
makes section 2 pass.

**Section 2's 12 s wait cannot survive this sample's loop.** It waits for the frame it fetched
over HTTP to come round on the socket, but the sample is 284 frames at ~9.3 fps — a **~30.5 s
loop** — so once frame 7 has passed, 12 s is not enough and the run dies `DID NOT RUN` at
27 assertions. Raising it to 45 s in a scratch copy took the same tool to 53 assertions and
a clean section 2:

```
  PASS  the frame API answers a full frame and a ÷4 one  depth 434176 and 27136
  PASS  and the ÷4 frame is smaller in exactly the depth block, colour untouched  52669 colour bytes against 52669
  PASS  the same frame at ÷4 is byte-identical off the socket and off the frame API  c9ce3a283010 against c9ce3a283010
```

Neither is fixed here — `monitor-check`'s scope in #42 is the colour-off section — but a
one-line timeout change plus a warm sidecar would make the tool runnable again, and I would
open a follow-up if you want it.

## The unmutated baselines

- `editor-check --url … --take sample --no-render` — **exit 0**, zero failed assertions.
- `keyframe-check --url …` — **1 failed**, the `0 frames rendered after` row described above.
  A pristine `907b87f` tree fails the identical row against the identical server, so it is not
  this change. It wants an idle machine to confirm it is contention rather than a standing
  defect, and this machine has not been idle.
- `library-check --node-port 8610 --mac-port 8611` — **347 assertions, none failed, exit 0**,
  measured at `907b87f` before any of the three merges below.

That last one answers #42 step 5, and it answers it in the negative: the eight `--no-color`
servers now stream depth-only frames, and **not one row moved**. The step anticipated the
low-space row on the `nearly-full` server rising toward its `secondsLeft < 120` assertion as
the observed byte rate dropped; it did not, so `tools/library-check.mjs` carries no repair
here — its only change in this PR is #28's re-anchoring. Ports were moved off the defaults
because another agent's run was holding 8210 and 8211..8227.

**That figure has not been reproduced since the merges, and the attempt is a run to throw
away rather than a number.** Post-merge the tool reports 365 assertions with five failing —
`2 closed` against `3 closed`, `1161ms into 400ms` against `989ms into 575ms`, a focus row
landing on `BODY:` — all of them counts and timings, on a machine whose load average was
between 249 and 290 throughout. This repo's own rule is to read the health number the
measurement reports and discard the run when it is wrong, and that is what these are. What
does discriminate is deductive and does not need the machine: the only change to
`tools/library-check.mjs` is the inert `marks-ignore-retime` entry, and the fixture's
colour-off path is reached only with `--no-color` in argv. The figure wants an idle machine;
until it gets one there is no post-merge number to quote.

## What was and was not run

Section 6's rows above were produced by a driver that replicates its arm verbatim against the
staged tree, because the stock `monitor-check` cannot reach section 6 on this machine for the
two reasons above. The fixture measurements, both `syntax-check` controls, the unrecognised-shape
control, all three re-anchored mutations and `decimate-reaches-recorder` are runs of the real
tools.

**Section 6 has not been re-measured since the merges, and the attempt did not fail for a
reason about the page.** Three driver runs stalled inside playwright's own click, past
`done scrolling` and into the hit-target loop, at 30s and then at 90s. Probed directly, the
control scrolls into view, sits inside the viewport, hit-tests to `INPUT#colorCam` and stays
there over 1.5s — so the element is actionable and the stall is the actionability loop starving
on a machine at load 250 to 290. Nothing in main's diff touches `#colorCam` or its handler.
Re-run against a settled machine, not re-diagnosed.

What was re-measured after the merges and is quoted above: `npm test` at exit 0, the
`syntax-check` anchor count, `--mutate spec-drifts`, both anchor controls, and the colour-on
byte identity against a pristine `9121217`.

The machine was contended throughout by another agent's concurrent runs (three `library-check`
processes and an `editor-check` holding `:8080`); everything here was re-run until it was
stable, and one transient `page.click` timeout and one section-5 `server never came up` were
discarded as contention rather than recorded as findings.
