### PR TITLE
Give seven small surfaces a way to say what they already know

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,8 @@ node tools/library-check.mjs --mutate delete-guesses-past-an-unreachable-node # 
 node tools/library-check.mjs --mutate first-load-bounded       # ... a cold library is slow for a reason, and the load is not the poll
 node tools/library-check.mjs --mutate first-load-strands-the-page  # ... and a first listing that fails leaves a page that still works
 node tools/library-check.mjs --mutate listing-ignores-client-abort # ... a caller that gave up takes the node fetch with it
+node tools/library-check.mjs --mutate cancel-watches-the-consumed-request # ... including on a route that read its body before asking
+node tools/library-check.mjs --mutate listing-takes-a-refusal-as-a-library # ... and a refusal that parses is not a library
 node tools/library-check.mjs --mutate faint-fixed-in-one-page       # ... one token, and the page that drifts is named
 node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FAIL
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ node tools/library-check.mjs --mutate poll-first-tick-is-blind       # ... and t
 node tools/library-check.mjs --mutate poll-forgets-a-failed-refresh  # ... and a refresh that failed leaves its transition unseen
 node tools/library-check.mjs --mutate poll-ticks-overlap             # ... while one that has not come back is not asked again
 node tools/library-check.mjs --mutate post-action-poll-discarded     # ... and a press asks again rather than taking the answer in flight
+node tools/library-check.mjs --mutate listing-never-times-out        # ... and a listing nothing will answer frees itself
+node tools/library-check.mjs --mutate delete-guesses-past-an-unreachable-node # ... a node that did not answer is not a node with nothing on it
 node tools/library-check.mjs --mutate faint-fixed-in-one-page       # ... one token, and the page that drifts is named
 node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FAIL
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL
@@ -191,6 +193,7 @@ node tools/editor-check.mjs --mutate tick-seeks-source-seconds --no-render # ...
 node tools/editor-check.mjs --mutate offer-ignores-take-hash --no-render # ... the resume offer joins on footage, not on a name
 node tools/editor-check.mjs --mutate resume-waits-for-every-list --no-render # ... and a broken neighbouring library does not strand it
 node tools/editor-check.mjs --mutate resume-fetches-the-moving-name --no-render # ... and restores the document it offered, not what the name holds by then
+node tools/editor-check.mjs --mutate resume-restores-without-keeping --no-render # ... and keeps it, so the recovery outlives the tab
 node tools/editor-check.mjs --mutate shortcuts-reject-altgr --no-render # ... the mark keys work on the layouts that need AltGr to type them
 node tools/editor-check.mjs --mutate marks-ignore-the-clip-range --no-render # ... and offer only the marks a trimmed clip can reach
 node tools/editor-check.mjs --mutate tick-seeks-outside-the-trim --no-render # ... the ruler's ticks obey the same rule the keys do
@@ -248,7 +251,7 @@ ffmpeg and ffprobe.
 the depth texture, which is what lets it grade the plane fit against a normal it chose.
 
 **`library-check` binds a span of fixed ports** — `--node-port`, and `--mac-port` through
-`--mac-port + 16`, which default to 8210 and 8211..8227. It checks the whole span before it
+`--mac-port + 17`, which default to 8210 and 8211..8228. It checks the whole span before it
 spawns anything and **exits 2 naming what is held**, because the old failure was silent: two
 worktrees running at once did not collide, they shared a server, and the suite asserted
 against the other tree's fixture. Pass a range nothing else holds, and check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,9 @@ node tools/library-check.mjs --mutate pulse-ignores-the-node        # ... and th
 node tools/library-check.mjs --mutate health-answers-beside-the-table # ... a route answering outside the table is one no sweep can see
 node tools/library-check.mjs --mutate empty-window-keeps-its-start  # ... a window with no frames in it still closes
 node tools/library-check.mjs --mutate respawns-count-a-colour-toggle # ... and a restart somebody asked for is not the sensor flapping
+node tools/library-check.mjs --mutate respawns-dip-before-the-spawn  # ... and the count does not read low while that restart is in flight
+node tools/library-check.mjs --mutate openpath-drops-at-the-stop     # ... a take is the recorder's until its index exists, not until it stops
+node tools/library-check.mjs --mutate poll-first-tick-is-blind       # ... and the first tick answers against the grid already painted
 node tools/library-check.mjs --mutate faint-fixed-in-one-page       # ... one token, and the page that drifts is named
 node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FAIL
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL
@@ -183,6 +186,8 @@ node tools/editor-check.mjs --mutate zoom-pans-at-the-clamp --no-render # ... an
 node tools/editor-check.mjs --mutate note-skips-title --no-render      # ... the whole of a long refusal stays reachable
 node tools/editor-check.mjs --mutate tick-seeks-source-seconds --no-render # ... a mark tick seeks where it is drawn
 node tools/editor-check.mjs --mutate offer-ignores-take-hash --no-render # ... the resume offer joins on footage, not on a name
+node tools/editor-check.mjs --mutate resume-waits-for-every-list --no-render # ... and a broken neighbouring library does not strand it
+node tools/editor-check.mjs --mutate shortcuts-reject-altgr --no-render # ... the mark keys work on the layouts that need AltGr to type them
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows
 node tools/monitor-check.mjs --mutate decimate-reaches-recorder  # ... and must FAIL mutated
 node tools/monitor-check.mjs --mutate bind-ignores-grid          # ... and must FAIL mutated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ node tools/library-check.mjs --mutate refusal-declared-but-never-pushed # ... an
 node tools/library-check.mjs --mutate openable-recomputes-the-band # ... and a band that decides for itself beside the table
 node tools/library-check.mjs --mutate recording-decides-openable-itself # ... and the take being written, which answered twice
 node tools/library-check.mjs --mutate node-admits-an-old-manifest  # ... a node one build behind, refused at the link
+node tools/library-check.mjs --mutate node-admits-an-old-record-state # ... and behind on the other route, whose absent field is not an idle recorder
 node tools/library-check.mjs --mutate badges-inherit-from-object   # ... and one build ahead, whose reason still badges
 node tools/library-check.mjs --mutate refusals-must-be-nonempty    # ... and a healthy node not refused for being healthy
                                                                    #     (wide: takes the link off, so it stops at 125 of 392 -

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ node tools/library-check.mjs --mutate respawns-count-a-colour-toggle # ... and a
 node tools/library-check.mjs --mutate respawns-dip-before-the-spawn  # ... and the count does not read low while that restart is in flight
 node tools/library-check.mjs --mutate openpath-drops-at-the-stop     # ... a take is the recorder's until its index exists, not until it stops
 node tools/library-check.mjs --mutate poll-first-tick-is-blind       # ... and the first tick answers against the grid already painted
+node tools/library-check.mjs --mutate poll-forgets-a-failed-refresh  # ... and a refresh that failed leaves its transition unseen
 node tools/library-check.mjs --mutate faint-fixed-in-one-page       # ... one token, and the page that drifts is named
 node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FAIL
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL
@@ -188,6 +189,8 @@ node tools/editor-check.mjs --mutate tick-seeks-source-seconds --no-render # ...
 node tools/editor-check.mjs --mutate offer-ignores-take-hash --no-render # ... the resume offer joins on footage, not on a name
 node tools/editor-check.mjs --mutate resume-waits-for-every-list --no-render # ... and a broken neighbouring library does not strand it
 node tools/editor-check.mjs --mutate shortcuts-reject-altgr --no-render # ... the mark keys work on the layouts that need AltGr to type them
+node tools/editor-check.mjs --mutate marks-ignore-the-clip-range --no-render # ... and offer only the marks a trimmed clip can reach
+node tools/editor-check.mjs --mutate beyond-mark-loses-focus --no-render # ... a mark past the end still answers a keyboard
 node tools/editor-check.mjs --mutate clip-range-unclamped --no-render # ... a trim the program cannot hold
 node tools/editor-check.mjs --mutate clip-bound-coerces-nonnumeric --no-render # ... and a trim that is not a time at all
 node tools/editor-check.mjs --mutate refusal-strands-the-picker --no-render # ... and the menu that named what was refused

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,9 @@ node tools/library-check.mjs --mutate poll-ticks-overlap             # ... while
 node tools/library-check.mjs --mutate post-action-poll-discarded     # ... and a press asks again rather than taking the answer in flight
 node tools/library-check.mjs --mutate listing-never-times-out        # ... and a listing nothing will answer frees itself
 node tools/library-check.mjs --mutate delete-guesses-past-an-unreachable-node # ... a node that did not answer is not a node with nothing on it
+node tools/library-check.mjs --mutate first-load-bounded       # ... a cold library is slow for a reason, and the load is not the poll
+node tools/library-check.mjs --mutate first-load-strands-the-page  # ... and a first listing that fails leaves a page that still works
+node tools/library-check.mjs --mutate listing-ignores-client-abort # ... a caller that gave up takes the node fetch with it
 node tools/library-check.mjs --mutate faint-fixed-in-one-page       # ... one token, and the page that drifts is named
 node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FAIL
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL
@@ -217,6 +220,7 @@ node tools/editor-check.mjs --mutate clip-range-unclamped --no-render # ... a tr
 node tools/editor-check.mjs --mutate clip-bound-coerces-nonnumeric --no-render # ... and a trim that is not a time at all
 node tools/editor-check.mjs --mutate refusal-strands-the-picker --no-render # ... and the menu that named what was refused
 node tools/editor-check.mjs --mutate resize-skips-repaint --no-render # ... and the picture a resize clears
+node tools/editor-check.mjs --mutate resume-races-the-autosave --no-render # ... the recovery is written after the edits already on the wire
 node tools/editor-check.mjs --mutate restore-accepts-view-track --no-render # ... and a track the writer never writes
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows
 node tools/monitor-check.mjs --mutate decimate-reaches-recorder  # ... and must FAIL mutated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ node tools/library-check.mjs --mutate openpath-drops-at-the-stop     # ... a tak
 node tools/library-check.mjs --mutate poll-first-tick-is-blind       # ... and the first tick answers against the grid already painted
 node tools/library-check.mjs --mutate poll-forgets-a-failed-refresh  # ... and a refresh that failed leaves its transition unseen
 node tools/library-check.mjs --mutate poll-ticks-overlap             # ... while one that has not come back is not asked again
+node tools/library-check.mjs --mutate post-action-poll-discarded     # ... and a press asks again rather than taking the answer in flight
 node tools/library-check.mjs --mutate faint-fixed-in-one-page       # ... one token, and the page that drifts is named
 node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FAIL
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL
@@ -189,6 +190,7 @@ node tools/editor-check.mjs --mutate note-skips-title --no-render      # ... the
 node tools/editor-check.mjs --mutate tick-seeks-source-seconds --no-render # ... a mark tick seeks where it is drawn
 node tools/editor-check.mjs --mutate offer-ignores-take-hash --no-render # ... the resume offer joins on footage, not on a name
 node tools/editor-check.mjs --mutate resume-waits-for-every-list --no-render # ... and a broken neighbouring library does not strand it
+node tools/editor-check.mjs --mutate resume-fetches-the-moving-name --no-render # ... and restores the document it offered, not what the name holds by then
 node tools/editor-check.mjs --mutate shortcuts-reject-altgr --no-render # ... the mark keys work on the layouts that need AltGr to type them
 node tools/editor-check.mjs --mutate marks-ignore-the-clip-range --no-render # ... and offer only the marks a trimmed clip can reach
 node tools/editor-check.mjs --mutate tick-seeks-outside-the-trim --no-render # ... the ruler's ticks obey the same rule the keys do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,10 @@ node tools/library-check.mjs --mutate menu-close-strands-focus     # ... and a m
 node tools/library-check.mjs --mutate run-strands-focus            # ... and an action that held the surface down
 node tools/library-check.mjs --mutate reveal-drops-the-path        # ... what the file manager was told
 node tools/library-check.mjs --mutate reveal-answers-any-caller    # ... and who may start a process
+node tools/library-check.mjs --mutate poll-refreshes-every-tick     # ... the gallery follows the recorder rather than the page load
+node tools/library-check.mjs --mutate health-answers-beside-the-table # ... a route answering outside the table is one no sweep can see
+node tools/library-check.mjs --mutate empty-window-keeps-its-start  # ... a window with no frames in it still closes
+node tools/library-check.mjs --mutate faint-fixed-in-one-page       # ... one token, and the page that drifts is named
 node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FAIL
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL
 node tools/library-check.mjs --mutate open-take-swallows-library # ... and must FAIL
@@ -172,6 +176,9 @@ node tools/editor-check.mjs --mutate pause-keeps-resume --no-render   # ... and 
 node tools/editor-check.mjs --mutate bounds-compare-off-grid --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate detent-in-rate-units --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate zoom-pans-at-the-clamp --no-render # ... and must FAIL
+node tools/editor-check.mjs --mutate note-skips-title --no-render      # ... the whole of a long refusal stays reachable
+node tools/editor-check.mjs --mutate tick-seeks-source-seconds --no-render # ... a mark tick seeks where it is drawn
+node tools/editor-check.mjs --mutate offer-ignores-take-hash --no-render # ... the resume offer joins on footage, not on a name
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows
 node tools/monitor-check.mjs --mutate decimate-reaches-recorder  # ... and must FAIL mutated
 node tools/monitor-check.mjs --mutate bind-ignores-grid          # ... and must FAIL mutated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ node tools/library-check.mjs --mutate respawns-dip-before-the-spawn  # ... and t
 node tools/library-check.mjs --mutate openpath-drops-at-the-stop     # ... a take is the recorder's until its index exists, not until it stops
 node tools/library-check.mjs --mutate poll-first-tick-is-blind       # ... and the first tick answers against the grid already painted
 node tools/library-check.mjs --mutate poll-forgets-a-failed-refresh  # ... and a refresh that failed leaves its transition unseen
+node tools/library-check.mjs --mutate poll-ticks-overlap             # ... while one that has not come back is not asked again
 node tools/library-check.mjs --mutate faint-fixed-in-one-page       # ... one token, and the page that drifts is named
 node tools/library-check.mjs --mutate write-overwrites-builtin # ... and must FAIL
 node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FAIL
@@ -190,6 +191,7 @@ node tools/editor-check.mjs --mutate offer-ignores-take-hash --no-render # ... t
 node tools/editor-check.mjs --mutate resume-waits-for-every-list --no-render # ... and a broken neighbouring library does not strand it
 node tools/editor-check.mjs --mutate shortcuts-reject-altgr --no-render # ... the mark keys work on the layouts that need AltGr to type them
 node tools/editor-check.mjs --mutate marks-ignore-the-clip-range --no-render # ... and offer only the marks a trimmed clip can reach
+node tools/editor-check.mjs --mutate tick-seeks-outside-the-trim --no-render # ... the ruler's ticks obey the same rule the keys do
 node tools/editor-check.mjs --mutate beyond-mark-loses-focus --no-render # ... a mark past the end still answers a keyboard
 node tools/editor-check.mjs --mutate clip-range-unclamped --no-render # ... a trim the program cannot hold
 node tools/editor-check.mjs --mutate clip-bound-coerces-nonnumeric --no-render # ... and a trim that is not a time at all

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -812,3 +812,49 @@ way that read as a missing feature — `camera.project()` answers in canvas coor
 `page.mouse` takes viewport ones, which were the same number only while the canvas sat at the
 window's corner. **When a change moves where the canvas is, the tools that drive it by
 coordinate are all suspect, not just the ones that mention size.**
+
+**A table of rules where the rule bodies are never called is a table of claims nothing
+enforces.** `editor-check` section 1 sweeps every control the editor renders and requires each
+to be covered by a `DRIVER_RULES` entry. Every entry carried a `match` written against a DOM
+element — and `covered()` re-spelled the same condition against the serialized row, so no
+`match` in the file was ever executed. The field read as the implementation and was decoration.
+
+What that cost: a rule added for the ruler's mark ticks matched nothing, said nothing, and the
+sweep went on reporting every control covered. The ticks were not in the selector either, so
+the class was outside the enumeration twice over — a pressable control the page renders, with a
+driver entry written for it, and a sweep that could not see either. Both halves passed, and
+each half is the reason the other was invisible.
+
+`match` is the implementation now and `covered()` walks the table, so a rule with no branch is
+impossible rather than silent. The row that would have caught it is the new one: **every rule
+in the table matches at least one control the page renders.** A rule is a claim that a class of
+control exists and is driven, so a rule with no instance is either a control that has been
+removed — delete the rule and the section it names — or a sweep that cannot see it. Ordering
+became precedence in the same change, with the widest rule last, because a table walked in
+order credits a control to the first rule that claims it and the panel-wide rule would
+otherwise take controls three narrower rules are the honest attribution for.
+
+**Generalise: when a check has a table of rules and a dispatcher, ask which one the running
+code reads.** If the answer is "the dispatcher", the table is documentation, and documentation
+that looks like enforcement is worse than none — somebody will add a rule to it and believe the
+class is closed.
+
+**A section that stages its subject one way cannot see a defect that only exists the other
+way.** The gallery's five-second poll was proved by a section that opened the gallery on the
+server holding the recorder, where "this machine's recorder" and "the recorder that owns the
+take" are the same process. On an editing station — `--node`, no sensor — they are not, and the
+poll watched a flag that never moves while the grid it gates was drawn from both libraries. The
+section passed every row on a build where the feature did nothing on the machine it is used
+from. The fix is a second gallery in the same section, served by a station whose captures
+directory is empty and whose `--node` is the recording server, so every take in that grid is
+the node's and a row about the remote tile cannot be answered by a local one. **When a feature
+spans two machines, staging both of them on one is not a simplification of the fixture, it is a
+different fixture.**
+
+Its own trap, worth writing down because it read as a defect: a remote take that has stopped
+offers **Download**, not Open. `availability` gives Open to a remote take only while it is
+shooting, because a take mid-write has no settled hash and the node answers 409 for it. So the
+transition the linked station gets out of following the node is disabled Open to enabled
+Download, and a row copied from the local gallery asserts `find('Open').disabled === false`
+against an `undefined` and fails on a build that works perfectly. **`?.field === false` on a
+`find` that returned nothing is a missing element reported as a wrong value.**

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -154,3 +154,31 @@ Likewise **a multi-line script through `bash -c "..."` loses twice**: the outer 
 every `$(...)` before bash sees it, and JSON quoting carries newlines as two literal
 characters. Ship it base64. And on this node `pkill -f` matches the remote shell running your
 own command — resolve listeners by port through `ss`.
+
+## A route's cost is per item, so measure it against a library the size of a shoot
+
+The gallery's poll had to pick between the cheap question and the true one:
+`/record/state`, which is memory the process already holds, and `/library/all`, which is
+what the grid is actually drawn from. "The listing is more expensive" is the kind of
+reasoning this repo does not accept on its own, so it was measured.
+
+Interleaved A/B on this rig, 20 pairs alternating the two routes against a 200-take
+library, both servers' indexes warm and the sidecars written, page cache settling
+discarded as the first eight pairs: **1.2ms for `/record/state` against 145ms for
+`/library/all`**, with the linked pair on one machine so the listing includes its node
+round trip. The steady-state figures are the last twelve pairs; the first two reads were
+5.3s and 1.6s and are the cache, not the route.
+
+The number that decides is not the ratio but where it comes from. `describeTake` reads a
+marks sidecar per take on both machines, so the listing's cost is per take and a
+five-second cadence would spend four hundred sidecar reads every tick to answer a question
+that is almost always no — against a recorder whose own comment says exactly this
+contention is what turns a slow card into dropped frames. **A route measured against a
+fixture-sized library reports a constant where the thing you need is a slope.** The
+200-take fixture is hardlinks of one capture, so the bytes are one file and the per-take
+work is real.
+
+Cold is a different quantity and worth stating so nobody re-derives it as a regression:
+the first listing over 200 unindexed takes took **7m30s**, because `cachedIndex` scans each
+file once and writes a `.idx` beside it. The second server over the same directory warmed
+in 2.4s off those sidecars.

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -57,6 +57,25 @@ same way. The convention was reached independently several times and it is one r
 `--mutate <name>` serves a deliberately broken `main.js` into the running server, or for the
 two vendoring tools rebuilds a deliberately broken source tree.
 
+**Read the first line of the output before reading anything else.** A mutated run says
+`MUTATED: <name> delivered`; an unmutated one says `unmutated tree`. That distinction is what
+tells a run that caught nothing from a run that tested nothing, and the second is easy to
+produce by accident from a shell. A batch built as
+
+```sh
+for m in first-load-bounded listing-never-times-out; do
+  args="--mutate $m"; node tools/library-check.mjs $args --node-port 8210   # WRONG under zsh
+done
+```
+
+runs five baselines: **zsh does not word-split an unquoted parameter**, so the tool receives one
+argument spelled `--mutate first-load-bounded`, matches no flag, and runs the tree as it is.
+Every run then reports the same assertions and the same failures, which reads exactly like four
+mutations a check could not catch — the same conclusion, from the opposite cause. That cost a
+seventy-minute batch here. Pass the name as its own quoted word, `--mutate "$m"`, or write the
+invocations out; and either way check the header, because the tool already says which tree it
+ran and the header is cheaper than the inference.
+
 **Fourteen tools carry mutations by one of those two mechanisms** — editor, export, guard, jobs,
 keyframe, level, library, monitor, registration, registry, sensor-view, timeline, vcam and
 vendor — and all of them refuse a mutation whose text they cannot find exactly once, because a

--- a/server/index.js
+++ b/server/index.js
@@ -1249,6 +1249,41 @@ const serveDownloads = (req, res) => sendJson(res, {
   }),
 });
 const serveDescriptors = (req, res) => sendJson(res, { open: openCaptureCount(), real: realDescriptorCount() });
