### PR TITLE
Let CLAUDE.md's jobs-check entry describe the tool that exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ node tools/library-check.mjs --mutate list-swallows-unreadable # ... and must FA
 node tools/library-check.mjs --mutate open-take-swallows-library # ... and must FAIL
 node tools/library-check.mjs --mutate one-refusal-for-older-versions # ... and must FAIL
 node tools/library-check.mjs --mutate open-ignores-format          # ... the capture's generation, at all four doors at once
+node tools/library-check.mjs --mutate exit-keeps-the-child-reference # ... a grabber that exited is not one that is running
 node tools/editor-check.mjs --url http://localhost:8080   # the editor's controls: that they exist, that pressing them changes something
 node tools/editor-check.mjs --mutate lanes-clear-siblings --no-render  # ... and must FAIL
 node tools/editor-check.mjs --mutate plant-unswept-control --no-render # ... and must FAIL
@@ -201,12 +202,19 @@ node tools/vcam-check.mjs --mutate refusal-ignores-webcam # ... what the take is
 node tools/guard-check.mjs                                # the socket's origin rule, the bind, and the rebinding rule
 node tools/guard-check.mjs --mutate upgrade-skips-origin  # ... and must FAIL mutated
 node tools/guard-check.mjs --mutate host-accepts-a-name   # ... and must FAIL mutated
-node tools/jobs-check.mjs                                 # step 8: the queue, the pin, and a real render
+node tools/jobs-check.mjs                                 # step 8: the queue, the pin, and two real renders
 node tools/jobs-check.mjs --mutate claim-ignores-renderer # ... and must FAIL mutated
+node tools/jobs-check.mjs --no-render --mutate codec-read-through-prototype # ... a codec read off Object.prototype
+node tools/jobs-check.mjs --mutate heartbeat-stops-on-first-error # ... the beat, and the one here that needs the render
 ```
 
-`jobs-check` needs a GPU browser and ffprobe and renders one real job through
-`tools/render-worker.mjs`; `--no-render` drops that row. **Six spawn their own servers and need
+`jobs-check` needs a GPU browser and ffprobe and renders two real jobs through
+`tools/render-worker.mjs`; `--no-render` drops both rows, and **it is not a flag to put on every
+mutation run of that tool** — `heartbeat-stops-on-first-error` names a line in the worker's beat
+that only a render reaches, so passing it there runs the check without the thing under test and
+passes green. The block above carries the flag per line for that reason; the mutation lists in it
+are a selection rather than the full set, so take the names from each tool's own refusal.
+**Six spawn their own servers and need
 none running** — `guard-check` on 8321, `jobs-check` on 8231, `level-check` on 8377,
 `monitor-check` on 8341, `vcam-check` on 8361, and `library-check` across the span described
 below — so what each of those needs is a free port rather than a server, and the distinction is


### PR DESCRIPTION
Follow-up to #52, which flagged this rather than fixing it because issue #46's done criteria put `CLAUDE.md` out of scope. Stacked on that branch, since every correction here only becomes true once #52 merges.

### The one clause that is actually false

`CLAUDE.md` says `jobs-check` "renders one real job through `tools/render-worker.mjs`; `--no-render` drops that row". After #52 it renders two — the original, and a whole render driven through a forwarding proxy that drops a heartbeat on the floor — and `--no-render` drops both.

### The drift that costs something

Every `jobs-check` mutation line in that block ran without `--no-render`, and every `editor-check` line ran with it, so the block taught a per-tool rule by uniformity. After #52 that rule is wrong for exactly one mutation: `heartbeat-stops-on-first-error` names a line in the worker's beat that only a render reaches, so `--no-render` there runs the check without the thing under test and passes green — a control recorded as verified having never executed. The block now carries the flag per line, which is the repo's usual answer to this (have the list *be* the dispatch rather than describe it), and the prose says why.

### A correction to my own flag in #52

I wrote there that `CLAUDE.md` "lists none of this branch's three new mutations where `main`'s convention would put them", which assumed the convention is exhaustive listing. It is not — the file lists **22 of `library-check`'s 67** mutations and, before this change, **1 of `jobs-check`'s 12**. So these three lines are additions to a curated selection, not the closing of an enforced gap, and I have said so in the prose rather than leaving the list looking complete. That matters because this file's own header records that the version which absorbed everything reached 704 lines and stopped being read.

The three earn their place on distinct-claim-area grounds rather than completeness: the supervisor's child reference, the codec table, and the beat had no other entry between them. `syntax-check` enforces that every tool in `tools/` is named here; it does not enforce mutations, so nothing failed on their absence and nothing will fail if a later one is left out.

### Verification

Every command line added here was executed on this tree (`fdac528`) during #52's merge verification, on darwin against the real 138MB `captures/sample.knct`:

| Command | Result |
|---|---|
| `jobs-check` | 53 assertions, 0 failed, both renders |
| `jobs-check --no-render --mutate codec-read-through-prototype` | 1 row |
| `jobs-check --mutate heartbeat-stops-on-first-error` | 1 row — heartbeat equal to claimed, against 68.124s fixed |
| `library-check --mutate exit-keeps-the-child-reference` | 2 rows — both claim rows, three provenance rows green |
| `syntax-check` | 39 files, 0 failed; `tools/ all 28 named in CLAUDE.md`, `docs/ all 3 cited pages exist` |

No code changes, so the suite is unaffected beyond `syntax-check`, which is the tool that reads this file.