+
+/**
+ * Whether the sensor is delivering, answered without anything attaching to it.
+ *
+ * **The point is what it does not cost.** These numbers existed already - the health
+ * interval computes them every five seconds and prints one line to a console nobody
+ * is reading during a shoot - and the only way to find out whether the sensor was
+ * healthy was to open a monitor over the socket. `consumersCostingTheTake` exists
+ * because an attached monitor can cost the take frames, so the one instrument for
+ * "is this sensor well" made it less well, which is an instrument that changes what
+ * it measures. Reading it off HTTP removes the trade entirely.
+ *
+ * Neither `write` nor `live` in the table, and both absences are decisions. Nothing
+ * here changes, so there is no mutation to guard. And this reports numbers *about*
+ * the sensor rather than what the sensor is seeing - a frame count is not a picture
+ * of the room - so the origin rule that covers `/camera.mjpg` has nothing to bite on.
+ *
+ * The window is served as its own length and its own frame count rather than only as
+ * a rate, because those are the two readings that tell a gap from a slow link: five
+ * seconds carrying zero frames and five seconds carrying a hundred and fifty are
+ * different facts, and a rate alone reports the first as silence.
+ */
+const serveSensorHealth = (req, res) => sendJson(res, {
+  state: sensorState,
+  // The last window that carried frames, which is deliberately older than the window
+  // below whenever the sensor has stopped - see the health interval.
+  fps: observedFps,
+  bytesPerSec: observedBytesPerSec,
+  // And the last window that closed, whether or not anything arrived in it.
+  window: lastWindow,
+  dropped: droppedTotal,
+  // The first spawn is a start rather than a respawn, which is the number somebody
+  // reading this is after: on a healthy node it is zero for the life of the process.
+  respawns: Math.max(0, grabberSpawns - 1),
+});
 /**
  * What the recorder is doing, and what the monitors attached to it would cost.
  *
@@ -1399,6 +1434,16 @@ const ROUTES = [
   // declaring itself rather than by somebody remembering - the same move the table
   // already made for mutations.
   { path: '/camera.mjpg', pattern: /^\/camera\.mjpg$/, live: true, read: (req, res) => webcam.attach(req, res) },
+
+  // ---- the sensor
+  //
+  // A namespace of its own rather than a corner of `/library`, because the table's
+  // existing first segments each name the subsystem the route reads from - a capture,
+  // the library, the recorder, the queue - and this one reads the sensor. An entry
+  // and not a branch beside the dispatcher, which is the part that matters: `/library
+  // /routes` publishes this table and `library-check` sweeps what it publishes, so a
+  // route answering from anywhere else is a route no sweep can see.
+  { path: '/sensor/health', pattern: /^\/sensor\/health$/, read: serveSensorHealth },
 
   // ---- recording
   { path: '/record/state', pattern: /^\/record\/state$/, read: serveRecordState },
@@ -1711,6 +1756,33 @@ const stats = { frames: 0, dropped: 0, bytes: 0, since: Date.now() };
 // library on a cold server still needs a number.
 let observedBytesPerSec = 0;
 const recordingRate = () => (observedBytesPerSec > 0 ? observedBytesPerSec : undefined);
+// The frame rate over the same window, kept beside the byte rate rather than derived
+// from it. A frame rate recovered by dividing bytes by a nominal frame size would be
+// an estimate wearing a measurement's clothes, and the two quantities move apart for
+// real reasons - a link delivering half the frames at full size and one delivering
+// every frame at half size are the same MB/s and different faults.
+let observedFps = 0;
+
+// The window that closed last, empty ones included, and it is deliberately not the
+// same age as the two rates above. A window with no frames in it has no rate to
+// report, so the rates keep the last honest measurement across a gap - but the
+// window's own length and frame count are exactly what says the sensor stopped
+// delivering, and they would say nothing if they were held back with the rates.
+let lastWindow = null;
+
+// Every frame the broadcast has dropped since this process started. Accumulated as
+// each window closes rather than counted in `broadcastFrame`, so the hot path is
+// untouched, and monotonic because the per-window count is zeroed every five seconds
+// - a number that resets cannot answer "has this link been dropping frames".
+let droppedTotal = 0;
+
+// How many grabbers this process has started. Kept at module scope because the
+// supervisor's own `attempt` cannot answer the question this one is for: `attempt` is
+// an index into the backoff's delay table and is deliberately zeroed on a clean
+// handshake and on a colour toggle, so it says how long until the next try and
+// nothing at all about how many times the sensor has already dropped. Two numbers
+// because they are two questions, not one number written down twice.
+let grabberSpawns = 0;
 
 let sensorState = 'starting';
 
@@ -2062,13 +2134,35 @@ function handleMessage(msg) {
 }
 
 setInterval(() => {
-  const dt = (Date.now() - stats.since) / 1000;
-  if (stats.frames === 0) return;
-  const fps = (stats.frames / dt).toFixed(1);
-  const mbs = (stats.bytes / dt / 1e6).toFixed(1);
-  observedBytesPerSec = stats.bytes / dt;
-  console.log(`[server] ${fps} fps  ${mbs} MB/s  dropped=${stats.dropped}  clients=${wss.clients.size}`);
+  // **The window closes before anything decides whether it was interesting**, and
+  // that ordering is the whole of this. The reset used to sit past the early return,
+  // so a five-second window in which no frame arrived was never closed at all and
+  // `stats.since` carried its old value across the gap. After a sixty-second USB drop
+  // the next window's frames were divided by sixty-five seconds - about a thirteenth
+  // of the true rate, into the log and into `observedBytesPerSec`, which the
+  // remaining-time readout divides free space by. An operator was then promised card
+  // space that does not exist at the rate the sensor is actually writing.
+  //
+  // **Resetting `dropped` alongside the other three is safe by construction.**
+  // `stats.dropped++` only ever runs inside `broadcastFrame`, on a path that has
+  // already run `stats.frames++` for the same frame, so a window that ends with
+  // `frames` at zero cannot have a drop in it to lose.
+  const closed = { ms: Date.now() - stats.since, frames: stats.frames, dropped: stats.dropped, bytes: stats.bytes };
   Object.assign(stats, { frames: 0, dropped: 0, bytes: 0, since: Date.now() });
+  lastWindow = { ms: closed.ms, frames: closed.frames };
+  droppedTotal += closed.dropped;
+  // **And what stays behind the return is the derived rate, deliberately left stale.**
+  // A window that carried no frames has no rate in it, and computing one anyway would
+  // replace the last honest measurement with a number over a window that never
+  // happened. The length and the frame count above are what say the gap occurred; the
+  // rates say what delivery looked like when there last was any.
+  if (closed.frames === 0) return;
+  const dt = closed.ms / 1000;
+  const fps = (closed.frames / dt).toFixed(1);
+  const mbs = (closed.bytes / dt / 1e6).toFixed(1);
+  observedBytesPerSec = closed.bytes / dt;
+  observedFps = closed.frames / dt;
+  console.log(`[server] ${fps} fps  ${mbs} MB/s  dropped=${closed.dropped}  clients=${wss.clients.size}`);
 }, 5000);
 
 // The Kinect v2 drops off the bus under sustained load on a marginal USB link,
@@ -2184,6 +2278,11 @@ function startLive() {
   };
 
   const spawnGrabber = () => {
+    // Counted here rather than in the backoff, because every road to a running
+    // grabber ends at this function - the exit handler's retry, the colour toggle's
+    // restart, and the boot - so a path added later is counted by going through it
+    // rather than by somebody remembering to add a line to it.
+    grabberSpawns++;
     const grabberArgs = buildArgs();
     console.log(`[server] starting grabber: ${bin} ${grabberArgs.join(' ')}`);
     setSensorState('starting');

--- a/server/index.js
+++ b/server/index.js
@@ -613,9 +613,33 @@ function revealAvailability(req) {
   return { available: true, label, why: null };
 }
 
+/**
+ * A signal that fires when the caller hangs up, for handing to the node.
+ *
+ * **Every route that awaits the node passes one, and that is the class rather than the
+ * one route where it was noticed.** `node.takes` crosses the network to a machine that
+ * may accept a connection and then say nothing, and a handler awaiting it holds this
+ * process's socket and the outbound one for as long as that lasts - which, once the
+ * gallery's listing is bounded and retries, is another pair every five seconds for as
+ * long as the page is open. The gallery is only the route that made it accumulate; a
+ * download, a removal and a mark sync all await the same unbounded fetch, so a rule that
+ * covered the one would leave the next one added outside it. `library-check` walks the
+ * source for `node.takes(` and requires a signal at every call, so a route written later
+ * is asked by existing.
+ *
+ * `close` rather than `aborted`, because it fires for a connection that ended either way
+ * and an abort after the answer has gone out costs nothing - the fetch it would cancel
+ * has already settled.
+ */
+const untilCallerLeaves = (req) => {
+  const ctl = new AbortController();
+  req.on('close', () => ctl.abort());
+  return ctl.signal;
+};
+
 async function serveLibrary(req, res) {
   const here = await localTakes();
-  const there = node ? await node.takes() : null;
+  const there = node ? await node.takes(untilCallerLeaves(req)) : null;
   const takes = reconcile(here.takes, there);
   sendJson(res, {
     here: HERE_NAME,
@@ -736,7 +760,7 @@ async function serveRemoval(req, res, [id], kind) {
     sendJson(res, { error: `${id} is being recorded right now: stop the take before removing it` }, 409);
     return;
   }
-  const there = node ? await node.takes() : null;
+  const there = node ? await node.takes(untilCallerLeaves(req)) : null;
   const theirs = (there ?? []).find((t) => t.hash === (mine?.hash ?? body.hash));
 
   if (kind === 'reclaim') {
@@ -834,7 +858,7 @@ async function serveDownload(req, res, [id]) {
     sendJson(res, { error: 'no capture node is linked, so there is nothing to download from' }, 409);
     return;
   }
-  const there = await node.takes();
+  const there = await node.takes(untilCallerLeaves(req));
   if (there === null) {
     sendJson(res, { error: `${node.name} is unreachable: ${node.lastError}` }, 502);
     return;
@@ -925,7 +949,7 @@ async function serveMarkSync(req, res, [id]) {
     // library is built to handle, so the one place that reached for a filename
     // would be the one place the design does not hold.
     const here = (await localTakes()).takes.find((t) => t.id === id);
-    const theirTakes = await node.takes();
+    const theirTakes = await node.takes(untilCallerLeaves(req));
     const match = here && (theirTakes ?? []).find((t) => t.hash === here.hash);
     if (!match) {
       sendJson(res, { merged: 0, marks: await readMarks(path), note: `${node.name} does not hold this take` });

--- a/server/index.js
+++ b/server/index.js
@@ -630,16 +630,39 @@ function revealAvailability(req) {
  * `close` rather than `aborted`, because it fires for a connection that ended either way
  * and an abort after the answer has gone out costs nothing - the fetch it would cancel
  * has already settled.
+ *
+ * **Watched on the response and not on the request, because half these routes read a
+ * body first.** An `IncomingMessage` is a stream, and it emits `close` when it *ends* -
+ * so by the time `serveRemoval` and `serveMarkSync` have awaited `readBody(req)` the
+ * request is already `destroyed` and a listener attached after it can never fire again.
+ * Both of them built a signal that was structurally incapable of aborting anything, and
+ * the source sweep could not see it: the call carried a signal, the argument was
+ * spelled correctly, and only the two routes that read no body actually worked. Measured
+ * directly rather than reasoned about - a listener on the consumed request does not fire
+ * when the client aborts, one on the response does.
+ *
+ * The response is the object whose lifetime is the handler's, which is what this wanted
+ * to name all along, so taking it here closes the class instead of reordering two call
+ * sites and leaving the third route somebody writes next year to be found the same way.
+ *
+ * What that rests on, checked rather than assumed, because it is the way this trade goes
+ * wrong: `close` on a response also fires when the answer finishes normally, so a route
+ * that had already written one before awaiting the node would abort a fetch still in
+ * flight - a signal that fires too early, which fails some of the time and is worse than
+ * one that never fires at all. Every write ahead of a `node.takes` call on all four
+ * routes is an early refusal that returns, so no path reaching the node has touched the
+ * response. A route that wants to stream before it asks the node needs a different
+ * answer, and this sentence is where it will find out.
  */
-const untilCallerLeaves = (req) => {
+const untilCallerLeaves = (res) => {
   const ctl = new AbortController();
-  req.on('close', () => ctl.abort());
+  res.on('close', () => ctl.abort());
   return ctl.signal;
 };
 
 async function serveLibrary(req, res) {
   const here = await localTakes();
-  const there = node ? await node.takes(untilCallerLeaves(req)) : null;
+  const there = node ? await node.takes(untilCallerLeaves(res)) : null;
   const takes = reconcile(here.takes, there);
   sendJson(res, {
     here: HERE_NAME,
@@ -760,7 +783,7 @@ async function serveRemoval(req, res, [id], kind) {
     sendJson(res, { error: `${id} is being recorded right now: stop the take before removing it` }, 409);
     return;
   }
-  const there = node ? await node.takes(untilCallerLeaves(req)) : null;
+  const there = node ? await node.takes(untilCallerLeaves(res)) : null;
   const theirs = (there ?? []).find((t) => t.hash === (mine?.hash ?? body.hash));
 
   if (kind === 'reclaim') {
@@ -858,7 +881,7 @@ async function serveDownload(req, res, [id]) {
     sendJson(res, { error: 'no capture node is linked, so there is nothing to download from' }, 409);
     return;
   }
-  const there = await node.takes(untilCallerLeaves(req));
+  const there = await node.takes(untilCallerLeaves(res));
   if (there === null) {
     sendJson(res, { error: `${node.name} is unreachable: ${node.lastError}` }, 502);
     return;
@@ -949,7 +972,7 @@ async function serveMarkSync(req, res, [id]) {
     // library is built to handle, so the one place that reached for a filename
     // would be the one place the design does not hold.
     const here = (await localTakes()).takes.find((t) => t.id === id);
-    const theirTakes = await node.takes(untilCallerLeaves(req));
+    const theirTakes = await node.takes(untilCallerLeaves(res));
     const match = here && (theirTakes ?? []).find((t) => t.hash === here.hash);
     if (!match) {
       sendJson(res, { merged: 0, marks: await readMarks(path), note: `${node.name} does not hold this take` });

--- a/server/index.js
+++ b/server/index.js
@@ -2454,10 +2454,19 @@ function startLive() {
         // reports. This is the one place that knows the difference: `spawnGrabber`
         // sees every road to a running grabber and none of them carry why.
         restarting = false;
-        grabberRestarts++;
         const delay = killedHard ? RESPAWN_AFTER_KILL_MS : RESPAWN_AFTER_CLEAN_MS;
         killedHard = false;
-        setTimeout(spawnGrabber, delay);
+        // **Counted beside the spawn it excuses rather than here, where it is learned.**
+        // `respawns` is `grabberSpawns - 1 - grabberRestarts`, so incrementing on the
+        // exit and leaving the matching spawn a quarter of a second to a second and a
+        // half away makes that subtraction run one ahead of itself for the whole gap -
+        // a node that had genuinely lost its sensor once read one respawn, then zero
+        // while an operator's colour toggle was in flight, then one again. A health
+        // number that dips to zero over a real earlier failure is worse than one that
+        // never noticed it, because somebody looking in that second is told the node is
+        // well. Both halves move in the same tick now, so the reading has no gap to
+        // pass through.
+        setTimeout(() => { grabberRestarts++; spawnGrabber(); }, delay);
         return;
       }
       scheduleRetry();

--- a/server/index.js
+++ b/server/index.js
@@ -1285,7 +1285,18 @@ const serveSensorHealth = (req, res) => sendJson(res, {
   bytesPerSec: observedBytesPerSec,
   // And the last window that closed, whether or not anything arrived in it.
   window: lastWindow,
-  dropped: droppedTotal,
+  // **Named for what it counts, which is not what a reader of a sensor-health route
+  // would assume.** `stats.dropped` is incremented inside `broadcastFrame`, per socket
+  // whose send buffer is over the ceiling - so it is monitors failing to keep up with
+  // the output, not the sensor failing to deliver. Called `dropped` on this route it
+  // reads as sensor loss and is wrong in both directions at once: a node whose sensor is
+  // struggling with nobody watching reports zero, because the function returns before
+  // this can move when `wss.clients.size` is zero, and one frame that two lagging
+  // monitors both missed counts twice. There is no sensor-loss number here to rename it
+  // to - the frames that never arrived are absent from `window.frames`, which is the
+  // reading that already says so - so the honest move is to stop this one claiming to be
+  // one. `dropped` is beside the recorder's own, which counts what the disk refused.
+  monitorDropped: droppedTotal,
   // The first spawn is a start rather than a respawn, which is the number somebody
   // reading this is after: on a healthy node it is zero for the life of the process.
   // The restarts somebody asked for come off it for the same reason - a colour toggle

--- a/server/library.js
+++ b/server/library.js
@@ -449,10 +449,21 @@ export class NodeLink {
    * The whole manifest and never take by take. Admitting the readable ones would hide
    * the rest behind a shelf that looks complete, and "some of that node's takes are
    * missing" is the failure a link is supposed to make impossible to have silently.
+   *
+   * **`signal` is the caller's request going away, and it is a signal rather than a
+   * timeout on purpose.** This crosses the network to have a directory walked and an
+   * index built per take, and a cold node measured 7m30s over 200 unindexed takes - so
+   * any bound short enough to catch a dead link is short enough to refuse the case the
+   * link exists for. What the caller does know is whether anybody is still waiting: a
+   * route hands in its own request's abort, and a node that accepts the connection and
+   * then says nothing is dropped the moment the browser gives up rather than held until
+   * it eventually settles. Without it the gallery's fifteen-second retry left one more
+   * handler and one more outbound socket parked on this machine every five seconds, for
+   * as long as the page stayed open.
    */
-  async takes() {
+  async takes(signal = null) {
     try {
-      const body = await this.fetchJson('/library/takes');
+      const body = await this.fetchJson('/library/takes', signal ? { signal } : undefined);
       // The hash is filtered beside the id because it is the other field of a node's
       // that reaches a path here. **A take still being shot advertises no hash at
       // all** - `describeTake` reports null on purpose, and `reconcile` keys those by

--- a/server/library.js
+++ b/server/library.js
@@ -374,13 +374,25 @@ export class NodeLink {
   async recordState() {
     try {
       const body = await this.fetchJson('/record/state', { signal: AbortSignal.timeout(3000) });
-      return { name: this.name, reachable: true, recording: Boolean(body.recording), takeId: body.takeId ?? null };
+      return {
+        name: this.name,
+        reachable: true,
+        recording: Boolean(body.recording),
+        takeId: body.takeId ?? null,
+        // The node's own answer to "which take do you still own", carried across
+        // unchanged. The gallery on this machine draws that node's takes, so the
+        // window in which a tile may not offer Open is the node's window and not
+        // this one's - reading it off `recording` here would end the remote tile's
+        // refusal the moment the node's writing stopped, several seconds before its
+        // index existed.
+        writingId: body.writingId ?? null,
+      };
     } catch {
       // Deliberately not written to `lastError`. That field is what the gallery prints
       // beside "unreachable", and it is set by the listing this side actually draws
       // from - overwriting it here would let a poll's timeout replace the reason the
       // library failed with a reason nothing on screen is about.
-      return { name: this.name, reachable: false, recording: false, takeId: null };
+      return { name: this.name, reachable: false, recording: false, takeId: null, writingId: null };
     }
   }
 }

--- a/server/library.js
+++ b/server/library.js
@@ -61,6 +61,7 @@ export const VALID_HASH = /^sha256:[0-9a-f]{64}$/;
 // and now quote `openRefusals`, leaving `OPEN_REFUSALS.format` below and the editor's
 // `openTake`, which is handed a hello and never a manifest.
 import { PROJECT_VERSION, VALID_ID, captureFormatRefusal } from '../web/format.js';
+import { POLLED_NODE_FIELDS } from '../web/record-poll.js';
 
 export { PROJECT_VERSION };
 
@@ -419,6 +420,10 @@ export class NodeLink {
     this.url = url.replace(/\/$/, '');
     this.name = name;
     this.lastError = null;
+    // Null until the poll has spoken to the node once. A link that has answered
+    // nothing yet is not a link that has failed, so the first listing goes out and is
+    // refused by its own gate if the manifest is the half that is old.
+    this.buildRefusal = null;
   }
 
   async fetchJson(path, init) {
@@ -462,6 +467,17 @@ export class NodeLink {
    * as long as the page stayed open.
    */
   async takes(signal = null) {
+    // The poll's refusal, read here because this is the request that draws something.
+    // `recordState` is the only caller that learns the node's build is too old to be
+    // followed and it paints nothing itself, so a refusal left where it was found is
+    // one the operator never sees - the gallery would go on listing that node's takes
+    // beside a recorder state frozen at the first tick. Refused before the fetch rather
+    // than after it, because there is nothing to ask a node whose answers cannot be
+    // followed, and the reason lands in `lastError` where the shelf already prints it.
+    if (this.buildRefusal) {
+      this.lastError = this.buildRefusal;
+      return null;
+    }
     try {
       const body = await this.fetchJson('/library/takes', signal ? { signal } : undefined);
       // The hash is filtered beside the id because it is the other field of a node's
@@ -513,6 +529,39 @@ export class NodeLink {
   async recordState() {
     try {
       const body = await this.fetchJson('/record/state', { signal: AbortSignal.timeout(3000) });
+      // **The same "two machines are two builds" refusal `takes()` makes, arriving at
+      // the second route.** The manifest gate up there is passed by the build
+      // immediately before this one, whose `/record/state` predates `writingId` and
+      // omits the key entirely - and `?? null` below would read that as a node that
+      // owns no take. It is a legal value for a recorder sitting idle, so nothing
+      // would look wrong: the fingerprint the poll computes is constant from the first
+      // tick, no remote start or stop can ever change it, and the gallery quietly
+      // stops rereading the library for the machine it is drawing half its grid from.
+      // Absent and "not writing" are two different facts and only one of them may be
+      // spelled `null`.
+      //
+      // Asked of `POLLED_NODE_FIELDS` rather than of `writingId` by name, because the
+      // poll is what decides which fields matter: a field added to that fingerprint
+      // tightens this by existing, where a name written out here is a second list to
+      // keep in step and the copy that goes stale is this one - the far side is the
+      // half nobody tests on a single machine.
+      const missing = POLLED_NODE_FIELDS.filter((f) => body[f] === undefined);
+      // **Its own field rather than `lastError`, and the reason is which way each one
+      // has to move.** `lastError` is written per listing and cleared by the next one
+      // that succeeds, so a refusal parked in it would either be wiped by the very next
+      // `/library/all` - which is what it has to survive to be read - or, if `takes()`
+      // returned early on it, would latch: nothing would fetch again, so nothing would
+      // clear it, and a node upgraded ten minutes later would stay refused until this
+      // process restarted. Set and cleared on every tick of the poll instead, so the
+      // refusal lasts exactly as long as the build that earns it and an upgrade heals
+      // the link within one cadence with nobody doing anything.
+      this.buildRefusal = missing.length === 0 ? null
+        : 'it is running an older build whose recorder state carries no '
+          + `${missing.join(', ')} - the gallery cannot follow a recorder it cannot ask, `
+          + 'so its takes are not listed here. Upgrade the node to this build.';
+      if (this.buildRefusal) {
+        return { name: this.name, reachable: false, recording: false, takeId: null, writingId: null };
+      }
       return {
         name: this.name,
         reachable: true,

--- a/server/recorder.js
+++ b/server/recorder.js
@@ -152,6 +152,16 @@ export class Recorder {
     // so the next hello has to open take four without anyone pressing anything.
     this.armed = false;
     this.take = null;
+    // **The take that has stopped but is not finished yet.** `close` nulls `this.take`
+    // before it awaits the flush and builds the index, which it has to - the marks and
+    // the mid-write handler both depend on the open take being gone the moment it stops
+    // - and the effect was that every question about "is the recorder still holding
+    // this file" answered no while the recorder was still holding it. On a slow disk
+    // the index build is seconds, and a gallery that refreshed inside that window drew
+    // Download, Rename and Remove over a take whose sidecar and hash did not exist yet.
+    // The take is kept here for exactly as long as the close is running, so `openPath`
+    // can go on telling the truth about a file this process still owns.
+    this.finalizing = null;
   }
 
   get state() {
@@ -171,12 +181,38 @@ export class Recorder {
       dropped: take?.dropped ?? 0,
       buffered: take ? take.stream.writableLength : 0,
       cannotRecord: this.cannotRecord(),
+      // **The take this process still owns, which is a longer window than `recording`
+      // and a different question from it.** `recording` is what the recorder panel
+      // shows and it goes false the instant a take stops, which is right for a panel.
+      // A gallery tile asks something else - may I offer Open, Download, Rename and
+      // Remove on this file yet - and the honest answer stays no until the index and
+      // the hash exist. Reported as the id rather than as a flag so the reading is
+      // absolute: a surface can compare it against the take it drew and know whether
+      // it is looking at the same world, where two flags only ever say that something
+      // moved between two observations it happened to make.
+      writingId: take?.id ?? this.finalizing?.id ?? null,
     };
   }
 
-  /** The file a take is being written into right now, or null. */
+  /**
+   * The file a take is being written into right now, or null - and "right now" runs
+   * to the end of the close rather than to the end of the writing. See `finalizing`.
+   *
+   * **A known remaining hole, written down rather than left to be rediscovered: this is
+   * one path and a grabber restart can own two.** `split()` closes the old take without
+   * being awaited and the replacement's hello opens the next one about 250ms later,
+   * while `armed` is still true on purpose - so for the rest of that index build
+   * `this.take` is the new take, wins here, and the old one stops being covered exactly
+   * while it is still being read. sha256 over a 138MB capture is well past 250ms, so the
+   * window is real on the restart path even though the stop path is now closed.
+   *
+   * Closing it means every caller asking `owns(path)` rather than comparing against one
+   * value - `beingRecorded`, `scanTakes` and `renameTake` are the three - which is a
+   * wider change than the one this note sits inside, and it is deliberately not being
+   * made silently in passing.
+   */
   get openPath() {
-    return this.take?.path ?? null;
+    return this.take?.path ?? this.finalizing?.path ?? null;
   }
 
   /**
@@ -377,6 +413,10 @@ export class Recorder {
     const take = this.take;
     if (!take) return null;
     this.take = null;
+    // Handed straight over, in the same statement that gives it up: between these two
+    // lines is the only moment this object could be asked about the take and answer
+    // that nobody owns it, and there is no await in it.
+    this.finalizing = take;
     take.stream.end();
     let closeError = null;
     try {
@@ -403,10 +443,22 @@ export class Recorder {
     // a flush skipped here is the orphaning the mid-write handler had - the marks
     // travel forward into whichever take closes next, stamped in source milliseconds
     // from a start that take never had.
-    settle(take);
-    await flushMarks(take);
-    forgetCapture(take.path);
-    const index = await buildIndex(take.path);
+    let index;
+    try {
+      settle(take);
+      await flushMarks(take);
+      forgetCapture(take.path);
+      index = await buildIndex(take.path);
+    } finally {
+      // **Given up in a `finally` rather than on the line after, because the failing
+      // case is the one that matters.** An index build that threw - the disk that ate
+      // the flush above is the likeliest reason - would otherwise leave this process
+      // claiming a file it had stopped working on for as long as it lived, and every
+      // gallery tile for that take refusing Open, Download, Rename and Remove forever
+      // with no way back but a restart. A close that failed still ends the recorder's
+      // ownership: whatever landed is on disk and nothing here will touch it again.
+      this.finalizing = null;
+    }
     console.log(
       `[recorder] take ${take.id} closed (${reason}): ${index.frames.offset.length} frames, ${index.hash}`
       + (take.dropped ? `, ${take.dropped} frames dropped to a slow disk` : ''),

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -234,6 +234,43 @@ const MUTATIONS = {
     ]],
   },
 
+  // The autosave offer goes back to being withheld whenever any part of the library
+  // failed to list. That gate was right while the offer was a sentence written through
+  // `say`, which would have painted over the note naming what broke - and wrong the
+  // moment it became a button, since a button overwrites nothing and what the gate now
+  // does is throw away the only control that reaches `__working__`, a document the
+  // project picker deliberately does not show, because an unrelated presets directory
+  // was pointed one level too high.
+  //
+  // Must redden only the row about a broken neighbour. Every other row in section 13
+  // lists cleanly, so the gate and the fix agree across all of them - which is exactly
+  // how this survived a section that had already asserted the offer twelve ways.
+  'resume-waits-for-every-list': {
+    file: 'web/main.js',
+    edits: [[
+      '  if (listed.projects) offerWorkingDocument(listed.projects);',
+      '  if (!unavailable.length) offerWorkingDocument(listed.projects);',
+    ]],
+  },
+
+  // AltGr goes back to being read as the ctrl+alt it arrives as. On a German, Nordic or
+  // Polish layout `[` and `]` are AltGr presses and Windows delivers AltGr by setting
+  // both of those bits, so the modifier guard returns before the mark-stepping keys can
+  // run and this program advertises two shortcuts nobody on those layouts can press.
+  //
+  // Must redden the AltGr row and leave the row beside it - plain ctrl+alt on a layout
+  // that needs no composing, which is still not ours - green. A mutation that only
+  // widened the guard would pass the first and fail the second, which is why both are
+  // there.
+  'shortcuts-reject-altgr': {
+    file: 'web/main.js',
+    edits: [[
+      "  const composed = e.key.length === 1 && e.getModifierState('AltGraph');\n"
+      + '  if ((e.metaKey || e.ctrlKey || e.altKey) && !composed) return;',
+      '  if (e.metaKey || e.ctrlKey || e.altKey) return;',
+    ]],
+  },
+
   'plant-unswept-control': {
     file: 'web/index.html',
     edits: [[
@@ -4444,6 +4481,34 @@ try {
       'and the offer withdraws once it has been taken, since restoring what is already on screen is a button that does nothing',
       `chip ${afterRestore.shown ? 'still shown' : 'hidden'}`);
 
+    // **A neighbour that will not list must not take the recovery with it.** Opening a
+    // take refreshes three libraries and lets all three fail softly, and the offer used
+    // to be withheld unless every one of them came back. That was right while the offer
+    // was a sentence written through `say`, which would have painted over the note
+    // naming what broke - and it stopped being right the moment the offer became a
+    // button, because a button overwrites nothing. What the gate did instead was strand
+    // the only control that reaches `__working__`, which the project picker deliberately
+    // does not list, on a station whose `--builtin-presets` pointed one directory too
+    // high. The autosave was there, intact, stamped with this take, and unreachable.
+    //
+    // The presets route is refused at the page's edge rather than by misconfiguring a
+    // server, so the failure is exactly one list and the row can say which.
+    await putDoc(WORKING, workingBody({ id: openId, hash: openHash }));
+    await page.route('**/presets', (route) => route.fulfill({
+      status: 500, contentType: 'application/json', body: '{"error":"the presets directory is not there"}',
+    }));
+    await reopen();
+    const brokenNote = await page.evaluate("document.getElementById('tNote').textContent");
+    const offeredAnyway = await offerState();
+    await page.unroute('**/presets');
+    check(/library unavailable/.test(brokenNote) && /presets/.test(brokenNote),
+      'a presets list that refuses is reported by name, which is what makes the row below about the gate rather than about a request that quietly worked',
+      `note "${brokenNote.slice(0, 100)}"`);
+    check(offeredAnyway.shown && offeredAnyway.button,
+      'and the autosave is offered anyway, because the projects list is the only one the offer is made of and a broken neighbour is not a reason to hide the work',
+      `chip ${offeredAnyway.shown ? 'shown' : 'hidden'}, "${offeredAnyway.when}"`);
+    await reopen();
+
     await page.selectOption('#tProject', OTHER);
     await page.click('#tProjectOpen');
     await page.waitForFunction("document.getElementById('tNote').textContent.includes('different footage')",
@@ -4585,6 +4650,53 @@ try {
     check(near(back, geometry.program[0], TOL),
       'and the previous-mark key walks back the way it came',
       `${back.toFixed(3)}s against ${geometry.program[0].toFixed(3)}s`);
+
+    // **And the layouts those two keys are actually typed on.** `[` and `]` are
+    // unmodified only on a US or UK keyboard. On German, Nordic and Polish layouts they
+    // are AltGr presses, and Windows delivers AltGr by setting ctrl and alt together -
+    // so the guard that rejects command modifiers rejected the character as well, and
+    // the two keys this section just asserted were unreachable for most of Europe. The
+    // rows above cannot see it, because Playwright presses the US key.
+    //
+    // Dispatched rather than pressed, because that is the only way to say AltGr from
+    // here: `page.keyboard` has no modifier for it, while `KeyboardEventInit` carries
+    // `modifierAltGraph` and Chromium reports it back through `getModifierState`. Both
+    // halves are asserted - the composed press has to work and the bare ctrl+alt press
+    // has to go on being refused - because a guard simply deleted would pass the first.
+    const pressComposed = async (key, altGraph) => {
+      await page.evaluate(`document.dispatchEvent(new KeyboardEvent('keydown', {
+        key: ${JSON.stringify(key)}, ctrlKey: true, altKey: true,
+        modifierAltGraph: ${altGraph}, bubbles: true, cancelable: true,
+      }))`);
+      await settle();
+      return (await read()).programSec;
+    };
+    await page.evaluate('__kinect.timeline.transport().seek(0)');
+    await settle();
+    await focusStage();
+    const altGr = await pressComposed(']', true);
+    check(near(altGr, geometry.program[0], TOL),
+      'the next-mark key works when it is typed with AltGr, which is how a German, Nordic or Polish keyboard types it at all',
+      `${altGr.toFixed(3)}s against ${geometry.program[0].toFixed(3)}s`);
+    const plainCtrlAlt = await pressComposed(']', false);
+    check(near(plainCtrlAlt, altGr, TOL),
+      'and the same two bits without AltGraph behind them move nothing, so the guard still hands ctrl+alt to the browser it belongs to',
+      `${plainCtrlAlt.toFixed(3)}s, unmoved from ${altGr.toFixed(3)}s`);
+    // The other half of the guard, in the direction the widening could have broken it:
+    // AltGr held over a key that is a command rather than a character is the right-hand
+    // Alt being used as a modifier, and that is still not ours.
+    const altGrArrow = await page.evaluate(`(() => {
+      const before = __kinect.timeline.transport().programSec;
+      document.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'ArrowRight', ctrlKey: true, altKey: true, modifierAltGraph: true,
+        bubbles: true, cancelable: true,
+      }));
+      return before;
+    })()`);
+    await settle();
+    check(near((await read()).programSec, altGrArrow, TOL),
+      'and a named key under the same modifier is still the browser\'s, since AltGr only composes characters and there is no character here',
+      `${(await read()).programSec.toFixed(3)}s against ${altGrArrow.toFixed(3)}s`);
 
     const legend = await page.evaluate('__kinect.editor.shortcuts()');
     check(/\[\/\]/.test(legend),

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -265,8 +265,27 @@ const MUTATIONS = {
   'resume-fetches-the-moving-name': {
     file: 'web/main.js',
     edits: [[
-      '    await loadProjectNamed(WORKING_PROJECT, offeredWorkingBody);',
+      '    await loadProjectNamed(WORKING_PROJECT, accepted);',
       '    await loadProjectNamed(WORKING_PROJECT);',
+    ]],
+  },
+
+  // The accepted snapshot is applied and then dropped without being written back, so the
+  // recovery lives only in the tab: `__working__` still holds the edit that overwrote the
+  // offer, and a reload after being told "restored" loads that edit back.
+  //
+  // The write and not the capture, because `resume-fetches-the-moving-name` already takes
+  // the capture. Must redden only the row that reads the store after the press.
+  'resume-restores-without-keeping': {
+    file: 'web/main.js',
+    edits: [[
+      "    const kept = await fetch(`/projects/${WORKING_PROJECT}`, {\n"
+      + "      method: 'PUT',\n"
+      + "      headers: { 'Content-Type': 'application/json' },\n"
+      + '      body: JSON.stringify(accepted),\n'
+      + '    });\n'
+      + "    if (!kept.ok) throw new Error(`restored on screen, but the auto-save could not be rewritten: ${(await kept.text().catch(() => '')).slice(0, 80)}`);\n",
+      '',
     ]],
   },
 
@@ -4889,6 +4908,20 @@ try {
     check(restoredAfterMove.outputSize === differing.outputSize,
       'and pressing it restores the document that was offered rather than whatever the name holds by then, since the work it was advertising is the work being recovered',
       `${restoredAfterMove.outputSize} against the offered ${differing.outputSize} and the store's ${moved.outputSize}`);
+
+    // **And the store holds it afterwards, or the recovery lasted only as long as the
+    // tab.** Holding the offered body fixed which document the press restores; it did
+    // not make the restore survive a reload. `__working__` still held the edit that
+    // overwrote the offer, the retained snapshot was the only other copy, and nothing
+    // rewrites that slot until the next edit - so closing the page after being told
+    // "restored the autosaved edit" loaded the overwriting edit straight back.
+    const storedAfterRestore = await page.evaluate(`(async () => {
+      const doc = await (await fetch('/projects/${WORKING}')).json();
+      return doc.body?.outputSize ?? null;
+    })()`);
+    check(storedAfterRestore === differing.outputSize,
+      'and the auto-save is rewritten with what was restored, so a reload after the recovery loads the recovered work rather than the edit that had overwritten it',
+      `stored ${storedAfterRestore} against the restored ${differing.outputSize} and the ${moved.outputSize} it had been overwritten with`);
 
     const afterRestore = await offerState();
     check(!afterRestore.shown,

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -252,6 +252,24 @@ const MUTATIONS = {
   // Must redden only the row about a broken neighbour. Every other row in section 13
   // lists cleanly, so the gate and the fix agree across all of them - which is exactly
   // how this survived a section that had already asserted the offer twelve ways.
+  // The resume chip goes back to fetching `__working__` when it is pressed, rather than
+  // restoring the document it was offering. That name is rewritten by `history.commit()`
+  // on every edit, so a nudge of any control between the offer appearing and the button
+  // being pressed means the press restores the nudge and reports it as a recovery - with
+  // the work it was advertising already overwritten.
+  //
+  // Must redden only the row that moves the document under the offer. Every other resume
+  // row presses the chip with nothing having touched the store in between, where fetching
+  // the name and holding the body give the same answer - which is how this survived a
+  // section that already presses the chip and reads the restored document back.
+  'resume-fetches-the-moving-name': {
+    file: 'web/main.js',
+    edits: [[
+      '    await loadProjectNamed(WORKING_PROJECT, offeredWorkingBody);',
+      '    await loadProjectNamed(WORKING_PROJECT);',
+    ]],
+  },
+
   'resume-waits-for-every-list': {
     file: 'web/main.js',
     edits: [[
@@ -4840,6 +4858,35 @@ try {
     check(restored.outputSize === differing.outputSize,
       'and pressing it restores the autosaved document onto the open take, without leaving the page for a URL that would drop the take',
       `${restored.outputSize} against the autosave's ${differing.outputSize} and the fresh clip's ${fresh.outputSize}`);
+    // **And the offer survives the store moving under it.** `__working__` is the one
+    // name in this library that rewrites itself: `history.commit()` autosaves over it on
+    // every edit, so between the chip appearing and somebody pressing it the document it
+    // was offering can already be gone. Fetching the name at that point restores the
+    // edit made *since* the offer and calls it a recovery, with the work the operator
+    // was looking at overwritten and unrecoverable.
+    //
+    // The store is moved by writing it directly rather than by driving an edit, because
+    // what the defect turns on is that the contents changed between the offer and the
+    // press - `history.commit()` is one way to change them and not the property under
+    // test. Writing it makes the row say which document came back rather than depend on
+    // which control happened to autosave.
+    await putDoc(WORKING, differing);
+    await reopen();
+    const offeredBeforeMove = await offerState();
+    const moved = workingBody({ id: openId, hash: openHash });
+    moved.outputSize = fresh.outputSize === '1280x720' ? '1920x1080' : '1280x720';
+    moved.pointSize = (Number(differing.pointSize) || 1) + 7;
+    await putDoc(WORKING, moved);
+    check(offeredBeforeMove.shown && moved.pointSize !== differing.pointSize,
+      'the offer is on screen and then the document behind its name is replaced, which is what an edit made while the chip is up does to it',
+      `chip ${offeredBeforeMove.shown ? 'shown' : 'hidden'}, offered pointSize ${differing.pointSize} against the store's new ${moved.pointSize}`);
+    await page.click('#tResumeOpen');
+    await settle();
+    const restoredAfterMove = await page.evaluate('__kinect.keyframes.project()');
+    check(restoredAfterMove.pointSize === differing.pointSize,
+      'and pressing it restores the document that was offered rather than whatever the name holds by then, since the work it was advertising is the work being recovered',
+      `pointSize ${restoredAfterMove.pointSize} against the offered ${differing.pointSize} and the store's ${moved.pointSize}`);
+
     const afterRestore = await offerState();
     check(!afterRestore.shown,
       'and the offer withdraws once it has been taken, since restoring what is already on screen is a button that does nothing',

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -59,6 +59,9 @@
 //   node tools/editor-check.mjs --mutate orbit-arms-stale-position --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate release-seeks-past-target --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate pin-keeps-orbit-armed  --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate note-skips-title       --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate tick-seeks-source-seconds --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate offer-ignores-take-hash --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate export-ignores-name              # must FAIL
 //
 // `--no-render` drops the real-export rows and says so in the verdict, the way
@@ -172,6 +175,63 @@ const MUTATIONS = {
         + '  applyStoredPreset({ name: saved.name, rev: saved.rev, body });',
       ],
     ],
+  },
+
+  // The editor's note goes back to being written into an element that truncates, with
+  // nothing carrying the whole sentence. `#tNote` sits in `.tchips`, which scrolls
+  // horizontally with its scrollbar hidden, so a message wider than the strip has no
+  // scrollbar to drag and no `title` to hover - it is off the right edge and there is
+  // no gesture that reaches it. Every note in the editor went through that element and
+  // only that element, and the messages that overflow are the refusals.
+  //
+  // Only the `title` goes. The text still lands and the strip still scrolls, which is
+  // what makes this the control for one row rather than a blanket switch: a mutation
+  // that also stopped the note being written would redden every row that reads it and
+  // say nothing about whether the sentence was reachable.
+  //
+  // Must redden: section 13's "the whole of a long refusal is reachable off the note's
+  // title", and that row alone. The export note's own rows stay green - `sayExport`
+  // writes its own title and a mutation reaching it would be saying something wider
+  // than this fix is.
+  'note-skips-title': {
+    file: 'web/main.js',
+    edits: [['  ui.note.title = text;\n', '']],
+  },
+
+  // A mark tick seeks to the mark's own source second instead of the program second
+  // the drawing code clamped it to, which undoes the retime the tick was positioned
+  // through. The two coincide exactly at rate 1 with no keys, so the row that drives
+  // this **must** establish a non-unity rate first or the mutation is invisible and
+  // the control proves nothing - section 13 asserts the separation before it presses.
+  //
+  // The click handler alone, so `markSecondsInOrder` is untouched and the two keys go
+  // on jumping correctly. A mutation that took the whole control away would redden the
+  // key rows and the section 1 sweep as well, and then "the seek is wrong" would not
+  // be what the run had shown.
+  'tick-seeks-source-seconds': {
+    file: 'web/main.js',
+    edits: [[
+      "    el.addEventListener('click', (e) => { e.stopPropagation(); goTo(at); });",
+      "    el.addEventListener('click', (e) => { e.stopPropagation(); goTo(mark.sourceMs / 1000); });",
+    ]],
+  },
+
+  // The resume offer joins the working document to a take by id rather than by hash.
+  // A rename frees the old id and a later take can be renamed into it (#13), so an id
+  // match is a claim about a name where a hash match is a claim about footage - and
+  // the offer this makes is somebody's edit put back on top of material it was never
+  // authored against.
+  //
+  // Must redden: section 13's "no offer for a working document belonging to different
+  // footage". The row asserting the offer *is* made on a hash match stays green, since
+  // a mutation that suppressed the offer outright would pass the first row for exactly
+  // the wrong reason.
+  'offer-ignores-take-hash': {
+    file: 'web/main.js',
+    edits: [[
+      '  if (!openTakeHash || working.body?.take?.hash !== openTakeHash) return;',
+      '  if (!openTakeId || working.body?.take?.id !== openTakeId) return;',
+    ]],
   },
 
   'plant-unswept-control': {
@@ -941,6 +1001,17 @@ const DRIVER_RULES = [
     what: 'a camera-composition control',
     by: 'keyframe-check drives the path; sensor-view-check drives `sensor view`',
     match: (el) => el.closest('#cameraGroup') || el.id === 'camSensor',
+  },
+  {
+    key: 'mark',
+    what: 'a mark tick on the ruler',
+    // A rule rather than an id, because there is one of these per mark on the take
+    // and the fixture decides how many. Section 14 presses one and reads the playhead
+    // back, which is the row that matters here: the sweep can only say the control is
+    // covered, and a tick that seeks to the wrong second is a covered control that
+    // does the wrong thing.
+    by: 'section 14 presses a tick under a non-unity rate and reads where the playhead landed',
+    match: (el) => el.classList.contains('tmk'),
   },
   {
     key: 'nav',
@@ -4183,9 +4254,268 @@ try {
     await cleanupPresets();
   }
 
-  // ================================ 13. the pinned drive takes the loop away with it
+  // ============== 13. the note can be read, the ticks seek, and the auto-save comes back
 
-  console.log('\n[13] pinning the drive drops what the loop was going to serve');
+  console.log('\n[13] the note carries its whole sentence, a ruler tick seeks, and the auto-save is offered back');
+  //
+  // Three claims that share a shape rather than a subsystem: in each of them the
+  // editor already knew the right answer and had no way to say it. The note knew the
+  // whole refusal and showed the part that fitted; the tick knew the program second to
+  // seek to and was a `span`; the auto-save was on disk under a name the picker
+  // deliberately hides, with nothing offering it back.
+  //
+  // **Before section 13's pin**, because every row here needs the animation loop and
+  // the transport, and pinning the drive takes both away for good.
+  {
+    // A project built on footage this take is not, so pressing Open produces the
+    // longest refusal this program writes - which is the message the note's failure
+    // was about. A real document through the real store, driven by the real button:
+    // a `showTimelineError` called from `page.evaluate` would test the helper and
+    // leave the path an operator actually takes unmeasured.
+    const OTHER = 'editor-check-other-footage';
+    const WORKING = '__working__';
+    const putDoc = async (name, body) => {
+      const res = await fetch(`${URL_BASE}/projects/${encodeURIComponent(name)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return res.json();
+    };
+    const dropDoc = (name) => fetch(`${URL_BASE}/projects/${encodeURIComponent(name)}`, {
+      method: 'DELETE', headers: { 'Content-Type': 'application/json' },
+    }).catch(() => {});
+
+    // Every page error this section is answerable for, and the mark moves once more
+    // below. Counted from here rather than from zero because section 12 refuses two
+    // malformed presets on purpose and both refusals reach the console, so a row
+    // asserting the array is empty would report another section's deliberate work as
+    // this one's fault.
+    let errorsBefore = errors.length;
+    // **Waits for the open to have finished, not for the transport to exist.** The two
+    // are two fetches apart: `timeline` is assigned less than halfway through
+    // `openTake`, before the library is listed and before the resume offer is decided,
+    // so a wait on the transport reads the note before anything has written it - and
+    // `settled()` does not close the gap, because a transport with nothing queued is
+    // idle in exactly that window. Measured: the note came back empty here while the
+    // identical sequence on a fresh page reported the offer every time.
+    const reopen = async () => {
+      await page.reload({ waitUntil: 'load' });
+      await page.waitForFunction('globalThis.__kinect?.library?.opened() === true', null, { timeout: 30000 });
+      await settle();
+    };
+
+    // ---- what a fresh open of this take actually gives
+    //
+    // **Measured rather than assumed, and that is the repair this block is.** The
+    // documents below have to differ from the clip a fresh open produces, and the first
+    // draft built them by toggling `outputSize` on whatever twelve sections of edits
+    // had left on screen - which lands on the fresh value roughly half the time and
+    // turns the offer's silence into a pass for the wrong reason. So the fresh document
+    // is read first and everything else is derived from it.
+    await dropDoc(WORKING);
+    await reopen();
+    const fresh = await page.evaluate('__kinect.keyframes.project()');
+    const openHash = await page.evaluate('__kinect.library.takeHash()');
+    const openId = await page.evaluate('__kinect.library.takeId()');
+    check(typeof openHash === 'string' && openHash.length > 20,
+      'the open take has a content hash, which is what the resume offer joins on', String(openHash).slice(0, 24));
+    const noDocument = await text('#tNote');
+    check((noDocument ?? '') === '',
+      'a take opened with no working document beside it offers nothing, which is what makes the rows below about the document',
+      `"${(noDocument ?? '').slice(0, 60)}"`);
+
+    // The working document as the auto-save writes it: the whole project, stamped with
+    // the take. `differ` changes one field away from the value a fresh open gives, and
+    // the row below asserts that it did - the offer is deliberately silent when the two
+    // agree, so a document that accidentally matched would test the wrong branch.
+    const workingBody = (stamp, differ = true) => {
+      const body = JSON.parse(JSON.stringify(fresh));
+      if (differ) body.outputSize = fresh.outputSize === '1280x720' ? '1920x1080' : '1280x720';
+      return { ...body, take: stamp };
+    };
+    // Long enough that it cannot be read off a chip, and different footage besides.
+    const foreignHash = `sha256:${'0'.repeat(64)}`;
+
+    // ---- reload one: the offer is made, and then the note has to carry a refusal
+    const differing = workingBody({ id: openId, hash: openHash });
+    check(differing.outputSize !== fresh.outputSize,
+      'the document about to be planted differs from what a fresh open puts on screen, or there is nothing for the offer to be about',
+      `${differing.outputSize} against ${fresh.outputSize}`);
+    await putDoc(WORKING, differing);
+    await putDoc(OTHER, { ...JSON.parse(JSON.stringify(fresh)), take: { id: 'some-other-take', hash: foreignHash } });
+    await reopen();
+
+    const offered = await text('#tNote');
+    check(/autosaved work/.test(offered ?? ''),
+      'a working document stamped with this take\'s hash is offered back when it differs from the clip on screen',
+      `"${(offered ?? '').slice(0, 90)}"`);
+    // The precondition, in its own row and asked of the list rather than of the note.
+    // Read off the note it would pass on an empty string, which is the answer a red row
+    // above produces - so it would agree with any failure instead of ruling one out.
+    const listedWorking = await page.evaluate(`(async () => {
+      const list = (await (await fetch('/projects')).json()).projects ?? [];
+      const w = list.find((d) => d.name === '${WORKING}');
+      return { there: Boolean(w), stamped: w?.body?.take?.hash ?? null };
+    })()`);
+    check(listedWorking.there && listedWorking.stamped === openHash,
+      'and the library listed the working document carrying this take\'s hash, so the row above is about the offer rather than about a store that answered nothing',
+      `${listedWorking.there ? 'listed' : 'absent'}, stamped ${String(listedWorking.stamped).slice(0, 24)}`);
+
+    await page.selectOption('#tProject', OTHER);
+    await page.click('#tProjectOpen');
+    await page.waitForFunction("document.getElementById('tNote').textContent.includes('different footage')",
+      null, { timeout: 15000 }).catch(() => {});
+    const noteBox = await page.evaluate(`(() => {
+      const note = document.getElementById('tNote');
+      const chips = note.closest('.tchips');
+      return {
+        text: note.textContent,
+        title: note.title,
+        overflows: chips.scrollWidth > chips.clientWidth + 1,
+        scrollLeft: chips.scrollLeft,
+        scrollWidth: chips.scrollWidth,
+        clientWidth: chips.clientWidth,
+      };
+    })()`);
+    // The row that makes the next one mean something: a message that fitted would be
+    // readable whatever the title said.
+    check(noteBox.overflows && noteBox.text.length > 120,
+      'the refusal is genuinely wider than the strip it is written into, which is what the title is for',
+      `${noteBox.text.length} characters, ${noteBox.scrollWidth}px of content in ${noteBox.clientWidth}px`);
+    check(noteBox.title === noteBox.text && /different footage/.test(noteBox.title),
+      'and the whole of it is reachable off the note\'s title, which is the only surface it fits on',
+      `title "${noteBox.title.slice(0, 60)}..." against text "${noteBox.text.slice(0, 60)}..."`);
+    check(noteBox.scrollLeft > 0,
+      'and the strip scrolled to the message that just arrived rather than leaving it off the right edge',
+      `scrollLeft ${noteBox.scrollLeft} of ${noteBox.scrollWidth - noteBox.clientWidth} available`);
+    // The refusal above is this section's own doing and `showTimelineError` logs every
+    // note it writes, so the mark moves past it. Left where it was, the page-error row
+    // at the foot of the section would be reporting the fixture it was handed.
+    errorsBefore = errors.length;
+
+    // ---- reload two: different footage under the same name
+    //
+    // The id is deliberately the take's own. A rename frees an id and a later take can
+    // be renamed into it, so this is the document that an id comparison accepts and a
+    // hash comparison refuses - and accepting it puts somebody's edit on top of
+    // material it was never authored against.
+    await putDoc(WORKING, workingBody({ id: openId, hash: foreignHash }));
+    await reopen();
+    const wrongFootage = await text('#tNote');
+    check(!/autosaved work/.test(wrongFootage ?? ''),
+      'a working document carrying this take\'s id and different footage\'s hash is not offered',
+      `"${(wrongFootage ?? '(nothing)').slice(0, 90)}"`);
+
+    // ---- reload three: the same document that is already on screen
+    await putDoc(WORKING, workingBody({ id: openId, hash: openHash }, false));
+    await reopen();
+    const sameAsScreen = await text('#tNote');
+    check(!/autosaved work/.test(sameAsScreen ?? ''),
+      'and neither is one that matches the clip on screen, since restoring what is already there is not an offer',
+      `"${(sameAsScreen ?? '(nothing)').slice(0, 90)}"`);
+
+    await dropDoc(WORKING);
+    await dropDoc(OTHER);
+
+    // ---- the ruler's marks are controls
+    //
+    // **Under a non-unity rate, and that is the whole of what makes these rows able to
+    // fail.** A mark is stored in source milliseconds and drawn in program seconds, and
+    // at rate 1 with no keys the two are the same number - so a tick that seeks to the
+    // source second would land exactly where a correct one does and the control would
+    // prove nothing. The separation is asserted before anything is pressed.
+    const RATE = 0.5;
+    const MARKS = [
+      { id: 'em0', sourceMs: 1000, label: 'first' },
+      { id: 'em1', sourceMs: 3000, label: 'second' },
+      { id: 'em2', sourceMs: 5000, label: 'third' },
+    ];
+    await page.evaluate('__kinect.keyframes.setRetime({ rate: 1, keys: [] })');
+    await page.evaluate(`(() => {
+      const el = document.getElementById('tRate');
+      el.value = String(__kinect.editor.rateSlider.toValue(${RATE}));
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    })()`);
+    await focusStage();
+    await settle();
+    await page.evaluate(`__kinect.editor.setMarks(${JSON.stringify(MARKS)})`);
+    await page.evaluate('__kinect.editor.view.fit()');
+    await settle();
+
+    const geometry = await page.evaluate(`(() => {
+      const total = __kinect.editor.view.window().duration;
+      return {
+        rate: __kinect.timeline.retime.rate,
+        total,
+        program: ${JSON.stringify(MARKS)}.map((m) => Math.max(0, Math.min(total,
+          __kinect.timeline.retime.programSecAt(m.sourceMs / 1000)))),
+        source: ${JSON.stringify(MARKS)}.map((m) => m.sourceMs / 1000),
+        ticks: __kinect.library.markTicks().length,
+      };
+    })()`);
+    const TOL = 0.08;
+    const separated = geometry.program
+      .map((p, i) => Math.abs(p - geometry.source[i]))
+      .filter((d) => d > TOL * 4);
+    check(geometry.rate !== 1 && separated.length >= 2,
+      'the fixture runs at a rate where a mark\'s program second and its source second are different numbers, or nothing below can fail',
+      `rate ${geometry.rate}, program ${geometry.program.map((p) => p.toFixed(2)).join('/')}`
+      + ` against source ${geometry.source.map((s) => s.toFixed(2)).join('/')}`);
+    check(geometry.ticks === MARKS.length, 'every mark drew a tick on the ruler', `${geometry.ticks} ticks`);
+
+    // Pressing the tick. The middle one, so a build that seeked to either end would
+    // land somewhere this row can tell apart from the answer.
+    await page.evaluate('__kinect.timeline.transport().seek(0)');
+    await settle();
+    await page.locator('#tMarks .tmk').nth(1).click();
+    await settle();
+    const pressed = (await read()).programSec;
+    check(near(pressed, geometry.program[1], TOL),
+      'pressing a mark tick parks the playhead on the program second the tick is drawn at',
+      `playhead ${pressed.toFixed(3)}s against the tick's ${geometry.program[1].toFixed(3)}s`
+      + ` (the source second is ${geometry.source[1].toFixed(3)}s)`);
+    check(!near(pressed, geometry.source[1], TOL),
+      'and not on the mark\'s own source second, which is where the retime would be undone',
+      `${pressed.toFixed(3)}s against ${geometry.source[1].toFixed(3)}s`);
+
+    // And the keyboard, which is the half that is actually usable on a five-pixel
+    // diamond. Through `goTo` like Home and End, so a jump pauses and clamps.
+    await page.evaluate('__kinect.timeline.transport().seek(0)');
+    await settle();
+    await focusStage();
+    await page.keyboard.press(']');
+    await settle();
+    const forward = (await read()).programSec;
+    check(near(forward, geometry.program[0], TOL),
+      'the next-mark key jumps to the first mark ahead of the playhead',
+      `${forward.toFixed(3)}s against ${geometry.program[0].toFixed(3)}s`);
+    await page.keyboard.press(']');
+    await settle();
+    const forwardAgain = (await read()).programSec;
+    check(near(forwardAgain, geometry.program[1], TOL),
+      'and pressing it again steps to the next one rather than finding the mark it is standing on',
+      `${forwardAgain.toFixed(3)}s against ${geometry.program[1].toFixed(3)}s`);
+    await page.keyboard.press('[');
+    await settle();
+    const back = (await read()).programSec;
+    check(near(back, geometry.program[0], TOL),
+      'and the previous-mark key walks back the way it came',
+      `${back.toFixed(3)}s against ${geometry.program[0].toFixed(3)}s`);
+
+    const legend = await page.evaluate('__kinect.editor.shortcuts()');
+    check(/\[\/\]/.test(legend),
+      'and the ? legend describes the whole keyboard, including the two keys this section added',
+      legend.slice(-90));
+
+    check(errors.length === errorsBefore, 'none of it raises a page error',
+      errors.slice(errorsBefore, errorsBefore + 2).join(' | '));
+  }
+
+  // ================================ 14. the pinned drive takes the loop away with it
+
+  console.log('\n[14] pinning the drive drops what the loop was going to serve');
 
   // The third state that strands an armed position, and the only one `pumpParkedDraft`
   // cannot notice on its own: `drive.pin` calls `setAnimationLoop(null)`, so that

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -218,8 +218,8 @@ const MUTATIONS = {
   'tick-seeks-source-seconds': {
     file: 'web/main.js',
     edits: [[
-      "    el.addEventListener('click', (e) => { e.stopPropagation(); goTo(at); });",
-      "    el.addEventListener('click', (e) => { e.stopPropagation(); goTo(mark.sourceMs / 1000); });",
+      '      goTo(at);',
+      '      goTo(mark.sourceMs / 1000);',
     ]],
   },
 
@@ -289,9 +289,26 @@ const MUTATIONS = {
   'marks-ignore-the-clip-range': {
     file: 'web/main.js',
     edits: [[
-      '      const seconds = markSecondsInOrder()\n'
-      + '        .filter((s) => s >= timeline.clipInSec - 1e-6 && s <= timeline.clipOutSec + 1e-6);',
+      '      const seconds = markSecondsInOrder().filter(reachableInClip);',
       '      const seconds = markSecondsInOrder();',
+    ]],
+  },
+
+  // The ruler's ticks go back to seeking wherever they are drawn, trim or no trim. The
+  // seek is clamped into in..out, so pressing a diamond that sits inside the shading
+  // moves the playhead to the boundary instead - a control doing something other than
+  // what it shows, which is worse than one that declines.
+  //
+  // The click and not the predicate, because the predicate is shared with the keys now:
+  // removing it would redden the key rows as well and the run could no longer say which
+  // surface was broken. Must redden only the click rows.
+  'tick-seeks-outside-the-trim': {
+    file: 'web/main.js',
+    edits: [[
+      "      if (!reachableInClip(at)) {\n"
+      + "        say('that mark is outside the clip range, so the edit cannot reach it');\n"
+      + '        return;\n      }\n',
+      '',
     ]],
   },
 
@@ -5104,6 +5121,48 @@ try {
     check(near(forwardInTrim, trim.inside, TOL),
       'and the key is working while it declines, because the same press forward still reaches the mark the trim does keep',
       `${forwardInTrim.toFixed(3)}s against the kept mark at ${trim.inside.toFixed(3)}s`);
+
+    // **The same rule, pressed rather than typed.** The keys were taught to refuse a
+    // mark the trim excludes and the ruler's own ticks were not, so the diamond drawn
+    // inside the shading still seeked - and the seek was clamped to the boundary, which
+    // is a control doing something other than what it shows. Both go through
+    // `reachableInClip` now; this row is the half that had no coverage at all.
+    //
+    // The tick is found by its drawn position rather than by index, because the ticks
+    // are sorted by where they land and an index would be a second claim about the
+    // ordering that the row does not want to be making.
+    const outsideTickIndex = await page.evaluate(`(() => {
+      const ticks = globalThis.__kinect.library.markTicks();
+      const lefts = ticks.map((t) => t.left);
+      return lefts.indexOf(Math.min(...lefts));
+    })()`);
+    await page.evaluate(`__kinect.timeline.transport().seek(${trim.park})`);
+    await settle();
+    await page.locator('#tMarks .tmk').nth(outsideTickIndex).click();
+    await settle();
+    const afterClickingOutside = (await read()).programSec;
+    const noteAfter = await page.evaluate("document.getElementById('tNote').textContent");
+    check(near(afterClickingOutside, trim.park, TOL),
+      'pressing a tick the trim excludes moves the playhead nowhere, rather than seeking to a boundary the diamond is not drawn at',
+      `${afterClickingOutside.toFixed(3)}s, parked at ${trim.park.toFixed(3)}s with the in point at ${trimmed.in?.toFixed(2)}s`);
+    check(/outside the clip range/.test(noteAfter),
+      'and it says so, because a key stepping past nothing has nothing to report while a diamond somebody aimed at does',
+      `note "${noteAfter.slice(0, 80)}"`);
+    // The liveness half again, on the click path this time: the tick the trim keeps has
+    // to still seek, or the row above passes against a ruler whose ticks are all dead.
+    const insideTickIndex = await page.evaluate(`(() => {
+      const ticks = globalThis.__kinect.library.markTicks();
+      const lefts = ticks.map((t) => t.left);
+      return lefts.indexOf(Math.max(...lefts));
+    })()`);
+    await page.evaluate(`__kinect.timeline.transport().seek(${trim.park})`);
+    await settle();
+    await page.locator('#tMarks .tmk').nth(insideTickIndex).click();
+    await settle();
+    const afterClickingInside = (await read()).programSec;
+    check(near(afterClickingInside, trim.inside, TOL),
+      'and the tick the trim keeps still seeks to itself, so the refusal above is about reachability rather than about a ruler that stopped working',
+      `${afterClickingInside.toFixed(3)}s against the kept mark at ${trim.inside.toFixed(3)}s`);
 
     // **A mark the edit never reaches still answers a keyboard.** `.tmk.beyond` and
     // `.tmk:hover` have equal specificity, so the one written last wins - and with the

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -5055,38 +5055,55 @@ try {
       { id: 'outside', sourceMs: 2000, label: 'outside' },
       { id: 'inside', sourceMs: 8000, label: 'inside' },
     ])`);
+    await settle();
+    // **Where the trim goes is derived from where the marks landed, never assumed.**
+    // This section deliberately runs at a rate where a mark's program second and its
+    // source second are different numbers - which is the whole point of the rows above -
+    // so a trim written as two constants put both marks on the same side of it and the
+    // liveness row below failed against a correct build. The boundaries are computed
+    // from the curve the page is actually holding.
+    const trim = await page.evaluate(`(() => {
+      const total = __kinect.editor.view.window().duration;
+      const at = (s) => Math.max(0, Math.min(total, __kinect.timeline.retime.programSecAt(s)));
+      const outside = at(2);
+      const inside = at(8);
+      const inAt = (outside + inside) / 2;
+      return { total, outside, inside, inAt, park: (inAt + inside) / 2, outAt: Math.min(total, inside + 1) };
+    })()`);
     // Set through the buttons the operator uses rather than through a hook, because a
     // hook that set the trim directly would be a second road to a value the keys have to
-    // agree with - and the row below is about exactly that agreement.
-    await page.evaluate('__kinect.timeline.transport().seek(5)');
+    // agree with - and the rows below are about exactly that agreement.
+    await page.evaluate(`__kinect.timeline.transport().seek(${trim.inAt})`);
     await settle();
     await page.click('#tSetIn');
-    await page.evaluate('__kinect.timeline.transport().seek(12)');
+    await page.evaluate(`__kinect.timeline.transport().seek(${trim.outAt})`);
     await settle();
     await page.click('#tSetOut');
     await settle();
     const trimmed = await page.evaluate('({ in: __kinect.timeline.transport().clipInSec, out: __kinect.timeline.transport().clipOutSec })');
     const marksNow = await page.evaluate('__kinect.library.markTicks().length');
-    check(Math.abs(trimmed.in - 5) < 0.05 && trimmed.out > 8 && marksNow === 2,
-      'the clip is trimmed with one mark outside it and one inside, which is the arrangement the clamp can be seen through',
-      `in ${trimmed.in?.toFixed(2)}s out ${trimmed.out?.toFixed(2)}s, ${marksNow} ticks`);
-    await page.evaluate('__kinect.timeline.transport().seek(6)');
+    check(marksNow === 2 && trim.outside < trimmed.in - TOL && trimmed.in < trim.park
+      && trim.park < trim.inside - TOL && trim.inside < trimmed.out + TOL,
+      'the clip is trimmed with one mark outside it and one inside, and the playhead parks between the in point and the mark it keeps - which is the arrangement the clamp can be seen through',
+      `outside ${trim.outside.toFixed(2)}s | in ${trimmed.in?.toFixed(2)}s | park ${trim.park.toFixed(2)}s`
+      + ` | inside ${trim.inside.toFixed(2)}s | out ${trimmed.out?.toFixed(2)}s, ${marksNow} ticks`);
+    await page.evaluate(`__kinect.timeline.transport().seek(${trim.park})`);
     await settle();
     await focusStage();
     await page.keyboard.press('[');
     await settle();
-    const backFromSix = (await read()).programSec;
-    check(Math.abs(backFromSix - 6) < 0.05,
+    const backFromPark = (await read()).programSec;
+    check(near(backFromPark, trim.park, TOL),
       'stepping back from inside the trim past a mark the trim excludes moves nothing at all, rather than throwing the playhead onto the in point it can never get past',
-      `${backFromSix.toFixed(3)}s, still where it was rather than at the in point ${trimmed.in?.toFixed(2)}s`);
+      `${backFromPark.toFixed(3)}s, parked at ${trim.park.toFixed(3)}s with the in point at ${trimmed.in?.toFixed(2)}s`);
     // The liveness half. Without it the row above passes against a key that does
     // nothing whatever, which is the same reading and the opposite defect.
     await page.keyboard.press(']');
     await settle();
     const forwardInTrim = (await read()).programSec;
-    check(forwardInTrim > 7 && forwardInTrim < 9,
+    check(near(forwardInTrim, trim.inside, TOL),
       'and the key is working while it declines, because the same press forward still reaches the mark the trim does keep',
-      `${forwardInTrim.toFixed(3)}s`);
+      `${forwardInTrim.toFixed(3)}s against the kept mark at ${trim.inside.toFixed(3)}s`);
 
     // **A mark the edit never reaches still answers a keyboard.** `.tmk.beyond` and
     // `.tmk:hover` have equal specificity, so the one written last wins - and with the

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -278,6 +278,47 @@ const MUTATIONS = {
     ]],
   },
 
+  // The mark keys go back to offering every mark on the take, including the ones the
+  // trim puts out of reach. `Transport.frameAt` clamps every seek into in..out, so the
+  // press lands back where it started - and at the in point, which is where somebody
+  // steps backwards from, the key reads as unbound.
+  //
+  // Must redden only the row about a trimmed clip. Every other mark row in section 13
+  // runs on the whole take, where the clamp cannot change the answer, which is exactly
+  // how the defect survived a section that already pressed both keys four times.
+  'marks-ignore-the-clip-range': {
+    file: 'web/main.js',
+    edits: [[
+      '      const seconds = markSecondsInOrder()\n'
+      + '        .filter((s) => s >= timeline.clipInSec - 1e-6 && s <= timeline.clipOutSec + 1e-6);',
+      '      const seconds = markSecondsInOrder();',
+    ]],
+  },
+
+  // `.tmk.beyond` goes back under the two interaction states. Same specificity, so the
+  // later rule wins and a beyond tick keeps its resting colour while hovered and while
+  // focused - and since `:focus-visible` turns the native outline off on the grounds
+  // that the colour change describes the same thing, the keyboard gets no answer at all.
+  //
+  // The order and not the colour, because the colour is right in both builds at rest.
+  // Must redden the focused-beyond row and leave the focused-ordinary row green: a
+  // mutation that broke focus everywhere would take both, and this defect is specific to
+  // the one state that was written last.
+  // Both halves of the move, because putting `.tmk.beyond` back between the two states
+  // would restore the hover defect and not the focus one - and focus is the half that
+  // leaves the keyboard with no answer at all.
+  'beyond-mark-loses-focus': {
+    file: 'web/index.html',
+    edits: [
+      ['  .tmk.beyond { background: var(--faint); }\n  .tmk:hover', '  .tmk:hover'],
+      [
+        '  .tmk:focus-visible { outline: 0; background: var(--ink); }',
+        '  .tmk:focus-visible { outline: 0; background: var(--ink); }\n'
+        + '  .tmk.beyond { background: var(--faint); }',
+      ],
+    ],
+  },
+
   'plant-unswept-control': {
     file: 'web/index.html',
     edits: [[
@@ -5003,6 +5044,93 @@ try {
     check(near((await read()).programSec, altGrArrow, TOL),
       'and a named key under the same modifier is still the browser\'s, since AltGr only composes characters and there is no character here',
       `${(await read()).programSec.toFixed(3)}s against ${altGrArrow.toFixed(3)}s`);
+
+    // **And a trimmed clip, which is the case every row above is blind to.** The rows
+    // so far run on the whole take, where `Transport.frameAt`'s clamp into in..out
+    // cannot change where a press lands - so a key offering marks outside the trim
+    // looked identical to one that did not. With an in point at 5s and a mark at 2s,
+    // pressing `[` from inside asks to go to 2 and arrives back at 5: the playhead
+    // teleports to the edge, and at the edge itself the key reads as unbound.
+    await page.evaluate(`__kinect.editor.setMarks([
+      { id: 'outside', sourceMs: 2000, label: 'outside' },
+      { id: 'inside', sourceMs: 8000, label: 'inside' },
+    ])`);
+    // Set through the buttons the operator uses rather than through a hook, because a
+    // hook that set the trim directly would be a second road to a value the keys have to
+    // agree with - and the row below is about exactly that agreement.
+    await page.evaluate('__kinect.timeline.transport().seek(5)');
+    await settle();
+    await page.click('#tSetIn');
+    await page.evaluate('__kinect.timeline.transport().seek(12)');
+    await settle();
+    await page.click('#tSetOut');
+    await settle();
+    const trimmed = await page.evaluate('({ in: __kinect.timeline.transport().clipInSec, out: __kinect.timeline.transport().clipOutSec })');
+    const marksNow = await page.evaluate('__kinect.library.markTicks().length');
+    check(Math.abs(trimmed.in - 5) < 0.05 && trimmed.out > 8 && marksNow === 2,
+      'the clip is trimmed with one mark outside it and one inside, which is the arrangement the clamp can be seen through',
+      `in ${trimmed.in?.toFixed(2)}s out ${trimmed.out?.toFixed(2)}s, ${marksNow} ticks`);
+    await page.evaluate('__kinect.timeline.transport().seek(6)');
+    await settle();
+    await focusStage();
+    await page.keyboard.press('[');
+    await settle();
+    const backFromSix = (await read()).programSec;
+    check(Math.abs(backFromSix - 6) < 0.05,
+      'stepping back from inside the trim past a mark the trim excludes moves nothing at all, rather than throwing the playhead onto the in point it can never get past',
+      `${backFromSix.toFixed(3)}s, still where it was rather than at the in point ${trimmed.in?.toFixed(2)}s`);
+    // The liveness half. Without it the row above passes against a key that does
+    // nothing whatever, which is the same reading and the opposite defect.
+    await page.keyboard.press(']');
+    await settle();
+    const forwardInTrim = (await read()).programSec;
+    check(forwardInTrim > 7 && forwardInTrim < 9,
+      'and the key is working while it declines, because the same press forward still reaches the mark the trim does keep',
+      `${forwardInTrim.toFixed(3)}s`);
+
+    // **A mark the edit never reaches still answers a keyboard.** `.tmk.beyond` and
+    // `.tmk:hover` have equal specificity, so the one written last wins - and with the
+    // beyond rule underneath, a beyond tick kept its resting colour through both states
+    // while `:focus-visible` had already turned the native outline off on the grounds
+    // that the colour change said the same thing. The net effect was a focused control
+    // with no focus indication of any kind, which no row here had looked for because the
+    // existing presses are all on ordinary ticks.
+    await page.evaluate(`__kinect.editor.setMarks([
+      { id: 'ordinary', sourceMs: 3000, label: 'ordinary' },
+      { id: 'past', sourceMs: 9000000, label: 'past the end' },
+    ])`);
+    await settle();
+    const ticks = await page.evaluate('__kinect.library.markTicks()');
+    check(ticks.length === 2 && ticks.some((t) => t.beyond) && ticks.some((t) => !t.beyond),
+      'one tick is a beyond mark and one is ordinary, so the two rows below are a comparison rather than two readings of the same thing',
+      ticks.map((t) => (t.beyond ? 'beyond' : 'ordinary')).join(' '));
+    // Focus arrives by Tab rather than by `.focus()`, because `:focus-visible` is a
+    // claim about how focus got there - a programmatic focus does not match it in
+    // Chromium, so a row built that way would read the resting colour on both builds
+    // and agree with the defect.
+    const focusColours = async (selector) => page.evaluate(`(async () => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      const rest = getComputedStyle(el).backgroundColor;
+      return { rest, el: Boolean(el) };
+    })()`);
+    const beforeFocus = await focusColours('#tMarks .tmk.beyond');
+    await page.evaluate("document.querySelector('#tMarks .tmk:not(.beyond)').focus()");
+    await page.keyboard.press('Tab');
+    const focused = await page.evaluate(`(() => {
+      const el = document.activeElement;
+      return {
+        isBeyond: el?.classList?.contains('beyond') ?? false,
+        visible: el?.matches(':focus-visible') ?? false,
+        background: el ? getComputedStyle(el).backgroundColor : null,
+        outline: el ? getComputedStyle(el).outlineStyle : null,
+      };
+    })()`);
+    check(focused.isBeyond && focused.visible,
+      'tabbing off the ordinary tick lands keyboard focus on the beyond one, which is what makes the row below about the colour rather than about where focus went',
+      `beyond ${focused.isBeyond}, :focus-visible ${focused.visible}`);
+    check(focused.background !== beforeFocus.rest,
+      'and a focused beyond mark looks different from a resting one - the outline is off on the grounds that the colour says it instead, so the colour has to say it',
+      `resting ${beforeFocus.rest}, focused ${focused.background}, outline ${focused.outline}`);
 
     const legend = await page.evaluate('__kinect.editor.shortcuts()');
     check(/\[\/\]/.test(legend),

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -276,14 +276,19 @@ const MUTATIONS = {
   //
   // The write and not the capture, because `resume-fetches-the-moving-name` already takes
   // the capture. Must redden only the row that reads the store after the press.
+  // The recovery write goes back to racing the auto-saves instead of queueing behind
+  // them, so an edit still on the wire can land after it and put itself back.
+  'resume-races-the-autosave': { file: 'web/main.js', edits: [[
+    'const kept = await writeWorking(accepted);',
+    "const kept = await fetch(`/projects/${WORKING_PROJECT}`, {\n"
+    + "      method: 'PUT',\n      headers: { 'Content-Type': 'application/json' },\n"
+    + '      body: JSON.stringify(accepted),\n    });',
+  ]] },
+
   'resume-restores-without-keeping': {
     file: 'web/main.js',
     edits: [[
-      "    const kept = await fetch(`/projects/${WORKING_PROJECT}`, {\n"
-      + "      method: 'PUT',\n"
-      + "      headers: { 'Content-Type': 'application/json' },\n"
-      + '      body: JSON.stringify(accepted),\n'
-      + '    });\n'
+      '    const kept = await writeWorking(accepted);\n'
       + "    if (!kept.ok) throw new Error(`restored on screen, but the auto-save could not be rewritten: ${(await kept.text().catch(() => '')).slice(0, 80)}`);\n",
       '',
     ]],
@@ -4927,6 +4932,61 @@ try {
     check(!afterRestore.shown,
       'and the offer withdraws once it has been taken, since restoring what is already on screen is a button that does nothing',
       `chip ${afterRestore.shown ? 'still shown' : 'hidden'}`);
+
+    // **And it is the last write, not merely a later one.** The auto-save is
+    // fire-and-forget and `DocumentStore.write` gives every write its own numbered
+    // scratch file before renaming, so two puts to one document both succeed and the one
+    // on disk is whichever `rename` finished last - which has nothing to do with which
+    // was asked for first. An edit made just before the operator presses Restore is
+    // exactly that case: it can still be on the wire, land after the recovery, and put
+    // the overwriting document straight back - after the page has said "restored the
+    // autosaved edit" and dropped the only other copy.
+    //
+    // The competing write is a real auto-save from a real control rather than a put from
+    // here, because what has to be ordered is the page's own write path. Held three
+    // seconds at the browser so it is unambiguously still in flight when the press lands:
+    // the mutated build's restore goes out immediately, finishes first, and the held
+    // auto-save then overwrites it.
+    await putDoc(WORKING, differing);
+    await reopen();
+    const armedOffer = await offerState();
+    let workingPuts = 0;
+    await page.route('**/projects/__working__', async (route) => {
+      if (route.request().method() !== 'PUT') { await route.continue(); return; }
+      workingPuts++;
+      if (workingPuts === 1) await new Promise((done) => { setTimeout(done, 3000); });
+      await route.continue();
+    });
+    // Any control that commits will do, so it is found rather than named - a row keyed to
+    // one parameter's id goes quiet the day that parameter is renamed, and what it needs
+    // is an auto-save on the wire rather than a particular edit.
+    const toggled = await page.evaluate(`(() => {
+      const box = document.querySelector('#panelBody input[type="checkbox"]');
+      if (!box) return null;
+      box.checked = !box.checked;
+      box.dispatchEvent(new Event('change', { bubbles: true }));
+      return box.id || 'a panel toggle';
+    })()`);
+    for (let i = 0; i < 12 && workingPuts === 0; i++) {
+      await new Promise((done) => { setTimeout(done, 100); });
+    }
+    // The fixture says whether it built the condition, because a press with nothing in
+    // flight is a press both builds survive - the row above it would then be reporting
+    // the ordering of one write.
+    check(toggled !== null && workingPuts === 1 && armedOffer.shown,
+      'an edit\'s auto-save is on the wire and the offer is up, which is the pair the row below needs rather than a press with nothing to race',
+      `toggled ${toggled ?? 'nothing - no committing control was found'}, ${workingPuts} auto-save in flight, chip ${armedOffer.shown ? 'shown' : 'hidden'}`);
+    await page.click('#tResumeOpen');
+    // Past the three-second hold and the write that follows it, so both have landed.
+    await new Promise((done) => { setTimeout(done, 6000); });
+    await page.unroute('**/projects/__working__');
+    const storedAfterRace = await page.evaluate(`(async () => {
+      const doc = await (await fetch('/projects/${WORKING}')).json();
+      return doc.body?.outputSize ?? null;
+    })()`);
+    check(storedAfterRace === differing.outputSize,
+      'and the recovery is written after the auto-saves already in flight, so an edit still on the wire cannot land behind it and put back the document the operator just recovered from',
+      `stored ${storedAfterRace} against the restored ${differing.outputSize}`);
 
     // **A neighbour that will not list must not take the recovery with it.** Opening a
     // take refreshes three libraries and lets all three fail softly, and the offer used

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -5832,12 +5832,31 @@ try {
     // Any control that commits will do, so it is found rather than named - a row keyed to
     // one parameter's id goes quiet the day that parameter is renamed, and what it needs
     // is an auto-save on the wire rather than a particular edit.
+    //
+    // **Found off the registry rather than off the panel's order**, and that distinction
+    // is what this row got wrong first. `#panelBody input[type="checkbox"]` took whatever
+    // the panel happened to render first, which was a look value when the row was written
+    // and became `colorCam` when the panel gained its groups - a sensor toggle that
+    // changes the sensor rather than the document, so it commits nothing and puts no
+    // auto-save on the wire. The row caught it, because it asserts the condition it built
+    // instead of assuming it; a fixture selected by position is one an unrelated edit to
+    // the page silently re-points, which is the same "arrives through the container"
+    // shape section 1's selector is written the way it is for.
+    //
+    // A `step` parameter is the checkbox kind - `panelRow` gives the input the parameter's
+    // own name for an id - so this asks the look registry which of its values render as
+    // one and takes the first that is on the page.
     const toggled = await page.evaluate(`(() => {
-      const box = document.querySelector('#panelBody input[type="checkbox"]');
-      if (!box) return null;
-      box.checked = !box.checked;
-      box.dispatchEvent(new Event('change', { bubbles: true }));
-      return box.id || 'a panel toggle';
+      const steps = __kinect.params.names('look')
+        .filter((n) => __kinect.params.spec(n).kind === 'step');
+      for (const name of steps) {
+        const box = document.getElementById(name);
+        if (!box || box.type !== 'checkbox' || !box.closest('#panelBody')) continue;
+        box.checked = !box.checked;
+        box.dispatchEvent(new Event('change', { bubbles: true }));
+        return box.id;
+      }
+      return null;
     })()`);
     for (let i = 0; i < 12 && workingPuts === 0; i++) {
       await new Promise((done) => { setTimeout(done, 100); });

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -4873,19 +4873,22 @@ try {
     await putDoc(WORKING, differing);
     await reopen();
     const offeredBeforeMove = await offerState();
-    const moved = workingBody({ id: openId, hash: openHash });
-    moved.outputSize = fresh.outputSize === '1280x720' ? '1920x1080' : '1280x720';
-    moved.pointSize = (Number(differing.pointSize) || 1) + 7;
+    // Three distinguishable values, and that is the whole arrangement: the clip a fresh
+    // open gives, the document the chip is offering, and what the name holds by the time
+    // it is pressed. The first draft of this row moved a field the project does not
+    // carry, so both sides read `undefined`, the row passed on every build and the tool
+    // reported NOT CAUGHT - which is the honest reading of a row testing nothing.
+    const moved = workingBody({ id: openId, hash: openHash }, false);
     await putDoc(WORKING, moved);
-    check(offeredBeforeMove.shown && moved.pointSize !== differing.pointSize,
-      'the offer is on screen and then the document behind its name is replaced, which is what an edit made while the chip is up does to it',
-      `chip ${offeredBeforeMove.shown ? 'shown' : 'hidden'}, offered pointSize ${differing.pointSize} against the store's new ${moved.pointSize}`);
+    check(offeredBeforeMove.shown && moved.outputSize !== differing.outputSize,
+      'the offer is on screen and then the document behind its name is replaced by a different one, which is what an edit made while the chip is up does to it',
+      `chip ${offeredBeforeMove.shown ? 'shown' : 'hidden'}, offered ${differing.outputSize} against the store's new ${moved.outputSize}`);
     await page.click('#tResumeOpen');
     await settle();
     const restoredAfterMove = await page.evaluate('__kinect.keyframes.project()');
-    check(restoredAfterMove.pointSize === differing.pointSize,
+    check(restoredAfterMove.outputSize === differing.outputSize,
       'and pressing it restores the document that was offered rather than whatever the name holds by then, since the work it was advertising is the work being recovered',
-      `pointSize ${restoredAfterMove.pointSize} against the offered ${differing.pointSize} and the store's ${moved.pointSize}`);
+      `${restoredAfterMove.outputSize} against the offered ${differing.outputSize} and the store's ${moved.outputSize}`);
 
     const afterRestore = await offerState();
     check(!afterRestore.shown,

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -653,8 +653,30 @@ const MUTATIONS = {
   // hangs. The pile-up guard and the timeout are two halves of one arrangement: without
   // the bound, the guard turns one dead listing into a gallery that has stopped.
   'listing-never-times-out': { file: 'web/library.js', edits: [[
-    "await fetch('/library/all', { signal: AbortSignal.timeout(LISTING_TIMEOUT_MS) })",
-    "await fetch('/library/all')",
+    'signal: bound ? AbortSignal.timeout(LISTING_TIMEOUT_MS) : undefined,',
+    'signal: undefined,',
+  ]] },
+
+  // The bound goes back onto the first listing, where a cold library is slow for a
+  // legitimate reason and fifteen seconds is not enough to build 200 indexes.
+  'first-load-bounded': { file: 'web/library.js', edits: [[
+    'try {\n  await refresh();\n} catch (err) {\n  say(`the library could not be read',
+    'try {\n  await refresh({ bound: true });\n} catch (err) {\n  say(`the library could not be read',
+  ]] },
+
+  // The first listing goes back to being unguarded, so anything it throws ends module
+  // evaluation before the poll is started and before the page has a hook to drive.
+  'first-load-strands-the-page': { file: 'web/library.js', edits: [[
+    'try {\n  await refresh();\n} catch (err) {\n'
+    + '  say(`the library could not be read: ${err.message}`);\n  paint();\n}',
+    'await refresh();',
+  ]] },
+
+  // The listing route stops telling the node that its caller has gone, so a browser that
+  // gave up leaves the outbound fetch running here.
+  'listing-ignores-client-abort': { file: 'server/index.js', edits: [[
+    'await node.takes(untilCallerLeaves(req)) : null;\n  const takes = reconcile(',
+    'await node.takes() : null;\n  const takes = reconcile(',
   ]] },
 
   // Delete goes back to being offered while the node is unreachable, where the copy count
@@ -7377,7 +7399,126 @@ async function runChecks() {
       `${requestsBeforePress} requests before the press, ${requestsAfterPress} within 3s after it`);
     await post(`${liveUrl}/record/stop`);
     await slow.close();
+
+    // **The bound belongs to the poll, and the first listing is the case it must not
+    // reach.** A cold library is slow for a legitimate reason - `cachedIndex` scans each
+    // file once and writes a `.idx` beside it, measured at 7m30s over 200 unindexed takes
+    // against 2.4s for a second server off those sidecars - and the load is a top-level
+    // await, so a bound that fires there ends module evaluation before the poll starts
+    // and before `globalThis.__library` exists. What the operator gets is not a slow
+    // gallery but a blank one that never recovers.
+    //
+    // Eighteen seconds because the bound is fifteen: long enough that a bounded load has
+    // certainly given up, short enough not to pay for more than one of them. Held rather
+    // than made genuinely slow, since what is under test is which listing carries a
+    // deadline, not how fast an index builds.
+    const cold = await browser.newPage();
+    let coldListings = 0;
+    await cold.route('**/library/all', async (route) => {
+      coldListings++;
+      if (coldListings === 1) await new Promise((done) => { setTimeout(done, 18000); });
+      await route.continue();
+    });
+    await cold.goto(galleryPage(liveUrl), { waitUntil: 'domcontentloaded' });
+    let coldInstalled = true;
+    await cold.waitForFunction('globalThis.__library !== undefined', null, { timeout: 30000 })
+      .catch(() => { coldInstalled = false; });
+    const coldTiles = coldInstalled ? await cold.evaluate('globalThis.__library.tiles().length') : 0;
+    check(coldInstalled && coldTiles > 0,
+      'a first listing slower than the poll\'s own bound still paints, because a cold library is the case that listing exists to get through rather than a link to give up on',
+      coldInstalled ? `held 18s, ${coldTiles} tiles` : 'the page never installed its hook - module evaluation ended on the load');
+    await cold.close();
+
+    // **And the class the bound was only one way into.** Anything the first listing
+    // throws ends the module there, so a node that resets, a 500 out of `serveLibrary`
+    // and a body that is not JSON all leave the same blank shelf with no error on it.
+    // Answered with a 500 rather than aborted, because a refused request is the shape a
+    // reader would least expect to be fatal.
+    const broken = await browser.newPage();
+    let brokenListings = 0;
+    await broken.route('**/library/all', async (route) => {
+      brokenListings++;
+      if (brokenListings === 1) { await route.fulfill({ status: 500, body: 'the library is unavailable' }); return; }
+      await route.continue();
+    });
+    await broken.goto(galleryPage(liveUrl), { waitUntil: 'domcontentloaded' });
+    let brokenInstalled = true;
+    await broken.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 })
+      .catch(() => { brokenInstalled = false; });
+    check(brokenInstalled,
+      'and a first listing that fails outright leaves a page that still has its hook, rather than ending module evaluation on a top-level await',
+      brokenInstalled ? 'installed after a 500' : 'the page never installed its hook');
+    const repaired = brokenInstalled
+      ? await broken.evaluate('globalThis.__library.refresh().then(() => globalThis.__library.tiles().length).catch(() => -1)')
+      : -1;
+    check(repaired > 0,
+      'and it comes back on the next listing that works, so the failure costs a refresh rather than the session',
+      repaired === -1 ? 'no working refresh was reachable' : `${repaired} tiles after the next refresh`);
+    await broken.close();
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
+
+    // **A node that stops answering must not leave this machine holding the pair.**
+    // `serveLibrary` awaits `node.takes`, which crosses the network with no bound of its
+    // own - and once the gallery's listing is bounded, every retry that gives up leaves
+    // another handler here and another outbound socket over there, one pair per tick for
+    // as long as the page is open. The browser's abort cancels its own request and
+    // nothing else unless this process is told to pass it on.
+    //
+    // Driven with a plain `fetch` rather than through a page, because what is under test
+    // is what this server does when its caller leaves - a browser would only add a second
+    // place for the answer to come from. The node is a stub on a kernel-assigned port for
+    // the same reason the older-build stub is: anything spawned from `stageServer` runs
+    // the build under test and answers correctly by construction.
+    const deafHeld = [];
+    const deaf = await new Promise((done) => {
+      const srv = createServer((req, res) => {
+        if (req.url === '/library/takes') {
+          const seen = { closedAt: null, answered: false };
+          deafHeld.push(seen);
+          // `close` fires for a request that ended either way, so what it answered is
+          // recorded with it - a row that counted closes alone would read a completed
+          // request as a cancelled one.
+          req.on('close', () => { seen.closedAt = Date.now(); seen.answered = res.writableEnded; });
+          return;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' }).end('{"takes":[]}');
+      });
+      srv.listen(0, '127.0.0.1', () => done({ srv, url: `http://127.0.0.1:${srv.address().port}` }));
+    });
+    const deafUrl = await startServer(root, [
+      '--captures', macCaps, '--name', 'mac-deaf',
+      '--node', deaf.url, '--node-name', 'a-node-that-never-answers',
+    ], MAC_PORT + 11);
+    const heldBefore = deafHeld.length;
+    await fetch(`${deafUrl}/library/all`, { signal: AbortSignal.timeout(2000) }).catch(() => {});
+    const gaveUpAt = Date.now();
+    check(deafHeld.length > heldBefore,
+      'the listing really did reach the node and is being held there, which is what makes the row below about cancellation rather than about a request that never went out',
+      `${deafHeld.length - heldBefore} held at the node`);
+    const mine = deafHeld[deafHeld.length - 1];
+    for (let i = 0; i < 24 && mine && mine.closedAt === null; i++) {
+      await new Promise((done) => { setTimeout(done, 250); });
+    }
+    const freed = mine?.closedAt === null ? null : mine.closedAt - gaveUpAt;
+    check(mine != null && mine.closedAt !== null && mine.answered === false && freed < 1500,
+      'and a caller giving up drops the node fetch with it, so a listing nobody is waiting for stops costing a handler here and a socket over there',
+      mine?.closedAt === null ? 'the node still holds it 6s after the caller gave up'
+        : `dropped ${freed}ms after the caller gave up, unanswered`);
+    for (const p of servers.filter((sv) => sv.port === MAC_PORT + 11)) p.child.kill('SIGKILL');
+    deaf.srv.close();
+
+    // **Every route that awaits the node, and not the one where it was noticed.** The
+    // gallery is only the caller whose retry made the leak accumulate; a download, a
+    // removal and a mark sync await the same unbounded fetch behind a browser that can
+    // close at any point. Read off the source so a route added later is asked by
+    // existing, rather than off the four that were found.
+    const indexSrc = readFileSync(join(root, 'server/index.js'), 'utf8');
+    const nodeCalls = [...indexSrc.matchAll(/await node\.takes\(([^)]*)\)/g)].map((m) => m[1]);
+    const unsignalled = nodeCalls.filter((args) => !/untilCallerLeaves|signal/.test(args));
+    check(nodeCalls.length >= 4 && unsignalled.length === 0,
+      'and every route that awaits the node hands it the caller it is waiting for, so the next one written inherits the rule rather than being outside a list',
+      unsignalled.length ? `${unsignalled.length} of ${nodeCalls.length} pass nothing`
+        : `${nodeCalls.length} calls, all signalled`);
   }
 
   // ------------------------- 15. one token, three declarations, one shared stylesheet

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -572,7 +572,52 @@ const MUTATIONS = {
   // breath as `respawns` goes to one: both halves of the reading are wrong, and a
   // mutation that only moved the total would leave the second number right by accident.
   'respawns-count-a-colour-toggle': { file: 'server/index.js', edits: [[
-    '        grabberRestarts++;\n', '',
+    'grabberRestarts++; ', '',
+  ]] },
+
+  // The requested restart is counted where it is learned rather than beside the spawn it
+  // excuses, which is where it used to be. `respawns` is `grabberSpawns - 1 -
+  // grabberRestarts`, so a restart counted on the exit runs the subtraction one ahead of
+  // itself for the whole backoff - a quarter of a second after a clean stop, a second and
+  // a half after a hard one - and a node that had genuinely lost its sensor reads one
+  // respawn, then zero, then one again.
+  //
+  // Must redden only the monotonicity row. The totals this section already asserts are
+  // right on both builds, because the reading is correct at both ends of the gap and
+  // wrong only inside it: a control that moved the totals would be a different defect.
+  'respawns-dip-before-the-spawn': { file: 'server/index.js', edits: [[
+    'setTimeout(() => { grabberRestarts++; spawnGrabber(); }, delay);',
+    'grabberRestarts++;\n        setTimeout(spawnGrabber, delay);',
+  ]] },
+
+  // `openPath` goes back to answering only for the take currently being written, so the
+  // whole of a close - the flush, the marks, the index and the content hash - becomes
+  // time in which this process says nobody owns a file it is still reading and writing.
+  // `/library/all` calls that take finalised and the gallery offers Download, Rename and
+  // Remove on a take with no hash yet.
+  //
+  // The getter rather than the field, because `finalizing` has a second reader in
+  // `writingId`: clearing the field would move both, and a run could not then say which
+  // of the two the gallery was actually following. Must redden section 14's finalisation
+  // rows and leave the rows above them - the ones about a take that is genuinely still
+  // recording - green.
+  'openpath-drops-at-the-stop': { file: 'server/recorder.js', edits: [[
+    'return this.take?.path ?? this.finalizing?.path ?? null;',
+    'return this.take?.path ?? null;',
+  ]] },
+
+  // The gallery's poll goes back to a first tick that cannot disagree with anything. The
+  // page reads `/library/all`, paints from it, and only then asks the recorder - so a
+  // take that stops inside that gap is stopped in the first fingerprint and in every one
+  // after it, none of them differ, and the tile goes on refusing to open a finished take
+  // until somebody reloads.
+  //
+  // Must redden the row that stops a take with the first `/record/state` held, and leave
+  // every other row in section 14 green: an unseeded poll is still a working poll for
+  // every transition that happens after it has an observation to compare against, which
+  // is why this survived a section built out of those.
+  'poll-first-tick-is-blind': { file: 'web/library.js', edits: [[
+    '}, believedFromLibrary());', '});',
   ]] },
 
   // One page's `--faint` goes back to the value that fails AA, which is the drift three
@@ -5456,6 +5501,108 @@ async function runChecks() {
     check(afterToggle.restarts === 1,
       'it is counted as the requested restart it is, beside the respawns rather than folded into them - or a node that restarted forty times for forty toggles would read as never having restarted at all',
       `${afterToggle.restarts} restarts`);
+
+    // **And the number gets there without passing through a lie.** Both readings above
+    // are taken at rest, and the subtraction they check is right at rest on a build that
+    // counted the restart on the exit and on one that counts it beside the spawn. What
+    // separates those two is the quarter-second to second and a half in between: a
+    // restart counted when the old grabber died leaves `grabberRestarts` one ahead of
+    // `grabberSpawns` for the whole backoff, so `respawns` reads one lower than it is,
+    // and a node that had genuinely lost its sensor reports itself well to anyone who
+    // looks in that window. A health number is read exactly when something feels wrong,
+    // which is the worst possible moment for it to be briefly reassuring.
+    //
+    // A real fault first, because `Math.max(0, ...)` hides the whole defect below one.
+    // From nought respawns the dip is negative and clamps to nought, which is what it
+    // already reads - so the drop only becomes visible once there is a genuine failure
+    // underneath it to hide, and that is also the only case anybody is harmed by.
+    // Found by walking the tree rather than by asking for a direct child, because it is
+    // not one: `pgrep -P` on the server returned nothing here and the row correctly said
+    // it had measured nothing rather than passing on a kill that never happened. How
+    // many processes sit between this suite and a grabber is a detail of how the server
+    // is launched, and a row that depends on that number is a row that goes quiet the
+    // next time it changes - so the whole subtree is walked and the grabber is picked
+    // out by name.
+    // `findLast` rather than `find`, and that is a bug this row already paid for: an
+    // earlier section starts and kills its own server on this same port, so `find`
+    // returned a process that had been dead since section 12. Its subtree was empty,
+    // no grabber was ever found, and the row reported that it had measured nothing -
+    // correctly, which is the only reason the mistake was visible at all.
+    const toggleProc = servers.findLast((sv) => sv.port === MAC_PORT + 13)?.child;
+    const grabberUnder = (root) => {
+      // `-ww` because macOS `ps` truncates the command at the terminal width by default,
+      // and the grabber is named at the end of a long absolute path - so the match below
+      // silently found nothing while the process was right there.
+      const rows = execFileSync('ps', ['-ww', '-Ao', 'pid=,ppid=,command='], { encoding: 'utf8' }).trim().split('\n');
+      const parsed = rows.map((r) => r.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/)).filter(Boolean);
+      const family = new Set([root]);
+      for (let grew = true; grew;) {
+        grew = false;
+        for (const m of parsed) {
+          if (family.has(Number(m[2])) && !family.has(Number(m[1]))) { family.add(Number(m[1])); grew = true; }
+        }
+      }
+      // **The server is excluded by name as well as by pid, because it also matches.**
+      // `--grabber <path>/fake-grabber.mjs` is one of its own arguments, so a filter on
+      // the word alone picks the server out of its own subtree - and this row then
+      // SIGKILLs the process every remaining row in the block is talking to, which
+      // arrives as `fetch failed` several rows later rather than as anything naming the
+      // kill. The grabber is the descendant that runs the file rather than the one that
+      // names it.
+      return parsed
+        .filter((m) => family.has(Number(m[1])) && Number(m[1]) !== root
+          && /fake-grabber/.test(m[3]) && !/server\/index\.js/.test(m[3]))
+        .map((m) => Number(m[1]));
+    };
+    // Retried, because `grabberSpawns` is incremented at the top of `spawnGrabber` and
+    // the loop above breaks the instant that reading moves - which is microseconds
+    // before there is a process to find. Waiting for `live` rather than sleeping a
+    // fixed amount, so the row is about the kill rather than about a guess at how long
+    // a handshake takes.
+    let grabberPid = null;
+    let lookupError = null;
+    for (let i = 0; i < 40 && grabberPid === null; i++) {
+      await new Promise((done) => { setTimeout(done, 250); });
+      try {
+        grabberPid = grabberUnder(toggleProc.pid)[0] ?? null;
+      } catch (err) { lookupError = err.message; }
+    }
+    if (grabberPid) process.kill(grabberPid, 'SIGKILL');
+    let faulted = afterToggle;
+    for (let i = 0; i < 80; i++) {
+      await new Promise((done) => { setTimeout(done, 250); });
+      faulted = await getJson(`${toggleUrl}/sensor/health`);
+      if (faulted.respawns >= 1 && faulted.state === 'live') break;
+    }
+    check(faulted.respawns === 1 && faulted.restarts === 1,
+      'a grabber killed under the server is counted as the fault it is, which is the one respawn the reading below has to keep reporting',
+      grabberPid ? `killed ${grabberPid}: ${faulted.respawns} respawns, ${faulted.restarts} restarts, state ${faulted.state}`
+        : `no grabber found under the server after 10s, so this row measured nothing${lookupError ? ` (${lookupError})` : ''}`);
+
+    // Sampled across the whole of the next restart rather than at its ends. The cadence
+    // is what makes the row able to fail: the backoff is 250ms at its shortest, so a
+    // sample every 40ms cannot miss it, and the widest gap between two samples is
+    // reported so a run on a machine that stalled says so instead of passing.
+    const toggleBack = new WebSocket(toggleUrl.replace('http', 'ws'));
+    await new Promise((done, fail) => { toggleBack.on('open', done); toggleBack.on('error', fail); });
+    const readings = [{ at: performance.now(), h: faulted }];
+    toggleBack.send(JSON.stringify({ camera: { color: false } }));
+    for (let i = 0; i < 150; i++) {
+      await new Promise((done) => { setTimeout(done, 40); });
+      readings.push({ at: performance.now(), h: await getJson(`${toggleUrl}/sensor/health`) });
+      if (totalSpawns(readings.at(-1).h) > totalSpawns(faulted)) break;
+    }
+    toggleBack.close();
+    const widest = Math.max(...readings.slice(1).map((r, i) => r.at - readings[i].at));
+    const spanned = readings.at(-1).at - readings[0].at;
+    check(totalSpawns(readings.at(-1).h) === totalSpawns(faulted) + 1 && widest <= 200 && spanned >= 250,
+      'the second toggle really did stop and respawn the grabber, and the whole of it was sampled faster than the shortest backoff it can run at',
+      `${readings.length} readings over ${Math.round(spanned)}ms, widest gap ${Math.round(widest)}ms`);
+    const dip = readings.find((r, i) => i > 0 && r.h.respawns < readings[i - 1].h.respawns);
+    check(dip === undefined,
+      'and the respawn count never goes backwards while it happens - the failure this node really had stays reported for every moment of the restart it did not have',
+      dip ? `fell to ${dip.h.respawns} at ${Math.round(dip.at - readings[0].at)}ms`
+        : `held at ${readings.map((r) => r.h.respawns).join('')} throughout`);
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 13)) p.child.kill('SIGKILL');
   }
 
@@ -5566,10 +5713,55 @@ async function runChecks() {
       'and its own recorder is idle while the node it names is shooting, which is the split that made the local flag useless here',
       `local ${linkedOwn.recording}, node ${linkedOwn.node?.name} ${linkedOwn.node?.recording} (reachable ${linkedOwn.node?.reachable})`);
 
+    // **A take stops being recorded several seconds before it stops being the
+    // recorder's, and everything below is about what the library says inside that gap.**
+    // `close` gives up `this.take` at the front of it, because the marks and the
+    // mid-write handler both need the open take gone the moment it stops - and then
+    // flushes the stream, writes the sidecar and reads the whole file back to build the
+    // index and the content hash, which are what make a take a gallery entry at all. On
+    // a slow disk that is seconds. Answer "nobody is writing this" in there and
+    // `/library/all` calls the take finalised, so the gallery offers Download on a take
+    // with no hash and Remove on a file this process is mid-read of.
+    //
+    // Observed while it runs rather than reasoned about: `/record/stop` does not answer
+    // until the close has finished, so every sample taken while that request is in
+    // flight and reporting `recording: false` is a sample from inside the window.
+    const stopping = post(`${liveUrl}/record/stop`);
+    let stopSettled = false;
+    stopping.then(() => { stopSettled = true; }, () => { stopSettled = true; });
+    let insideSamples = 0;
+    let askedInside = null;
+    while (!stopSettled && insideSamples < 400) {
+      const s = await getJson(`${liveUrl}/record/state`);
+      if (s.recording !== false) continue;
+      insideSamples++;
+      if (askedInside !== null) continue;
+      // **The frame API rather than the listing, because it is the cheap question and
+      // the window is short.** Both doors are the same `beingRecorded` predicate over
+      // the same `openPath`, but `/library/all` walks the directory and hashes what it
+      // finds - and on the broken build that hash runs against the file `buildIndex` is
+      // reading, so the listing took longer than the window it was meant to be read
+      // inside and the row reddened for missing rather than for what it saw. This one
+      // is a predicate and a 409.
+      //
+      // Confirmed inside the window by the stop not having answered yet: the response
+      // below arrived first, and the window does not close until that request does.
+      const asked = await fetch(`${liveUrl}/capture/${shooting.takeId}/index`);
+      const body = await asked.json().catch(() => null);
+      if (!stopSettled) askedInside = { status: asked.status, error: body?.error ?? null };
+    }
+    await stopping;
+    check(insideSamples > 0,
+      'the close was caught while it was still running, which is what makes the row below a reading from inside the window rather than one that missed it',
+      `${insideSamples} samples taken inside the close`);
+    check(askedInside?.status === 409,
+      'and the take is still the recorder\'s for the whole of it - the frame API refuses a take whose index and hash do not exist yet, which is the same refusal every surface offering Download, Rename or Remove is drawn from',
+      askedInside === null ? 'no answer came back inside the window at all, which on this route means the server went scanning a file it should have refused'
+        : `HTTP ${askedInside.status}: ${askedInside.error ?? '(no refusal)'}`);
+
     // And the half the gate is not allowed to swallow. Stopping the take changes the
     // recording flag, which is exactly the fact a tile is drawn from - and it has to
     // reach both galleries, the one served by the recorder and the one a network away.
-    await post(`${liveUrl}/record/stop`);
     await page.waitForFunction(
       `(() => { const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(shooting.takeId)});
         return t && !t.flags.includes('recording'); })()`,
@@ -5607,6 +5799,80 @@ async function runChecks() {
 
     check(errors.length === 0, 'and the gallery raises no page error while it follows', errors.slice(0, 2).join(' | '));
     await page.close();
+
+    // **The gap between the listing a gallery paints and the first tick it compares
+    // against.** The page reads `/library/all`, draws a take as being written, and only
+    // then asks the recorder what it is doing. A first tick with nothing behind it
+    // cannot report a change, so a take that stopped inside that gap was stopped in the
+    // first fingerprint and in every one after it - none of them ever differed, the
+    // library was never reread, and the tile refused to open a finished take for as long
+    // as the page stayed up. It survived every row above because all of them watch a
+    // transition that happens *after* the page has an observation to compare against.
+    //
+    // The gap is held open rather than raced for: the first `/record/state` is caught at
+    // the page's edge and kept there while the take is stopped underneath, so the tick
+    // that is finally allowed through is answering about a world that moved while it was
+    // waiting. That is the same shape as the real failure and none of its timing.
+    const second = await post(`${liveUrl}/record/start`);
+    let shootingAgain = null;
+    for (let i = 0; i < 40; i++) {
+      await new Promise((done) => { setTimeout(done, 250); });
+      shootingAgain = await getJson(`${liveUrl}/record/state`);
+      if (shootingAgain.recording) break;
+    }
+    check(shootingAgain?.recording === true && shootingAgain.takeId !== shooting.takeId,
+      'a second take is open, so the page below paints a tile that is genuinely mid-write rather than one left over from the first',
+      `${shootingAgain?.takeId} (was ${shooting.takeId}), start said ${JSON.stringify(second).slice(0, 60)}`);
+
+    const blind = await browser.newPage();
+    const blindErrors = [];
+    blind.on('pageerror', (err) => blindErrors.push(String(err)));
+    blind.on('console', (msg) => { if (msg.type() === 'error') blindErrors.push(msg.text()); });
+    // **Every tick is held, not only the first, and that is the difference between a
+    // control and a coincidence.** The poll re-asks on a five-second timer whatever the
+    // held request is doing, so a second tick let through while the take was still
+    // being written would give the unseeded build an observation to compare against -
+    // and the tick after *that* would see the stop, report a change, and refresh. The
+    // defect would have been repaired by the fixture rather than by the code, and this
+    // row would have gone green on the build it exists to redden. Holding the lot means
+    // every tick this page ever gets answers about the world after the stop, which is
+    // precisely the state a first tick with nothing behind it cannot act on.
+    const heldTicks = [];
+    let releaseTicks = false;
+    await blind.route('**/record/state', async (route) => {
+      if (releaseTicks) { await route.continue(); return; }
+      heldTicks.push(route);
+    });
+    await blind.goto(galleryPage(liveUrl), { waitUntil: 'domcontentloaded' });
+    await blind.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 });
+    const paintedMidWrite = await blind.evaluate(`(() => {
+      const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(shootingAgain?.takeId)});
+      return t ? t.flags.includes('recording') : null;
+    })()`);
+    check(paintedMidWrite === true && heldTicks.length > 0,
+      'the page painted that take as being written and every tick it has asked for is held at the edge, which is the state the gap leaves a real gallery in',
+      `painted mid-write ${paintedMidWrite}, ${heldTicks.length} /record/state held`);
+    await post(`${liveUrl}/record/stop`);
+    const restedAfter = await getJson(`${liveUrl}/record/state`);
+    check(restedAfter.writingId === null,
+      'and the take finished underneath it - index, hash and all - before the tick was let go, so the tick answers about a world that moved while it waited',
+      `writingId ${restedAfter.writingId}, recording ${restedAfter.recording}`);
+    releaseTicks = true;
+    for (const route of heldTicks) await route.continue().catch(() => {});
+    const cameBack = await blind.waitForFunction(
+      `(() => { const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(shootingAgain?.takeId)});
+        return t && !t.flags.includes('recording') && t.acts.find((a) => a.label === 'Open')?.disabled === false; })()`,
+      null, { timeout: 25000 },
+    ).then(() => true).catch(() => false);
+    const blindTile = await blind.evaluate(`(() => {
+      const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(shootingAgain?.takeId)});
+      return t ? { flags: t.flags, acts: t.acts.map((a) => a.label + (a.disabled ? ' (off)' : '')) } : null;
+    })()`);
+    check(cameBack,
+      'and the tile stops refusing a take that finished in the gap, because the first tick is compared against the grid that was painted rather than against nothing',
+      blindTile === null ? 'no tile for that take' : `flags ${blindTile.flags.join(',') || '(none)'}, acts ${blindTile.acts.join(' ')}`);
+    check(blindErrors.length === 0, 'and that page raises no error while it catches up', blindErrors.slice(0, 2).join(' | '));
+    await blind.close();
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
   }
 

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -6104,7 +6104,7 @@ async function runChecks() {
       `recording ${started.recording}, take ${started.takeId}`);
     check(requestsAfterPress > requestsBeforePress,
       'and pressing it asks the recorder again rather than settling for the answer already in flight, which was taken before the press and would repaint the world as it was',
-      `${requestsBeforePress} requests before the press, ${requestsAfterPress} within 2.5s after it`);
+      `${requestsBeforePress} requests before the press, ${requestsAfterPress} within 3s after it`);
     await post(`${liveUrl}/record/stop`);
     await slow.close();
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -620,6 +620,21 @@ const MUTATIONS = {
     '}, believedFromLibrary());', '});',
   ]] },
 
+  // The poll goes back to recording a tick as seen before the caller has managed to do
+  // anything with it. One refresh losing its connection then advances the fingerprint
+  // past the transition it failed on, every later tick matches, and the grid keeps a
+  // finished take's actions disabled until some other transition happens along - the
+  // same permanent staleness `poll-first-tick-is-blind` covers at the other end of the
+  // page's life, reached by a different road.
+  //
+  // The module and not the gallery's `throw`, because those are two halves of one
+  // arrangement and this is the half that decides. Must redden only the retry row.
+  'poll-forgets-a-failed-refresh': { file: 'web/record-poll.js', edits: [[
+    '    try {\n      await saw(state, changed);\n      previous = mark;\n'
+    + '    } catch { /* not seen, so not recorded as seen - the next tick offers it again */ }',
+    '    previous = mark;\n    saw(state, changed);',
+  ]] },
+
   // One page's `--faint` goes back to the value that fails AA, which is the drift three
   // separate declarations of one token invite. Deliberately one page and not all three:
   // the rows are per page, so the run says *which* surface regressed rather than that
@@ -5873,6 +5888,69 @@ async function runChecks() {
       blindTile === null ? 'no tile for that take' : `flags ${blindTile.flags.join(',') || '(none)'}, acts ${blindTile.acts.join(' ')}`);
     check(blindErrors.length === 0, 'and that page raises no error while it catches up', blindErrors.slice(0, 2).join(' | '));
     await blind.close();
+
+    // **A refresh that fails is a transition the gallery has not seen yet.** The poll
+    // used to record a tick as seen the moment it had one, so a single `/library/all`
+    // losing its connection advanced the fingerprint past the very transition its
+    // refresh had failed on - and since every later tick then matched, the gallery never
+    // looked again and the tile kept a finished take's actions disabled for the life of
+    // the page. One unlucky five-second window, permanent.
+    //
+    // The failure is injected at the page's edge and withdrawn after exactly one, which
+    // is what separates "retries" from "kept trying forever": the row below wants the
+    // next tick to succeed, not the fetch to be broken for the rest of the section.
+    const third = await post(`${liveUrl}/record/start`);
+    let shootingThird = null;
+    for (let i = 0; i < 40; i++) {
+      await new Promise((done) => { setTimeout(done, 250); });
+      shootingThird = await getJson(`${liveUrl}/record/state`);
+      if (shootingThird.recording) break;
+    }
+    check(shootingThird?.recording === true,
+      'a third take is open, so the page below has a transition to miss and then catch up on',
+      `${shootingThird?.takeId}, start said ${JSON.stringify(third).slice(0, 50)}`);
+
+    const flaky = await browser.newPage();
+    const flakyErrors = [];
+    flaky.on('pageerror', (err) => flakyErrors.push(String(err)));
+    flaky.on('console', (msg) => { if (msg.type() === 'error') flakyErrors.push(msg.text()); });
+    let listings = 0;
+    let refused = 0;
+    await flaky.route('**/library/all', async (route) => {
+      listings++;
+      // The first listing is the page's own load and has to succeed, or there is no
+      // painted grid for the tick to disagree with and the row measures the wrong hole.
+      // The second is the refresh the stop transition asks for, and it is the one that
+      // fails.
+      if (listings === 2) { refused++; await route.abort('connectionfailed'); return; }
+      await route.continue();
+    });
+    await flaky.goto(galleryPage(liveUrl), { waitUntil: 'domcontentloaded' });
+    await flaky.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 });
+    const flakyPainted = await flaky.evaluate(`(() => {
+      const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(shootingThird?.takeId)});
+      return t ? t.flags.includes('recording') : null;
+    })()`);
+    check(flakyPainted === true,
+      'that page painted the open take as being written, from a listing that was allowed through',
+      `painted mid-write ${flakyPainted}, ${listings} listings so far`);
+    await post(`${liveUrl}/record/stop`);
+    const caughtUp = await flaky.waitForFunction(
+      `(() => { const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(shootingThird?.takeId)});
+        return t && !t.flags.includes('recording') && t.acts.find((a) => a.label === 'Open')?.disabled === false; })()`,
+      null, { timeout: 30000 },
+    ).then(() => true).catch(() => false);
+    check(refused === 1,
+      'and exactly one of its listings was refused - the refresh the stop asked for, so the tick after it is a retry rather than a first attempt',
+      `${refused} refused of ${listings} listings`);
+    const flakyTile = await flaky.evaluate(`(() => {
+      const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(shootingThird?.takeId)});
+      return t ? { flags: t.flags, acts: t.acts.map((a) => a.label + (a.disabled ? ' (off)' : '')) } : null;
+    })()`);
+    check(caughtUp,
+      'and the gallery comes back from it on a later tick, because a refresh that failed leaves the transition unseen rather than spending it',
+      flakyTile === null ? 'no tile for that take' : `flags ${flakyTile.flags.join(',') || '(none)'}, acts ${flakyTile.acts.join(' ')}`);
+    await flaky.close();
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
   }
 

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -4980,16 +4980,19 @@ async function runChecks() {
     // library's own state can tell apart, since both would report the same take.
     await page.evaluate("document.querySelector('.tile').__quietProbe = 'planted'");
     const pollsAtProbe = polls;
-    // Longer than one cadence, so at least one tick has certainly been taken and
-    // answered while nothing about the recorder changed.
-    await new Promise((done) => { setTimeout(done, 6500); });
+    // Comfortably longer than one cadence rather than barely, because this row's
+    // meaning rests on a tick having happened: at 6.5s it came back with exactly one
+    // request and no headroom, and a five-second timer on a machine three other agents
+    // are also running checks on can drift further than that. A row whose control
+    // depends on scheduling luck is a row that teaches people to re-run.
+    await new Promise((done) => { setTimeout(done, 8500); });
     const quiet = await page.evaluate(`(() => ({
       probe: document.querySelector('.tile')?.__quietProbe ?? null,
       tiles: globalThis.__library.tiles().length,
     }))()`);
     check(polls > pollsAtProbe,
       'the poll is running, which is what makes the row below about the gate rather than about a page that stopped asking',
-      `${polls - pollsAtProbe} requests to /record/state in 6.5s`);
+      `${polls - pollsAtProbe} requests to /record/state in 8.5s`);
     check(quiet.probe === 'planted',
       'and a tick in which the recorder did not move replaces no tile - the menu an operator has open and the skim under their pointer both survive it',
       quiet.probe === 'planted' ? `${quiet.tiles} tiles, the same nodes` : 'the grid was rebuilt');

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -6078,20 +6078,25 @@ async function runChecks() {
       stateRequests++;
       const answered = await route.fetch();
       const body = await answered.text();
-      await new Promise((done) => { setTimeout(done, 4000); });
+      await new Promise((done) => { setTimeout(done, 3000); });
       await route.fulfill({ status: answered.status(), body, headers: answered.headers() });
     });
     await slow.goto(recorderPage(liveUrl), { waitUntil: 'domcontentloaded' });
     await slow.waitForFunction("document.getElementById('recGo') !== null", null, { timeout: 30000 });
     // Pressed while one is in flight, which is the whole condition. The first tick goes
-    // out at load and takes four seconds to come back, so a click one second in is
-    // inside it without having to race anything.
-    await new Promise((done) => { setTimeout(done, 1000); });
+    // out at load and takes three seconds to come back, so a click 1.2s in is inside it
+    // without having to race anything.
+    await new Promise((done) => { setTimeout(done, 1200); });
     const requestsBeforePress = stateRequests;
     await slow.click('#recGo');
-    // Comfortably under the five-second cadence, so an extra request in this window is
-    // the button's own and cannot be the interval's.
-    await new Promise((done) => { setTimeout(done, 2500); });
+    // **Long enough for the rerun to have gone out, and short enough that the cadence
+    // has not.** The rerun is chained onto the request in flight, so it cannot be
+    // observed before that one comes back - the first draft of this row measured 2.5s
+    // after a press made 1s into a 4s response and found nothing on a correct build,
+    // which is a fixture that closed its window before the thing it was watching for.
+    // The in-flight response lands at about 3.2s and the rerun goes out behind it; the
+    // interval's first fire is at 5s and skips anyway while that rerun runs.
+    await new Promise((done) => { setTimeout(done, 3000); });
     const requestsAfterPress = stateRequests;
     const started = await getJson(`${liveUrl}/record/state`);
     check(started.recording === true,

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -629,6 +629,19 @@ const MUTATIONS = {
   //
   // The module and not the gallery's `throw`, because those are two halves of one
   // arrangement and this is the half that decides. Must redden only the retry row.
+  // The poll goes back to starting a tick whether or not the last one has finished. On
+  // its own that is harmless; beside the retry it is not, because a handler that never
+  // returns leaves `previous` where it was and every later tick then reports the same
+  // change and starts another `/library/all` - which on a station with a `--node` is a
+  // request and a connection to the other machine every five seconds, for as long as
+  // the page is open.
+  //
+  // Must redden only the overlap row. The retry rows have to stay green, or the control
+  // is proving that the guard broke the retry rather than that it bounded it.
+  'poll-ticks-overlap': { file: 'web/record-poll.js', edits: [[
+    '    if (inFlight) return;\n    inFlight = true;\n', '',
+  ]] },
+
   'poll-forgets-a-failed-refresh': { file: 'web/record-poll.js', edits: [[
     '    try {\n      await saw(state, changed);\n      previous = mark;\n'
     + '    } catch { /* not seen, so not recorded as seen - the next tick offers it again */ }',
@@ -5400,10 +5413,19 @@ async function runChecks() {
       'the sensor health route is a ROUTES entry the table publishes, read-only and not a live sensor feed, and it answers',
       entry ? `published: read=${entry.read} mutates=${entry.mutates} live=${entry.live}, state ${health.state}`
         : `not in the table of ${table.length}`);
-    check(typeof health.dropped === 'number' && typeof health.respawns === 'number'
+    check(typeof health.monitorDropped === 'number' && typeof health.respawns === 'number'
       && typeof health.fps === 'number' && typeof health.bytesPerSec === 'number',
       'and it carries the four numbers an operator would otherwise have attached a monitor to read',
-      `dropped=${health.dropped} respawns=${health.respawns} fps=${health.fps} B/s=${health.bytesPerSec.toFixed(0)}`);
+      `monitorDropped=${health.monitorDropped} respawns=${health.respawns} fps=${health.fps} B/s=${health.bytesPerSec.toFixed(0)}`);
+    // **And it does not offer a number that would be read as sensor loss.** The count
+    // behind it moves inside `broadcastFrame`, once per socket that is over its buffer
+    // ceiling - so under the old name a node whose sensor was struggling with nobody
+    // watching read zero drops, and one frame two lagging monitors both missed read as
+    // two. The row is written against the bare name rather than against the new one,
+    // because what had to go is the word an operator would trust.
+    check(health.dropped === undefined,
+      'and nothing on it is called `dropped` unqualified, since the only count here is monitors failing to keep up with the output rather than the sensor failing to deliver',
+      `dropped=${JSON.stringify(health.dropped)}, monitorDropped=${health.monitorDropped}`);
     // A machine with no sensor on it, said as a state rather than as silence. This is
     // also the reading that makes the window row below about an *empty* window.
     check(['lost', 'absent', 'starting'].includes(health.state) && health.respawns >= 1,
@@ -5951,6 +5973,56 @@ async function runChecks() {
       'and the gallery comes back from it on a later tick, because a refresh that failed leaves the transition unseen rather than spending it',
       flakyTile === null ? 'no tile for that take' : `flags ${flakyTile.flags.join(',') || '(none)'}, acts ${flakyTile.acts.join(' ')}`);
     await flaky.close();
+
+    // **And the retry is bounded, which is the debt holding the fingerprint back took
+    // on.** A handler that never returns leaves `previous` where it was, so without a
+    // guard every later tick reports the same change and starts another `/library/all`
+    // - and where a `--node` is linked that is a request and a connection to the other
+    // machine every five seconds for as long as the page is open. The failure mode is
+    // not a wrong answer but an unbounded one, so what this counts is requests.
+    //
+    // The listing is accepted and then never answered, which is the shape that matters:
+    // a refused request returns and lets the handler finish, and the whole defect is
+    // about a handler that does not.
+    const fourth = await post(`${liveUrl}/record/start`);
+    let shootingFourth = null;
+    for (let i = 0; i < 40; i++) {
+      await new Promise((done) => { setTimeout(done, 250); });
+      shootingFourth = await getJson(`${liveUrl}/record/state`);
+      if (shootingFourth.recording) break;
+    }
+    check(shootingFourth?.recording === true,
+      'a fourth take is open, so the page below has a transition whose refresh can be left hanging',
+      `${shootingFourth?.takeId}, start said ${JSON.stringify(fourth).slice(0, 50)}`);
+
+    const hung = await browser.newPage();
+    let hungListings = 0;
+    let ticksSeen = 0;
+    const heldForever = [];
+    await hung.route('**/library/all', async (route) => {
+      hungListings++;
+      // The first is the page's own load and has to answer, or there is no painted grid
+      // and no transition to follow. Every one after it is held open for good.
+      if (hungListings === 1) { await route.continue(); return; }
+      heldForever.push(route);
+    });
+    await hung.route('**/record/state', async (route) => { ticksSeen++; await route.continue(); });
+    await hung.goto(galleryPage(liveUrl), { waitUntil: 'domcontentloaded' });
+    await hung.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 });
+    await post(`${liveUrl}/record/stop`);
+    // Four cadences, so a poll that started a listing per tick would have started four
+    // and a poll that waits for the one in flight has started exactly one. The margin
+    // is what keeps a slow machine from reading as a catch.
+    await new Promise((done) => { setTimeout(done, 21000); });
+    const heldCount = heldForever.length;
+    check(ticksSeen >= 3,
+      'the page went on polling the recorder while its listing hung, which is what makes the row below about the listings rather than about a page that stopped',
+      `${ticksSeen} ticks to /record/state in 21s`);
+    check(heldCount === 1,
+      'and it has exactly one listing in flight however long that one takes - a refresh that has not come back is the question already being asked, not a reason to ask it again every five seconds',
+      `${heldCount} listings left hanging, ${hungListings} requested in total`);
+    for (const route of heldForever) await route.abort('connectionfailed').catch(() => {});
+    await hung.close();
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
   }
 

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -639,7 +639,29 @@ const MUTATIONS = {
   // Must redden only the overlap row. The retry rows have to stay green, or the control
   // is proving that the guard broke the retry rather than that it bounded it.
   'poll-ticks-overlap': { file: 'web/record-poll.js', edits: [[
-    '    if (inFlight) return;\n    inFlight = true;\n', '',
+    '  const tick = () => {\n'
+    + '    if (running) {\n'
+    + '      if (!rerun) rerun = running.then(() => { rerun = null; return tick(); });\n'
+    + '      return rerun;\n    }\n'
+    + '    running = run().finally(() => { running = null; });\n'
+    + '    return running;\n  };\n'
+    + '  const onCadence = () => { if (!running) tick(); };',
+    '  const tick = () => run();\n  const onCadence = () => { tick(); };',
+  ]] },
+
+  // A caller asking during a tick gets the tick already in flight instead of a rerun -
+  // which is the round-4 guard before it learned the difference between the two ways
+  // in. The record button awaits this to repaint from the state its own POST produced,
+  // and the in-flight request snapshotted `recorder.state` before the press, so the
+  // surface paints the world as it was and the next click can choose start where it
+  // meant stop.
+  //
+  // The returned promise and not the guard, because the guard is right: the cadence
+  // must go on skipping. Must redden only the row counting the button's own read.
+  'post-action-poll-discarded': { file: 'web/record-poll.js', edits: [[
+    '      if (!rerun) rerun = running.then(() => { rerun = null; return tick(); });\n'
+    + '      return rerun;',
+    '      return running;',
   ]] },
 
   'poll-forgets-a-failed-refresh': { file: 'web/record-poll.js', edits: [[
@@ -6034,6 +6056,52 @@ async function runChecks() {
       `${listingsWhileHung} listings while it hung, ${hungListings} after it cleared,`
       + ` ${ticksSeen} ticks to /record/state throughout`);
     await hung.close();
+
+    // **The other way into the same poll, which the guard above nearly closed.** The
+    // cadence wants to be skipped while a tick runs; the record button wants the
+    // opposite. It awaits the poll after its own POST so the surface repaints from the
+    // world its press produced - and handing it the request already in flight hands it
+    // a `recorder.state` snapshot taken before the press. The button re-enables against
+    // that, and the next click chooses start or stop from it.
+    //
+    // Counted in requests rather than read off the painted surface, because the paint
+    // is repaired by the next cadence tick a few seconds later: a row that waited to
+    // read it would pass on both builds and only be measuring the interval. What
+    // separates them is whether the press caused a read of its own at all.
+    //
+    // The response is fetched immediately and delivered late, which is what makes the
+    // in-flight request one that snapshotted before the click. Delaying the request
+    // instead would snapshot after it and there would be nothing to catch.
+    const slow = await browser.newPage();
+    let stateRequests = 0;
+    await slow.route('**/record/state', async (route) => {
+      stateRequests++;
+      const answered = await route.fetch();
+      const body = await answered.text();
+      await new Promise((done) => { setTimeout(done, 4000); });
+      await route.fulfill({ status: answered.status(), body, headers: answered.headers() });
+    });
+    await slow.goto(recorderPage(liveUrl), { waitUntil: 'domcontentloaded' });
+    await slow.waitForFunction("document.getElementById('recGo') !== null", null, { timeout: 30000 });
+    // Pressed while one is in flight, which is the whole condition. The first tick goes
+    // out at load and takes four seconds to come back, so a click one second in is
+    // inside it without having to race anything.
+    await new Promise((done) => { setTimeout(done, 1000); });
+    const requestsBeforePress = stateRequests;
+    await slow.click('#recGo');
+    // Comfortably under the five-second cadence, so an extra request in this window is
+    // the button's own and cannot be the interval's.
+    await new Promise((done) => { setTimeout(done, 2500); });
+    const requestsAfterPress = stateRequests;
+    const started = await getJson(`${liveUrl}/record/state`);
+    check(started.recording === true,
+      'the record button really did start a take, so the row below is about the read that followed a press rather than about a press that did nothing',
+      `recording ${started.recording}, take ${started.takeId}`);
+    check(requestsAfterPress > requestsBeforePress,
+      'and pressing it asks the recorder again rather than settling for the answer already in flight, which was taken before the press and would repaint the world as it was',
+      `${requestsBeforePress} requests before the press, ${requestsAfterPress} within 2.5s after it`);
+    await post(`${liveUrl}/record/stop`);
+    await slow.close();
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
   }
 

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -5524,10 +5524,19 @@ async function runChecks() {
       const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(id)});
       return t ? { flags: t.flags, acts: t.acts } : null;
     })()`);
+    // **The action a remote take offers is Download, and while it is being written it
+    // is not offered at all.** `availability` gives a remote take a Download button
+    // only once it has stopped, because a take mid-write has no settled hash and the
+    // node answers 409 for it - so what a shooting remote tile carries is the same
+    // disabled Open a local one does. That transition, disabled Open to enabled
+    // Download, is what this station gets out of following the node's recorder, and it
+    // is a different pair of buttons from the one the direct gallery below reads.
+    const actLabels = (t) => (t?.acts ?? []).map((a) => `${a.label}${a.disabled ? ' (off)' : ''}`).join(' ') || '(none)';
     const remoteBefore = await linkedFlags(shooting.takeId);
-    check(remoteBefore?.flags?.includes('recording') === true,
-      'a station with no sensor of its own draws the node\'s open take into its grid and says it is being written',
-      `flags ${remoteBefore?.flags?.join(',') ?? '(no tile)'}`);
+    check(remoteBefore?.flags?.includes('recording') === true
+      && remoteBefore?.acts?.find((a) => a.label === 'Open')?.disabled === true,
+      'a station with no sensor of its own draws the node\'s open take into its grid, says it is being written, and refuses every action behind that',
+      `flags ${remoteBefore?.flags?.join(',') ?? '(no tile)'}, acts ${actLabels(remoteBefore)}`);
     // This machine's own recorder, said out loud. It is the reading that makes the row
     // below a claim about following the *node* rather than about following anything:
     // a gallery here that polled only what this process holds would be polling a flag
@@ -5556,10 +5565,9 @@ async function runChecks() {
       'the station is polling, which is what makes the row below about what the poll watches rather than about a page that stopped asking',
       `${linkedPolls} requests to /record/state`);
     check(remoteAfter?.flags?.includes('recording') === false
-      && remoteAfter?.acts?.find((a) => a.label === 'Open')?.disabled === false,
-      'and it follows the node\'s recorder rather than its own, so the finished take stops being refused without anybody reloading',
-      `flags ${remoteAfter?.flags?.join(',') || '(none)'}, `
-      + `Open ${remoteAfter?.acts?.find((a) => a.label === 'Open')?.disabled ? 'still disabled' : 'enabled'}`);
+      && remoteAfter?.acts?.find((a) => a.label === 'Download')?.disabled === false,
+      'and it follows the node\'s recorder rather than its own, so the finished take stops being refused and becomes downloadable without anybody reloading',
+      `flags ${remoteAfter?.flags?.join(',') || '(none)'}, acts ${actLabels(remoteAfter)}`);
     check(linked.errors.length === 0, 'and the linked gallery raises no page error while it follows',
       linked.errors.slice(0, 2).join(' | '));
     await linked.page.close();

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -98,7 +98,7 @@ const MAC_PORT = Number(flag('--mac-port', '8211'));
 // and the failure reads exactly like a finding about the recorder. The span is checked
 // end to end before anything spawns, and `startServer` asserts its port is inside it, so
 // a section added later at `+17` is caught by arithmetic rather than by a wrong reading.
-const PORT_SPAN = 16;
+const PORT_SPAN = 17;
 const MUTATE = flag('--mutate');
 const HEADED = argv.includes('--headed');
 const WORK = flag('--work') ?? join(REPO, '.library-check');
@@ -638,6 +638,25 @@ const MUTATIONS = {
   //
   // Must redden only the overlap row. The retry rows have to stay green, or the control
   // is proving that the guard broke the retry rather than that it bounded it.
+  // The gallery's listing loses its bound, so a node that accepts a connection and never
+  // answers hangs it - and single-flight then skips every later tick for as long as it
+  // hangs. The pile-up guard and the timeout are two halves of one arrangement: without
+  // the bound, the guard turns one dead listing into a gallery that has stopped.
+  'listing-never-times-out': { file: 'web/library.js', edits: [[
+    "await fetch('/library/all', { signal: AbortSignal.timeout(LISTING_TIMEOUT_MS) })",
+    "await fetch('/library/all')",
+  ]] },
+
+  // Delete goes back to being offered while the node is unreachable, where the copy count
+  // it rests on came from a manifest read that failed rather than from a node with
+  // nothing on it.
+  'delete-guesses-past-an-unreachable-node': { file: 'web/library.js', edits: [[
+    '  if (library.node && !library.node.reachable) {\n'
+    + '    return `${library.node.name} cannot be reached, so whether this take has a second copy `\n'
+    + "      + 'is unknown - delete is refused rather than guessed at';\n  }\n",
+    '',
+  ]] },
+
   'poll-ticks-overlap': { file: 'web/record-poll.js', edits: [[
     '  const tick = () => {\n'
     + '    if (running) {\n'
@@ -5859,6 +5878,40 @@ async function runChecks() {
     check(errors.length === 0, 'and the gallery raises no page error while it follows', errors.slice(0, 2).join(' | '));
     await page.close();
 
+    // **A node that did not answer is not a node with nothing on it.** `/library/all`
+    // hands `reconcile` a null when the manifest read fails and null reads as an empty
+    // array, so a dropped link removes every node-only tile and turns every `both` take
+    // into a `local` one - and the delete confirmation that refuses to remove the last
+    // copy is drawn from exactly that count. The tile then offers a delete whose safety
+    // rests on a reading that says "no second copy" where what happened is "no answer".
+    //
+    // A station of its own pointed at a port nothing holds, so the node is unreachable
+    // from the first listing rather than made so mid-run - there is no window here for a
+    // successful read to have populated anything.
+    const blindNodeUrl = await startServer(root, [
+      '--captures', macCaps, '--name', 'mac-blind',
+      '--node', `http://127.0.0.1:${MAC_PORT + 17}`, '--node-name', 'a-node-that-is-not-there',
+    ], MAC_PORT + 11);
+    const dark = await openPage(browser, galleryPage(blindNodeUrl));
+    await dark.page.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 });
+    const darkState = await dark.page.evaluate('globalThis.__library.state()');
+    const darkTiles = await dark.page.evaluate('globalThis.__library.tiles()');
+    check(darkState.node?.reachable === false && darkTiles.length > 0,
+      'the station has a node it cannot reach and takes of its own on screen, which is the pair the row below needs',
+      `node ${darkState.node?.name} reachable ${darkState.node?.reachable}, ${darkTiles.length} tiles`);
+    const deletable = darkTiles.filter((t) => t.menu.some((m) => m.item === 'delete' && !m.disabled));
+    check(deletable.length === 0,
+      'and not one of them offers Delete while the node is unreachable, because the copy count that would make it safe came from a read that failed rather than from a node with nothing on it',
+      deletable.length ? `${deletable.length} of ${darkTiles.length} still deletable: ${deletable.map((t) => t.id).join(' ')}`
+        : `${darkTiles.length} tiles, every Delete refused`);
+    const why = darkTiles[0]?.menu.find((m) => m.item === 'delete')?.why ?? '';
+    check(/cannot be reached/.test(why),
+      'and it says which node it could not reach, so the refusal is a fact about the link rather than a control that went dead',
+      `"${why.slice(0, 90)}"`);
+    check(dark.errors.length === 0, 'and that gallery raises no page error', dark.errors.slice(0, 2).join(' | '));
+    await dark.page.close();
+    for (const p2 of servers.filter((sv) => sv.port === MAC_PORT + 11)) p2.child.kill('SIGKILL');
+
     // **The gap between the listing a gallery paints and the first tick it compares
     // against.** The page reads `/library/all`, draws a take as being written, and only
     // then asks the recorder what it is doing. A first tick with nothing behind it
@@ -6032,29 +6085,33 @@ async function runChecks() {
     await hung.goto(galleryPage(liveUrl), { waitUntil: 'domcontentloaded' });
     await hung.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 });
     await post(`${liveUrl}/record/stop`);
-    // Four cadences, so a poll that started a listing per tick would have started four
-    // and a poll that waits for the one in flight has started exactly one. The margin
-    // is what keeps a slow machine from reading as a catch.
-    await new Promise((done) => { setTimeout(done, 21000); });
+    // Two cadences and change, so a poll that started a listing per tick would have
+    // started two or three and a poll that waits for the one in flight has started
+    // exactly one - and deliberately short of the fifteen-second listing timeout, which
+    // the rows after this one are about. The margin keeps a slow machine from reading as
+    // a catch without letting the bound fire early and change what is being counted.
+    await new Promise((done) => { setTimeout(done, 11000); });
     const heldCount = heldForever.length;
     const listingsWhileHung = hungListings;
     check(heldCount === 1,
       'it has exactly one listing in flight however long that one takes - a refresh that has not come back is the question already being asked, not a reason to ask it again every five seconds',
       `${heldCount} listings left hanging, ${hungListings} requested in total`);
-    // **The liveness half is that it comes back, not that it kept polling.** The guard
-    // holds for the whole tick, so while a handler hangs the recorder is not asked
-    // either - which is right, since the answer would have nowhere to go, and is why a
-    // row counting `/record/state` during the hang reads two and means nothing. What
-    // proves the page was alive rather than dead is that clearing the hang starts a
-    // listing again: the abort makes the handler throw, the fingerprint stays where it
-    // was, and the next tick offers the same transition. One row, both properties - the
-    // guard releases and the retry underneath it still works.
-    for (const route of heldForever) await route.abort('connectionfailed').catch(() => {});
-    await new Promise((done) => { setTimeout(done, 11000); });
+    // **The liveness half is that it comes back on its own, and nothing here clears the
+    // hang for it.** The single-flight guard and the listing's timeout are two halves of
+    // one arrangement: without the bound, the guard turns one dead listing into a gallery
+    // that has stopped, since the guard holds for the whole tick and the tick is waiting
+    // on a request that will never answer. The earlier version of this row aborted the
+    // held listing itself and then checked that a new one went out, which proves the
+    // retry works and says nothing about whether anything would ever have released it.
+    // So the fixture now just waits: past fifteen seconds the page's own bound fails the
+    // listing, the handler throws, the fingerprint stays where it was, and the next tick
+    // offers the same transition again.
+    await new Promise((done) => { setTimeout(done, 12000); });
     check(hungListings > listingsWhileHung,
-      'and it asks again once that one is out of the way, so the single listing above is a poll waiting rather than a poll that died',
-      `${listingsWhileHung} listings while it hung, ${hungListings} after it cleared,`
+      'and the page frees itself from a listing nothing was ever going to answer, so the single listing above is a poll waiting rather than a poll that has stopped',
+      `${listingsWhileHung} listings while it hung, ${hungListings} after its own timeout fired,`
       + ` ${ticksSeen} ticks to /record/state throughout`);
+    for (const route of heldForever) await route.abort('connectionfailed').catch(() => {});
     await hung.close();
 
     // **The other way into the same poll, which the guard above nearly closed.** The

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -5899,13 +5899,23 @@ async function runChecks() {
     check(darkState.node?.reachable === false && darkTiles.length > 0,
       'the station has a node it cannot reach and takes of its own on screen, which is the pair the row below needs',
       `node ${darkState.node?.name} reachable ${darkState.node?.reachable}, ${darkTiles.length} tiles`);
-    const deletable = darkTiles.filter((t) => t.menu.some((m) => m.item === 'delete' && !m.disabled));
-    check(deletable.length === 0,
+    // **Delete is an act, and the first draft of these two rows looked for it in the ⋯
+    // menu.** `menu` holds rename, reveal and reclaim; there is no `delete` in it on any
+    // build, so "not one of them offers Delete" was a filter over an empty match and
+    // passed whatever the page did - the mutation restored the offer and the row went on
+    // agreeing. The missing-Delete arm below is what stops that recurring: a lookup that
+    // finds nothing now fails here rather than reading as a refusal.
+    const deleteAct = (t) => t.acts.find((a) => a.item === 'delete');
+    const noDelete = darkTiles.filter((t) => !deleteAct(t));
+    const deletable = darkTiles.filter((t) => !deleteAct(t)?.disabled);
+    check(noDelete.length === 0 && deletable.length === 0,
       'and not one of them offers Delete while the node is unreachable, because the copy count that would make it safe came from a read that failed rather than from a node with nothing on it',
-      deletable.length ? `${deletable.length} of ${darkTiles.length} still deletable: ${deletable.map((t) => t.id).join(' ')}`
-        : `${darkTiles.length} tiles, every Delete refused`);
-    const why = darkTiles[0]?.menu.find((m) => m.item === 'delete')?.why ?? '';
-    check(/cannot be reached/.test(why),
+      noDelete.length
+        ? `${noDelete.length} of ${darkTiles.length} render no Delete at all, so this row would be reading nothing`
+        : deletable.length ? `${deletable.length} of ${darkTiles.length} still deletable: ${deletable.map((t) => t.id).join(' ')}`
+          : `${darkTiles.length} tiles, every Delete refused`);
+    const why = darkTiles[0] ? deleteAct(darkTiles[0])?.why ?? '' : '';
+    check(/cannot be reached/.test(why) && why.includes('a-node-that-is-not-there'),
       'and it says which node it could not reach, so the refusal is a fact about the link rather than a control that went dead',
       `"${why.slice(0, 90)}"`);
     check(dark.errors.length === 0, 'and that gallery raises no page error', dark.errors.slice(0, 2).join(' | '));
@@ -6074,12 +6084,14 @@ async function runChecks() {
     let hungListings = 0;
     let ticksSeen = 0;
     const heldForever = [];
+    const heldAt = [];
     await hung.route('**/library/all', async (route) => {
       hungListings++;
       // The first is the page's own load and has to answer, or there is no painted grid
       // and no transition to follow. Every one after it is held open for good.
       if (hungListings === 1) { await route.continue(); return; }
       heldForever.push(route);
+      heldAt.push(Date.now());
     });
     await hung.route('**/record/state', async (route) => { ticksSeen++; await route.continue(); });
     await hung.goto(galleryPage(liveUrl), { waitUntil: 'domcontentloaded' });
@@ -6106,10 +6118,24 @@ async function runChecks() {
     // So the fixture now just waits: past fifteen seconds the page's own bound fails the
     // listing, the handler throws, the fingerprint stays where it was, and the next tick
     // offers the same transition again.
-    await new Promise((done) => { setTimeout(done, 12000); });
+    //
+    // **Timed from the held listing rather than from here, because the two are not a
+    // fixed distance apart.** The transition is only noticed on the first tick after the
+    // stop has flushed, indexed and hashed, so the listing that hangs goes out somewhere
+    // in the first cadences rather than at a known moment - and the bound then runs
+    // fifteen seconds from *it*, with the retry landing on the next five-second tick
+    // after that. A flat twelve-second wait from here read twenty-three seconds against a
+    // listing that went out at five and could not have been reasked before twenty-five,
+    // which failed a correct build for being two seconds early. Polled to a deadline that
+    // moves with the listing instead, and reported as the interval it actually took.
+    const freeBy = (heldAt[0] ?? Date.now()) + 15000 + 5000 + 6000;
+    while (Date.now() < freeBy && hungListings === listingsWhileHung) {
+      await new Promise((done) => { setTimeout(done, 250); });
+    }
+    const freedAfter = heldAt[0] ? Date.now() - heldAt[0] : null;
     check(hungListings > listingsWhileHung,
       'and the page frees itself from a listing nothing was ever going to answer, so the single listing above is a poll waiting rather than a poll that has stopped',
-      `${listingsWhileHung} listings while it hung, ${hungListings} after its own timeout fired,`
+      `${listingsWhileHung} listings while it hung, ${hungListings} ${freedAfter}ms after that listing went out,`
       + ` ${ticksSeen} ticks to /record/state throughout`);
     for (const route of heldForever) await route.abort('connectionfailed').catch(() => {});
     await hung.close();

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -672,10 +672,52 @@ const MUTATIONS = {
     'await refresh();',
   ]] },
 
+  // The listing goes back to being believed whatever the server said about it, which is
+  // where it was until a JSON refusal was found walking straight past the catch above.
+  // `res.json()` resolves on a 500 carrying `{ error }`, so `library` becomes an object
+  // with no `takes` and no `storage`, `paint()` throws reading `library.storage.label`,
+  // and the throw lands inside the catch that was supposed to recover from it.
+  //
+  // **Must redden all four rows of the first-load class, both arms, and that is not what
+  // this comment predicted.** The guess was that the non-JSON arm would stay green, on
+  // the reasoning that `res.json()` throws on a body that will not parse and so never
+  // reaches the assignment. It does not any more: the parse failure is caught into
+  // `null` beside the refusal now, so both doors arrive at the same check and removing
+  // it strands the page through either. Written down rather than quietly narrowed,
+  // because the run said something better than the prediction did - before the fix only
+  // one of the two doors was shut, and it was shut by accident, by a `SyntaxError`
+  // nobody chose escaping from `res.json()` with a message that named nothing.
+  //
+  // So this is not a revert to the build that shipped, and calling it one would be the
+  // more useful-sounding claim: that build strands on a refusal that parses and survives
+  // one that does not. What the mutation stages is the guard's absence, which is the
+  // thing under test.
+  'listing-takes-a-refusal-as-a-library': { file: 'web/library.js', edits: [[
+    '  if (!res.ok || !Array.isArray(body?.takes)) {\n'
+    + '    throw new Error(body?.error ?? `the library could not be listed: HTTP ${res.status}`);\n'
+    + '  }\n  library = body;',
+    '  library = body;',
+  ]] },
+
+  // The cancellation goes back to watching the request rather than the response. Every
+  // call site still passes a signal and the source sweep still reads clean - which is
+  // exactly what shipped - but on the two routes that await `readBody(req)` first the
+  // request has already ended, so a listener attached afterwards can never fire.
+  //
+  // `res.req` rather than reordering the call sites, because the defect being staged is
+  // *which object is watched* and reaching the request through the response leaves the
+  // signature and all four callers untouched. Must redden the removal arm and leave the
+  // listing arm green: the listing reads no body, so it worked on both builds and is
+  // what makes this a control for the ordering rather than for cancellation at large.
+  'cancel-watches-the-consumed-request': { file: 'server/index.js', edits: [[
+    "  res.on('close', () => ctl.abort());",
+    "  res.req.on('close', () => ctl.abort());",
+  ]] },
+
   // The listing route stops telling the node that its caller has gone, so a browser that
   // gave up leaves the outbound fetch running here.
   'listing-ignores-client-abort': { file: 'server/index.js', edits: [[
-    'await node.takes(untilCallerLeaves(req)) : null;\n  const takes = reconcile(',
+    'await node.takes(untilCallerLeaves(res)) : null;\n  const takes = reconcile(',
     'await node.takes() : null;\n  const takes = reconcile(',
   ]] },
 
@@ -7552,6 +7594,48 @@ async function runChecks() {
       'and it comes back on the next listing that works, so the failure costs a refresh rather than the session',
       repaired === -1 ? 'no working refresh was reachable' : `${repaired} tiles after the next refresh`);
     await broken.close();
+
+    // **And the same refusal in the shape this server actually sends it.** The arm above
+    // answers with a body that is not JSON, so `res.json()` throws before anything is
+    // assigned and the intact default is what gets painted - a real door, and not the one
+    // `serveLibrary` uses. What it writes is `sendJson(res, { error }, 500)`, and that
+    // body parses: read straight through it landed in `library` whole, `paint()` went for
+    // `library.storage.label` on an object with no storage, and the throw arrived *inside*
+    // the catch added to recover from it - where a throw is uncaught, so module evaluation
+    // ended anyway. A fixture is a claim about which failures were tried, and this one had
+    // tried the half the server does not send.
+    const refusedPage = await browser.newPage();
+    let refusedListings = 0;
+    await refusedPage.route('**/library/all', async (route) => {
+      refusedListings++;
+      if (refusedListings === 1) {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'the captures directory cannot be read: ENOTDIR' }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+    await refusedPage.goto(galleryPage(liveUrl), { waitUntil: 'domcontentloaded' });
+    let refusedInstalled = true;
+    await refusedPage.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 })
+      .catch(() => { refusedInstalled = false; });
+    check(refusedInstalled,
+      'and a refusal that parses - the only kind this server sends - is not believed as a library, so the page still installs its hook',
+      refusedInstalled ? 'installed after a JSON 500' : 'the page never installed its hook');
+    // Asked separately, because a page that installed its hook over a blank shelf with no
+    // sentence on it is the failure this surface is named for. The server took trouble to
+    // say which directory and why, and that is the whole difference between a five-second
+    // fix and a mystery.
+    const refusedSaid = refusedInstalled
+      ? await refusedPage.evaluate('document.getElementById("note")?.textContent ?? ""')
+      : '';
+    check(/ENOTDIR/.test(refusedSaid),
+      'and the server\'s own sentence is what reaches the note, rather than a TypeError raised while painting the refusal',
+      JSON.stringify(refusedSaid));
+    await refusedPage.close();
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
 
     // **A node that stops answering must not leave this machine holding the pair.**
@@ -7601,6 +7685,34 @@ async function runChecks() {
       'and a caller giving up drops the node fetch with it, so a listing nobody is waiting for stops costing a handler here and a socket over there',
       mine?.closedAt === null ? 'the node still holds it 6s after the caller gave up'
         : `dropped ${freed}ms after the caller gave up, unanswered`);
+    // **And the same question asked of a route that reads a body first**, which is where
+    // the signal was structurally dead while every arm above stayed green. An
+    // `IncomingMessage` is a stream and emits `close` when it *ends*, so once
+    // `serveRemoval` has awaited `readBody(req)` the request is already destroyed and a
+    // listener attached after it never fires again. The listing reads no body and so
+    // worked, which is why one arm over one route could not see it - the two halves of
+    // the class are the two shapes of handler, not the four route names, and the source
+    // sweep below reads clean on both builds because the call really does carry a signal.
+    const heldBeforePost = deafHeld.length;
+    await fetch(`${deafUrl}/library/delete/a-take-this-machine-does-not-have`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hash: `sha256:${'ab'.repeat(32)}` }),
+      signal: AbortSignal.timeout(2000),
+    }).catch(() => {});
+    const postGaveUpAt = Date.now();
+    check(deafHeld.length > heldBeforePost,
+      'a removal reaches the node too, so the row below is about a body-reading route rather than one that never asked',
+      `${deafHeld.length - heldBeforePost} held at the node`);
+    const posted = deafHeld[deafHeld.length - 1];
+    for (let i = 0; i < 24 && posted && posted.closedAt === null; i++) {
+      await new Promise((done) => { setTimeout(done, 250); });
+    }
+    const postFreed = posted?.closedAt === null ? null : posted.closedAt - postGaveUpAt;
+    check(posted != null && posted.closedAt !== null && posted.answered === false && postFreed < 1500,
+      'and a route that read its body before asking still drops the node fetch when its caller goes, rather than watching a request that had already ended',
+      posted?.closedAt === null ? 'the node still holds it 6s after the caller gave up'
+        : `dropped ${postFreed}ms after the caller gave up, unanswered`);
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 11)) p.child.kill('SIGKILL');
     deaf.srv.close();
 

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -6015,13 +6015,24 @@ async function runChecks() {
     // is what keeps a slow machine from reading as a catch.
     await new Promise((done) => { setTimeout(done, 21000); });
     const heldCount = heldForever.length;
-    check(ticksSeen >= 3,
-      'the page went on polling the recorder while its listing hung, which is what makes the row below about the listings rather than about a page that stopped',
-      `${ticksSeen} ticks to /record/state in 21s`);
+    const listingsWhileHung = hungListings;
     check(heldCount === 1,
-      'and it has exactly one listing in flight however long that one takes - a refresh that has not come back is the question already being asked, not a reason to ask it again every five seconds',
+      'it has exactly one listing in flight however long that one takes - a refresh that has not come back is the question already being asked, not a reason to ask it again every five seconds',
       `${heldCount} listings left hanging, ${hungListings} requested in total`);
+    // **The liveness half is that it comes back, not that it kept polling.** The guard
+    // holds for the whole tick, so while a handler hangs the recorder is not asked
+    // either - which is right, since the answer would have nowhere to go, and is why a
+    // row counting `/record/state` during the hang reads two and means nothing. What
+    // proves the page was alive rather than dead is that clearing the hang starts a
+    // listing again: the abort makes the handler throw, the fingerprint stays where it
+    // was, and the next tick offers the same transition. One row, both properties - the
+    // guard releases and the retry underneath it still works.
     for (const route of heldForever) await route.abort('connectionfailed').catch(() => {});
+    await new Promise((done) => { setTimeout(done, 11000); });
+    check(hungListings > listingsWhileHung,
+      'and it asks again once that one is out of the way, so the single listing above is a poll waiting rather than a poll that died',
+      `${listingsWhileHung} listings while it hung, ${hungListings} after it cleared,`
+      + ` ${ticksSeen} ticks to /record/state throughout`);
     await hung.close();
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
   }

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -448,6 +448,74 @@ const MUTATIONS = {
   // against today's tree rather than only once `jobs` exists. What must fail is the
   // shadowing row: with `presets` unowned, the file planted at web/presets/ is
   // served off disk with a 200 where the route table should have answered 404.
+  // The health route answers from a branch ahead of the dispatcher instead of from a
+  // `ROUTES` entry - which is exactly the shape no route sweep can see. The handler
+  // still works and still touches nothing, so the read sweep's resource rows have
+  // nothing to say about it; what goes is `/library/routes` publishing it, and with
+  // that the enumeration that drives every route by existing.
+  //
+  // This is the general failure the table was built to end, aimed at the newest entry:
+  // a branch beside the dispatch is a route that is real to a browser and invisible to
+  // every check that walks the published list.
+  'health-answers-beside-the-table': {
+    file: 'server/index.js',
+    edits: [
+      ["  { path: '/sensor/health', pattern: /^\\/sensor\\/health$/, read: serveSensorHealth },\n", ''],
+      [
+        '  // The table first, the file tree second. `serveRoute` answers false only for a',
+        '  if (urlPath === \'/sensor/health\') { serveSensorHealth(req, res); return; }\n\n'
+        + '  // The table first, the file tree second. `serveRoute` answers false only for a',
+      ],
+    ],
+  },
+
+  // The health window's reset goes back below the early return, so a five-second window
+  // that carried no frames is never closed and `stats.since` keeps its value across the
+  // gap. The next window after a sixty-second USB drop is then measured over sixty-five
+  // seconds - roughly a thirteenth of the true rate, into the log and into
+  // `observedBytesPerSec`, which the remaining-time readout divides free space by.
+  //
+  // Must redden: the row reading the window length back off `/sensor/health` on a
+  // server with no sensor, which reports about 5000ms closed and the server's whole
+  // uptime open. The steady-delivery row stays green, because delivery never takes the
+  // early return and a control that reddened it would be measuring a different fault.
+  'empty-window-keeps-its-start': {
+    file: 'server/index.js',
+    edits: [
+      [
+        '  const closed = { ms: Date.now() - stats.since, frames: stats.frames, dropped: stats.dropped, bytes: stats.bytes };\n'
+        + '  Object.assign(stats, { frames: 0, dropped: 0, bytes: 0, since: Date.now() });\n',
+        '  const closed = { ms: Date.now() - stats.since, frames: stats.frames, dropped: stats.dropped, bytes: stats.bytes };\n',
+      ],
+      [
+        '  console.log(`[server] ${fps} fps  ${mbs} MB/s  dropped=${closed.dropped}  clients=${wss.clients.size}`);\n}, 5000);',
+        '  console.log(`[server] ${fps} fps  ${mbs} MB/s  dropped=${closed.dropped}  clients=${wss.clients.size}`);\n'
+        + '  Object.assign(stats, { frames: 0, dropped: 0, bytes: 0, since: Date.now() });\n}, 5000);',
+      ],
+    ],
+  },
+
+  // The gallery's poll loses its change gate, so every tick calls `refresh()`. This is
+  // the fault the gate exists to prevent rather than a way of switching the poll off:
+  // the fetch still happens on the cadence, and `paint()` now closes every menu,
+  // releases every skim and replaces every tile five seconds apart for as long as the
+  // page is open.
+  //
+  // Must redden: the row asserting a tick that changed nothing leaves the tiles it
+  // found. The row asserting a tick that *did* change the recording flag repaints has
+  // to stay green, or the control is only proving the poll stopped running.
+  'poll-refreshes-every-tick': { file: 'web/library.js', edits: [[
+    '  if (!changed) return;\n', '',
+  ]] },
+
+  // One page's `--faint` goes back to the value that fails AA, which is the drift three
+  // separate declarations of one token invite. Deliberately one page and not all three:
+  // the rows are per page, so the run says *which* surface regressed rather than that
+  // some surface did, and the two pages left alone are what makes that reading possible.
+  'faint-fixed-in-one-page': { file: 'web/library.html', edits: [[
+    '    --faint: #828c99;', '    --faint: #6d7683;',
+  ]] },
+
   'namespaces-hardcoded': { file: 'server/index.js', edits: [[
     'export const OWNED_NAMESPACES = new Set(ROUTES.map((r) => {',
     // Two parens are open at the anchor (`new Set(` and `ROUTES.map(`), so the
@@ -704,9 +772,14 @@ const MUTATIONS = {
   ]] },
   // The editor goes back to swallowing a library that will not load, which is the
   // empty picker an operator gets told nothing about.
+  //
+  // Re-anchored when the same loop started keeping each list rather than discarding
+  // it - the resume offer reads the projects out of it. The mutated line still throws
+  // the reason away, which is what this control is about, and still returns `null` for
+  // the list, so the offer's own rows are not what goes red here.
   'open-take-swallows-library': { file: 'web/main.js', edits: [[
-    '    await refresh().catch((err) => unavailable.push(`${what} (${err.message})`));',
-    '    await refresh().catch(() => {});',
+    '    listed[what] = await refresh().catch((err) => { unavailable.push(`${what} (${err.message})`); return null; });',
+    '    listed[what] = await refresh().catch(() => null);',
   ]] },
   // Every version older than this build gets one sentence again, so a document with no
   // conversion path is told the thing that is true of a document from the future.
@@ -1432,6 +1505,12 @@ const macUrl = await startServer(root, ['--captures', macCaps, '--name', 'mac',
   '--node', nodeUrl, '--node-name', 'pi-01',
   '--presets', join(WORK, 'presets'), '--projects', join(WORK, 'projects'),
   '--builtin-presets', join(WORK, 'builtin-presets')], MAC_PORT);
+
+// When this process last had a server with no sensor come up. Read by the sensor-health
+// section far below, which asserts that a five-second window closes at five seconds
+// rather than growing for as long as the sensor is away - and "rather than" needs the
+// number it is not, or the row is a threshold with nothing behind it.
+const bootedAt = Date.now();
 
 const { chromium } = await loadPlaywright();
 const browser = await chromium.launch({ headless: !HEADED, args: ['--use-gl=angle', '--use-angle=default'] });
@@ -4758,6 +4837,253 @@ async function runChecks() {
     check(armed?.armed === true, 'and it can be armed, which is the whole point of provisioning it',
       JSON.stringify({ armed: armed?.armed, error: armed?.error }));
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 13)) p.child.kill('SIGKILL');
+  }
+
+  // --------------------------- 13. the sensor answers for its own health over HTTP
+  //
+  // **The point of the route is what reading it does not cost.** These numbers already
+  // existed - the health interval computes them every five seconds and prints one line
+  // to a console nobody is reading during a shoot - and the only way to find out
+  // whether the sensor was delivering was to attach a monitor over the socket.
+  // `consumersCostingTheTake` exists because an attached monitor can cost the take
+  // frames, so the one instrument for "is this sensor well" made it less well.
+  //
+  // Two servers, because the two claims need opposite fixtures. `macUrl` has no sensor
+  // and has never had one, so every window it closes is empty - which is the case the
+  // window used to carry across a gap. The live server below has a fake grabber
+  // delivering steadily, which is the case that must go on reporting a rate.
+  console.log('\n[library] the sensor answers for its own health, and a window with no frames in it still closes');
+  const liveDir = join(WORK, 'health-live');
+  rmSync(liveDir, { recursive: true, force: true });
+  mkdirSync(liveDir, { recursive: true });
+  // Spawned here and killed at the end of section 14, because both sections need a
+  // server that is genuinely delivering frames and recording, and the port span has
+  // one slot left in it. Named at the two places that matter rather than left to be
+  // noticed.
+  const liveUrl = await startServer(root, [
+    '--captures', liveDir, '--name', 'shooting-live', '--record', '--no-color',
+    '--grabber', `${join(REPO, 'tools/fake-grabber.mjs')} --source ${SAMPLE} --fps 40`,
+  ], MAC_PORT + 1);
+  {
+    const table = (await getJson(`${macUrl}/library/routes`)).routes;
+    const entry = table.find((r) => r.path === '/sensor/health');
+    // **Published and answering, asked as one row.** A route that answers from a branch
+    // beside the dispatcher is real to a browser and invisible to the sweep that drives
+    // every entry by existing, and a route in the table with no handler is the mirror -
+    // so both halves are here, and the mutation takes the first one.
+    const health = await getJson(`${macUrl}/sensor/health`);
+    check(Boolean(entry) && entry.read === true && entry.mutates === false && entry.live === false
+      && typeof health.state === 'string',
+      'the sensor health route is a ROUTES entry the table publishes, read-only and not a live sensor feed, and it answers',
+      entry ? `published: read=${entry.read} mutates=${entry.mutates} live=${entry.live}, state ${health.state}`
+        : `not in the table of ${table.length}`);
+    check(typeof health.dropped === 'number' && typeof health.respawns === 'number'
+      && typeof health.fps === 'number' && typeof health.bytesPerSec === 'number',
+      'and it carries the four numbers an operator would otherwise have attached a monitor to read',
+      `dropped=${health.dropped} respawns=${health.respawns} fps=${health.fps} B/s=${health.bytesPerSec.toFixed(0)}`);
+    // A machine with no sensor on it, said as a state rather than as silence. This is
+    // also the reading that makes the window row below about an *empty* window.
+    check(['lost', 'absent', 'starting'].includes(health.state) && health.respawns >= 1,
+      'a server with no sensor says so and counts the grabbers it has been through, which is the flapping question the backoff\'s own counter cannot answer',
+      `state ${health.state}, ${health.respawns} respawns`);
+
+    // **The window that closed last, on a server where no window has ever carried a
+    // frame.** The reset used to sit past the early return, so `stats.since` kept its
+    // value for the life of the process and the first window after a gap was measured
+    // over the gap. Read against this server's uptime, which by now is far longer than
+    // one window - so the separation between "about five seconds" and "as long as the
+    // server has been up" is what this row reads rather than a bare threshold.
+    let closed = null;
+    for (let i = 0; i < 24; i++) {
+      closed = (await getJson(`${macUrl}/sensor/health`)).window;
+      if (closed) break;
+      await new Promise((done) => { setTimeout(done, 500); });
+    }
+    const uptimeMs = Date.now() - bootedAt;
+    check(closed !== null && closed.frames === 0 && closed.ms > 3500 && closed.ms < 7500,
+      'a five-second window that carried no frames still closes at about five seconds rather than growing for as long as the sensor is away',
+      closed ? `${closed.ms}ms carrying ${closed.frames} frames, against ${(uptimeMs / 1000).toFixed(0)}s of server uptime`
+        : 'no window had closed after 12s');
+    // The other half of the same change, and the reason the rates are not in the row
+    // above: a window with no frames has no rate in it, so the last honest measurement
+    // is left standing rather than replaced by one computed over a window that never
+    // happened. On this server there has never been one, so it is still zero.
+    const rates = await getJson(`${macUrl}/sensor/health`);
+    check(rates.fps === 0 && rates.bytesPerSec === 0,
+      'and the rate is left alone by an empty window rather than recomputed over it - on this server there has never been one, so it is still nothing',
+      `${rates.fps} fps, ${rates.bytesPerSec} B/s after ${(uptimeMs / 1000).toFixed(0)}s of empty windows`);
+
+    // Steady delivery, which never takes the early return at all. The control for the
+    // row above: a mutation that only breaks the empty-window path must leave this one
+    // green, or what it caught was something else.
+    //
+    // **A second sample, taken a window after the first.** The grabber takes a few
+    // seconds to come up, so the first window this server closes is usually an empty
+    // one - and reading the very next window would be reading the boot transient,
+    // which is a genuinely long window on a build with the fault and therefore a row
+    // that goes red for the one reason it is supposed to control for.
+    let delivering = null;
+    for (let i = 0; i < 40; i++) {
+      await new Promise((done) => { setTimeout(done, 500); });
+      delivering = await getJson(`${liveUrl}/sensor/health`);
+      if (delivering.window?.frames > 0 && delivering.fps > 0) break;
+    }
+    await new Promise((done) => { setTimeout(done, 5500); });
+    const settled = await getJson(`${liveUrl}/sensor/health`);
+    check(settled?.window?.frames > 0 && settled.fps > 0 && settled.bytesPerSec > 0,
+      'a server whose sensor is delivering reports a rate over a window that carried frames, which is the reading the empty-window fix must not have touched',
+      `${settled?.fps?.toFixed(1)} fps over ${settled?.window?.ms}ms carrying ${settled?.window?.frames} frames`);
+    check(Math.abs((settled?.window?.ms ?? 0) - 5000) <= 1500,
+      'and its window is the same five seconds, so the two servers disagree about the frames rather than about the clock',
+      `${settled?.window?.ms}ms`);
+  }
+
+  // ------------------- 14. the gallery follows the recorder rather than the page load
+  //
+  // `refresh()` ran once at module load and nothing polled, so a tile went on saying a
+  // take was still being written for as long as the page stayed open - and `cannotOpen`
+  // reads that same warning out to disable Open, Download, Rename and Remove behind it.
+  // Once the recorder stopped, every one of those was wrong until somebody reloaded:
+  // the take is finished, hashed and openable, and the gallery refuses to open it.
+  console.log('\n[library] the gallery follows the recorder rather than the moment it was loaded');
+  {
+    let shooting = null;
+    for (let i = 0; i < 40; i++) {
+      await new Promise((done) => { setTimeout(done, 250); });
+      shooting = await getJson(`${liveUrl}/record/state`);
+      if (shooting.recording) break;
+    }
+    check(shooting?.recording === true,
+      'a take is genuinely open, which is what makes the tile below a tile that is lying rather than one that is right',
+      String(shooting?.takeId));
+
+    const { page, errors } = await openPage(browser, galleryPage(liveUrl));
+    await page.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 });
+    // Counted rather than assumed. Every row below is about what the poll *decides*,
+    // and all of them would pass on a page that had stopped polling at all - which is
+    // the opposite failure and the one a gate is most likely to be written into.
+    let polls = 0;
+    page.on('request', (req) => { if (req.url().endsWith('/record/state')) polls++; });
+
+    const flagsOf = async (id) => page.evaluate(`(() => {
+      const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(id)});
+      return t ? { flags: t.flags, acts: t.acts } : null;
+    })()`);
+    const before = await flagsOf(shooting.takeId);
+    check(before?.flags?.includes('recording') === true,
+      'the tile of the take being written says so, and its Open is refused behind that',
+      `flags ${before?.flags?.join(',')}, Open ${before?.acts?.find((a) => a.label === 'Open')?.disabled ? 'disabled' : 'enabled'}`);
+
+    // **A property on the node itself, because that is what a repaint destroys.**
+    // `paint()` calls `grid.replaceChildren()`, so a tile that survived a tick is the
+    // same object and a tile that did not is a new one - which no reading of the
+    // library's own state can tell apart, since both would report the same take.
+    await page.evaluate("document.querySelector('.tile').__quietProbe = 'planted'");
+    const pollsAtProbe = polls;
+    // Longer than one cadence, so at least one tick has certainly been taken and
+    // answered while nothing about the recorder changed.
+    await new Promise((done) => { setTimeout(done, 6500); });
+    const quiet = await page.evaluate(`(() => ({
+      probe: document.querySelector('.tile')?.__quietProbe ?? null,
+      tiles: globalThis.__library.tiles().length,
+    }))()`);
+    check(polls > pollsAtProbe,
+      'the poll is running, which is what makes the row below about the gate rather than about a page that stopped asking',
+      `${polls - pollsAtProbe} requests to /record/state in 6.5s`);
+    check(quiet.probe === 'planted',
+      'and a tick in which the recorder did not move replaces no tile - the menu an operator has open and the skim under their pointer both survive it',
+      quiet.probe === 'planted' ? `${quiet.tiles} tiles, the same nodes` : 'the grid was rebuilt');
+
+    // And the half the gate is not allowed to swallow. Stopping the take changes the
+    // recording flag, which is exactly the fact a tile is drawn from.
+    await post(`${liveUrl}/record/stop`);
+    await page.waitForFunction(
+      `(() => { const t = globalThis.__library.tiles().find((x) => x.id === ${JSON.stringify(shooting.takeId)});
+        return t && !t.flags.includes('recording'); })()`,
+      null, { timeout: 20000 },
+    ).catch(() => {});
+    const after = await flagsOf(shooting.takeId);
+    check(after?.flags?.includes('recording') === false,
+      'and a tick in which the recorder stopped repaints, so the tile stops claiming a finished take is still being written',
+      `flags ${after?.flags?.join(',') || '(none)'}`);
+    check(after?.acts?.find((a) => a.label === 'Open')?.disabled === false,
+      'and its Open, Download, Rename and Remove come back without anybody reloading the page',
+      after?.acts?.map((a) => `${a.label}${a.disabled ? ' (off)' : ''}`).join(' '));
+    const probeAfter = await page.evaluate("document.querySelector('.tile')?.__quietProbe ?? null");
+    check(probeAfter === null,
+      'which is a genuine repaint rather than a tile edited in place, since the nodes the tick found are gone',
+      String(probeAfter));
+
+    check(errors.length === 0, 'and the gallery raises no page error while it follows', errors.slice(0, 2).join(' | '));
+    await page.close();
+    for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
+  }
+
+  // ------------------------- 15. one token, three declarations, one shared stylesheet
+  //
+  // `--faint` is declared separately in every page and `web/nav.css` styles the current
+  // surface with `var(--faint)` while declaring it nowhere - so the shared stylesheet
+  // already depends on each page saying the same thing, and fixing one page's hex is
+  // how the three drift apart.
+  //
+  // **The pages are enumerated rather than named**, so a fourth page that declares the
+  // token is asked about by existing. Same for the surfaces: every `--paper` the page
+  // declares is a background the token can end up on, and a floor that only covered the
+  // ones somebody checked would be a floor with a hole the shape of the next design.
+  console.log('\n[library] the faint token clears AA on every page that declares it');
+  {
+    const channel = (c) => (c / 255 <= 0.04045 ? c / 255 / 12.92 : ((c / 255 + 0.055) / 1.055) ** 2.4);
+    const luminance = (hex) => {
+      const n = Number.parseInt(hex.slice(1), 16);
+      return 0.2126 * channel((n >> 16) & 255) + 0.7152 * channel((n >> 8) & 255) + 0.0722 * channel(n & 255);
+    };
+    const ratio = (a, b) => {
+      const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+      return (hi + 0.05) / (lo + 0.05);
+    };
+    // The floor WCAG AA sets for body text, and these are 9px readouts.
+    const AA = 4.5;
+    const tokenIn = (css, name) => (css.match(new RegExp(`--${name}:\\s*(#[0-9a-fA-F]{6})`)) ?? [])[1] ?? null;
+
+    // **The build under test, which on a mutated run is not what is on disk.** A `web/`
+    // mutation is delivered by intercepting the page's own request for the file, so
+    // nothing ever writes it to the tree - and a static row reading the tree would
+    // measure the unmutated source, pass, and have the run recorded as this check
+    // having missed a bug it was never shown. That is the same failure the
+    // match-exactly-once rule exists for, arriving through the delivery instead of the
+    // anchor, and `openPage` carries the other half of the story.
+    const sourceOf = (rel) => (pageMutation?.file === rel ? pageMutation.body : readFileSync(join(REPO, rel), 'utf8'));
+
+    const pages = readdirSync(join(REPO, 'web')).filter((f) => f.endsWith('.html')).sort();
+    const declaring = pages
+      .map((file) => ({ file, css: sourceOf(`web/${file}`) }))
+      .filter((p) => tokenIn(p.css, 'faint') !== null);
+    check(declaring.length >= 3,
+      `every page declaring --faint is measured rather than three being named (${pages.length} pages in web/, ${declaring.length} declaring it)`,
+      declaring.map((p) => p.file).join(' '));
+
+    // One row per page, and that split is the point: it makes a run say *which* surface
+    // regressed rather than that some surface did.
+    for (const { file, css } of declaring) {
+      const faint = tokenIn(css, 'faint');
+      const surfaces = [...css.matchAll(/--(paper(?:-\d)?):\s*(#[0-9a-fA-F]{6})/g)]
+        .map((m) => ({ name: m[1], hex: m[2] }));
+      const measured = surfaces.map((s) => ({ ...s, ratio: ratio(faint, s.hex) }));
+      const worst = measured.reduce((a, b) => (a.ratio <= b.ratio ? a : b), measured[0]);
+      check(measured.length >= 2 && worst.ratio >= AA,
+        `${file}: --faint clears ${AA}:1 against every surface the page declares`,
+        `${faint} - ${measured.map((m) => `${m.name} ${m.ratio.toFixed(2)}`).join(', ')}`);
+    }
+
+    // And the restating itself, which is the finding the contrast is a symptom of.
+    const values = new Set(declaring.map((p) => tokenIn(p.css, 'faint')));
+    check(values.size === 1,
+      'and every page declares the same value, because nav.css reads the token without declaring one and cannot be right on two pages that disagree',
+      declaring.map((p) => `${p.file} ${tokenIn(p.css, 'faint')}`).join(', '));
+    const navCss = sourceOf('web/nav.css');
+    check(/var\(--faint\)/.test(navCss) && tokenIn(navCss, 'faint') === null,
+      'which is not a hypothetical: the shared stylesheet uses the token and declares none',
+      `nav.css reads it, declares ${tokenIn(navCss, 'faint') ?? 'nothing'}`);
   }
 
   for (const { log } of servers) {

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1325,6 +1325,23 @@ const MUTATIONS = {
     '      const older = takes.find((t) => !carriesRefusals(t));\n      if (older) {',
     '      const older = takes.find((t) => !carriesRefusals(t));\n      if (false) {',
   ]] },
+
+  // The same gate on the other route goes away: a `/record/state` with no `writingId`
+  // in it is read as a recorder that owns no take, which is what `?? null` did before
+  // the refusal existed. The field is still filtered for, so the mutation is the
+  // conclusion drawn from it rather than the question - a build that stopped asking
+  // would also stop the heal arm working and could not say which half was wrong.
+  //
+  // Must redden two rows and leave three green: the refusal itself and the listing that
+  // carries it go red, while the node that carries the field, the takes that still list
+  // beside it, and the heal all pass on both builds - the mutated build never refuses,
+  // so it has nothing to recover from and the heal row reads as success. That
+  // asymmetry is the point: a control reddening the whole section would not show that
+  // absence and an idle recorder had stopped being told apart.
+  'node-admits-an-old-record-state': { file: 'server/library.js', edits: [[
+    '      const missing = POLLED_NODE_FIELDS.filter((f) => body[f] === undefined);',
+    '      const missing = POLLED_NODE_FIELDS.filter((f) => body[f] === undefined) && [];',
+  ]] },
   // **The monitor's cost line goes back to spelling the grid out inline**, which is
   // where it was for as long as the comment above it promised the opposite. It
   // computes exactly the same number, renders identical pixels and serves identical
@@ -3000,6 +3017,86 @@ async function runChecks() {
         for (const p of servers.filter((sv) => sv.port === MAC_PORT + 8)) p.child.kill('SIGKILL');
       } finally {
         ahead.srv.close();
+      }
+
+      // ---- and a node one build behind on the *other* route, which the gate above
+      //      cannot see
+      //
+      // The manifest gate asks `/library/takes` about its build and answers for the
+      // whole link, but a node is two routes and they moved in different releases: the
+      // build immediately before this one serves a manifest that carries `openRefusals`
+      // - so it passes everything above - and a `/record/state` that predates
+      // `writingId` entirely. Read with a `?? null` that node is a recorder sitting
+      // idle, which is a legal state and therefore invisible: the fingerprint the
+      // gallery's poll computes is constant from the first tick, no remote start or
+      // stop can ever change it, and the shelf stops rereading the library for the
+      // machine half its tiles come from. **The object every observation happened to
+      // skip**, and it was skipped because the version question looked already asked.
+      //
+      // The stub routes on the path rather than answering everything alike, because
+      // the whole shape of this defect is one route being current while the other is
+      // not - a fixture that served one body to both could not stage it.
+      const twoRoute = (recordState) => new Promise((done) => {
+        const srv = createServer((req, res) => {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify(req.url.startsWith('/record/state')
+            ? recordState()
+            : { takes: [newShape, openableShape] }));
+        });
+        srv.listen(0, '127.0.0.1', () => done({ srv, url: `http://127.0.0.1:${srv.address().port}` }));
+      });
+      // Written out rather than derived by deleting a key from the current one, for the
+      // reason `oldShape` above is: a fixture built by subtracting from today's shape
+      // follows the code it exists to outlive.
+      let served = { recording: false, takeId: null };
+      const behind = await twoRoute(() => served);
+      const carries = await twoRoute(() => ({ recording: false, takeId: null, writingId: null }));
+      try {
+        const blind = new NodeLink(behind.url, 'behind-node');
+        // Before the poll has said anything, because a link that has answered nothing
+        // is not a link that has failed - and a gate that refused on a null would
+        // refuse every node at boot while passing every row below it.
+        check(Array.isArray(await blind.takes()),
+          'a node is listed before the poll has spoken to it, since a link with no answer yet has not failed one',
+          `${blind.lastError === null ? 'no error' : blind.lastError}`);
+
+        const polled = await blind.recordState();
+        check(polled.reachable === false,
+          'a recorder state with no writingId in it is refused rather than read as a node that owns no take',
+          `reachable ${polled.reachable}, writingId ${JSON.stringify(polled.writingId)}`);
+        const refused = await blind.takes();
+        check(refused === null && /older build/.test(blind.lastError ?? '') && /writingId/.test(blind.lastError ?? ''),
+          'and the refusal reaches the listing, which is the only one of the two routes that draws anything',
+          `${refused === null ? 'null' : `${refused.length} takes`}, ${JSON.stringify(blind.lastError)}`);
+
+        // **The other arm, and the rows above are unfalsifiable without it.** A guard
+        // that refused every node would satisfy both of them while taking the link off,
+        // which is the same defect one build further along - and `writingId: null` is
+        // the exact value the absent case was being confused with, so this is the arm
+        // that says the gate reads absence rather than emptiness.
+        const well = new NodeLink(carries.url, 'carrying-node');
+        const wellPolled = await well.recordState();
+        check(wellPolled.reachable === true && wellPolled.writingId === null,
+          'a node carrying the field and simply not writing is not refused for it, so the gate reads absence rather than an idle recorder',
+          `reachable ${wellPolled.reachable}, writingId ${JSON.stringify(wellPolled.writingId)}`);
+        check(Array.isArray(await well.takes()),
+          'and its takes still list, so this is a version band rather than the poll switched off',
+          `${well.lastError === null ? 'no error' : well.lastError}`);
+
+        // **The refusal has to be able to end, and nothing else here would notice if it
+        // could not.** Parked in `lastError` it would either be wiped by the next
+        // listing that succeeded - never surviving to be read - or latch, and a node
+        // upgraded ten minutes later would stay refused until this process restarted.
+        // Both failures pass every row above, which is why the heal is its own arm.
+        served = { recording: false, takeId: null, writingId: null };
+        await blind.recordState();
+        const healed = await blind.takes();
+        check(healed !== null && blind.lastError === null,
+          'and a node upgraded under a running link is followed again within one tick, rather than staying refused until this process restarts',
+          `${healed === null ? `still refused: ${blind.lastError}` : `${healed.length} takes`}`);
+      } finally {
+        behind.srv.close();
+        carries.srv.close();
       }
     } finally {
       old.srv.close();

--- a/web/index.html
+++ b/web/index.html
@@ -422,15 +422,23 @@
   .tmk { position: absolute; bottom: 2px; width: 5px; height: 5px; margin-left: -2.5px;
     padding: 0; border: 0; background: var(--accent); transform: rotate(45deg);
     pointer-events: auto; cursor: pointer; }
+  /* A mark the edit never reaches stacks at the right edge rather than being
+     dropped: the moment is still in the footage, and a tick nobody can explain is
+     better than a tick that silently vanished when the curve was retimed.
+
+     **Above the two interaction states rather than below them, and the order is the
+     whole of it.** `.tmk.beyond` and `.tmk:hover` have the same specificity, so
+     whichever is written last wins - and with this rule underneath, a beyond mark kept
+     its resting colour while hovered and while focused. Focus was the worse half: the
+     rule below turns the native outline off on the grounds that the colour change says
+     the same thing, so a beyond tick answered a keyboard with no change of any kind. */
+  .tmk.beyond { background: var(--faint); }
   .tmk:hover { background: var(--ink); }
   /* Rotated 45 degrees, so the focus ring would be a diamond around a diamond and
      land under the neighbouring lane. Drawn as the same colour change hovering
-     gives, which is the state the ring would have been describing anyway. */
+     gives, which is the state the ring would have been describing anyway - which is
+     only true while these sit after every rule that sets a resting colour. */
   .tmk:focus-visible { outline: 0; background: var(--ink); }
-  /* A mark the edit never reaches stacks at the right edge rather than being
-     dropped: the moment is still in the footage, and a tick nobody can explain is
-     better than a tick that silently vanished when the curve was retimed. */
-  .tmk.beyond { background: var(--faint); }
 
   .tplayhead { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--ink);
     pointer-events: none; z-index: 3; }

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,14 @@
     --paper-1: #0d1014;
     --paper-2: #151920;
     --paper-3: #1e232b;
-    --faint: #6d7683;
+    /* 4.63:1 on --paper-3, which is the lightest surface it is ever read against, and
+       5.92:1 on the page. It was #6d7683, which is 3.43:1 there and 4.15:1 on the page
+       - under the 4.5:1 floor for body text on every one of the four. **Raise it here
+       and it is still wrong on the other two pages**: this token is declared
+       identically in library.html and menu.html, and nav.css styles the current
+       surface with var(--faint) while declaring it nowhere, so the shared stylesheet
+       already depends on all three saying the same thing. */
+    --faint: #828c99;
     --line-2: rgba(255, 255, 255, 0.2);
     --line-3: rgba(255, 255, 255, 0.34);
     --accent-low: rgba(90, 209, 196, 0.14);
@@ -400,9 +407,19 @@
      which is the payoff for putting them in a sidecar. Drawn in program time
      through the retime curve, because the ruler is program time and a mark is
      source time, and the two only coincide at rate 1 with no keys. */
+  /* The strip stays transparent to the pointer so a scrub that crosses a mark is
+     still a scrub, and each tick takes its own events back - the ticks are buttons
+     that seek to the mark, and a layer that swallowed nothing would have swallowed
+     the drag as well. */
   .tmarks { position: absolute; inset: 0; pointer-events: none; z-index: 2; }
   .tmk { position: absolute; bottom: 2px; width: 5px; height: 5px; margin-left: -2.5px;
-    background: var(--accent); transform: rotate(45deg); }
+    padding: 0; border: 0; background: var(--accent); transform: rotate(45deg);
+    pointer-events: auto; cursor: pointer; }
+  .tmk:hover { background: var(--ink); }
+  /* Rotated 45 degrees, so the focus ring would be a diamond around a diamond and
+     land under the neighbouring lane. Drawn as the same colour change hovering
+     gives, which is the state the ring would have been describing anyway. */
+  .tmk:focus-visible { outline: 0; background: var(--ink); }
   /* A mark the edit never reaches stacks at the right edge rather than being
      dropped: the moment is still in the footage, and a tick nobody can explain is
      better than a tick that silently vanished when the curve was retimed. */

--- a/web/library.html
+++ b/web/library.html
@@ -19,7 +19,12 @@
     --well: #04060a;
     --ink: #e8ecf1;
     --dim: #8b94a1;
-    --faint: #6d7683;
+    /* 4.63:1 on --paper-3, 5.17:1 on --paper-2 - which is the popup menu a disabled
+       item is read on - and 5.92:1 on the page. It was #6d7683, under the 4.5:1 floor
+       on all four. The identical value is in index.html and menu.html and has to stay
+       identical: nav.css reads var(--faint) without declaring it, so one page raised
+       on its own makes the same nav item legible on one surface and not the next. */
+    --faint: #828c99;
     --line: rgba(255, 255, 255, 0.1);
     --line-2: rgba(255, 255, 255, 0.2);
     --line-3: rgba(255, 255, 255, 0.34);

--- a/web/library.js
+++ b/web/library.js
@@ -1654,6 +1654,15 @@ await refresh();
  * already uses: a gallery that quietly stopped following the recorder looks exactly
  * like a gallery with nothing to follow.
  *
+ * **And re-thrown after it is reported, which is what buys the retry.** The poll only
+ * records a tick as seen once this handler returns, so a refresh that lost its
+ * connection leaves the fingerprint where it was and the next tick offers the same
+ * transition again. Reporting it and returning normally - which is what this did - made
+ * one unlucky five-second window permanent: the fingerprint had already advanced past
+ * the transition the refresh failed on, every later tick matched it, and the grid kept a
+ * finished take's Open, Download, Rename and Remove disabled until some *other*
+ * transition happened along.
+ *
  * **Seeded with what the grid on screen already says, because the listing above and
  * the poll's first tick are two reads of a moving world.** A take that stopped between
  * them left the paint saying "being written" and every fingerprint from then on saying
@@ -1662,9 +1671,14 @@ await refresh();
  * comparison against the paint rather than against nothing, so the disagreement is
  * caught on the tick that finds it.
  */
-pollRecordState((state, changed) => {
+pollRecordState(async (state, changed) => {
   if (!changed) return;
-  refresh().catch((err) => say(`the library could not be reread: ${err.message}`));
+  try {
+    await refresh();
+  } catch (err) {
+    say(`the library could not be reread: ${err.message}`);
+    throw err;
+  }
 }, believedFromLibrary());
 
 // What a check reads. Every number here comes from the library's own state rather

--- a/web/library.js
+++ b/web/library.js
@@ -1609,6 +1609,25 @@ async function refresh() {
   paint();
 }
 
+/**
+ * The listing just painted, said back in the shape `/record/state` answers in, so the
+ * poll can compare its first tick against the grid rather than against nothing.
+ *
+ * Read off `local` and `remote` rather than off the reconciled record, because those
+ * are the two recorders the poll asks and the reconciled `recording` flag is whichever
+ * side won the spread. A take mid-write has no hash and so is never merged, which is
+ * why one of the two is always the whole answer for its machine.
+ */
+const believedFromLibrary = () => ({
+  writingId: library.takes.find((t) => t.local?.recording)?.local.id ?? null,
+  node: library.node
+    ? {
+      reachable: library.node.reachable,
+      writingId: library.takes.find((t) => t.remote?.recording)?.remote.id ?? null,
+    }
+    : null,
+});
+
 for (const tab of document.querySelectorAll('.tab')) {
   tab.addEventListener('click', () => { filter = tab.dataset.filter; paint(); });
 }
@@ -1634,11 +1653,19 @@ await refresh();
  * The failure is reported rather than swallowed, on the line the unreachable node
  * already uses: a gallery that quietly stopped following the recorder looks exactly
  * like a gallery with nothing to follow.
+ *
+ * **Seeded with what the grid on screen already says, because the listing above and
+ * the poll's first tick are two reads of a moving world.** A take that stopped between
+ * them left the paint saying "being written" and every fingerprint from then on saying
+ * "nothing is" - all identical, so nothing ever changed, and the tile refused to open a
+ * finished take for as long as the page stayed up. The seed makes the first tick a
+ * comparison against the paint rather than against nothing, so the disagreement is
+ * caught on the tick that finds it.
  */
 pollRecordState((state, changed) => {
   if (!changed) return;
   refresh().catch((err) => say(`the library could not be reread: ${err.message}`));
-});
+}, believedFromLibrary());
 
 // What a check reads. Every number here comes from the library's own state rather
 // than from the DOM, except the mark ticks - those are read back off the page on

--- a/web/library.js
+++ b/web/library.js
@@ -1698,9 +1698,27 @@ function paint() {
 const LISTING_TIMEOUT_MS = 15000;
 
 async function refresh({ bound = false } = {}) {
-  library = await (await fetch('/library/all', {
+  const res = await fetch('/library/all', {
     signal: bound ? AbortSignal.timeout(LISTING_TIMEOUT_MS) : undefined,
-  })).json();
+  });
+  const body = await res.json().catch(() => null);
+  // **Checked before it replaces the last library that worked**, because the server's
+  // refusals are JSON. `res.json()` on a 500 carrying `{ error: ... }` resolves
+  // perfectly happily, so assigning it straight through put an object with no `takes`
+  // and no `storage` into `library` - and `paint()` reads `library.storage.label`. The
+  // throw then landed *inside* the top-level catch, which paints again against the same
+  // wrecked object, and a throw inside a catch is uncaught: module evaluation ends,
+  // `__library` is never installed and the poll never starts. That is the exact failure
+  // the catch was added to end, arriving through the one door it did not cover, and the
+  // fixture missed it by serving a body that was not JSON - so `res.json()` threw, the
+  // assignment never happened, and the intact default was what got painted.
+  //
+  // The same shape `documentsIn` in `web/main.js` uses against the same server, rather
+  // than a second way of asking whether a listing is a listing.
+  if (!res.ok || !Array.isArray(body?.takes)) {
+    throw new Error(body?.error ?? `the library could not be listed: HTTP ${res.status}`);
+  }
+  library = body;
   paint();
 }
 

--- a/web/library.js
+++ b/web/library.js
@@ -76,7 +76,28 @@ const stamp = (ms) => {
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`;
 };
 
-let library = { takes: [], node: null, here: '?', reveal: { available: false, label: null, why: null } };
+// **Every field `paint` reads, because `paint` can now run against it.** This is what the
+// page holds before the first listing lands, and until the load was allowed to fail it
+// was never drawn - so `storage` being absent cost nothing and stayed absent. The moment
+// a failed first listing paints an empty shelf instead of ending module evaluation,
+// `paint` reads `library.storage.label` off `undefined` and throws from inside the very
+// catch that was meant to keep the page alive, stranding it exactly as before for a
+// second reason. `remaining` reports the same fields, so what the page draws before it
+// has asked and what it draws after are one shape rather than two.
+//
+// `secondsLeft` at `Infinity` rather than zero: the readout below turns red under fifteen
+// minutes, and a page that has not asked yet has not been told the card is nearly full.
+let library = {
+  takes: [],
+  node: null,
+  here: '?',
+  storage: {
+    // A dash rather than a sentence, because the readout reads `<label> left at current
+    // settings` and any phrase here becomes a claim inside it.
+    freeBytes: null, bytesPerSec: null, secondsLeft: Infinity, label: '—', error: null,
+  },
+  reveal: { available: false, label: null, why: null },
+};
 let filter = 'all';
 
 // **Written to both status lines, because a modal covers one of them.** `#note` sits

--- a/web/library.js
+++ b/web/library.js
@@ -1723,7 +1723,15 @@ globalThis.__library = {
     id: el.dataset.id,
     hash: el.dataset.hash,
     state: el.dataset.state,
-    acts: [...el.querySelectorAll('.acts .act')].map((b) => ({ label: b.textContent, disabled: b.disabled })),
+    // The same four fields the menu below reports, and the symmetry is load-bearing
+    // rather than tidy: acts used to carry the label and the disabled flag alone, so a
+    // check asking why an act was off got `undefined` and a check looking an act up in
+    // `menu` found nothing and read that as a refusal. A row asserting no tile offers
+    // Delete passed on every build there could be, because Delete is an act and it was
+    // looking through the ⋯ items. Both lists answer the same questions now.
+    acts: [...el.querySelectorAll('.acts .act')].map((b) => ({
+      item: b.dataset.act, label: b.textContent, disabled: b.disabled, why: b.title,
+    })),
     menu: [...el.querySelectorAll('.menu .mi')].map((b) => ({
       item: b.dataset.item, label: b.textContent, disabled: b.disabled, why: b.title,
     })),
@@ -1888,12 +1896,16 @@ globalThis.__library = {
       note: vNote.textContent,
       flags: [...document.querySelectorAll('#vFlags .flag')].map((f) => f.dataset.flag),
       marks: [...vBar.querySelectorAll('.mk')].map((m) => Number.parseFloat(m.style.left)),
-      acts: [...document.querySelectorAll('#vActs .act')].map((b) => ({ label: b.textContent, disabled: b.disabled })),
       // Reported in the same shape `tiles()` reports a tile's, because what reads them
       // is one comparison: the two surfaces have to offer a take the same things, and a
       // reader that could see only one half of each would be comparing the halves that
       // never disagreed. The ⋯ itself is in the header rather than in `#vActs`, so the
-      // action rows line up without either side needing to be trimmed of it.
+      // action rows line up without either side needing to be trimmed of it. That is
+      // why the key order here is the key order there - the comparison is on the
+      // serialised object, so a field in a different place reads as a disagreement.
+      acts: [...document.querySelectorAll('#vActs .act')].map((b) => ({
+        item: b.dataset.act, label: b.textContent, disabled: b.disabled, why: b.title,
+      })),
       menu: [...viewer.querySelectorAll('.menu .mi')].map((b) => ({
         item: b.dataset.item, label: b.textContent, disabled: b.disabled, why: b.title,
       })),

--- a/web/library.js
+++ b/web/library.js
@@ -500,6 +500,22 @@ function addButton(row, label, cls, onClick, { disabled = false, why = '', item 
  */
 function cannotDelete(take) {
   if (take.recording === true) return warningsOf(take)[0].why;
+  // **A node we could not reach is not a node with nothing on it.** `/library/all` hands
+  // `reconcile` a null when the manifest read fails and null is read as an empty array,
+  // so a link dropping removes every node-only tile and turns every `both` take into a
+  // `local` one - and the confirmation that refuses to delete the last copy is drawn
+  // from exactly that count. The take then offers a delete whose safety rests on a
+  // reading that says "no second copy" when what happened is "no answer".
+  //
+  // Refused for every take rather than only the ones that were `both`, because after the
+  // repaint there is no way to tell which those were: the reading that would say so is
+  // the one that failed. This is the conservative half of the fix and it is deliberately
+  // not the whole of it - the tiles still disappear on a failed read, which is a
+  // separate change to how a failed manifest is carried.
+  if (library.node && !library.node.reachable) {
+    return `${library.node.name} cannot be reached, so whether this take has a second copy `
+      + 'is unknown - delete is refused rather than guessed at';
+  }
   if (take.state === 'remote') {
     return `${take.id} is only on ${library.node?.name ?? 'the node'}, and delete removes a file on this machine`;
   }
@@ -1604,8 +1620,22 @@ function paint() {
   }
 }
 
+// **Bounded, because a listing that never comes back stops this page following the
+// recorder at all.** `NodeLink.recordState` carries a three-second timeout and
+// `NodeLink.takes` carries none, so a node that accepts a connection and then says
+// nothing leaves `/library/all` hanging - and single-flight, which is what stops those
+// piling up, then means every later tick is skipped for as long as it hangs. The two
+// together turn one unlucky listing into a gallery frozen until somebody reloads.
+//
+// Fifteen seconds rather than the node poll's three: this crosses the network to have a
+// directory walked and a sidecar read per take, measured at 145ms against a 200-take
+// library, so the bound is there to catch a link that has died rather than to hurry a
+// listing that is working. Failing is enough, because a failed refresh is a transition
+// this poll has not seen - it says so and the next tick offers it again.
+const LISTING_TIMEOUT_MS = 15000;
+
 async function refresh() {
-  library = await (await fetch('/library/all')).json();
+  library = await (await fetch('/library/all', { signal: AbortSignal.timeout(LISTING_TIMEOUT_MS) })).json();
   paint();
 }
 

--- a/web/library.js
+++ b/web/library.js
@@ -48,6 +48,7 @@
 // the place it is enforced.
 
 import { VALID_ID } from '/format.js';
+import { pollRecordState } from '/record-poll.js';
 
 const DEPTH_W = 512;
 const DEPTH_H = 424;
@@ -1582,6 +1583,31 @@ for (const tab of document.querySelectorAll('.tab')) {
 }
 
 await refresh();
+
+/**
+ * The gallery stops being a snapshot taken at load.
+ *
+ * A tile of a take that is mid-write says so, and `cannotOpen` reads that same
+ * warning out to disable Open, Download, Rename and Remove behind it. Nothing polled,
+ * so the moment the recorder stopped every one of those was wrong until somebody
+ * reloaded: the take is finished, hashed and openable, and the gallery went on
+ * refusing to open it for as long as the page stayed up.
+ *
+ * **Gated here rather than inside the poll, and the gate is the whole of this.**
+ * `paint()` closes every menu, releases every skim and replaces every tile, so an
+ * ungated refresh would take an open menu away every five seconds and reset a skim
+ * under the pointer. The recording flag and the take id are what decide what a tile
+ * is allowed to claim about a take, so they are what a repaint is worth paying for;
+ * a frame count ticking up is not.
+ *
+ * The failure is reported rather than swallowed, on the line the unreachable node
+ * already uses: a gallery that quietly stopped following the recorder looks exactly
+ * like a gallery with nothing to follow.
+ */
+pollRecordState((state, changed) => {
+  if (!changed) return;
+  refresh().catch((err) => say(`the library could not be reread: ${err.message}`));
+});
 
 // What a check reads. Every number here comes from the library's own state rather
 // than from the DOM, except the mark ticks - those are read back off the page on

--- a/web/library.js
+++ b/web/library.js
@@ -1663,10 +1663,23 @@ function paint() {
 // library, so the bound is there to catch a link that has died rather than to hurry a
 // listing that is working. Failing is enough, because a failed refresh is a transition
 // this poll has not seen - it says so and the next tick offers it again.
+//
+// **The bound belongs to the poll's refresh and to nothing else, and the first draft of
+// it put the bound in here where every caller got it.** There are three: the load below,
+// an operator action's refresh in `run`, and the poll. Only the poll has the single-
+// flight guard, so only the poll can turn one dead listing into a page that has stopped
+// asking - the other two fail an action or a load that somebody is watching, and would
+// rather wait than be cut off. That matters most on the load: a **cold** library is slow
+// for a legitimate reason, `cachedIndex` scans each file once and writes a `.idx` beside
+// it, and the first listing over 200 unindexed takes measured **7m30s** against the 2.4s
+// a second server took off those sidecars. Bounded at fifteen seconds, the one case this
+// page exists to get through would have been the case it refused.
 const LISTING_TIMEOUT_MS = 15000;
 
-async function refresh() {
-  library = await (await fetch('/library/all', { signal: AbortSignal.timeout(LISTING_TIMEOUT_MS) })).json();
+async function refresh({ bound = false } = {}) {
+  library = await (await fetch('/library/all', {
+    signal: bound ? AbortSignal.timeout(LISTING_TIMEOUT_MS) : undefined,
+  })).json();
   paint();
 }
 
@@ -1693,7 +1706,22 @@ for (const tab of document.querySelectorAll('.tab')) {
   tab.addEventListener('click', () => { filter = tab.dataset.filter; paint(); });
 }
 
-await refresh();
+// **A first listing that fails leaves a page that works, and that is the class rather
+// than the timeout that revealed it.** This is a top-level await, so anything it throws
+// ends the module here - before the poll is started and before `globalThis.__library`
+// exists. The bound above was one way to reach that and unbounding it closes only that
+// one: a node that resets the connection, a 500 out of `serveLibrary`, a listing that
+// parses as something other than JSON all end module evaluation identically, and what
+// the operator gets is a blank shelf with no error on it and no way to retry short of a
+// reload. Caught here, the page paints what it has, says what went wrong, and starts the
+// poll - which asks again every five seconds and repairs the grid the moment the library
+// can be read.
+try {
+  await refresh();
+} catch (err) {
+  say(`the library could not be read: ${err.message}`);
+  paint();
+}
 
 /**
  * The gallery stops being a snapshot taken at load.
@@ -1735,7 +1763,7 @@ await refresh();
 pollRecordState(async (state, changed) => {
   if (!changed) return;
   try {
-    await refresh();
+    await refresh({ bound: true });
   } catch (err) {
     say(`the library could not be reread: ${err.message}`);
     throw err;

--- a/web/main.js
+++ b/web/main.js
@@ -7212,10 +7212,22 @@ addEventListener('keydown', (e) => {
     // and going nowhere, which reads as the key not being bound at all. It is a
     // microsecond of program time - smaller than any frame this program can show, so
     // it can never skip a mark that is genuinely a step away.
+    // **Only the marks the playhead can actually get to.** `markSecondsInOrder` clamps
+    // to the take, not to the trim, and `Transport.frameAt` clamps every seek into
+    // in..out - so on a clip trimmed to start at five seconds, pressing `[` at the in
+    // point found a mark at two, asked to go there, and arrived back at five. The key
+    // read as unbound at exactly the edge where somebody is most likely to press it.
+    //
+    // Filtered here rather than in `markSecondsInOrder`, because the ticks must go on
+    // being drawn where they are: a mark outside the trim is drawn inside `.tshade`,
+    // which is the shading that exists to say "the export will not reach this". Moving
+    // those ticks to the boundary would put them where the export *does* reach and
+    // report a moment that is not there. What is unreachable is the seek, not the mark.
     case '[': case ']': {
       e.preventDefault();
       const here = timeline.programSec;
-      const seconds = markSecondsInOrder();
+      const seconds = markSecondsInOrder()
+        .filter((s) => s >= timeline.clipInSec - 1e-6 && s <= timeline.clipOutSec + 1e-6);
       const to = e.key === '['
         ? seconds.filter((s) => s < here - 1e-6).pop()
         : seconds.find((s) => s > here + 1e-6);

--- a/web/main.js
+++ b/web/main.js
@@ -8591,8 +8591,14 @@ async function importPresetFile(file) {
  * would put a round trip in the path of every take opening for the sake of an offer
  * that usually has nothing to make.
  */
+// The document the resume chip is currently offering, held from the moment it is
+// offered because the name it came from does not stay still. Null whenever no offer
+// is on screen.
+let offeredWorkingBody = null;
+
 function offerWorkingDocument(projects) {
   ui.resume.hidden = true;
+  offeredWorkingBody = null;
   const working = projects?.find((doc) => doc.name === WORKING_PROJECT);
   if (!working) return;
   // **Matched on hash rather than on id.** A rename frees the old id and a later take
@@ -8612,6 +8618,15 @@ function offerWorkingDocument(projects) {
   // When, because "there is autosaved work" is not enough to decide with: an operator
   // who stopped an hour ago and one who lost the tab a minute ago want opposite things
   // from this button, and the stamp is the only thing that tells them apart.
+  // **Held, not merely pointed at.** The next edit autosaves over `__working__`, so a
+  // chip that fetched the name when pressed would restore the edit made *since* the
+  // offer and report it as a recovery, with the work it was actually offering already
+  // overwritten. What the operator was shown is what the button now restores.
+  //
+  // The store still has one slot, so a reload before the offer is taken still loses the
+  // older document - that is a property of autosaving to a single name and is not what
+  // this is fixing. What is fixed is a button that advertised one thing and did another.
+  offeredWorkingBody = JSON.parse(JSON.stringify(working.body));
   ui.resumeWhen.textContent = `autosaved ${new Date(working.savedAt).toLocaleString()}`;
   ui.resume.hidden = false;
 }
@@ -10122,8 +10137,9 @@ ui.projectOpen.addEventListener('click', async () => {
 // looks like it does something.
 ui.resumeOpen.addEventListener('click', async () => {
   try {
-    await loadProjectNamed(WORKING_PROJECT);
+    await loadProjectNamed(WORKING_PROJECT, offeredWorkingBody);
     ui.resume.hidden = true;
+    offeredWorkingBody = null;
     say('restored the autosaved edit');
   } catch (err) {
     showTimelineError(err);
@@ -10187,8 +10203,24 @@ ui.deliverableNew.addEventListener('click', async () => {
  * so a retime curve swapped underneath a running playhead asks the source to go
  * backwards on the very next step, from inside the animation loop.
  */
-async function loadProjectNamed(name) {
-  const doc = await (await fetch(`/projects/${encodeURIComponent(name)}`)).json();
+/**
+ * Loads a project by name, or applies a document the caller is already holding.
+ *
+ * **`offered` exists because one name in this store moves under its own reader.**
+ * `__working__` is rewritten by `history.commit()` on every edit, so a document the
+ * resume chip offered can be gone by the time somebody presses the chip - fetching the
+ * name then restores whatever was typed in between and calls it a recovery. The offer
+ * captures what it is offering and hands it back here, so the button restores the
+ * document it advertised rather than the current contents of a slot.
+ *
+ * One implementation and not two: everything below this line - the footage check, the
+ * transport, the history stack - runs identically either way. What the parameter
+ * decides is only whether this function still has to go and get the document.
+ */
+async function loadProjectNamed(name, offered = null) {
+  const doc = offered === null
+    ? await (await fetch(`/projects/${encodeURIComponent(name)}`)).json()
+    : { body: offered };
   if (doc.error) throw new Error(doc.error);
   const take = doc.body.take;
   if (take && openTakeHash && take.hash && take.hash !== openTakeHash) {

--- a/web/main.js
+++ b/web/main.js
@@ -6980,7 +6980,18 @@ addEventListener('keydown', (e) => {
   if (!EDITING || !timeline) return;
   // A modifier other than shift means the key belongs to the browser or the OS.
   // Shift is ours: it is the difference between a frame and a second.
-  if (e.metaKey || e.ctrlKey || e.altKey) return;
+  //
+  // **AltGr is not one of those modifiers - it is how a character gets typed.** On a
+  // German, Nordic or Polish layout `[` and `]` are AltGr presses, and Windows delivers
+  // AltGr as ctrl+alt, so a guard reading those two bits returned before the mark keys
+  // below could run and this program advertised two shortcuts nobody on those layouts
+  // could press. The test is whether the press produced a character or a command:
+  // `e.key` is already the composed one, so a single character under AltGr means the
+  // modifier did its composing job and the key that came out is ours, while
+  // `ArrowRight` under the same two bits is the right-hand Alt being used as a command
+  // modifier and is still not.
+  const composed = e.key.length === 1 && e.getModifierState('AltGraph');
+  if ((e.metaKey || e.ctrlKey || e.altKey) && !composed) return;
 
   const step = (frames) => {
     pauseTransport();
@@ -10219,10 +10230,18 @@ async function openTake(id) {
   // somewhere honest to land rather than an empty document.
   history.begin();
   // After `begin`, because the offer is about whether the auto-save differs from the
-  // clip on screen and `baseline` is that clip serialised. Skipped when any part of
-  // the library failed to list, so the offer cannot write over the sentence naming
-  // what is broken - a note nobody can see is the failure this whole change is about.
-  if (!unavailable.length) offerWorkingDocument(listed.projects);
+  // clip on screen and `baseline` is that clip serialised.
+  //
+  // **Gated on the projects list alone, and deliberately not on the other two.** The
+  // offer used to be withheld whenever any part of the library failed to list, back
+  // when it was a sentence written through `say` that would have painted over the note
+  // naming what was broken. It is a button now - `offerWorkingDocument` writes
+  // `#tResume` and nothing else - so there is nothing left for it to overwrite, and
+  // what the old gate actually did was throw away the one control that can reach
+  // `__working__` because an unrelated `--builtin-presets` pointed at the wrong
+  // directory. That document is deliberately absent from the project picker, so
+  // withholding this button is withholding the only road back to the operator's work.
+  if (listed.projects) offerWorkingDocument(listed.projects);
   await timeline.seek(0);
   // Two things per frame, and the second is not an afterthought: with the playhead
   // parked `tick` returns immediately, so this is the only clock a paused editor has.

--- a/web/main.js
+++ b/web/main.js
@@ -3565,6 +3565,43 @@ function restoreProject(project) {
 // hundred.
 const UNDO_LIMIT = 100;
 
+/**
+ * Every write to the working document, in the order they were asked for.
+ *
+ * **The server does not order them and it is right not to.** `DocumentStore.write` gives
+ * each write its own numbered scratch file precisely so two overlapping puts to one
+ * document cannot share it, and then renames - so concurrent writes all succeed and the
+ * last `rename` to complete is the one on disk. Which that is has nothing to do with
+ * which was asked for first: they are separate connections doing separate disk work.
+ *
+ * That is fine for the auto-save on its own, where every write is a later state of the
+ * same document and losing a race costs one interaction's worth. It is not fine next to
+ * the recovery: the auto-save is fire-and-forget, so an edit made just before the
+ * operator presses Restore can still be in flight, land after the restore's write, and
+ * put the overwriting edit back - after the page has said "restored the autosaved edit"
+ * and dropped the only other copy. A reload then loses the work a second time, having
+ * twice reported it recovered.
+ *
+ * Chained rather than cancelled, because a write already on the wire cannot be recalled
+ * and the ordering is the whole requirement - the restore has to be last, not alone.
+ *
+ * **The chain carries no failure forward**, which is the difference between serialising
+ * and stopping: `.catch` on the link rather than on the returned promise means one
+ * auto-save that failed - a dropped connection, a 500 - leaves the next write to go out
+ * normally instead of silently ending persistence for the rest of the session. Callers
+ * still see their own rejection on what they were handed back.
+ */
+let workingWrites = Promise.resolve();
+function writeWorking(body) {
+  const wrote = workingWrites.then(() => fetch(`/projects/${WORKING_PROJECT}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+  workingWrites = wrote.catch(() => {});
+  return wrote;
+}
+
 const history = {
   stack: [],
   // What the document looked like at the end of the last interaction. Comparing
@@ -3608,11 +3645,7 @@ const history = {
     // Auto-save the project after every change. Fire-and-forget: a failed save is
     // logged in the UI but it must not block the interaction that caused it.
     const workingBody = { ...serialiseProject(), take: { id: openTakeId, hash: openTakeHash } };
-    fetch(`/projects/${WORKING_PROJECT}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(workingBody),
-    }).then(async (res) => {
+    writeWorking(workingBody).then(async (res) => {
       if (!res.ok) {
         const text = await res.text().catch(() => '');
         say(`auto-save failed: ${text.slice(0, 80)}`);
@@ -10149,11 +10182,12 @@ ui.resumeOpen.addEventListener('click', async () => {
     // the single moment the operator asked for their work back. A failure here has to
     // reach them, and the snapshot is kept if it does - dropping it would throw away the
     // last copy on the way out of a failed save.
-    const kept = await fetch(`/projects/${WORKING_PROJECT}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(accepted),
-    });
+    //
+    // Through `writeWorking` and not straight to `fetch`, which is what makes it the last
+    // write rather than merely a later one: an auto-save from the edit that overwrote the
+    // offer can still be on the wire, and the server orders writes by whichever `rename`
+    // finishes first.
+    const kept = await writeWorking(accepted);
     if (!kept.ok) throw new Error(`restored on screen, but the auto-save could not be rewritten: ${(await kept.text().catch(() => '')).slice(0, 80)}`);
     ui.resume.hidden = true;
     offeredWorkingBody = null;

--- a/web/main.js
+++ b/web/main.js
@@ -7226,8 +7226,7 @@ addEventListener('keydown', (e) => {
     case '[': case ']': {
       e.preventDefault();
       const here = timeline.programSec;
-      const seconds = markSecondsInOrder()
-        .filter((s) => s >= timeline.clipInSec - 1e-6 && s <= timeline.clipOutSec + 1e-6);
+      const seconds = markSecondsInOrder().filter(reachableInClip);
       const to = e.key === '['
         ? seconds.filter((s) => s < here - 1e-6).pop()
         : seconds.find((s) => s > here + 1e-6);
@@ -8214,6 +8213,22 @@ const clampToClip = (sec, total) => Math.max(0, Math.min(total, sec));
  * marks that is right until the moment somebody edits the timing - which is exactly
  * the moment a jump-to-mark key gets pressed.
  */
+/**
+ * Whether a seek to this program second would land where it was asked to.
+ *
+ * `Transport.frameAt` clamps every seek into in..out, so a mark the trim excludes is a
+ * destination that silently becomes the boundary instead - and the two surfaces that
+ * offer marks both had to know it. The keys learned first and the ruler's ticks did
+ * not, which is the instance being fixed rather than the class: one expression, called
+ * by both, so the surface added next is asked by existing rather than by somebody
+ * remembering this paragraph.
+ *
+ * The epsilons are the same slack the key stepping uses. A mark sitting exactly on a
+ * boundary is reachable, because the boundary is inside the range.
+ */
+const reachableInClip = (programSec) => !timeline
+  || (programSec >= timeline.clipInSec - 1e-6 && programSec <= timeline.clipOutSec + 1e-6);
+
 const markSecondsInOrder = () => {
   const total = view.duration;
   return takeMarks
@@ -8266,7 +8281,24 @@ function paintMarks() {
     // the press starting a scrub to wherever the pointer was, and the tick's own seek
     // arriving afterwards reads as a drag that happened to end on a mark.
     el.addEventListener('pointerdown', (e) => e.stopPropagation());
-    el.addEventListener('click', (e) => { e.stopPropagation(); goTo(at); });
+    // **A tick outside the trim declines and says so, rather than seeking somewhere it
+    // is not.** The seek would be clamped to the boundary, so pressing a diamond drawn
+    // inside the shading moved the playhead to the edge of the edit - a control that
+    // answers, in the one way that is worse than not answering, by doing something
+    // other than what it shows. The keys already refuse these; a class closed on one
+    // surface and left open on the other is the same defect with a second address.
+    //
+    // Said out loud rather than declined in silence, because a press is a person
+    // pointing at a specific thing: a key that steps past nothing has nothing to report,
+    // and a diamond that was aimed at does.
+    el.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (!reachableInClip(at)) {
+        say('that mark is outside the clip range, so the edit cannot reach it');
+        return;
+      }
+      goTo(at);
+    });
     host.appendChild(el);
   }
   // The same marks on the overview, in whole-clip coordinates. Built here rather than

--- a/web/main.js
+++ b/web/main.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { PROJECT_VERSION, versionRefusal } from './format.js';
+import { pollRecordState } from './record-poll.js';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
@@ -3445,10 +3446,10 @@ const history = {
     }).then(async (res) => {
       if (!res.ok) {
         const text = await res.text().catch(() => '');
-        ui.note.textContent = `auto-save failed: ${text.slice(0, 80)}`;
+        say(`auto-save failed: ${text.slice(0, 80)}`);
       }
     }).catch((err) => {
-      ui.note.textContent = `auto-save failed: ${err.message}`;
+      say(`auto-save failed: ${err.message}`);
     });
     return true;
   },
@@ -5935,6 +5936,39 @@ const sayExport = (text) => {
   ui.exportNote.title = text;
 };
 
+/**
+ * The editor's one line of prose, and the only way anything writes it.
+ *
+ * `#tNote` is a chip in `.tchips`, which scrolls horizontally with its scrollbar
+ * hidden so the bar keeps its 51px - so a sentence wider than the strip has nothing
+ * to drag, and the fade `.tchips.more` paints says that something is off the right
+ * edge without ever saying what. The whole of the editor's error channel wrote into
+ * that element and nothing else, which left a long refusal unreadable by any means
+ * available to the person it was written for, and a refusal is exactly the message
+ * that runs long. `title` is the same sentence somewhere it cannot be cut off, which
+ * is the repair `sayExport` above already made for the export note beside it.
+ *
+ * **The scroll is why every note comes through here and not only the errors.** A
+ * message that has just arrived should be the part of the strip on screen, and the
+ * strip is wherever the last one left it. Taken after the text lands, because
+ * `scrollWidth` read before the write is the previous message's width and would park
+ * the strip at the end of a sentence that is no longer there.
+ *
+ * A declaration rather than a `const` arrow like its neighbour, and that is about the
+ * auto-save fifteen hundred lines above this line: it reports a failed save through
+ * here, and a binding still in its temporal dead zone would turn that report into a
+ * throw out of the fetch handler - a save failure eating its own message.
+ */
+function say(text) {
+  ui.note.textContent = text;
+  ui.note.title = text;
+  // An empty note is the strip being cleared, and scrolling a cleared strip to its
+  // end moves it for no reason anybody watching could account for.
+  if (!text) return;
+  const chips = ui.note.closest('.tchips');
+  if (chips) chips.scrollLeft = chips.scrollWidth;
+}
+
 let timeline = null;
 
 const timecode = (sec) => {
@@ -5944,7 +5978,7 @@ const timecode = (sec) => {
 };
 
 function showTimelineError(err) {
-  ui.note.textContent = String(err?.message ?? err);
+  say(String(err?.message ?? err));
   console.error('[timeline]', err);
 }
 
@@ -6889,7 +6923,8 @@ const isTyping = (el) => el instanceof HTMLElement && (TYPING_TAGS.has(el.tagNam
 
 const SHORTCUTS = 'space play/pause · arrows step a frame, with shift a second · '
   + 'home/end · i/o set in/out, with shift jump to them · del removes the selected key · '
-  + 'm marks · +/- zoom the ruler, ,/. pan it, f fits the clip, z frames in..out · '
+  + 'm marks, [/] jump to the previous and next mark · '
+  + '+/- zoom the ruler, ,/. pan it, f fits the clip, z frames in..out · '
   + 'cmd-z undoes · h hides the panel';
 
 /**
@@ -6977,6 +7012,25 @@ addEventListener('keydown', (e) => {
       return;
     case 'Delete': case 'Backspace': e.preventDefault(); deleteSelectedKey(); return;
     case 'm': case 'M': e.preventDefault(); markHere().catch(showTimelineError); return;
+    // The other half of item three, and the half that is actually usable: a tick is
+    // five pixels of diamond, so pressing one is a gesture and stepping through them
+    // is a key. Through `goTo` like Home and End, so a jump pauses and clamps the
+    // same way every other seek on this keyboard does.
+    //
+    // The epsilon is what stops a playhead parked exactly on a mark finding itself
+    // and going nowhere, which reads as the key not being bound at all. It is a
+    // microsecond of program time - smaller than any frame this program can show, so
+    // it can never skip a mark that is genuinely a step away.
+    case '[': case ']': {
+      e.preventDefault();
+      const here = timeline.programSec;
+      const seconds = markSecondsInOrder();
+      const to = e.key === '['
+        ? seconds.filter((s) => s < here - 1e-6).pop()
+        : seconds.find((s) => s > here + 1e-6);
+      if (to !== undefined) goTo(to);
+      return;
+    }
     // Zoom about the playhead rather than about the centre of the window, for the same
     // reason the wheel zooms about the pointer: the playhead is what the keyboard is
     // pointing at, and zooming away from it is zooming away from the edit.
@@ -7009,7 +7063,7 @@ addEventListener('keydown', (e) => {
       e.preventDefault();
       if (view.frame(clipIn, clipOut ?? view.duration)) viewChanged();
       return;
-    case '?': e.preventDefault(); ui.note.textContent = SHORTCUTS; return;
+    case '?': e.preventDefault(); say(SHORTCUTS); return;
     default:
   }
 });
@@ -7942,6 +7996,28 @@ function timingChanged({ moved = false } = {}) {
 let takeMarks = [];
 let openTakeId = null;
 
+// Where a mark is allowed to be on the ruler. A mark past the end of the edit stacks
+// at the edge rather than being dropped, and the tick and the key that jumps to it
+// have to agree about where the edge is - so the clamp is one expression both call
+// rather than the same arithmetic written twice, which is how a press could land the
+// playhead somewhere its own tick is not.
+const clampToClip = (sec, total) => Math.max(0, Math.min(total, sec));
+
+/**
+ * Every mark's position on the ruler, in program seconds and in order.
+ *
+ * Recomputed on each press rather than cached beside the ticks: the curve moves under
+ * these whenever a retime key is dragged, and a cached list is a second copy of the
+ * marks that is right until the moment somebody edits the timing - which is exactly
+ * the moment a jump-to-mark key gets pressed.
+ */
+const markSecondsInOrder = () => {
+  const total = view.duration;
+  return takeMarks
+    .map((m) => clampToClip(retime.programSecAt(m.sourceMs / 1000), total))
+    .sort((a, b) => a - b);
+};
+
 function paintMarks() {
   const host = ui.marks;
   if (!host) return;
@@ -7958,7 +8034,13 @@ function paintMarks() {
     // look right - so this is drawn through `programSecAt` even when it is the
     // identity.
     const program = retime.programSecAt(mark.sourceMs / 1000);
-    const el = document.createElement('span');
+    // A button rather than a span, which is the whole of item three: the surface the
+    // marks were pressed *for* drew them as decoration while the gallery's viewer -
+    // which only reviews footage - made its own ticks pressable. The seek this needs
+    // was already computed here at draw time, so the tick was one element name away
+    // from being the control it looks like.
+    const el = document.createElement('button');
+    el.type = 'button';
     // A mark the edit never reaches is drawn at the edge in the dim colour rather
     // than dropped. `programSecAt` returns where the curve ends for a source
     // position it never gets to, so this is the honest reading of that answer: the
@@ -7966,10 +8048,22 @@ function paintMarks() {
     // somebody shortened the clip would be worse than one that needs explaining.
     const beyond = program >= total - 1e-9 && mark.sourceMs / 1000 > retime.sourceSecAt(total) + 1e-9;
     el.className = beyond ? 'tmk beyond' : 'tmk';
-    const at = Math.max(0, Math.min(total, program));
+    const at = clampToClip(program, total);
     el.style.left = `${view.pct(at)}%`;
     el.hidden = !view.holds(at);
     el.title = `${mark.label ?? mark.id} · source ${(mark.sourceMs / 1000).toFixed(2)}s`;
+    // **The clamped second, never the mark's own source second.** The two coincide
+    // only at rate 1 with no keys, which is exactly the case that would let a wrong
+    // implementation look right - and a tick drawn against the edge because the edit
+    // never reaches it has to seek to the edge it is drawn at, or pressing it lands
+    // the playhead somewhere the tick is not.
+    //
+    // Both events are stopped, and the pointerdown is the one that matters. The bed
+    // scrubs on `pointerdown` rather than on `click`, so a click-only guard leaves
+    // the press starting a scrub to wherever the pointer was, and the tick's own seek
+    // arriving afterwards reads as a drag that happened to end on a mark.
+    el.addEventListener('pointerdown', (e) => e.stopPropagation());
+    el.addEventListener('click', (e) => { e.stopPropagation(); goTo(at); });
     host.appendChild(el);
   }
   // The same marks on the overview, in whole-clip coordinates. Built here rather than
@@ -8238,6 +8332,42 @@ async function importPresetFile(file) {
   return saved;
 }
 
+/**
+ * Offers the auto-save back, when it belongs to the take that has just opened.
+ *
+ * The undo stack writes the whole document to `__working__` after every change, and
+ * `refreshProjects` deliberately keeps that name out of the picker - it is not a
+ * document anybody chose, and listing it beside real projects offers "the thing you
+ * were just doing" under a name that reads like a mistake. That reasoning is right
+ * and it left the working document unreachable: opening the same take again gave a
+ * fresh clip with no sign that a session's work was sitting on disk beside it.
+ *
+ * **No extra request.** The list arrives with every document's body already on it, so
+ * the stamp this needs is in hand at the moment the take opens - and a fetch here
+ * would put a round trip in the path of every take opening for the sake of a note
+ * that usually has nothing to say.
+ */
+function offerWorkingDocument(projects) {
+  const working = projects?.find((doc) => doc.name === WORKING_PROJECT);
+  if (!working) return;
+  // **Matched on hash rather than on id.** A rename frees the old id and a later take
+  // can be renamed into it (#13), so an id match is a claim about a name where a hash
+  // match is a claim about footage - and offering somebody their edit back on top of
+  // different footage is a wrong answer that looks exactly like a right one.
+  if (!openTakeHash || working.body?.take?.hash !== openTakeHash) return;
+  // And it has to differ from the clip on screen, or the offer is to restore what is
+  // already there. `history.begin` has just serialised the on-screen document into
+  // `baseline`, so this compares like with like rather than serialising it a second
+  // time - and the two fields the auto-save adds come off first, since neither of
+  // them is part of what the clip is.
+  const body = { ...working.body };
+  delete body.history;
+  delete body.take;
+  if (JSON.stringify(body) === history.baseline) return;
+  say(`this take has autosaved work from ${new Date(working.savedAt).toLocaleString()}`
+    + ` - open it with ?project=${WORKING_PROJECT}`);
+}
+
 async function refreshProjects() {
   const list = await documentsIn('projects');
   ui.project.replaceChildren(new Option('—', ''));
@@ -8425,8 +8555,8 @@ function removeRetimeKey(key) {
   const i = retime.keys.indexOf(key);
   if (i < 0) return false;
   if (i === 0 && retime.keys.length > 1) {
-    ui.note.textContent = 'the first retime key anchors the start of the clip - '
-      + 'remove the ones after it first';
+    say('the first retime key anchors the start of the clip - '
+      + 'remove the ones after it first');
     return false;
   }
   retime.keys.splice(i, 1);
@@ -8533,7 +8663,7 @@ function applyEasePreset(name) {
 for (const btn of ui.ease.querySelectorAll('button[data-ease]')) {
   btn.addEventListener('click', () => {
     const owner = selection?.owner ?? '';
-    if (applyEasePreset(btn.dataset.ease)) ui.note.textContent = `${btn.dataset.ease} ease on ${owner}`;
+    if (applyEasePreset(btn.dataset.ease)) say(`${btn.dataset.ease} ease on ${owner}`);
   });
 }
 
@@ -9618,7 +9748,7 @@ ui.presetApply.addEventListener('click', async () => {
   if (!name) return;
   try {
     applyStoredPreset(await (await fetch(`/presets/${encodeURIComponent(name)}`)).json());
-    ui.note.textContent = `applied ${name} · ${appliedPreset.rev.slice(7, 15)}`;
+    say(`applied ${name} · ${appliedPreset.rev.slice(7, 15)}`);
   } catch (err) {
     showTimelineError(err);
   }
@@ -9642,7 +9772,7 @@ ui.presetSave.addEventListener('click', async () => {
     // the provenance say a look this clip no longer has.
     appliedPreset = { name: saved.name, rev: saved.rev };
     await refreshPresets();
-    ui.note.textContent = `saved ${saved.name} · ${saved.rev.slice(7, 15)}`;
+    say(`saved ${saved.name} · ${saved.rev.slice(7, 15)}`);
     history.commit();
   } catch (err) {
     showTimelineError(err);
@@ -9657,7 +9787,7 @@ ui.presetExport.addEventListener('click', () => {
   try {
     const name = ui.preset.value || appliedPreset?.name || 'look';
     exportPresetFile(name, presetFromCurrentLook());
-    ui.note.textContent = `exported ${name}.braindance-preset.json`;
+    say(`exported ${name}.braindance-preset.json`);
   } catch (err) {
     showTimelineError(err);
   }
@@ -9677,7 +9807,7 @@ ui.presetFile.addEventListener('change', async () => {
     const saved = await importPresetFile(file);
     await refreshPresets();
     ui.preset.value = saved.name;
-    ui.note.textContent = `imported ${saved.name} · ${saved.rev.slice(7, 15)}`;
+    say(`imported ${saved.name} · ${saved.rev.slice(7, 15)}`);
   } catch (err) {
     showTimelineError(err);
   }
@@ -9701,7 +9831,7 @@ ui.projectSave.addEventListener('click', async () => {
     if (saved.error) throw new Error(saved.error);
     await refreshProjects();
     ui.project.value = saved.name;
-    ui.note.textContent = `saved ${saved.name} · ${saved.bytes} bytes`;
+    say(`saved ${saved.name} · ${saved.bytes} bytes`);
     rememberOpened();
   } catch (err) {
     showTimelineError(err);
@@ -9726,7 +9856,7 @@ ui.deliverable.addEventListener('change', async () => {
     if (doc.error) throw new Error(doc.error);
     applyDeliverable(doc.body);
     history.commit();
-    ui.note.textContent = `deliverable ${name}`;
+    say(`deliverable ${name}`);
   } catch (err) {
     showTimelineError(err);
   }
@@ -9740,7 +9870,7 @@ ui.deliverableNew.addEventListener('click', async () => {
     await saveDeliverable(name, activeDeliverable);
     await refreshDeliverables();
     ui.deliverable.value = name;
-    ui.note.textContent = `saved deliverable ${name}`;
+    say(`saved deliverable ${name}`);
   } catch (err) {
     showTimelineError(err);
   }
@@ -9793,7 +9923,7 @@ async function loadProjectNamed(name) {
   await timeline.seek(timeline.programSec);
   if (resume && gen === transportGen) timeline.play();
   ui.project.value = name;
-  ui.note.textContent = `opened ${name}`;
+  say(`opened ${name}`);
   rememberOpened();
   return doc;
 }
@@ -9855,13 +9985,12 @@ function paintRecord(storage) {
   }
 }
 
-async function pollRecord() {
-  try {
-    const state = await (await fetch('/record/state')).json();
-    recordState = state;
-    paintRecord(state.storage);
-  } catch { /* a server that went away is the status line's problem, not this one's */ }
-}
+// This page's tick of the shared poll, held so the record button can ask again the
+// instant it has changed something rather than waiting out the cadence. Assigned by
+// the boot block below, and only on the live surface: an editor has no recorder to
+// ask about, and a second poll started for the sake of a button is the copy this
+// module exists to avoid.
+let askRecordState = async () => {};
 
 if (ui.recGo) {
   ui.recGo.addEventListener('click', async () => {
@@ -9877,7 +10006,7 @@ if (ui.recGo) {
       if (body.error) ui.recNote.textContent = body.error;
     } finally {
       ui.recGo.disabled = false;
-      await pollRecord();
+      await askRecordState();
     }
   });
   ui.recMark.addEventListener('click', async () => {
@@ -9939,6 +10068,14 @@ ui.camView.addEventListener('click', () => {
 // the index the source already fetched rather than recomputed, because rehashing
 // gigabytes on every project save is exactly what step 2's design refuses.
 let openTakeHash = null;
+
+// Whether `openTake` has run to the end. Exposed on the check hook, and it is there
+// because a transport that exists is not a take that has opened: `timeline` is
+// assigned less than halfway through, before the library is listed and before the
+// resume offer has been decided, so a check waiting on the transport can read the note
+// a whole fetch before anything has written it. That is a race a passing run cannot be
+// told apart from a broken feature, and it cost a reproduction here.
+let takeOpened = false;
 
 async function openTake(id) {
   const source = await IndexedPairSource.open(id);
@@ -10024,23 +10161,30 @@ async function openTake(id) {
   // sequence leave only the last one on screen - and the recorder's own note, which
   // already reported this, is on a surface the editor does not show.
   const unavailable = [];
+  const listed = {};
   for (const [what, refresh] of [['presets', refreshPresets], ['projects', refreshProjects],
     ['deliverables', refreshDeliverables]]) {
-    await refresh().catch((err) => unavailable.push(`${what} (${err.message})`));
+    listed[what] = await refresh().catch((err) => { unavailable.push(`${what} (${err.message})`); return null; });
   }
-  if (unavailable.length) ui.note.textContent = `library unavailable: ${unavailable.join('; ')}`;
+  if (unavailable.length) say(`library unavailable: ${unavailable.join('; ')}`);
   ensureActiveDeliverable();
   applyDeliverable(activeDeliverable);
   timingChanged();
   // The stack starts from whatever the clip already is, so the first undo has
   // somewhere honest to land rather than an empty document.
   history.begin();
+  // After `begin`, because the offer is about whether the auto-save differs from the
+  // clip on screen and `baseline` is that clip serialised. Skipped when any part of
+  // the library failed to list, so the offer cannot write over the sentence naming
+  // what is broken - a note nobody can see is the failure this whole change is about.
+  if (!unavailable.length) offerWorkingDocument(listed.projects);
   await timeline.seek(0);
   // Two things per frame, and the second is not an afterthought: with the playhead
   // parked `tick` returns immediately, so this is the only clock a paused editor has.
   // A drag that continued itself off its own renders instead is what this loop was
   // added to replace - see `pumpDraft`.
   renderer.setAnimationLoop(() => { timeline.tick(); pumpParkedDraft(); });
+  takeOpened = true;
   return timeline;
 }
 
@@ -10159,8 +10303,16 @@ if (EDITING && !REQUESTED_TAKE) {
   // Polled rather than pushed because free space changes on its own - another
   // process writing, a card filling - and a number that only moved when the
   // recorder did would be stale in the one direction that matters.
-  pollRecord();
-  setInterval(pollRecord, 5000);
+  //
+  // **Which is why this caller ignores the change flag entirely.** The gallery gates
+  // on it because a repaint there throws away what the operator is pointing at; here
+  // there is nothing to throw away and a gated readout would simply stop being true.
+  // The flag is offered to both and read by one, which is the shape that lets the
+  // module have no opinion about either surface.
+  askRecordState = pollRecordState((state) => {
+    recordState = state;
+    paintRecord(state.storage);
+  });
 }
 
 // Handles for profiling and for poking at the scene from the console.
@@ -10459,6 +10611,12 @@ globalThis.__kinect = {
     markHere,
     takeId: () => openTakeId,
     takeHash: () => openTakeHash,
+    /**
+     * Whether `openTake` finished, which is the only moment its last decision - the
+     * resume offer - has been made. A check that waits for the transport instead is
+     * waiting on something assigned two fetches earlier.
+     */
+    opened: () => takeOpened,
     /** Where each mark ticks on the ruler, as the page actually drew it. */
     markTicks: () => [...document.querySelectorAll('#tMarks .tmk')].map((el) => ({
       left: Number.parseFloat(el.style.left),

--- a/web/main.js
+++ b/web/main.js
@@ -10137,7 +10137,27 @@ ui.projectOpen.addEventListener('click', async () => {
 // looks like it does something.
 ui.resumeOpen.addEventListener('click', async () => {
   try {
-    await loadProjectNamed(WORKING_PROJECT, offeredWorkingBody);
+    const accepted = offeredWorkingBody;
+    await loadProjectNamed(WORKING_PROJECT, accepted);
+    // **Written back before the snapshot is dropped, or the recovery lasts only as long
+    // as the tab.** Holding the offered body fixed which document the press restores;
+    // it did not make the restore survive anything. `__working__` still held the edit
+    // that overwrote the offer, this was the only remaining copy, and nothing writes the
+    // slot again until the next `history.commit()` - so closing the page after being
+    // told "restored the autosaved edit" loaded the overwriting edit back and lost the
+    // work a second time, having just reported it recovered.
+    //
+    // Awaited and reported rather than fired and forgotten, unlike the auto-save on
+    // every edit: that one is one of thousands and must not block a drag, while this is
+    // the single moment the operator asked for their work back. A failure here has to
+    // reach them, and the snapshot is kept if it does - dropping it would throw away the
+    // last copy on the way out of a failed save.
+    const kept = await fetch(`/projects/${WORKING_PROJECT}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(accepted),
+    });
+    if (!kept.ok) throw new Error(`restored on screen, but the auto-save could not be rewritten: ${(await kept.text().catch(() => '')).slice(0, 80)}`);
     ui.resume.hidden = true;
     offeredWorkingBody = null;
     say('restored the autosaved edit');

--- a/web/menu.html
+++ b/web/menu.html
@@ -18,7 +18,12 @@
     --paper-3: #1e232b;
     --ink: #e8ecf1;
     --dim: #8b94a1;
-    --faint: #6d7683;
+    /* 4.63:1 on --paper-3, 5.59:1 on --paper-1 - the tile an unreachable entry sits on
+       - and 5.92:1 on the page. It was #6d7683, under the 4.5:1 floor on all four. The
+       identical value is in index.html and library.html and has to stay identical:
+       nav.css reads var(--faint) without declaring it, so one page raised on its own
+       makes the same nav item legible on one surface and not the next. */
+    --faint: #828c99;
     --line: rgba(255, 255, 255, 0.1);
     --line-2: rgba(255, 255, 255, 0.2);
     --line-3: rgba(255, 255, 255, 0.34);

--- a/web/record-poll.js
+++ b/web/record-poll.js
@@ -1,0 +1,75 @@
+/**
+ * The one poll of `/record/state`, shared by the two surfaces that need it.
+ *
+ * **What is shared is the fetch and the change detection, and deliberately not the
+ * painting.** The editor's `pollRecord` was welded to `paintRecord`, `recordState`
+ * and the recorder's own elements, none of which exist on the gallery page - so
+ * lifting the whole thing would have brought a pile of `null` element writes with
+ * it, and copying the fetch into `library.js` would have been the second drifting
+ * path this design keeps rejecting. What both surfaces genuinely have in common is
+ * "ask the recorder what it is doing, on a cadence, and say whether it moved".
+ *
+ * **The gate lives at the caller, and that is not an accident of layering.** The two
+ * surfaces want opposite things from the same tick. The editor paints on every one,
+ * because the remaining-space readout changes on its own - another process writing,
+ * a card filling - and a number that only moved when the recorder did would be stale
+ * in the one direction that matters. The gallery must repaint on almost none of them:
+ * `paint()` closes every menu, releases every skim and replaces every tile, so a
+ * gallery that repainted every five seconds would fight the operator's pointer. A
+ * module that decided this would have to be wrong for one of them.
+ *
+ * `/record/state` rather than `/library/all`, because it is the cheap question. The
+ * library listing walks the captures directory and, where a node is linked, crosses
+ * the network to it; the recorder's state is memory this process already holds. The
+ * gallery pays for a listing only when the answer has changed.
+ *
+ * Not under a `record/` directory: `/record` is a namespace the server's route table
+ * owns, and the dispatcher answers for every path under an owned namespace before the
+ * file server gets a turn - so a module living there would be a 404 with a very
+ * confusing shape. A flat name at the web root has no namespace to collide with.
+ */
+
+// Five seconds, which is what the editor's own poll ran at and is short enough that a
+// gallery tile stops lying within one of them. Not a parameter: two surfaces polling
+// the same route at two cadences is two behaviours to reason about, and neither of
+// them has a reason to want a different one.
+const EVERY_MS = 5000;
+
+/**
+ * Polls the recorder and hands every tick to `saw(state, changed)`.
+ *
+ * `changed` is true when the recording flag or the take id differs from the previous
+ * tick - the two facts that decide what a gallery tile is allowed to say about a take.
+ * Frame counts and free space move constantly and are deliberately not in it, or the
+ * flag would be true on every tick and mean nothing.
+ *
+ * **The first tick reports `changed: false`**, because the flag is a difference
+ * between two observations and there has only been one. A first tick claiming a change
+ * would make every caller that gates on it do its expensive thing once at load, which
+ * on the gallery is a full repaint of a grid that was drawn a moment ago.
+ *
+ * Returns the tick itself, so a caller that has just changed something - pressing
+ * record is the case - can ask again immediately instead of waiting out the cadence.
+ * That is the same poll rather than a second one: it updates the same `previous`, so
+ * the tick it displaces cannot report a change that has already been seen.
+ */
+export function pollRecordState(saw) {
+  let previous = null;
+  const tick = async () => {
+    let state;
+    try {
+      state = await (await fetch('/record/state')).json();
+    } catch {
+      // A server that went away is the status line's problem, not this one's, and a
+      // poll that stopped on the first failed fetch would never notice it come back.
+      return;
+    }
+    const changed = previous !== null
+      && (previous.recording !== state.recording || previous.takeId !== state.takeId);
+    previous = state;
+    saw(state, changed);
+  };
+  tick();
+  setInterval(tick, EVERY_MS);
+  return tick;
+}

--- a/web/record-poll.js
+++ b/web/record-poll.js
@@ -114,7 +114,30 @@ const fingerprint = (state) => [
  */
 export function pollRecordState(saw, believed = null) {
   let previous = believed === null ? null : fingerprint(believed);
+  // **One tick at a time, which is the debt the retry above took on.** Holding
+  // `previous` back until the handler finishes is what lets a failed refresh be offered
+  // again - and it also means a handler that never finishes leaves every later tick
+  // still reporting the same change. The interval does not care: it would start another
+  // `/library/all` every five seconds for as long as the first one hung, and where the
+  // library spans a linked node that is a request and a connection to the other machine
+  // each time, accumulating for as long as the page is open. A node that accepts a
+  // connection and then says nothing is not hypothetical here - `recordState` carries a
+  // three-second timeout for exactly that machine.
+  //
+  // Skipped rather than queued, because a tick is a question about what is true now: a
+  // queue of them would answer with a backlog of stale moments, and the one still in
+  // flight is already asking the question the skipped tick wanted answered.
+  let inFlight = false;
   const tick = async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await run();
+    } finally {
+      inFlight = false;
+    }
+  };
+  const run = async () => {
     let state;
     try {
       state = await (await fetch('/record/state')).json();

--- a/web/record-poll.js
+++ b/web/record-poll.js
@@ -66,9 +66,27 @@ const EVERY_MS = 5000;
  * the same reason: the gallery prints "unreachable" beside the node's name, so a link
  * dropping or coming back changes what is on screen.
  */
+/**
+ * The fields of a node's `/record/state` this fingerprint is computed from, named once
+ * so the link that admits a node can require exactly them.
+ *
+ * **A list rather than a spelling inside the expression below, because the boundary is
+ * on the other machine's build and had no way to know what this reads.** `NodeLink`
+ * fills a missing field in with `?? null`, which is right for a node that is simply not
+ * writing and wrong for one that has never heard of the field: a build one older than
+ * this one answers `/record/state` without `writingId` at all, passes the manifest gate
+ * `takes()` applies, and then reads as an idle recorder on every tick forever - so the
+ * fingerprint is constant, no remote start or stop ever changes it, and the gallery
+ * stops following the recorder it is drawing. Exported, so `server/library.js` requires
+ * what this actually reads rather than a copy of it somebody has to remember to widen.
+ */
+export const POLLED_NODE_FIELDS = ['writingId'];
+
 const fingerprint = (state) => [
   state.writingId ?? '',
-  state.node ? `${state.node.reachable}:${state.node.writingId ?? ''}` : '',
+  state.node
+    ? [state.node.reachable, ...POLLED_NODE_FIELDS.map((f) => state.node[f] ?? '')].join(':')
+    : '',
 ].join('|');
 
 /**

--- a/web/record-poll.js
+++ b/web/record-poll.js
@@ -93,6 +93,20 @@ const fingerprint = (state) => [
  * first tick reports no change, because a first tick claiming one would make it do its
  * expensive thing once at load for no reason.
  *
+ * **A tick counts as seen only once the caller has actually dealt with it, which is
+ * what `await` and the missing assignment in the catch are for.** `previous` moving on
+ * its own made a failed handler permanent: the gallery reads the library when this
+ * reports a change, and one refresh losing its connection advanced the fingerprint past
+ * the transition it failed on - so every later tick matched, reported no change, and the
+ * grid kept a finished take's actions disabled until something else moved. A handler
+ * that throws leaves `previous` where it was, so the next tick puts the same change in
+ * front of it again and the retry costs nothing to arrange.
+ *
+ * Swallowed here rather than left to reject, because `tick` is what the interval calls:
+ * an async function rejecting into a timer is an unhandled rejection and a console the
+ * page's own error sweep would then fail on. The caller has already said whatever it
+ * wants to say about its own failure - this only decides whether to ask again.
+ *
  * Returns the tick itself, so a caller that has just changed something - pressing
  * record is the case - can ask again immediately instead of waiting out the cadence.
  * That is the same poll rather than a second one: it updates the same `previous`, so
@@ -111,8 +125,10 @@ export function pollRecordState(saw, believed = null) {
     }
     const mark = fingerprint(state);
     const changed = previous !== null && previous !== mark;
-    previous = mark;
-    saw(state, changed);
+    try {
+      await saw(state, changed);
+      previous = mark;
+    } catch { /* not seen, so not recorded as seen - the next tick offers it again */ }
   };
   tick();
   setInterval(tick, EVERY_MS);

--- a/web/record-poll.js
+++ b/web/record-poll.js
@@ -44,10 +44,19 @@ const EVERY_MS = 5000;
 /**
  * What a tick has to differ in for the answer drawn from it to be worth redrawing.
  *
- * The recording flag and the take id, on both machines - the two facts that decide
- * what a gallery tile is allowed to say about a take, asked of this server's recorder
- * and of the linked node's. Frame counts and free space move constantly and are
- * deliberately not in it, or the flag would be true on every tick and mean nothing.
+ * The take each recorder still owns, on both machines - the one fact that decides what
+ * a gallery tile is allowed to say about a take. Frame counts and free space move
+ * constantly and are deliberately not in it, or the flag would be true on every tick
+ * and mean nothing.
+ *
+ * **`writingId` rather than the recording flag and the take id, and the difference is
+ * the several seconds between them.** A take stops being recorded well before it stops
+ * being the recorder's: the stream still has to flush, the marks still have to land and
+ * the index and the content hash - which are what make the take a gallery entry at all
+ * - are built after that. The flag went false at the front of that window, so a gallery
+ * following it reread the library into the middle of a close and drew Download, Rename
+ * and Remove over a take with no hash yet. `writingId` spans the whole of it, so the
+ * one repaint this poll pays for lands where the answer actually changed.
  *
  * **Both recorders, because the gallery is a view of both libraries.** A station with
  * a `--node` draws the node's takes into the same grid, and it is the machine the
@@ -58,8 +67,8 @@ const EVERY_MS = 5000;
  * dropping or coming back changes what is on screen.
  */
 const fingerprint = (state) => [
-  state.recording, state.takeId ?? '',
-  state.node ? `${state.node.reachable}:${state.node.recording}:${state.node.takeId ?? ''}` : '',
+  state.writingId ?? '',
+  state.node ? `${state.node.reachable}:${state.node.writingId ?? ''}` : '',
 ].join('|');
 
 /**
@@ -67,18 +76,30 @@ const fingerprint = (state) => [
  *
  * `changed` is true when this tick's fingerprint differs from the previous one's.
  *
- * **The first tick reports `changed: false`**, because the flag is a difference
- * between two observations and there has only been one. A first tick claiming a change
- * would make every caller that gates on it do its expensive thing once at load, which
- * on the gallery is a full repaint of a grid that was drawn a moment ago.
+ * **`believed` is what the caller has already drawn, and passing it is what makes the
+ * first tick able to answer at all.** Without it the first tick has nothing to compare
+ * against and must report `changed: false`, which is a hole rather than a caution: the
+ * gallery reads `/library/all`, paints a take as being written, and only then asks the
+ * recorder - so a take that stopped inside that gap is stopped in every fingerprint
+ * this poll will ever compute, none of them differ, and the tile goes on refusing to
+ * open a finished take until somebody reloads the page. Seeded, the first tick is a
+ * comparison like every other one, against the world the caller actually drew.
+ *
+ * It is a state-shaped object rather than a fingerprint string, and it goes through
+ * the same `fingerprint` above, so there is one expression of what counts as a change
+ * rather than a caller's copy of it to drift.
+ *
+ * A caller with nothing painted yet passes nothing, and gets the old behaviour: the
+ * first tick reports no change, because a first tick claiming one would make it do its
+ * expensive thing once at load for no reason.
  *
  * Returns the tick itself, so a caller that has just changed something - pressing
  * record is the case - can ask again immediately instead of waiting out the cadence.
  * That is the same poll rather than a second one: it updates the same `previous`, so
  * the tick it displaces cannot report a change that has already been seen.
  */
-export function pollRecordState(saw) {
-  let previous = null;
+export function pollRecordState(saw, believed = null) {
+  let previous = believed === null ? null : fingerprint(believed);
   const tick = async () => {
     let state;
     try {

--- a/web/record-poll.js
+++ b/web/record-poll.js
@@ -127,16 +127,31 @@ export function pollRecordState(saw, believed = null) {
   // Skipped rather than queued, because a tick is a question about what is true now: a
   // queue of them would answer with a backlog of stale moments, and the one still in
   // flight is already asking the question the skipped tick wanted answered.
-  let inFlight = false;
-  const tick = async () => {
-    if (inFlight) return;
-    inFlight = true;
-    try {
-      await run();
-    } finally {
-      inFlight = false;
+  //
+  // **A caller asking during one gets a rerun rather than a discarded question, and
+  // that is the difference between the two ways in.** The cadence wants the guard: a
+  // tick that is still running is the tick this one would have been. The record button
+  // wants the opposite - it awaits this to repaint from the state its own POST just
+  // produced, so returning the request already in flight hands it a snapshot taken
+  // *before* the press, and on a station with a slow `--node` that snapshot is several
+  // seconds old. The button then re-enables against stale state and the next click can
+  // choose start where it meant stop.
+  //
+  // One rerun however many callers ask, and they all await the same one: the question
+  // is "what is true after my action", and a single fresh read answers it for all of
+  // them. The interval comes in through `onCadence` below, which skips instead, so a
+  // handler that hangs still cannot stack listings behind it.
+  let running = null;
+  let rerun = null;
+  const tick = () => {
+    if (running) {
+      if (!rerun) rerun = running.then(() => { rerun = null; return tick(); });
+      return rerun;
     }
+    running = run().finally(() => { running = null; });
+    return running;
   };
+  const onCadence = () => { if (!running) tick(); };
   const run = async () => {
     let state;
     try {
@@ -154,6 +169,6 @@ export function pollRecordState(saw, believed = null) {
     } catch { /* not seen, so not recorded as seen - the next tick offers it again */ }
   };
   tick();
-  setInterval(tick, EVERY_MS);
+  setInterval(onCadence, EVERY_MS);
   return tick;
 }


### PR DESCRIPTION
Closes #48.

Seven independent defects on the surfaces an operator looks at. They share a shape
rather than a subsystem: in every one the program knows the right answer and has no way
to say it, or says it somewhere nobody is looking.

## What changed

**One — the error channel was unreadable when it mattered most.** `showTimelineError`
wrote `#tNote` and nothing else, and fifteen sites wrote that property directly. `#tNote`
lives in `.tchips`, which is `overflow-x: auto` with `scrollbar-width: none`, so a
sentence wider than the strip had no scrollbar to drag and no `title` to hover — and a
refusal is exactly the message that runs long. All fifteen now go through one `say()`,
which writes the text, writes the same text into `title`, and scrolls the strip to the
message that just arrived (after the write, or `scrollWidth` is the previous message's).
`grep -c 'ui.note.textContent' web/main.js` returns 1 and that one line is inside `say`.

**Two — the gallery was a snapshot taken at load.** Nothing polled, so a tile went on
saying a take was still being written for as long as the page stayed open, with Open,
Download, Rename and Remove disabled behind that warning. `pollRecord` is now the shared
module `web/record-poll.js`: same five-second cadence, handing each caller the parsed
state plus a flag saying whether the recording flag or the take id moved. `pollRecord` is
**deleted, not duplicated** — `grep -rn "fetch('/record/state')" web/` matches one file.
The gate is at the caller and not in the module, because the two surfaces want opposite
things from one tick: the editor paints every time, since free space changes on its own,
and the gallery repaints only on a change, since `paint()` closes every menu, releases
every skim and replaces every tile.

**Three — marks were drawn on the editor's ruler and nothing jumped to one.** The tick is
a `button` now, seeking to the clamped program second the drawing code already computed,
plus `[` and `]` bound through `goTo` beside Home and End. The clamp is one expression the
tick and the keys both call, so a press cannot land the playhead where its own tick is
not. Both `pointerdown` and `click` are stopped — the bed scrubs on `pointerdown`, so a
click-only guard would let the press start a scrub first.

**Four — sensor health was readable only by attaching a monitor**, and
`consumersCostingTheTake` exists because an attached monitor can cost the take frames, so
the one instrument for "is this sensor well" made it less well. `/sensor/health` is a
`read` entry in `ROUTES` — not a branch beside the dispatcher, because `/library/routes`
publishes the table and `library-check` sweeps what it publishes. Neither `write` (it
changes nothing) nor `live` (it reports numbers about the sensor, not what the sensor is
seeing). It serves the sensor state, the last window's fps and byte rate, that window's
own length and frame count, a monotonic dropped count, and the respawns and the requested
restarts as two separate numbers.

**Five — the health window did not close when it was empty.** The reset sat past the
`stats.frames === 0` early return, so a frameless window kept `stats.since` and the first
window after a sixty-second drop was divided by sixty-five seconds — about a thirteenth of
the true rate, into the log and into `observedBytesPerSec`, which the remaining-time
readout divides free space by. The reset moved above the return; the printing and the rate
write stay behind it, so the last honest measurement stands rather than being replaced by
one computed over a window that never happened.

**Six — one token, three declarations.** `--faint` was `#6d7683`. It is `#828c99` in all
three pages, together, because `web/nav.css` styles the current surface with
`var(--faint)` and declares it nowhere.

**Seven — the auto-save had no way back into the editor.** `refreshProjects` hides
`__working__` from the picker for a good reason, and that left a session's work
unreachable. `openTake` offers it back as a chip beside the project picker — the stamp it
was saved at, and a button — when the working document's take hash matches the footage
just opened **and** the document differs from the clip on screen. On hash and not on id: a
rename frees an id and a later take can be renamed into it (#13), so an id match is a
claim about a name where a hash match is a claim about footage. No extra request; the list
already carries every document's body.

## What the review found, and what closed it

**The gallery's poll watched the wrong recorder on the machine it is used from.** An
editing station runs with `--node` and no sensor of its own, so `/library/all` reconciles
the node's takes into its grid while `/record/state` reported a recorder that never moves.
A take started and finished on the node changed nothing, and its tile went on refusing
every action for as long as the page stayed open — the exact staleness item two is about,
surviving on the one machine somebody is standing at. `/record/state` now carries the
linked node's recording flag and take id beside this machine's own, and the poll's
fingerprint spans both. Bounded at 3s where `NodeLink.takes()` is unbounded, because this
call sits on a five-second tick: a node that accepts a connection and then says nothing
would stall every tick behind it.

Polling `/library/all` directly was measured and rejected — the numbers are below.

**A colour toggle read as the sensor flapping.** `applyCamera` deliberately stops a
healthy grabber and spawns another, and the respawn counter counted it, so a
configuration change reported as a fault and the endpoint's own claim that a healthy node
reads zero stopped being true of any node anybody had touched. Requested restarts are
counted where the exit is *consumed* rather than where `restarting` is armed — that flag
can be set and never read, and an arm that never becomes a spawn would subtract a respawn
that did happen. Reported beside the respawns rather than folded into them, so a node that
restarted forty times for forty toggles cannot read as never having restarted.

**The autosave offer was an instruction that did not work.** It named
`?project=__working__`, which replaces the query the editor boots on, drops the `take`,
and lands on `/gallery`. An offer whose recovery path leaves the page is worse than no
offer, because the work is still there and the operator now believes they tried. It is a
button, and it presses `loadProjectNamed` — the same door the resume URL opens, so the
same hash refusal on the way in and no navigation at all.

**`editor-check`'s driver table had a rule that matched nothing.** Every entry carried a
`match` written against a DOM element while `covered()` re-spelled the same condition
against the serialized row, so no `match` in the file was ever executed. The rule added
for the mark ticks matched nothing, said nothing, and the sweep went on reporting every
control covered — with the ticks outside its selector as well, so the class was invisible
twice over and each half is why the other went unnoticed. `match` is the implementation
now and `covered()` walks the table; `.tlanes` is in the sweep; and a new row asserts
**every rule matches at least one control the page renders**, which is what would have
caught it. Order became precedence with the widest rule last, so the panel-wide rule
cannot claim a control three narrower rules are the honest attribution for.

## Measurements

**Contrast (item six).** sRGB relative luminance, ratios against every `--paper` token
the pages declare:

| | page `#05070a` | `--paper-1` `#0d1014` | `--paper-2` `#151920` | `--paper-3` `#1e232b` |
|---|---|---|---|---|
| old `#6d7683` | 4.39 | 4.15 | 3.83 | 3.43 |
| new `#828c99` | **5.92** | **5.59** | **5.17** | **4.63** |

All four clear the WCAG AA 4.5:1 floor for body text; the old value cleared none of them.
`--paper-2` is the popup menu a disabled item is read on and `--paper-3` is the lightest
surface in the palette, so the value is chosen against the worst case rather than against
the page. It stays darker than `--dim` (`#8b94a1`, 5.15 on `--paper-3`), so the intended
hierarchy is unchanged.

**The two routes the gallery could poll.** Interleaved A/B, 20 pairs alternating them
against a 200-take library, both servers' indexes warm and the sidecars written, the first
eight pairs discarded as page cache settling, the pair linked so the listing includes its
node round trip: **1.2ms for `/record/state` against 145ms for `/library/all`.** The
deciding fact is not the ratio but where it comes from — `describeTake` reads a marks
sidecar per take on both machines, so a five-second cadence over the listing would spend
four hundred sidecar reads per tick to answer a question that is almost always no, against
a recorder whose own comment says that contention is what turns a slow card into dropped
frames. Cold, for anyone who meets it as a regression: the first listing over 200
unindexed takes took 7m30s writing an `.idx` per file, and a second server over the same
directory warmed in 2.4s off those sidecars.

**The health window (item five).** On a server with no sensor: 5001ms at T+12s and 5001ms
at T+21s. Under `empty-window-keeps-its-start` the same reading is **416389ms carrying 0
frames against 417s of server uptime** — the window is the whole outage, which is the
defect. On a server with a fake grabber at 40fps: 15.5 fps over 5105ms carrying 79 frames.

**The note (item one).** The longest refusal this program writes measures 238 characters,
2632px of content in a 1203px strip.

## Proof

Run against the real `captures/sample.knct` (138MB) rather than a synthesised stand-in, so
the two decimation rows `docs/proof-tools.md` names are answerable.

```
editor-check --no-render                       252 assertions, 0 failed
  --mutate note-skips-title                    1 failed - the title row, alone
  --mutate tick-seeks-source-seconds           2 failed - both tick-press rows: the
                                               playhead lands at 3.000s, the source
                                               second, where the tick is drawn at 6.000s
  --mutate offer-ignores-take-hash             1 failed - the different-footage row, with
                                               the chip shown carrying its stamp
  --mutate plant-unswept-control               1 failed - "1 uncovered: tPlantedControl",
                                               which is the control for the section 1
                                               rewrite and still catches what it did

library-check                                  395 assertions, none failed
  --mutate health-answers-beside-the-table     the "is a ROUTES entry" row: not in the
                                               table of 38
  --mutate empty-window-keeps-its-start        the empty-window row: 30006ms carrying 0
                                               frames against 34s of uptime
  --mutate poll-refreshes-every-tick           the quiet-tick row: the grid was rebuilt
  --mutate pulse-ignores-the-node              2 failed - the split precondition (node
                                               undefined) and the follow row, whose tile
                                               still reads "flags recording, Open (off)"
  --mutate respawns-count-a-colour-toggle      2 failed - 1 respawn where a healthy node
                                               reads 0, and 0 restarts where the toggle
                                               made one
  --mutate faint-fixed-in-one-page             library.html's contrast row (4.39 / 4.15 /
                                               3.83 / 3.43) and the agreement row, with
                                               index.html and menu.html staying green
  --mutate marks-ignore-retime                 2 failed - the curve rows, ticks at the
                                               source fraction (16.3% where the curve
                                               puts 63.4%); the control this branch
                                               re-anchored
  --mutate open-take-swallows-library          2 failed - both empty-note rows; the other
                                               control this branch re-anchored

npm test                                       syntax-check + release-gate-check, 0 failed
  anchors/                                     all 259 in 14 tables match once, of 16
                                               declared - the sweep #58 added
```

`tick-seeks-source-seconds` is invisible at rate 1 with no keys, so the row that drives it
sets 0.5x through `#tRate` and asserts the separation before it presses anything.
`pulse-ignores-the-node` reddens only the linked station's rows and leaves the
direct-gallery rows above them green, which is the separation that says the defect is
specific to the machine whose recorder is somewhere else — the reason it survived a
section that served the gallery from the recorder.

## Three things a reviewer should know

**`web/main.js` gained `takeOpened` and a `library.opened()` check hook, which is beyond
the issue's scope list for that file.** It is named here rather than left to a diff. It
exists because `timeline` is assigned two fetches before the resume offer is decided, so a
check that waits on the transport reads the note before anything has written it — that
produced an empty note on a build that works, which is the shape this repo has twice
written down as a bug found.

**Two of the suite's own controls were re-anchored, and both were verified to still be the
control they were.** `open-take-swallows-library` names the library-refresh loop, which
item seven made keep each list instead of discarding it; the re-anchored version still
throws the reason away and still returns `null`. `marks-ignore-retime` was re-anchored by
#58 to the mark line *plus the `createElement('span')` after it*, because the mini-map
builds its ticks from the identical expression — and item three put a paragraph of comment
between the two, so the neighbour doing the separating stopped being adjacent. It anchors
on a property of the line itself now: a leading newline and four spaces cannot match the
six-space line inside the `miniMarks` map. Both redden their own rows above.

**Two pre-existing defects were found while proving this and filed rather than absorbed.**
#63 — `Transport.seek` can resolve without moving the playhead: `seekNow` stands down after
`SEEK_REPLANS` attempts when the span it needs is not resident, and `settled()` reports
idle either way, so a `seek(x); settled(); assert(...)` row goes red naming the thing under
test. Reproduced on `origin/main` at 1 in 8 and here at 1 in 5, load averages 199–241, same
script both sides. #64 — `library-check`'s log sweep runs whole log lines through
`/Error|throw|unhandled/i` and those lines carry absolute paths, so a worktree named after
an issue containing the word fails the run: 368 assertions none failed, then `FAIL (20)`
and exit 1, with the count coming from a bare `failures++` that prints no row. Every run
quoted above was taken from a neutrally-named worktree of this same commit.

Contention is worth stating too: this machine ran between load 11 and load 260 during these
runs, and the high end produced failures in rows this branch does not touch — the seek flake
above, a viewer focus row, and one crash in the gallery skim section. Each cleared on a
re-run at low load, and the quoted baselines were taken at 11–30. That is the case CLAUDE.md
documents costing five reproductions.
