### PR TITLE
State the sensor grid once and let the server say why a take will not open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,11 @@ node tools/library-check.mjs --mutate open-decides-its-own-reason  # ... one tak
 node tools/library-check.mjs --mutate menu-decides-its-own-reason  # ... and the menu is a surface too
 node tools/library-check.mjs --mutate refusal-without-a-badge      # ... a reason the server declares and no page can badge
 node tools/library-check.mjs --mutate node-admits-an-old-manifest  # ... a node one build behind, refused at the link
+node tools/library-check.mjs --mutate refusals-must-be-nonempty    # ... and a healthy node not refused for being healthy
+                                                                   #     (wide: takes the link off, so it stops at 109 of 366 -
+                                                                   #      read the rows, not the total. docs/instruments.md says why)
 node tools/library-check.mjs --mutate grid-declared-twice          # ... and the sensor grid stated once
+node tools/library-check.mjs --mutate grid-loses-a-dimension       # ... both halves of it, each asked for on its own
 node tools/library-check.mjs --mutate tile-height-follows-content  # ... the gallery's geometry
 node tools/library-check.mjs --mutate poster-height-in-js          # ... and its poster's box
 node tools/library-check.mjs --mutate viewer-splat-one             # ... and the viewer's density

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ node tools/export-check.mjs --url http://localhost:8080   # step 6: resolution, 
 node tools/export-check.mjs --mutate pointsize-absolute   # ... and must FAIL mutated
 node tools/library-check.mjs                              # step 7: library, recorder, routes
 node tools/library-check.mjs --mutate plant-open-take     # ... and must FAIL
+node tools/library-check.mjs --mutate open-decides-its-own-reason  # ... one take, one refusal, whichever surface asks
+node tools/library-check.mjs --mutate grid-declared-twice          # ... and the sensor grid stated once
 node tools/library-check.mjs --mutate tile-height-follows-content  # ... the gallery's geometry
 node tools/library-check.mjs --mutate poster-height-in-js          # ... and its poster's box
 node tools/library-check.mjs --mutate viewer-splat-one             # ... and the viewer's density

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,11 @@ node tools/library-check.mjs --mutate open-decides-its-own-reason  # ... one tak
 node tools/library-check.mjs --mutate menu-decides-its-own-reason  # ... and the menu is a surface too
 node tools/library-check.mjs --mutate refusal-without-a-badge      # ... a reason the server declares and no page can badge
 node tools/library-check.mjs --mutate refusal-declared-but-never-pushed # ... and one nothing can ever earn
+node tools/library-check.mjs --mutate openable-recomputes-the-band # ... and a band that decides for itself beside the table
 node tools/library-check.mjs --mutate node-admits-an-old-manifest  # ... a node one build behind, refused at the link
 node tools/library-check.mjs --mutate badges-inherit-from-object   # ... and one build ahead, whose reason still badges
 node tools/library-check.mjs --mutate refusals-must-be-nonempty    # ... and a healthy node not refused for being healthy
-                                                                   #     (wide: takes the link off, so it stops at 109 of 366 -
+                                                                   #     (wide: takes the link off, so it stops at 124 of 390 -
                                                                    #      read the rows, not the total. docs/instruments.md says why)
 node tools/library-check.mjs --mutate grid-declared-twice          # ... and the sensor grid stated once
 node tools/library-check.mjs --mutate grid-declared-in-another-spelling # ... whatever notation the second one is in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ node tools/library-check.mjs --mutate menu-decides-its-own-reason  # ... and the
 node tools/library-check.mjs --mutate refusal-without-a-badge      # ... a reason the server declares and no page can badge
 node tools/library-check.mjs --mutate refusal-declared-but-never-pushed # ... and one nothing can ever earn
 node tools/library-check.mjs --mutate node-admits-an-old-manifest  # ... a node one build behind, refused at the link
+node tools/library-check.mjs --mutate badges-inherit-from-object   # ... and one build ahead, whose reason still badges
 node tools/library-check.mjs --mutate refusals-must-be-nonempty    # ... and a healthy node not refused for being healthy
                                                                    #     (wide: takes the link off, so it stops at 109 of 366 -
                                                                    #      read the rows, not the total. docs/instruments.md says why)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ node tools/library-check.mjs --mutate refusals-must-be-nonempty    # ... and a h
                                                                    #     (wide: takes the link off, so it stops at 109 of 366 -
                                                                    #      read the rows, not the total. docs/instruments.md says why)
 node tools/library-check.mjs --mutate grid-declared-twice          # ... and the sensor grid stated once
+node tools/library-check.mjs --mutate grid-declared-in-another-spelling # ... whatever notation the second one is in
 node tools/library-check.mjs --mutate grid-loses-a-dimension       # ... both halves of it, each asked for on its own
 node tools/library-check.mjs --mutate tile-height-follows-content  # ... the gallery's geometry
 node tools/library-check.mjs --mutate poster-height-in-js          # ... and its poster's box

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,8 @@ registry and exits 2 when it cannot reach it, because it proves the gate by npm'
 rather than by reading a config key:
 
 ```
-node tools/syntax-check.mjs                          # every JS file this repo ships parses
+node tools/syntax-check.mjs                          # every JS file this repo ships parses, and the two
+                                                     #   constants the two languages cannot share agree
 node tools/syntax-check.mjs --mutate spec-drifts     # ... and the .knct decoder specification must FAIL when a constant moves under it
 node tools/release-gate-check.mjs                    # the .npmrc supply-chain gate is actually armed
 node tools/release-gate-check.mjs --mutate wrong-unit # ... and must FAIL (also: no-gate, absent)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,10 +117,11 @@ node tools/library-check.mjs --mutate menu-decides-its-own-reason  # ... and the
 node tools/library-check.mjs --mutate refusal-without-a-badge      # ... a reason the server declares and no page can badge
 node tools/library-check.mjs --mutate refusal-declared-but-never-pushed # ... and one nothing can ever earn
 node tools/library-check.mjs --mutate openable-recomputes-the-band # ... and a band that decides for itself beside the table
+node tools/library-check.mjs --mutate recording-decides-openable-itself # ... and the take being written, which answered twice
 node tools/library-check.mjs --mutate node-admits-an-old-manifest  # ... a node one build behind, refused at the link
 node tools/library-check.mjs --mutate badges-inherit-from-object   # ... and one build ahead, whose reason still badges
 node tools/library-check.mjs --mutate refusals-must-be-nonempty    # ... and a healthy node not refused for being healthy
-                                                                   #     (wide: takes the link off, so it stops at 124 of 390 -
+                                                                   #     (wide: takes the link off, so it stops at 125 of 392 -
                                                                    #      read the rows, not the total. docs/instruments.md says why)
 node tools/library-check.mjs --mutate grid-declared-twice          # ... and the sensor grid stated once
 node tools/library-check.mjs --mutate grid-declared-in-another-spelling # ... whatever notation the second one is in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ node tools/library-check.mjs --mutate refusals-must-be-nonempty    # ... and a h
                                                                    #      read the rows, not the total. docs/instruments.md says why)
 node tools/library-check.mjs --mutate grid-declared-twice          # ... and the sensor grid stated once
 node tools/library-check.mjs --mutate grid-declared-in-another-spelling # ... whatever notation the second one is in
+node tools/library-check.mjs --mutate grid-declared-with-a-leading-dot # ... including the one with no leading digit
 node tools/library-check.mjs --mutate grid-loses-a-dimension       # ... both halves of it, each asked for on its own
 node tools/library-check.mjs --mutate tile-height-follows-content  # ... the gallery's geometry
 node tools/library-check.mjs --mutate poster-height-in-js          # ... and its poster's box

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ node tools/library-check.mjs --mutate plant-open-take     # ... and must FAIL
 node tools/library-check.mjs --mutate open-decides-its-own-reason  # ... one take, one refusal, whichever surface asks
 node tools/library-check.mjs --mutate menu-decides-its-own-reason  # ... and the menu is a surface too
 node tools/library-check.mjs --mutate refusal-without-a-badge      # ... a reason the server declares and no page can badge
+node tools/library-check.mjs --mutate refusal-declared-but-never-pushed # ... and one nothing can ever earn
 node tools/library-check.mjs --mutate node-admits-an-old-manifest  # ... a node one build behind, refused at the link
 node tools/library-check.mjs --mutate refusals-must-be-nonempty    # ... and a healthy node not refused for being healthy
                                                                    #     (wide: takes the link off, so it stops at 109 of 366 -

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,9 @@ node tools/export-check.mjs --mutate pointsize-absolute   # ... and must FAIL mu
 node tools/library-check.mjs                              # step 7: library, recorder, routes
 node tools/library-check.mjs --mutate plant-open-take     # ... and must FAIL
 node tools/library-check.mjs --mutate open-decides-its-own-reason  # ... one take, one refusal, whichever surface asks
+node tools/library-check.mjs --mutate menu-decides-its-own-reason  # ... and the menu is a surface too
+node tools/library-check.mjs --mutate refusal-without-a-badge      # ... a reason the server declares and no page can badge
+node tools/library-check.mjs --mutate node-admits-an-old-manifest  # ... a node one build behind, refused at the link
 node tools/library-check.mjs --mutate grid-declared-twice          # ... and the sensor grid stated once
 node tools/library-check.mjs --mutate tile-height-follows-content  # ... the gallery's geometry
 node tools/library-check.mjs --mutate poster-height-in-js          # ... and its poster's box

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -370,6 +370,37 @@ manifest would pass the refusal arm while taking the link off entirely. **When a
 about two builds talking, one of them has to be a fixture — anything the rig spawns is the
 build under test.**
 
+### Two sections on one port, and the one that read a log read the wrong one
+
+The sibling of the `MAC_PORT + 9` case above, with this file on both ends of it instead of
+another worktree. `library-check` keeps its spawned servers in one `servers` array and
+finds them by port — `servers.find((s) => s.port === MAC_PORT + 1).log.join('')` is how a
+section reads what its server printed. Two sections claimed `+1`. The first killed its
+server long before the second started, so the bind succeeded and nothing failed; what was
+left was two entries for one port, and `find` answers with whichever was pushed first,
+which is the dead one.
+
+The respawn-backoff section therefore counted grabber exits in an empty log and reported
+`0 exits`, three rows red, against a supervisor that was working correctly — and the log
+it should have read carried twenty-two deaths, which the corroborating row beside it
+printed in full. **The reading was wrong rather than the code**, which is the worst way for
+a proof tool to be wrong: it is a finding about the instrument wearing the shape of a
+finding about the program, and the merge that surfaced it looked exactly like a
+regression. What settled it was a control run of the same tool on `main`, on a port span
+nothing else held: 365 assertions, none failed, against 390 with 3 failed here, with the
+three sections' code byte-identical between the two trees.
+
+Fixed by dropping the stale entry when an offset is claimed again, so a lookup by port
+answers with the server that is on it. Not by refusing the reuse and not by widening the
+span: reuse is deliberate — `+14` is a rename server and later a broken-preset one — and
+two more ports is a cost every worktree on the machine pays to route around a bug in the
+bookkeeping. Two *live* servers on one port is a case the kernel already rules out, so
+reaching the claim at all means the last holder let go.
+
+**The general shape is rule 4 read backwards.** A probe placed where its answer would be
+different is no good if something else can answer for it, and an array searched by a key
+two things share is exactly that. `find` on a non-unique key is a silent choice.
+
 ### A mutation that does nothing reads as a check that found nothing
 
 Step 5 produced one: a mutation meant to draw editor furniture into the rendered frame

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -225,6 +225,38 @@ row, with the width row still green — which is the split being necessary rathe
 tidy. **When a row's subject is a pair, ask for each half separately, or the half that is
 still there answers for the one that is not.**
 
+### A search for a number that searches for its digits is a search for one spelling
+
+The third thing wrong with the same row, found by review rather than by a failure. Having
+split the alternation into one regex per dimension, each was still
+`(?<![\d.])512(?![\d.])` — decimal digits with guards either side to keep `512` out of
+`1512` and `4.24`. That is a matcher for a *spelling* wearing the name of the number. A
+module redeclaring the width as `512.0` is rejected by the trailing guard, and `0x200`,
+`5.12e2`, `0b1000000000` and `5_12` are never looked at at all. Each of them is a second
+declaration of the sensor's geometry sitting under a row reporting one, which is exactly
+the drift the row exists to refuse.
+
+Closed by tokenising every JavaScript numeric literal and comparing its **value**, so the
+spellings stop being a list to keep up with — the boundary guards go with it, because
+`1512` tokenises whole and answers 1512. The bound is stated in the code rather than left
+to be discovered: this sees a literal in any notation and does not see an *expression* that
+computes the value, so `256 * 2` and `DEPTH_W - 88` are invisible to it. Legacy octal
+`01000` is left out because it is a SyntaxError in a module and `syntax-check` holds that.
+
+**The control is the part worth copying.** `grid-declared-in-another-spelling` plants the
+same second declaration as `grid-declared-twice` with nothing changed but the notation —
+`0x200` and `4.24e2` — and both mutations are kept, because they fail differently: one is
+caught by any matcher and the other only by one that compares values. Verified rather than
+argued, by running both matchers over both planted lines: the old one catches
+`grid-declared-twice` on both dimensions and misses `grid-declared-in-another-spelling` on
+both, where the new one catches all four. A control every version of the instrument passes
+is not a control for the change.
+
+The probe tree gained the same treatment, one file per dimension per spelling plus a file
+of near misses — `1512`, `4.24`, `0x201` — and the rows assert the whole matched list
+rather than membership, so a matcher that grew *looser* than the regex it replaced fails
+without needing a row of its own.
+
 ### An enumeration that walks a flat tree is the files that exist, not the tree
 
 The grid row above walks `web/` and `server/` rather than a list of the files that hold the

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -370,6 +370,39 @@ attribute value ends at whitespace and a capture reading it to the `>` answers
 `text/javascript defer`, which is in no list of anything. Same failure as the missing MIME
 types and from the same direction: a running script's body dropped.
 
+### Eight rounds of one seam, and what that says about hand-rolling a lexer
+
+The scan that answers "is this number written in the code" has now been corrected eight
+times, and every correction was the same sentence: a question about a *token* answered
+with a *character*. Leading-dot numbers, `return /re/`, postfix `++`, legacy octal,
+`\btype` inside `data-type`, an unquoted attribute running past its end, a quoted `>`
+ending a start tag, and a finished regex divided by something. Each was real, each was
+silent, and each was found by review rather than by a run.
+
+**That is the honest cost of a hand-rolled lexer, and it is worth stating rather than
+hiding behind the fixes.** The alternative was never a regex — a regex over a language is
+strictly worse — it was a dependency, and this repo has no parser and adds packages under
+a supply-chain gate. The scan is a hundred lines and every failure it has had is in the
+loud-or-silent taxonomy already written here, so the choice is defensible. But a reader
+arriving next year should know the shape: the property is easy to state, and the *scanner*
+is the part that is hard, and it will keep having edges.
+
+Two things make the cost bearable, and both are worth copying to any similar instrument:
+
+**The failures divide into loud and silent, and the design leans one way on purpose.** A
+misread that scans something which is not code over-reports and fails a clean tree, which
+somebody sees. A misread that skips something which *is* code goes unseen under a green
+row. Every ambiguous decision in the scan is resolved toward the first, and the one case
+left genuinely ambiguous — a `/` after `}` — is documented as such.
+
+**The probe files are the real arm, not the mutation table.** Most of these forms cannot be
+planted in the tree the mutations edit: octal is a SyntaxError in a module, no page here
+carries a `data-type` attribute, and a mutation of a file under `tools/` would be staged
+where nothing runs. So the probe carries them, it asserts the *whole matched list* rather
+than membership, and each planted file sits on one dimension's list and off the other's —
+which makes both a missed form and an over-read form fail, with no row of its own for
+either.
+
 ### A comment that was true when written, and false one commit later
 
 The scan's own paragraph said legacy octal could be ignored: `01000` is 512, it is a

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -257,6 +257,33 @@ of near misses — `1512`, `4.24`, `0x201` — and the rows assert the whole mat
 rather than membership, so a matcher that grew *looser* than the regex it replaced fails
 without needing a row of its own.
 
+### A JavaScript question asked of every file in the tree gets answered by prose and CSS
+
+The other end of the same row, and the two corrections pull in opposite directions, which is
+what makes the pair worth reading together. The walk is deliberately wide — every file under
+`web/` and `server/`, so a page added next year is asked by existing — and `web/` holds three
+HTML pages and a stylesheet as well as the modules. Asking "is 512 a literal here" of markup
+answers about layout and copy: a `width: 512px` rule in `nav.css`, or a paragraph mentioning
+a 424-line budget, would have made that file a second grid owner and failed a clean suite on
+a change that redeclared nothing.
+
+Narrowing the *walk* to `.js` closes it by opening a hole, because the pages here carry real
+code — `menu.html` holds `resolveResume` inline and this suite mutates it. So the walk stays
+wide and the **question** narrows: the whole of a module, and the `<script>` bodies of a
+page. Typed scripts are excluded by their `type` rather than by looking like data, because
+`index.html` carries an importmap, and a version string in a JSON blob is not a declaration
+of anything.
+
+The probe tree carries a page stating both numbers four times over — in prose, in a
+`<style>` rule, in the importmap, and finally in a module script — and a stylesheet stating
+both in a rule. Exactly one of those five is a declaration, and the rows assert the whole
+matched list, so either mistake fails: reading the paragraph, or no longer reading the
+script.
+
+**The general rule is that a scope has two halves and they are set separately.** What the
+enumeration reaches and what the question is asked of are different decisions, and collapsing
+them means every widening of one silently widens the other.
+
 ### An enumeration that walks a flat tree is the files that exist, not the tree
 
 The grid row above walks `web/` and `server/` rather than a list of the files that hold the
@@ -345,8 +372,8 @@ fail for different reasons and a combined row would report the wrong one.
 **The control for it is `--mutate refusals-must-be-nonempty`, and it is deliberately not
 a well-behaved one.** It reddens both arm rows, and then it reddens the node's own rows
 across the suite, because the bug it plants is exactly "every healthy node goes dark" and
-that is what that looks like from here — 124 assertions, 11 failed, where a clean run
-reaches 390. That is the blast-radius rule being broken knowingly rather than by accident:
+that is what that looks like from here — 125 assertions, 11 failed, where a clean run
+reaches 392. That is the blast-radius rule being broken knowingly rather than by accident:
 several sections assume a linked node holding remote takes, and the first of them,
 `drawn(undefined)`, waited out its own timeout and threw at 105. That one is guarded now,
 the same way the way-back anchor is; the next is the confirm dialog for a take in state
@@ -401,6 +428,36 @@ to outlive follows that code. And the row has two arms, because a gate that refu
 manifest would pass the refusal arm while taking the link off entirely. **When a claim is
 about two builds talking, one of them has to be a fixture — anything the rig spawns is the
 build under test.**
+
+### The branch that carried the argument against second answers, and then gave one
+
+`OPEN_REFUSALS` exists so that `openable` is "the refusal list is empty" and never a second
+expression of the same predicate, and the paragraph saying so sits directly above a
+`describeTake` whose two branches did not both do it. The settled-take branch derived.
+The take-being-written branch carried `openRefusals: [refusal('recording')]` and a hardcoded
+`openable: false` on the next line — two answers to one question, written in by the commit
+whose entire subject is that there should be one.
+
+Nothing was wrong yet, which is the whole difficulty: both said the take cannot be opened,
+so they agreed, and they would go on agreeing until one moved. What waits at the end of that
+is the quiet failure rather than a loud one — `cannotOpen` quotes the list, so a list that
+went while the boolean stayed leaves a *disabled* Open button explaining nothing, which
+looks like a take that simply cannot be opened rather than like a bug.
+
+**Every existing row was structurally unable to see it.** The two-table rows compare which
+keys the tables know and skip `recording` by name, for a reason of fact — no take on that
+server is being written, so the response cannot carry the key. The row that does watch a live
+recording take asked `openable === false`, which is true in both builds. So the exclusion
+that was correct in one place became the reason nothing covered the branch, which is rule 5
+arriving through a justification nobody had cause to look at twice.
+
+Two rows now. One asks every take in the listing whether `openable` is its list being empty
+— a claim about the scanner rather than about the fixture, so a third branch added later is
+asked by existing. The other stands where the recording take actually is and asks for the
+sentence, not the boolean. `--mutate recording-decides-openable-itself` empties the list and
+hardcodes the boolean together, because hardcoding alone changes nothing observable and
+would have been a control that did nothing: 1 failed assertion of 392, the row that carries
+the claim and no other.
 
 ### Two sections on one port, and the one that read a log read the wrong one
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -156,31 +156,43 @@ is a check nobody knows the sensitivity of.
 ### A source row that reads the staged tree cannot be falsified by a page mutation
 
 The match-exactly-once rule guards the *anchor*. This is the same hole one layer further
-out, in the **delivery**, where nothing refuses it — and it was almost shipped as the
+out, in the **delivery**, where nothing refused it — and it was almost shipped as the
 falsification control for a row about the sensor grid being declared once.
 
-`library-check` applies its two kinds of mutation by two different mechanisms, and only one
-of them touches the tree. `stageServer` writes a **server** mutation into the copied tree,
-so a row reading `join(root, 'server/…')` sees it. A **page** mutation never lands on disk
-at all: `openPage` installs a Playwright route interception, so the browser gets the
-mutated body and the staged `root/web/main.js` is still the clean file. A row that walked
+`library-check` applied its two kinds of mutation by two different mechanisms, and only one
+of them touched the tree. `stageServer` wrote a **server** mutation into the copied tree,
+so a row reading `join(root, 'server/…')` saw it. A **page** mutation never landed on disk
+at all: `openPage` installed a Playwright route interception, so the browser got the
+mutated body and the staged `root/web/main.js` was still the clean file. A row that walked
 the staged tree looking for a literal would therefore have passed against every page
 mutation there is, while looking exactly like a row with a control behind it.
 
-The fix is a `shippedSource(rel)` helper — the staged copy for every file, and
-`mutation.body` for the one file the mutation replaces — so the row reads what the run
-actually ships rather than what it happened to write down. Measured: with the helper,
-`--mutate grid-declared-twice` reddens the row and names both holders,
-`web/format.js web/main.js`, over a run that reached all 351 assertions. The other half is
-a code fact rather than a second measurement, and it is the whole mechanism: `stageServer`
-writes `serverMutation` and nothing else, so the staged `web/` is the clean tree on every
-page mutation and a row reading it would have counted one holder and passed.
+**The tool now has one delivery, and this section is kept for the shape rather than for
+the mechanism.** `stageServer` writes every mutation, whichever side of the wire it is on,
+and `requireMutationDelivered` then asks the server over HTTP whether the bytes it serves
+are the ones this run staged — `docs/proof-tools.md` carries that collapse in full,
+including why two mechanisms delivering the same bytes was a rule with nothing measuring
+it. The `shippedSource(rel)` helper written to close this therefore lost its conditional
+in the same breath: `mutation.body` and the staged copy became the same bytes, so the
+branch was a second path that could only ever agree, and it is one read now.
 
-`docs/proof-tools.md` already records this family's other member — `web/library.html` has
-no URL of its own, so a `**/library.html` interception matches nothing and the unmutated
-page loads. **Whenever a row reads source rather than behaviour, ask by what mechanism the
-mutation would reach the bytes that row reads**, and do not assume the answer is the same
-for every file the tool can mutate.
+Two things survive the mechanism that produced them, and they are why this is still here.
+
+**A source row and a behaviour row are falsified by different things**, and it is worth
+asking which you have. The row that catches a page mutation by driving the page is safe
+from this entirely; the row that greps the tree depends on a delivery it does not name.
+When the delivery changed, only the second kind had to be re-examined.
+
+**What holds the staging is the source rows' own controls.** Remove the write in
+`stageServer` and `grid-declared-twice` stops reddening — that is the arm, and it is
+already in the suite. A helper that guarantees the bytes independently of the staging
+would have been the second gate again: nothing could reach one without the other covering,
+so neither could be tested and one of them would be doing all the work.
+
+Measured when the conditional came out, which is the check that it was genuinely
+redundant rather than merely looking it: `--mutate grid-declared-twice` still reddens both
+dimension rows naming `web/format.js web/main.js`, and `grid-declared-in-another-spelling`
+still reddens its two, over a baseline of 392 assertions with none failed.
 
 ### A known intermittent in `library-check` section 9, written down with its signature
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -498,6 +498,40 @@ hardcodes the boolean together, because hardcoding alone changes nothing observa
 would have been a control that did nothing: 1 failed assertion of 392, the row that carries
 the claim and no other.
 
+### Splitting a list gave the lookups a right answer and the sweeps a short one
+
+The tail of the port-collision fix below, and the reason it is its own entry is that the
+fix was correct and still broke something. Moving a reclaimed offset's previous holder to
+a `retired` list is what makes `servers.find((s) => s.port === n)` answer with whoever is
+on the port. It also silently changed what `servers` *means*: it stopped being every
+server this run started, and the end-of-run fatal-log sweep had been reading it on the
+old meaning.
+
+Measured when the row went in: **four** servers are retired on a full run, so four
+servers' logs were outside the scan. A `cannot open` from any of them would have been a
+failure this tool detected and did not say, which is the worst shape a proof tool has —
+worse than not looking, because the verdict claims it looked.
+
+**The lesson is about the readers rather than the list.** Every consumer of a collection
+is either a *lookup*, which wants the one that is current, or a *sweep*, which wants all
+of them — and splitting a collection to fix a lookup gives every sweep a new bug at the
+same moment. The fix is a named `everyServer()` used by both sweeps, rather than
+`[...servers, ...retired]` spelled at each site, because there were two sites and the bug
+was one of them being forgotten.
+
+The row checks the *count* against a counter incremented where a server is started, not
+the collection the loop reads. What went wrong was never this loop naming the wrong
+variable; it was a list splitting somewhere else and one of its two readers not being
+told, so the row has to be red for that, including for the next collection somebody adds.
+
+**It has no `--mutate` entry, and that limit is worth knowing before you write a row about
+the instrument.** A mutation spec writes its body into the staged tree, and the stage is
+`server/` and `web/` — a mutation naming a file under `tools/` would be delivered to a
+copy nothing runs and would be recorded as a control that passed, which is the
+silent-delivery failure this file already carries two entries about. So it was
+mutation-tested by hand: `everyServer()` put back to `servers` reddens that row and
+nothing else, reporting `swept 18 of 22 started` against a clean `22 of 22`.
+
 ### Two sections on one port, and the one that read a log read the wrong one
 
 The sibling of the `MAC_PORT + 9` case above, with this file on both ends of it instead of

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -120,6 +120,85 @@ page loads. **Whenever a row reads source rather than behaviour, ask by what mec
 mutation would reach the bytes that row reads**, and do not assume the answer is the same
 for every file the tool can mutate.
 
+### An enumeration that walks a flat tree is the files that exist, not the tree
+
+The grid row above walks `web/` and `server/` rather than a list of the files that hold the
+number today, which is the close-the-class rule: a page added next year is asked by
+existing. Its first spelling walked the *direct children* of each and skipped anything that
+`statSync` said was a directory. Both directories are flat, so the walk found every file
+there is, the row was green for the right reason, and nothing about it said that the first
+subdirectory anybody made would be skipped silently — with a module inside it free to
+redeclare the grid under a row still printing green.
+
+The mistake is not the missing recursion. It is that the enumeration was **the files that
+exist** while the comment above it claimed the enumeration was **the tree**, and the two are
+the same list right up until they are not. A traversal cannot be falsified by the tree it
+walks when that tree has nothing in it to recurse into, so the control is a tree the row
+builds: `web/flat.js` with no grid and `web/nested/buried.js` with one, run through the same
+walker, asserting it answers `['web/nested/buried.js']`. A walker that stops at the top
+answers `[]` and the row goes red, where against the real `web/` it would answer exactly
+what the row wants. **When a row's claim is about a shape the subject does not currently
+have, build the shape and run the same code over it** — a mutation of the subject cannot
+reach a case the subject does not contain.
+
+### A row comparing two tables must compare the declarations, not the instances
+
+The gallery badges each refusal the server can send, and the two lists are genuinely
+separate — the sentence is the server's, the badge over a 228px poster is the page's — so a
+key added to one and not the other is the failure. The row's first spelling read the
+server's side by flattening the refusals the fixture takes happened to carry. That covers a
+key exactly as far as some fixture provokes it, which is the reverse of the guarantee: the
+next refusal will apply to a take shape `buildFixture` does not write, so it would be absent
+from the derived list, absent from the page's table, and the row would compare two keys
+against two keys and pass. Fixed by exporting `OPEN_REFUSALS` from `server/library.js` and
+reading `Object.keys` off it, with `--mutate refusal-without-a-badge` adding a declared key
+no take provokes and no page badges — a mutation the old row could not have caught, because
+nothing it read would have changed. **A row asserting two enumerations agree has to reach
+both enumerations; a sample of one of them is a row about the sample.**
+
+Its neighbour is the other direction and is one line: every key a take actually arrived with
+has to be in the table, or the declaration has drifted off the code the way the page's table
+did.
+
+### A claim about "whichever surface asks" needs a control per surface
+
+The refusal moved to the server so that one take gets one sentence on every surface, and the
+commit changed the gallery and the menu together. The control mutated only the gallery. So
+reverting the menu to its old hard-coded "no sensor hello, or under two frames" — or adding
+any new local derivation there — left every row green, and the claim was asserted rather
+than enforced for half of what it claimed.
+
+Adding the second control found the delivery hole underneath it. A page mutation is
+delivered by intercepting its route, and `openPage` knew one page: `library.html` at
+`/gallery`, with a throw for anything else. That throw is why the miss was loud rather than
+silent, and it is worth keeping in that shape — the table now names `menu.html` at `/` and
+still throws for a file with no URL. The glob went with it: `**${target}` for a page served
+at `/` is `**/`, which matches every directory-shaped URL the page requests, so the mutated
+menu would have been fulfilled for requests that are not the menu. It matches on the
+pathname now. **A claim that names more than one surface is not controlled until each
+surface has a mutation of its own, and the second control is usually what discovers that the
+delivery only ever worked for the first.**
+
+### Two machines on one network are two builds, and a rig that stages both cannot see it
+
+`library-check` spawns its node and its editing machine out of one staged tree, so both
+speak the build under test and every wire-format claim between them is an oracle agreeing
+with itself. The failure that shape cannot show is a version skew: the editing machine gets
+upgraded first, because it is the one somebody is standing at, and the node goes on serving
+the manifest of the build before. That manifest parses, survives the id and hash filters,
+and reconciles into the listing looking like any other take — so a field the pages now
+require is simply absent, and the gallery blanks on a `TypeError` while painting the first
+remote tile.
+
+The node in that row is a stub `http` server serving a manifest written out by hand, on a
+kernel-assigned port rather than one out of the reserved span, because a port `listen(0)`
+hands back cannot be held by another worktree. Written out field for field rather than
+generated by deleting a key from today's shape: a fixture derived from the code it is meant
+to outlive follows that code. And the row has two arms, because a gate that refused every
+manifest would pass the refusal arm while taking the link off entirely. **When a claim is
+about two builds talking, one of them has to be a fixture — anything the rig spawns is the
+build under test.**
+
 ### A mutation that does nothing reads as a check that found nothing
 
 Step 5 produced one: a mutation meant to draw editor furniture into the rendered frame

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -364,7 +364,38 @@ JavaScript over-reports loudly where dropping it goes unseen.
 The probe's second page carries executable code under a type nobody writes any more and a
 JSON block under a type that is not code, so it has to be a holder of one number and not
 the other: a check knowing only the modern four loses the first, and a check reading
-anything inside a `<script>` gains the second.
+anything inside a `<script>` gains the second. It also carries the unquoted form with an
+attribute behind it — `<script type=text/javascript defer>` — because an unquoted
+attribute value ends at whitespace and a capture reading it to the `>` answers
+`text/javascript defer`, which is in no list of anything. Same failure as the missing MIME
+types and from the same direction: a running script's body dropped.
+
+### The grid that is declared twice on purpose, in two languages that cannot share one
+
+Everything above is about the sensor grid being stated once. It cannot be. `native/grabber.cpp`
+holds `DW`/`DH` and is C++, so it cannot import `web/format.js` — the second declaration
+has to exist, and every row in `library-check` is structurally unable to see it, because
+that walk is `web/` and `server/` and could not honestly be anything else.
+
+**Two unavoidable declarations are not a drift problem solved by deleting one; they are a
+drift problem solved by comparing them.** `syntax-check` already did exactly this for
+`CAPTURE_FORMAT` and the grid is the same shape, so it is the same eight lines. What drift
+costs is worth naming, because it is not a wrong picture: the grabber emits a depth block
+of its own size, `server/capture.js` measures every frame against `DEPTH_W * DEPTH_H`, and
+so every frame is refused at the parser with the sensor working perfectly — a node that
+starts and serves nothing.
+
+Anchored on the *declaration* in each language and never on a mention, which matters more
+here than it did for the format constant: `grabber.cpp` also holds `char hello[512]`, a
+buffer with nothing to do with the sensor, and a search for the number would find it.
+Falsified by hand, since this row is in `syntax-check` and that tool carries no mutation
+table: `DH` moved to 423 fails with `DEPTH_H is 424 in web/format.js and DH is 423 in
+native/grabber.cpp`, and restoring it returns the run to 39 files and 0 failed.
+
+**The general form is worth more than the instance.** When a row proves a property within
+one language, ask what the same property looks like at the edge of that language — and
+whether the thing on the other side is a copy that must agree, rather than a copy that
+should not exist.
 
 ### An enumeration that walks a flat tree is the files that exist, not the tree
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -370,14 +370,24 @@ attribute value ends at whitespace and a capture reading it to the `>` answers
 `text/javascript defer`, which is in no list of anything. Same failure as the missing MIME
 types and from the same direction: a running script's body dropped.
 
-### Eight rounds of one seam, and what that says about hand-rolling a lexer
+### Nine rounds of one seam, and what that says about hand-rolling a lexer
 
-The scan that answers "is this number written in the code" has now been corrected eight
+The scan that answers "is this number written in the code" has now been corrected nine
 times, and every correction was the same sentence: a question about a *token* answered
 with a *character*. Leading-dot numbers, `return /re/`, postfix `++`, legacy octal,
 `\btype` inside `data-type`, an unquoted attribute running past its end, a quoted `>`
-ending a start tag, and a finished regex divided by something. Each was real, each was
-silent, and each was found by review rather than by a run.
+ending a start tag, a finished regex divided by something, and an identifier the ASCII
+classes could not finish reading. Each was real, each was silent, and each was found by
+review rather than by a run.
+
+**Three of the nine had the same *fix*, and that is the pattern worth taking away**: the
+language or the spec already publishes the set, and the code had a description of it
+instead. HTML's sixteen JavaScript MIME essences against `(text|application)/(java|ecma)script`;
+`\p{ID_Start}`/`\p{ID_Continue}` against `[A-Za-z_$]`; and the numeric grammar's two decimal
+shapes against the one that starts with a digit. In each case the enumeration *is* the
+definition, and a pattern that covers today's members is a claim about the future that
+nothing checks. **Reach for the published set before writing a character class that means
+"names" or "types" or "numbers".**
 
 **That is the honest cost of a hand-rolled lexer, and it is worth stating rather than
 hiding behind the fixes.** The alternative was never a regex — a regex over a language is

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -199,9 +199,23 @@ no take provokes and no page badges — a mutation the old row could not have ca
 nothing it read would have changed. **A row asserting two enumerations agree has to reach
 both enumerations; a sample of one of them is a row about the sample.**
 
-Its neighbour is the other direction and is one line: every key a take actually arrived with
-has to be in the table, or the declaration has drifted off the code the way the page's table
-did.
+**Its neighbour was written as the other direction and asserted the same one**, which is the
+part worth keeping. The comment promised that every key in the table is one the scanner can
+produce, and the code asked that every key a take arrived with is declared. Those are
+opposite containments, and only the second was being checked — so a refusal added to
+`OPEN_REFUSALS` and to the page's `BADGES` with the `describeTake` branch that pushes it
+forgotten would stay green forever: a declared reason, a badge for it, and no take that can
+ever wear either. A comment that describes a stronger check than the line under it is worse
+than no comment, because it is the thing a reader checks instead of the code.
+
+Both directions now, and `recording` is excluded from the second by a fact rather than for
+convenience: no take on that server is being written, so the response cannot carry that key
+however correct the scanner is, and it is proven where it can be proven — in the section that
+stands a recorder up. The cost is deliberate and belongs to whoever adds the next refusal: it
+now needs a fixture take that provokes it, because a reason nothing here can reach is a reason
+nothing here is testing. `--mutate refusal-declared-but-never-pushed` deletes the `no-hello`
+push and leaves the key declared and badged; 368 assertions, five failed, and they are one
+fact arriving in five places.
 
 ### A claim about "whichever surface asks" needs a control per surface
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -296,6 +296,33 @@ script.
 enumeration reaches and what the question is asked of are different decisions, and collapsing
 them means every widening of one silently widens the other.
 
+**And the same fact one layer further in: a string is not code either.** Narrowing to the
+JavaScript left `throw new Error('expected 512 bytes')` counting as a declaration of the
+sensor's width, so an ordinary debug message added to any module would have failed a clean
+suite. Comments were already excluded, by a regex; strings were not, and the two are the
+same exclusion — what the row wants is what a lexer would call a numeric token.
+
+The pair of regexes went, replaced by one scan. They were each approximating half of a
+lexer and each carrying a patch for the other's territory: the line-comment rule skipped a
+`//` preceded by a colon, which exists so that a URL *in a string* survives comment
+stripping. That is a lexer being written one exception at a time, and the exceptions only
+stop arriving when the thing knows what a literal is.
+
+Two decisions in it are worth copying. **Template expressions are scanned and template text
+is not**, because `${...}` is code by definition and swallowing the whole template would
+lose a declaration inside one silently. And **where it has to guess, it guesses toward
+reporting**: a `/` after `}` is division here, so a regex in that position is scanned as
+code and its digits are over-reported, which fails loudly. The other reading skips to the
+next `/` and swallows the code in between, which is a declaration going unseen under a
+green row. When an instrument must be wrong sometimes, choose the direction that announces
+itself.
+
+The probe carries one file that is on one list and off the other. Its 512s are all
+text — two strings, an escaped quote, a comment, a template — and its 424 appears both as
+text and inside a `${}`. A scan that reads strings puts it on the 512 list and fails; a
+scan that swallows template expressions takes it off the 424 list and fails. One file,
+both directions, which is what an arm for a scanner has to do.
+
 ### An enumeration that walks a flat tree is the files that exist, not the tree
 
 The grid row above walks `web/` and `server/` rather than a list of the files that hold the

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -370,6 +370,34 @@ attribute value ends at whitespace and a capture reading it to the `>` answers
 `text/javascript defer`, which is in no list of anything. Same failure as the missing MIME
 types and from the same direction: a running script's body dropped.
 
+### A comment that was true when written, and false one commit later
+
+The scan's own paragraph said legacy octal could be ignored: `01000` is 512, it is a
+SyntaxError in a module, and every file walked here is a module. Both halves were true when
+that was written. The second stopped being true the day the same check began reading
+`<script>` bodies out of pages — an **untyped** script is a *classic* script, classic
+scripts are sloppy mode, and there the form is legal and means 512. So a page could declare
+the width as `01000`, the browser would agree it was 512, and the scan would record 1000
+and report the grid as stated once.
+
+Nothing announced it. The comment was not edited into being wrong; the *code around it*
+grew a case its premise excluded, which is the version of documentation drift that no
+amount of care while writing prevents. **When you widen what a check accepts, re-read the
+exclusions it already carries — each one is a claim about the old input set.**
+
+The fix is to read the form rather than to rewrite the sentence, since the excuse for
+skipping it is gone. Only a leading zero followed by octal digits: `08` and `09` are the
+legacy *decimal* forms and mean eight and nine, `0` alone is zero, and anything with a dot
+or an exponent is decimal — all three fall out of the pattern rather than needing a case of
+their own.
+
+Its neighbour in the same round is the same shape one layer out. `\btype` was matching the
+`type` in `data-type`, because a word boundary sits between `-` and `type` as happily as
+after `<script` — so a page carrying `<script data-type="application/json">` had its body
+read as JSON and dropped, while the browser, seeing no `type` attribute at all, ran it. An
+attribute begins at whitespace or at the start of the attribute list, and `\b` is not that
+boundary however much it looks like one.
+
 ### The grid that is declared twice on purpose, in two languages that cannot share one
 
 Everything above is about the sensor grid being stated once. It cannot be. `native/grabber.cpp`

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -91,6 +91,35 @@ result, and it has now caught two flaws that reading the code did not:
 Report which mutations you ran and what each one caught. A check nobody has broken on purpose
 is a check nobody knows the sensitivity of.
 
+### A source row that reads the staged tree cannot be falsified by a page mutation
+
+The match-exactly-once rule guards the *anchor*. This is the same hole one layer further
+out, in the **delivery**, where nothing refuses it — and it was almost shipped as the
+falsification control for a row about the sensor grid being declared once.
+
+`library-check` applies its two kinds of mutation by two different mechanisms, and only one
+of them touches the tree. `stageServer` writes a **server** mutation into the copied tree,
+so a row reading `join(root, 'server/…')` sees it. A **page** mutation never lands on disk
+at all: `openPage` installs a Playwright route interception, so the browser gets the
+mutated body and the staged `root/web/main.js` is still the clean file. A row that walked
+the staged tree looking for a literal would therefore have passed against every page
+mutation there is, while looking exactly like a row with a control behind it.
+
+The fix is a `shippedSource(rel)` helper — the staged copy for every file, and
+`mutation.body` for the one file the mutation replaces — so the row reads what the run
+actually ships rather than what it happened to write down. Measured: with the helper,
+`--mutate grid-declared-twice` reddens the row and names both holders,
+`web/format.js web/main.js`, over a run that reached all 351 assertions. The other half is
+a code fact rather than a second measurement, and it is the whole mechanism: `stageServer`
+writes `serverMutation` and nothing else, so the staged `web/` is the clean tree on every
+page mutation and a row reading it would have counted one holder and passed.
+
+`docs/proof-tools.md` already records this family's other member — `web/library.html` has
+no URL of its own, so a `**/library.html` interception matches nothing and the unmutated
+page loads. **Whenever a row reads source rather than behaviour, ask by what mechanism the
+mutation would reach the bytes that row reads**, and do not assume the answer is the same
+for every file the tool can mutate.
+
 ### A mutation that does nothing reads as a check that found nothing
 
 Step 5 produced one: a mutation meant to draw editor furniture into the rendered frame

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -120,6 +120,29 @@ page loads. **Whenever a row reads source rather than behaviour, ask by what mec
 mutation would reach the bytes that row reads**, and do not assume the answer is the same
 for every file the tool can mutate.
 
+### A known intermittent in `library-check` section 9, written down with its signature
+
+`and it is stamped in source milliseconds rather than program time` goes red now and then,
+always reporting exactly `0ms against source 150ms at program 1.0s`. The row seeks the
+transport to program time 1.0, awaits `settled()`, presses mark, and compares the sidecar's
+`sourceMs` against `retime.sourceSecAt(1.0)`. `0ms` is not a near miss — it is the mark
+being taken with the playhead still at the start, so the seek had not been applied when
+`markHere` ran.
+
+Seen five times in about eleven runs while the refusal work was going through: four of them
+under back-to-back mutation sweeps, and **once in an unmutated baseline**, which is the part
+worth recording, because "only ever under load" was the reading until it was not. Two
+baselines run immediately afterwards on a machine with nothing else on it came back at 367
+assertions, none failed. Nothing in the diff that was being measured touches the retime
+curve, the transport or the mark sidecar, which is this file's own tell for flake rather
+than regression - a `git diff` rather than a judgement.
+
+It is recorded rather than diagnosed. The constant `0` and the constant `150` say the
+failure is discrete rather than noisy, so whatever it is has a single shape and is worth an
+hour when somebody has one: **the suspicion is that `settled()` can return before the seek
+it was waiting on has been applied**, which would make every row in that section that seeks
+and then reads a candidate rather than just this one.
+
 ### One regex over two constants cannot see one of them go missing
 
 The grid row asks whether the sensor's `512x424` is declared once, and its first spelling

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -345,6 +345,27 @@ two-thirds measured and read as whole. `grid-declared-with-a-leading-dot` is its
 mutation rather than a third number in that one, because the two fail differently and a
 control that covers a case is the only thing that says the case is covered.
 
+**And the last of them: a regex over an enumeration is a guess at it.** Deciding which
+`<script>` blocks hold JavaScript, the check matched `(text|application)/(java|ecma)script`
+— a shape, and a reasonable-looking one. HTML defines *sixteen* JavaScript MIME type
+essences, and that pattern is four of them. A page written with `application/x-javascript`
+runs in every browser and had its body discarded, so executable JavaScript was being
+dropped from a row about what the JavaScript declares. Silently, which is how a missing
+spelling always fails.
+
+There is no shape behind the sixteen — `text/livescript` and `text/jscript` are there for
+reasons twenty-five years old — so the enumeration *is* the definition, and the fix is to
+write it down rather than to describe it. **When a set is defined by a list somebody else
+maintains, copy the list; a pattern that covers today's members is a claim about the
+future that nothing checks.** Parameters are stripped before the comparison, because the
+spec matches the essence and because reading `text/javascript; charset=utf-8` as
+JavaScript over-reports loudly where dropping it goes unseen.
+
+The probe's second page carries executable code under a type nobody writes any more and a
+JSON block under a type that is not code, so it has to be a holder of one number and not
+the other: a check knowing only the modern four loses the first, and a check reading
+anything inside a `<script>` gains the second.
+
 ### An enumeration that walks a flat tree is the files that exist, not the tree
 
 The grid row above walks `web/` and `server/` rather than a list of the files that hold the

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -120,6 +120,26 @@ page loads. **Whenever a row reads source rather than behaviour, ask by what mec
 mutation would reach the bytes that row reads**, and do not assume the answer is the same
 for every file the tool can mutate.
 
+### One regex over two constants cannot see one of them go missing
+
+The grid row asks whether the sensor's `512x424` is declared once, and its first spelling
+asked with a single `512|424` alternation. A file "holds the grid" if it matches, and
+`web/format.js` matches for as long as *either* number is still written down there — so a
+`DEPTH_H` that stopped being a literal, or drifted off 424 while `DEPTH_W` held, leaves the
+holder list reading exactly `['web/format.js']` and the row green over a tree whose
+JavaScript no longer describes the frames the grabber sends.
+
+The duplication half was never at risk: a second file redeclaring either number lands in
+the list and the row fails. It is the row's *other* half that could not fire — its own
+failure message says "a grid that went missing", and it only said that when both went at
+once. Two rows now, one per dimension, and `--mutate grid-loses-a-dimension` turns
+`DEPTH_H = 424` into `DEPTH_H = DEPTH_W - 88`: the value is unchanged, so every page draws
+the same pixels and every message is the same size, and the only thing it can move is
+whether `424` is written down. Measured: 366 assertions, exactly one failed, the height
+row, with the width row still green — which is the split being necessary rather than
+tidy. **When a row's subject is a pair, ask for each half separately, or the half that is
+still there answers for the one that is not.**
+
 ### An enumeration that walks a flat tree is the files that exist, not the tree
 
 The grid row above walks `web/` and `server/` rather than a list of the files that hold the
@@ -178,6 +198,31 @@ menu would have been fulfilled for requests that are not the menu. It matches on
 pathname now. **A claim that names more than one surface is not controlled until each
 surface has a mutation of its own, and the second control is usually what discovers that the
 delivery only ever worked for the first.**
+
+### A positive arm built from the interesting shape misses the ordinary one
+
+The version-skew row above has a second arm because a gate that refused every manifest
+would satisfy the refusal arm while taking the link off entirely. The first spelling of
+that arm served one take, and it was the *refused* one — a take carrying a nonempty
+`openRefusals`, because that is the shape the row is about. It is the wrong shape to test
+a gate with. `openRefusals: []` is what an ordinary openable take sends, which is nearly
+every take there is, so a gate written as `length > 0` would take the link off for every
+healthy library while an arm holding only the refused take stayed green. The fixture
+carries both now, and the empty-list case has a row that names it, because the two takes
+fail for different reasons and a combined row would report the wrong one.
+
+**The control for it is `--mutate refusals-must-be-nonempty`, and it is deliberately not
+a well-behaved one.** It reddens both arm rows, and then it reddens the node's own rows
+across the suite, because the bug it plants is exactly "every healthy node goes dark" and
+that is what that looks like from here — 109 assertions, 11 failed, where a clean run
+reaches 366. That is the blast-radius rule being broken knowingly rather than by accident:
+several sections assume a linked node holding remote takes, and the first of them,
+`drawn(undefined)`, waited out its own timeout and threw at 105. That one is guarded now,
+the same way the way-back anchor is; the next is the confirm dialog for a take in state
+`both`, and the ones after that are download, reclaim and delete. Guarding the class —
+**every section that needs the node surviving a node that is not there** — is worth doing
+and is not done. Until it is, read this control by which rows went red and not by the
+assertion total, which is the rule this repo already states for every check.
 
 ### Two machines on one network are two builds, and a rig that stages both cannot see it
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -261,6 +261,33 @@ the same way the way-back anchor is; the next is the confirm dialog for a take i
 and is not done. Until it is, read this control by which rows went red and not by the
 assertion total, which is the rule this repo already states for every check.
 
+### A table indexed by a string off the wire has `Object.prototype` answering for it
+
+The version gate on `NodeLink` checks the *shape* of a node's manifest and deliberately not
+its vocabulary, so that a newer node can name a refusal this build has never heard of and
+have the tile badge the key as itself — visibly unmapped beating confidently wrong. That
+door is the point of the design, and the page's badge table was an ordinary object literal
+behind it. `BADGES['__proto__']` answers with `Object.prototype` rather than `undefined`, so
+the `?.` does not short-circuit, the call throws on a value that is not a function, and the
+gallery dies painting the tile — the same blank shelf the gate exists to prevent, arriving
+through the one door the gate was told to leave open. `constructor`, `toString` and
+`valueOf` are the quieter half: they are callable, so they badge a take `[object Object]`
+under a promise that an unmapped key reads as itself.
+
+`Object.create(null)` at the table, not a guard at the lookup, because the lookup is one
+today and the property that makes it safe belongs to the table. The same reading then
+applied to the instrument that checks it: the containment row asked `k in OPEN_REFUSALS`,
+and `in` walks the prototype chain, so a take arriving with `toString` would have been
+called a declared refusal. It is `Object.hasOwn` now. **An instrument asking `in` about keys
+that came off a wire is asking a question `Object.prototype` gets to answer.**
+
+The control drives it rather than reasoning about it: a stub node one build *ahead*, serving
+a take whose refusal key is `__proto__`, with a real server pointed at it and the real page
+loaded. `--mutate badges-inherit-from-object` puts the plain literal back and the row reports
+`TypeError: BADGES[refusal.key] is not a function`, the page never finishing its paint. Two
+rows, because surviving is not the claim — the second asks what the badge actually says, and
+that arm is the one the quieter half of the fault would fail.
+
 ### Two machines on one network are two builds, and a rig that stages both cannot see it
 
 `library-check` spawns its node and its editing machine out of one staged tree, so both

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -323,6 +323,28 @@ text and inside a `${}`. A scan that reads strings puts it on the 512 list and f
 scan that swallows template expressions takes it off the 424 list and fails. One file,
 both directions, which is what an arm for a scanner has to do.
 
+**Then the scan itself needed the same treatment twice, and both were about a token being
+asked of a character.** It entered its numeric branch only on a digit, so `.512e3` — 512,
+in the notation with no leading digit — was invisible: a whole spelling in which a second
+grid could ship under a green row. And it decided the `/` question from the previous
+*character*, so `return /512/` left it looking at the `n` of `return`, called that a value,
+called the slash division, and read the pattern's digits as code. A scan now takes an
+identifier whole and keeps it, because the question was always about the previous token.
+
+Two details in that are worth carrying. **A dot followed by a digit needs no
+disambiguation**, since `a.512` is a SyntaxError and property access can never look like
+this — the guard the first version had was protecting against a case the language does not
+have. And **the kept word has to be cleared by every branch that is not an identifier**,
+or a `return` left standing across the string in `return 'x' / 512` turns that division
+into a regex and swallows the code to the next slash. That is the silent direction, so the
+clearing is the part to get right rather than the keeping.
+
+**A spelling is only covered where a control plants it.** The mutation for notations
+planted hex and digit-leading scientific, so the row's claim to see *any* spelling was
+two-thirds measured and read as whole. `grid-declared-with-a-leading-dot` is its own
+mutation rather than a third number in that one, because the two fail differently and a
+control that covers a case is the only thing that says the case is covered.
+
 ### An enumeration that walks a flat tree is the files that exist, not the tree
 
 The grid row above walks `web/` and `server/` rather than a list of the files that hold the

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -345,8 +345,8 @@ fail for different reasons and a combined row would report the wrong one.
 **The control for it is `--mutate refusals-must-be-nonempty`, and it is deliberately not
 a well-behaved one.** It reddens both arm rows, and then it reddens the node's own rows
 across the suite, because the bug it plants is exactly "every healthy node goes dark" and
-that is what that looks like from here — 109 assertions, 11 failed, where a clean run
-reaches 366. That is the blast-radius rule being broken knowingly rather than by accident:
+that is what that looks like from here — 124 assertions, 11 failed, where a clean run
+reaches 390. That is the blast-radius rule being broken knowingly rather than by accident:
 several sections assume a linked node holding remote takes, and the first of them,
 `drawn(undefined)`, waited out its own timeout and threw at 105. That one is guarded now,
 the same way the way-back anchor is; the next is the confirm dialog for a take in state

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -332,15 +332,32 @@ rather than left to the takes that are generation zero incidentally, since a ban
 archive out of the editor.
 
 `--mutate open-ignores-format` is the control and it edits one line of `web/format.js`, which is
-the point of it rather than an implementation detail. Four doors decide whether a take may be
-opened — `openable` in `describeTake`, the badge and the dead Open button in the gallery, and
-`openTake` in the editor — and three of them are cheap to satisfy by inlining a comparison, which
-would pass every row here and drift the first time the band gains a member. So the assertion the
-mutation really carries is the *count*: it reddens **6 of 365**, one row per door plus the
-gallery's menu sentence and the editor's editing state, and the takes that must stay green stay
-green — both `no-hello-take` rows, `local-clip`'s `dateSource === 'hello'`, and all four
-generation-zero rows. A mutation that reddened fewer would mean the band had quietly become
-several predicates that agree.
+the point of it rather than an implementation detail. **There were four doors deciding whether a
+take may be opened and there are two**, which is the change the refusal table made: `openable` in
+`describeTake` and the gallery's badge and dead Open button were three separate comparisons, and
+the last two now quote `openRefusals` instead. What is left is `OPEN_REFUSALS.format`, which
+delegates the sentence, and `openTake` in the editor, which is handed a hello and never a
+manifest — so `format.js` is still where the band lives, and a comparison inlined at either door
+would still pass every row here and drift the first time the band gains a member.
+
+So the assertion the mutation really carries is the *count*: it reddens **8 of 390** — the
+listing's `openable`, the refusal the take carries, the two-table containment row, the gallery's
+badge and its Open button, the menu's sentence, and the editor's note and its refusal to open.
+The count grew when the surfaces stopped deriving, which is the right direction: quoting one
+sentence in five places means a band that stops refusing is visible in five places rather than in
+one. The takes that must stay green stay green — both `no-hello-take` rows, `local-clip`'s
+`dateSource === 'hello'`, and all four generation-zero rows. A mutation that reddened fewer would
+mean the band had quietly become several predicates that agree.
+
+**Its opposite number is `--mutate openable-recomputes-the-band`**, which puts the band back to
+being a term in `openable` rather than an entry in the table, and it exists because
+`openable` is false either way. Every row asking whether the future-format take opens passes a
+build where the band decides for itself again — measured: 4 of 390, and the three rows that
+brought the band into this suite are all still green under it. What reddens is what the take
+*carries*: the refusal itself, the containment row now declaring a `format` nothing produces, the
+badge over the poster and the sentence in the menu. **When a merge collapses two derivations into
+one, the row that proves it needs a mutation that restores the other — the shared predicate
+cannot tell them apart, which is why they were able to disagree.**
 
 Reaching all four needed the harness to stage `web/` mutations rather than leaving them to the
 browser route interception, because `server/library.js` imports `format.js` by path: served to

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -276,6 +276,22 @@ held, `startServer` throws if its own child exits instead of listening, and it r
 outside the declared span so a section added at `+17` is a failure rather than a hole. Pass
 `--node-port`/`--mac-port` a range nothing else holds.
 
+**Two more collisions inside the span, and both were silent.** An offset two sections both
+reach for binds without complaint, because the first holder is dead by the time the second
+starts — what is left is two entries for one port, and every `servers.find((s) => s.port ===
+n)` in the tool answers with whichever was pushed first, which is the dead one. Measured when
+it happened: the respawn-backoff section read another section's log and reported `0 exits`
+against a log carrying twenty-two deaths, which reads as a finding about the supervisor and is
+a finding about the reading. `startServer` drops the stale entry at the claim now — not at the
+lookup, because a section that only starts a server and never reads its log still poisons the
+one that does — and keeps it on a retired list the cleanup still walks.
+
+The other is a `--node-port` chosen *inside* the mac span, which the free check deduplicates
+away: both pass, the run starts, the node binds the shared offset first and is still live when
+a section reaches it, and the retire path then drops a running server off the cleanup list. The
+operator sees an EADDRINUSE several sections in, naming neither the overlap nor the node. It is
+a fact about the arguments, so `reservePorts` now answers it from the arguments and exits 2.
+
 **Three rows in it are flaky under machine contention, and they are written down here so the
 next person does not spend the afternoon on an innocent change.** Two are in the
 marks-on-the-scrubber section and are the same race: `and it is stamped in source milliseconds
@@ -340,7 +356,7 @@ delegates the sentence, and `openTake` in the editor, which is handed a hello an
 manifest — so `format.js` is still where the band lives, and a comparison inlined at either door
 would still pass every row here and drift the first time the band gains a member.
 
-So the assertion the mutation really carries is the *count*: it reddens **8 of 390** — the
+So the assertion the mutation really carries is the *count*: it reddens **8 of 392** — the
 listing's `openable`, the refusal the take carries, the two-table containment row, the gallery's
 badge and its Open button, the menu's sentence, and the editor's note and its refusal to open.
 The count grew when the surfaces stopped deriving, which is the right direction: quoting one
@@ -352,7 +368,7 @@ mean the band had quietly become several predicates that agree.
 **Its opposite number is `--mutate openable-recomputes-the-band`**, which puts the band back to
 being a term in `openable` rather than an entry in the table, and it exists because
 `openable` is false either way. Every row asking whether the future-format take opens passes a
-build where the band decides for itself again — measured: 4 of 390, and the three rows that
+build where the band decides for itself again — measured: 5 of 392, and the three rows that
 brought the band into this suite are all still green under it. What reddens is what the take
 *carries*: the refusal itself, the containment row now declaring a `format` nothing produces, the
 badge over the poster and the sentence in the menu. **When a merge collapses two derivations into

--- a/server/capture.js
+++ b/server/capture.js
@@ -22,6 +22,20 @@ import { open, readFile, writeFile, rename, stat } from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import { basename, resolve } from 'node:path';
 import { MAGIC, HEADER_BYTES, TYPE_HELLO, TYPE_FRAME, MAX_PAYLOAD_BYTES } from './protocol.js';
+// The depth grid every frame in this format carries, and the only reason it is
+// named on the server at all: the decimation below has to know the shape of the
+// array it is sampling down, and a divisor applied to a flat byte count would
+// take every k-th sample along one axis and none along the other. Checked against
+// the frame's own declared length before anything is sampled, so a capture whose
+// grid is not this one is refused rather than shredded.
+//
+// Imported rather than declared, and not re-exported: nothing outside this file
+// reached for the pair even while it was exported, so the `export ... from` that
+// `server/library.js` needs for `VALID_ID` - where the constant is both imported and
+// passed on, because `export ... from` puts nothing in local scope - would be a door
+// nobody uses. A second grabber or a different device changes `web/format.js` and
+// `native/grabber.cpp`, and nothing in between.
+import { DEPTH_H, DEPTH_W } from '../web/format.js';
 
 export const INDEX_VERSION = 2;
 
@@ -29,14 +43,6 @@ export const INDEX_VERSION = 2;
 // overhead, small enough that the scan's working set does not track file size.
 const SCAN_CHUNK = 4 * 1024 * 1024;
 
-// The depth grid every frame in this format carries, and the only reason it is
-// named on the server at all: the decimation below has to know the shape of the
-// array it is sampling down, and a divisor applied to a flat byte count would
-// take every k-th sample along one axis and none along the other. Checked against
-// the frame's own declared length before anything is sampled, so a capture whose
-// grid is not this one is refused rather than shredded.
-export const DEPTH_W = 512;
-export const DEPTH_H = 424;
 
 // What a frame run is read in. Bounded on purpose: a run can be the whole take,
 // and the point of this module is that no read is ever the size of the file.

--- a/server/library.js
+++ b/server/library.js
@@ -190,6 +190,16 @@ async function describeTake(dir, file, recording) {
       truncated: false,
       hasHello: null,
       hello: null,
+      // The same authority answering a case it already knows, rather than a second
+      // derivation: a take still being written has no settled hash, so nothing may
+      // open it whatever its frames turn out to be. The gallery's *warning* about a
+      // recording take is a wider statement - it names stopping before opening,
+      // downloading, renaming or removing - and stays a page concern for that reason,
+      // because an action list does not belong in a library scanner.
+      openRefusals: [{
+        key: 'recording',
+        why: 'this take is still being written, so it has no settled hash and nothing may open it until the recorder closes it',
+      }],
       openable: false,
       recording: true,
       // Cheap and it is the one thing that is true mid-take: marks pressed in the
@@ -212,6 +222,49 @@ async function describeTake(dir, file, recording) {
   // own modification time, and says which it used rather than presenting a guess
   // as a record.
   const fromHello = Number.isFinite(hello?.startedAt) && hello.startedAt > 0;
+
+  /**
+   * Why this take cannot be opened, in sentences, keyed so a surface can decide what
+   * to do with each - and this is the only place any of them is written.
+   *
+   * A list rather than one string, because a take can carry two blocking facts at
+   * once and a single string cannot serve a tile that badges both. `openable` below
+   * is then "the list is empty" rather than a second expression of the same
+   * predicate, which is what stops the two drifting.
+   *
+   * It is here rather than in the pages because it was in the pages, twice, twelve
+   * lines apart, and they disagreed. A take with a hello and no whole frame was
+   * badged "the scan found no whole frame in this take" and, on the button beside it,
+   * told it "needs two frames to bracket a position" - a sentence about a take that
+   * has one, shown over a take that has none. Measured on the shipped build before
+   * this moved, with the `hello-no-frames` fixture `library-check` now plants: nothing
+   * had ever reached that shape, because the take with zero frames carried no hello
+   * and answered on the branch above, and the take with a hello had a frame.
+   *
+   * Zero frames and one frame are different facts and the sentence says which, which
+   * is the distinction the gallery's badge already drew and the button did not.
+   *
+   * **The push order is the badge order**, since the gallery renders these in the
+   * order they arrive and `cannotOpen` quotes the first. Decided here rather than
+   * sorted there, because two files agreeing about an order is the same shape as two
+   * files agreeing about a sentence.
+   */
+  const openRefusals = [];
+  if (!index.hello) {
+    openRefusals.push({
+      key: 'no-hello',
+      why: 'this take carries no sensor hello, so its intrinsics are unknown and it cannot be unprojected',
+    });
+  }
+  if (stamps.length < 2) {
+    openRefusals.push({
+      key: 'short',
+      why: stamps.length === 0
+        ? 'the scan found no whole frame in this take, so there is nothing here to draw or to open'
+        : 'a take needs two frames to bracket a position, so there is nothing here to play',
+    });
+  }
+
   return {
     id,
     file,
@@ -239,7 +292,8 @@ async function describeTake(dir, file, recording) {
     hello: hello ? { fx: hello.fx, fy: hello.fy, cx: hello.cx, cy: hello.cy } : null,
     // Two frames is the floor for a pair source, so a shorter take lists and
     // refuses to open. Named here rather than discovered in the editor.
-    openable: Boolean(index.hello) && stamps.length >= 2,
+    openRefusals,
+    openable: openRefusals.length === 0,
     recording: false,
     marks,
   };

--- a/server/library.js
+++ b/server/library.js
@@ -156,6 +156,60 @@ export async function appendMarks(capturePath, records) {
 // ------------------------------------------------------------------- manifest
 
 /**
+ * Every reason this build can refuse to open a take, keyed, with the sentence each one
+ * carries - and this is the only place any of them is written.
+ *
+ * A list on the take rather than one string, because a take can carry two blocking
+ * facts at once and a single string cannot serve a tile that badges both. `openable` is
+ * then "the list is empty" rather than a second expression of the same predicate, which
+ * is what stops the two drifting.
+ *
+ * It is here rather than in the pages because it was in the pages, twice, twelve lines
+ * apart, and they disagreed. A take with a hello and no whole frame was badged "the
+ * scan found no whole frame in this take" and, on the button beside it, told it "needs
+ * two frames to bracket a position" - a sentence about a take that has one, shown over
+ * a take that has none. Measured on the shipped build before this moved, with the
+ * `hello-no-frames` fixture `library-check` now plants: nothing had ever reached that
+ * shape, because the take with zero frames carried no hello and answered on the
+ * recording branch, and the take with a hello had a frame.
+ *
+ * Zero frames and one frame are different facts and the sentence says which, which is
+ * the distinction the gallery's badge already drew and the button did not.
+ *
+ * **A table rather than three pushes with their sentences inline, because the keys have
+ * a second reader.** `web/library.js` keeps its own table of what each key is badged as
+ * over a 228px poster, and the two have to cover the same keys or a refusal arrives
+ * with no badge. A check comparing the page's table against the refusals that happen to
+ * be in a fixture library cannot see a key no fixture take produces; comparing it
+ * against this object can, which is why the enumeration is a value here and not a shape
+ * to be recovered from the branches below.
+ */
+export const OPEN_REFUSALS = {
+  recording: () => 'this take is still being written, so it has no settled hash and nothing may open it until the recorder closes it',
+  'no-hello': () => 'this take carries no sensor hello, so its intrinsics are unknown and it cannot be unprojected',
+  short: (frames) => (frames === 0
+    ? 'the scan found no whole frame in this take, so there is nothing here to draw or to open'
+    : 'a take needs two frames to bracket a position, so there is nothing here to play'),
+};
+
+/** One refusal, so a key that is not in the table above is a throw rather than a tile. */
+const refusal = (key, ...args) => ({ key, why: OPEN_REFUSALS[key](...args) });
+
+/**
+ * Whether a take from somewhere else carries refusals this build can render.
+ *
+ * The shape and not the vocabulary. A *newer* node may send a key this build has never
+ * heard of, and the gallery is built for that - an unmapped key is badged as itself,
+ * because visibly unmapped beats confidently wrong - so rejecting on an unknown key
+ * would refuse a node whose takes are perfectly listable. What cannot be rendered is a
+ * take with no refusals at all, which is what an *older* node sends: it carried
+ * `openable`, `hasHello` and `frames` and left every surface to derive the sentence,
+ * which is the derivation this design removed.
+ */
+const carriesRefusals = (take) => Array.isArray(take.openRefusals)
+  && take.openRefusals.every((r) => r && typeof r.key === 'string' && typeof r.why === 'string' && r.why !== '');
+
+/**
  * One take as the gallery sees it. Read through `cachedIndex`, which holds no
  * descriptor, so a directory of two hundred takes costs two hundred sidecar reads
  * and nothing that stays open.
@@ -196,10 +250,7 @@ async function describeTake(dir, file, recording) {
       // recording take is a wider statement - it names stopping before opening,
       // downloading, renaming or removing - and stays a page concern for that reason,
       // because an action list does not belong in a library scanner.
-      openRefusals: [{
-        key: 'recording',
-        why: 'this take is still being written, so it has no settled hash and nothing may open it until the recorder closes it',
-      }],
+      openRefusals: [refusal('recording')],
       openable: false,
       recording: true,
       // Cheap and it is the one thing that is true mid-take: marks pressed in the
@@ -223,47 +274,14 @@ async function describeTake(dir, file, recording) {
   // as a record.
   const fromHello = Number.isFinite(hello?.startedAt) && hello.startedAt > 0;
 
-  /**
-   * Why this take cannot be opened, in sentences, keyed so a surface can decide what
-   * to do with each - and this is the only place any of them is written.
-   *
-   * A list rather than one string, because a take can carry two blocking facts at
-   * once and a single string cannot serve a tile that badges both. `openable` below
-   * is then "the list is empty" rather than a second expression of the same
-   * predicate, which is what stops the two drifting.
-   *
-   * It is here rather than in the pages because it was in the pages, twice, twelve
-   * lines apart, and they disagreed. A take with a hello and no whole frame was
-   * badged "the scan found no whole frame in this take" and, on the button beside it,
-   * told it "needs two frames to bracket a position" - a sentence about a take that
-   * has one, shown over a take that has none. Measured on the shipped build before
-   * this moved, with the `hello-no-frames` fixture `library-check` now plants: nothing
-   * had ever reached that shape, because the take with zero frames carried no hello
-   * and answered on the branch above, and the take with a hello had a frame.
-   *
-   * Zero frames and one frame are different facts and the sentence says which, which
-   * is the distinction the gallery's badge already drew and the button did not.
-   *
-   * **The push order is the badge order**, since the gallery renders these in the
-   * order they arrive and `cannotOpen` quotes the first. Decided here rather than
-   * sorted there, because two files agreeing about an order is the same shape as two
-   * files agreeing about a sentence.
-   */
+  // Why this take cannot be opened, drawn from the one table above. **The push order
+  // is the badge order**, since the gallery renders these in the order they arrive and
+  // `cannotOpen` quotes the first. Decided here rather than sorted there, because two
+  // files agreeing about an order is the same shape as two files agreeing about a
+  // sentence.
   const openRefusals = [];
-  if (!index.hello) {
-    openRefusals.push({
-      key: 'no-hello',
-      why: 'this take carries no sensor hello, so its intrinsics are unknown and it cannot be unprojected',
-    });
-  }
-  if (stamps.length < 2) {
-    openRefusals.push({
-      key: 'short',
-      why: stamps.length === 0
-        ? 'the scan found no whole frame in this take, so there is nothing here to draw or to open'
-        : 'a take needs two frames to bracket a position, so there is nothing here to play',
-    });
-  }
+  if (!index.hello) openRefusals.push(refusal('no-hello'));
+  if (stamps.length < 2) openRefusals.push(refusal('short', stamps.length));
 
   return {
     id,
@@ -357,17 +375,46 @@ export class NodeLink {
     return res.json();
   }
 
-  /** The node's own takes, or null if it cannot be reached. Never throws upward. */
+  /**
+   * The node's own takes, or null if it cannot be read. Never throws upward.
+   *
+   * **Two machines on one network are two builds**, and the one that gets upgraded
+   * first is whichever the operator was standing at. A node still running the build
+   * before the refusals moved off the pages answers `/library/takes` with `openable`,
+   * `hasHello` and `frames` and no `openRefusals` at all - a manifest that parses,
+   * passes the id and hash filters below, and reconciles into the listing looking like
+   * any other take. The gallery then iterates a field that is not there while painting
+   * the first remote tile, and the whole shelf goes blank on a `TypeError` with nothing
+   * on screen saying why.
+   *
+   * Refused here, at the boundary, rather than guarded at each of the surfaces that
+   * read a take. A `?? []` on the page would draw a tile claiming a take is fine, which
+   * is a second implementation wearing a fallback and the fallback is the half that
+   * would be believed; and there are three surfaces, so the guard would be three
+   * guesses about one wire format. This is the one place a manifest from another build
+   * arrives, so it is the one place that can say the build is the problem.
+   *
+   * The whole manifest and never take by take. Admitting the readable ones would hide
+   * the rest behind a shelf that looks complete, and "some of that node's takes are
+   * missing" is the failure a link is supposed to make impossible to have silently.
+   */
   async takes() {
     try {
       const body = await this.fetchJson('/library/takes');
-      this.lastError = null;
       // The hash is filtered beside the id because it is the other field of a node's
       // that reaches a path here. **A take still being shot advertises no hash at
       // all** - `describeTake` reports null on purpose, and `reconcile` keys those by
       // side and name - so null is a take the gallery has to be able to list and
       // refuse to download. What must not pass is a string that is not a hash.
-      return body.takes.filter((t) => VALID_ID.test(t.id) && (t.hash === null || VALID_HASH.test(t.hash)));
+      const takes = body.takes.filter((t) => VALID_ID.test(t.id) && (t.hash === null || VALID_HASH.test(t.hash)));
+      const older = takes.find((t) => !carriesRefusals(t));
+      if (older) {
+        this.lastError = 'it is running an older build whose take manifest carries no open-refusal reasons, '
+          + `so nothing it holds can be listed here - ${older.id} arrived with none. Upgrade the node to this build.`;
+        return null;
+      }
+      this.lastError = null;
+      return takes;
     } catch (err) {
       this.lastError = err.message;
       return null;

--- a/server/library.js
+++ b/server/library.js
@@ -248,6 +248,16 @@ async function describeTake(dir, file, recording) {
   // than a figure that reads like a fact, and says the take is recording, which is
   // what the tile actually has to draw.
   if (recording) {
+    // **Hoisted so `openable` is derived here too, and it was not.** This branch used to
+    // carry the list and a hardcoded `openable: false` beside it, which is precisely the
+    // second expression of one predicate that the table above exists to remove - written
+    // into the branch by the commit that wrote the argument against it. Nothing caught it:
+    // both said the take cannot be opened, so they agreed until the day one moved, and the
+    // failure they would have produced is the quiet one - a disabled Open button whose
+    // reason is the empty string, because `cannotOpen` quotes the list and the list is
+    // what would have gone. The two-table rows cannot see this either, since they skip
+    // `recording` on purpose.
+    const openRefusals = [refusal('recording')];
     return {
       id,
       file,
@@ -270,8 +280,8 @@ async function describeTake(dir, file, recording) {
       // recording take is a wider statement - it names stopping before opening,
       // downloading, renaming or removing - and stays a page concern for that reason,
       // because an action list does not belong in a library scanner.
-      openRefusals: [refusal('recording')],
-      openable: false,
+      openRefusals,
+      openable: openRefusals.length === 0,
       recording: true,
       // Cheap and it is the one thing that is true mid-take: marks pressed in the
       // room land in the sidecar, and the sidecar is beside the take rather than in

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1110,6 +1110,15 @@ const MUTATIONS = {
     '  const depthKB = Math.ceil(DEPTH_W / state.divisor) * Math.ceil(DEPTH_H / state.divisor) * 2 / 1000;',
     '  const depthKB = Math.ceil(0x200 / state.divisor) * Math.ceil(4.24e2 / state.divisor) * 2 / 1000;',
   ]] },
+  // **And the notation with no leading digit**, which is its own mutation rather than a
+  // third number in the one above because a spelling is only covered where a control
+  // plants it: hex and digit-leading scientific were, and `.512e3` was not, so the row's
+  // claim to see any spelling was two-thirds measured. The scan entering only on a digit
+  // passes this and reports the grid as declared once.
+  'grid-declared-with-a-leading-dot': { file: 'web/main.js', edits: [[
+    '  const depthKB = Math.ceil(DEPTH_W / state.divisor) * Math.ceil(DEPTH_H / state.divisor) * 2 / 1000;',
+    '  const depthKB = Math.ceil(.512e3 / state.divisor) * Math.ceil(.424e3 / state.divisor) * 2 / 1000;',
+  ]] },
   // The loopback gate comes off the one route in this program that starts a process,
   // so a browser across the link opens a window on a machine nobody is standing at.
   'reveal-answers-any-caller': { file: 'server/index.js', edits: [[
@@ -1245,17 +1254,38 @@ const numbersIn = (src) => {
   const stack = [];
   const inTemplate = () => stack[stack.length - 1]?.kind === 'template';
   let depth = 0;
-  // The last significant character, which is what decides the `/` question. Not the last
-  // character: whitespace and comments do not answer it.
+  // The last significant character and the last identifier, which together decide the `/`
+  // question. Not the last character alone: `return` ends in a letter and a letter ends a
+  // value, so the character on its own calls every `return /re/` a division. `prevWord` is
+  // cleared by every branch that is not an identifier, because a `return` left standing
+  // across the string in `return 'x' / 2` would turn that division into a regex and
+  // swallow the code up to the next slash - which is the silent direction.
   let prev = '';
+  let prevWord = '';
   let i = 0;
-  const NUM = /^(?:0[xX][\dA-Fa-f](?:_?[\dA-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?(?:[eE][+-]?\d(?:_?\d)*)?)n?/;
+  // The decimal form has two shapes because JavaScript does: digits first, or a leading
+  // dot. `.512e3` is 512 and the first spelling of this scan could not see it, since it
+  // entered only on a digit - a whole notation in which a second grid could be declared
+  // under a green row, which is the direction that does not announce itself. A dot
+  // followed by a digit is never a property access, because `a.512` is a SyntaxError, so
+  // there is nothing to disambiguate here.
+  const NUM = /^(?:0[xX][\dA-Fa-f](?:_?[\dA-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?(?:[eE][+-]?\d(?:_?\d)*)?|\.\d(?:_?\d)*(?:[eE][+-]?\d(?:_?\d)*)?)n?/;
+  // The words after which a `/` is a pattern and never a quotient.
+  const REGEX_AFTER = new Set(['return', 'throw', 'case', 'yield', 'typeof', 'instanceof',
+    'in', 'of', 'delete', 'void', 'new', 'do', 'else', 'await']);
   while (i < src.length) {
     const c = src[i];
     if (inTemplate()) {
       if (c === '\\') { i += 2; continue; }
-      if (c === '`') { stack.pop(); prev = '`'; i++; continue; }
-      if (c === '$' && src[i + 1] === '{') { stack.push({ kind: 'code', depth }); depth++; prev = '{'; i += 2; continue; }
+      if (c === '`') { stack.pop(); prev = '`'; prevWord = ''; i++; continue; }
+      if (c === '$' && src[i + 1] === '{') {
+        stack.push({ kind: 'code', depth });
+        depth++;
+        prev = '{';
+        prevWord = '';
+        i += 2;
+        continue;
+      }
       i++;
       continue;
     }
@@ -1271,12 +1301,28 @@ const numbersIn = (src) => {
       while (i < src.length && src[i] !== c) i += src[i] === '\\' ? 2 : 1;
       i++;
       prev = c;
+      prevWord = '';
       continue;
     }
-    if (c === '`') { stack.push({ kind: 'template' }); i++; continue; }
-    // A regex only where a value cannot already have ended. `}` counts as a value ending,
-    // which is the ambiguous case resolved toward division, as the comment above says.
-    if (c === '/' && !/[\w$)\]}'"`]/.test(prev)) {
+    if (c === '`') { stack.push({ kind: 'template' }); i++; prevWord = ''; continue; }
+    // An identifier taken whole, because the `/` question below is about the previous
+    // *token* and asking it of the previous character gets `return /512/` wrong - `n` ends
+    // a word, a word ends a value, and a value means division. That reads the regex as
+    // code and reports its digits, which is the loud direction but still a clean tree
+    // failing over a module that returns a pattern.
+    if (/[A-Za-z_$]/.test(c)) {
+      let j = i;
+      while (j < src.length && /[\w$]/.test(src[j])) j++;
+      prevWord = src.slice(i, j);
+      prev = 'a';
+      i = j;
+      continue;
+    }
+    // A regex only where a value cannot already have ended - or after one of the words
+    // that cannot be followed by division, which is what makes `return /512/` a pattern
+    // and `total / 512` a quotient. `}` stays the ambiguous case resolved toward
+    // division, as the comment above says.
+    if (c === '/' && (!/[\w$)\]}'"`]/.test(prev) || REGEX_AFTER.has(prevWord))) {
       i++;
       let klass = false;
       while (i < src.length) {
@@ -1289,26 +1335,31 @@ const numbersIn = (src) => {
       }
       i++;
       prev = '/';
+      prevWord = '';
       continue;
     }
-    if (c === '{') { depth++; prev = c; i++; continue; }
+    if (c === '{') { depth++; prev = c; prevWord = ''; i++; continue; }
     if (c === '}') {
       depth--;
       const top = stack[stack.length - 1];
-      if (top?.kind === 'code' && top.depth === depth) { stack.pop(); i++; continue; }
+      if (top?.kind === 'code' && top.depth === depth) { stack.pop(); prevWord = ''; i++; continue; }
       prev = c;
+      prevWord = '';
       i++;
       continue;
     }
-    // A number, but only where one can start - `a.512` is a property and `x512` a name.
-    if (/\d/.test(c) && !/[\w$.]/.test(prev)) {
+    // A number, in either of the two shapes one can start in: a digit, or a dot with a
+    // digit behind it. `x512` is a name and never reached here, because the identifier
+    // branch above has already taken it whole.
+    if (/\d/.test(c) || (c === '.' && /\d/.test(src[i + 1] ?? ''))) {
       const [token] = NUM.exec(src.slice(i));
       values.push(Number(token.replace(/n$/, '').replace(/_/g, '')));
       i += token.length;
       prev = '0';
+      prevWord = '';
       continue;
     }
-    if (!/\s/.test(c)) prev = c;
+    if (!/\s/.test(c)) { prev = c; prevWord = ''; }
     i++;
   }
   return values;
@@ -2179,6 +2230,17 @@ async function runChecks() {
       'export const WIDE = 1512;\nexport const SMALL = 4.24;\nexport const HEX = 0x201;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'buried.js'), 'export const W = 512;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'hexadecimal.js'), 'export const W = 0x200;\n');
+    // **Two forms that the scan needs a token for rather than a character.** `.512e3` is
+    // 512 in the notation with no leading digit, and a scan entering only on a digit
+    // cannot see it - a whole spelling in which a second grid ships under a green row.
+    // `return /424/` is the other side: `return` ends in a letter, a letter ends a value,
+    // and a value means the `/` is division, so the pattern gets read as code and its
+    // digits reported. One file holds both, so it must land on the width list and not on
+    // the height list - a scan that misses the first or falls for the second gets exactly
+    // one of those wrong.
+    writeFileSync(join(probeRoot, 'web', 'nested', 'edge-forms.js'),
+      'export const W = .512e3;\n'
+      + 'export const rows = () => { return /424/; };\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'further.js'), 'export const H = 424;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'scientific.js'), 'export const H = 4.24e2;\n');
     // **The literal text a module carries, which is the same fact as the paragraph in the
@@ -2222,7 +2284,7 @@ async function runChecks() {
     // the 512 list and fails, and a scan that swallows template expressions takes it off
     // the 424 list and fails. One file, both directions.
     const WANT = {
-      512: ['web/nested/buried.js', 'web/nested/hexadecimal.js', 'web/page.html'],
+      512: ['web/nested/buried.js', 'web/nested/edge-forms.js', 'web/nested/hexadecimal.js', 'web/page.html'],
       424: ['web/nested/deeper/further.js', 'web/nested/deeper/scientific.js', 'web/nested/literals.js'],
     };
     for (const [what, n] of GRID) {

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1273,6 +1273,12 @@ const numbersIn = (src) => {
   // The words after which a `/` is a pattern and never a quotient.
   const REGEX_AFTER = new Set(['return', 'throw', 'case', 'yield', 'typeof', 'instanceof',
     'in', 'of', 'delete', 'void', 'new', 'do', 'else', 'await']);
+  // What may begin and continue a name, taken from the language rather than described.
+  // `$` and `_` are named because they are the two the properties leave out.
+  const ID_START = /[\p{ID_Start}$_]/u;
+  // The two joiners are written as escapes on purpose - they are zero-width, and a
+  // character class nobody can see the contents of is one nobody can review.
+  const ID_PART = /[\p{ID_Continue}$\u200C\u200D]/u;
   while (i < src.length) {
     const c = src[i];
     if (inTemplate()) {
@@ -1310,9 +1316,17 @@ const numbersIn = (src) => {
     // a word, a word ends a value, and a value means division. That reads the regex as
     // code and reports its digits, which is the loud direction but still a clean tree
     // failing over a module that returns a pattern.
-    if (/[A-Za-z_$]/.test(c)) {
+    //
+    // **`ID_Start` and `ID_Continue` rather than the ASCII classes**, which is the same
+    // correction as taking HTML's MIME list instead of a pattern shaped like it: these
+    // properties *are* the language's definition of an identifier, and `[A-Za-z_$]` is a
+    // guess at one that happens to cover the letters this tree uses today. `pixelsπ` is a
+    // perfectly good name; under the ASCII classes the `π` fell out of the identifier,
+    // landed as punctuation, and the division behind it read as a regex that swallowed
+    // the number - silently, and in a module the row is meant to be reading.
+    if (ID_START.test(c)) {
       let j = i;
-      while (j < src.length && /[\w$]/.test(src[j])) j++;
+      while (j < src.length && ID_PART.test(src[j])) j++;
       prevWord = src.slice(i, j);
       prev = 'a';
       i = j;
@@ -2322,7 +2336,11 @@ async function runChecks() {
       // A finished regex divided by something, which is the third way the slash question
       // gets answered wrongly: the slash that *closed* a pattern is not the slash that
       // could open one, and treating it as the latter swallows what follows.
-      + 'export const ratio = /x/ / 512;\n');
+      + 'export const ratio = /x/ / 512;\n'
+      // And a name the ASCII classes cannot finish reading. `π` is `ID_Continue`, so
+      // `pixelsπ` is one identifier; a scan that stops at the `s` leaves the `π` standing
+      // as punctuation, and the division behind it opens a regex over the number.
+      + 'export const perRow = (pixelsπ) => pixelsπ / 512;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'further.js'), 'export const H = 424;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'scientific.js'), 'export const H = 4.24e2;\n');
     // **The literal text a module carries, which is the same fact as the paragraph in the

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1056,6 +1056,19 @@ const MUTATIONS = {
     '  const depthKB = Math.ceil(DEPTH_W / state.divisor) * Math.ceil(DEPTH_H / state.divisor) * 2 / 1000;',
     '  const depthKB = Math.ceil(512 / state.divisor) * Math.ceil(424 / state.divisor) * 2 / 1000;',
   ]] },
+  // **The same second declaration, spelled so a search for the digits cannot see it.**
+  // `0x200` is 512 and `4.24e2` is 424, so this is `grid-declared-twice` with nothing
+  // changed but the notation - the line computes the same number and renders the same
+  // pixels. It is the control for the row's matcher rather than for the row: the version
+  // of this check that searched for decimal digits with boundary guards passes this
+  // mutation and reports the grid as declared once, which is a second implementation of
+  // the sensor's geometry under a green row. Its sibling above stays, because the two
+  // fail differently - that one is caught by any matcher and this one only by a matcher
+  // that compares values.
+  'grid-declared-in-another-spelling': { file: 'web/main.js', edits: [[
+    '  const depthKB = Math.ceil(DEPTH_W / state.divisor) * Math.ceil(DEPTH_H / state.divisor) * 2 / 1000;',
+    '  const depthKB = Math.ceil(0x200 / state.divisor) * Math.ceil(4.24e2 / state.divisor) * 2 / 1000;',
+  ]] },
   // The loopback gate comes off the one route in this program that starts a process,
   // so a browser across the link opens a window on a machine nobody is standing at.
   'reveal-answers-any-caller': { file: 'server/index.js', edits: [[
@@ -1900,8 +1913,36 @@ async function runChecks() {
   // grid that went missing" - that only fired when both went at once.
   console.log('\n[library] the sensor grid is declared once, and the tree is what says so');
   {
-    // A literal, with the guards that keep `512` out of `1512` and `4.24` alike.
-    const literal = (n) => new RegExp(`(?<![\\d.])${n}(?![\\d.])`);
+    // **Every numeric literal, compared by value.** The first spelling of this searched
+    // for the decimal digits with guards either side - `(?<![\d.])512(?![\d.])`, which
+    // keeps `512` out of `1512` and `4.24` - and that is a matcher for one *spelling* of a
+    // number wearing the name of the number. A module redeclaring the width as `512.0` is
+    // rejected by the trailing guard, `0x200` and `5.12e2` are never looked at, and each
+    // of them is a second declaration of the grid sitting under a row reporting one. The
+    // guards are not needed once the comparison is by value, because `1512` tokenises as
+    // `1512` and answers 1512.
+    //
+    // Bounded on purpose, and the boundary is where a reader would otherwise assume more:
+    // this sees a literal in any spelling and does not see an *expression* that computes
+    // the value. `256 * 2` is invisible to it and so is `DEPTH_W - 88`, which is what
+    // `grid-loses-a-dimension` plants - that mutation is a control for the missing-grid
+    // half of the row below rather than for this. A declaration written as arithmetic is
+    // outside what this claims, and saying so is the difference between a bound and a
+    // hole.
+    //
+    // Legacy octal - `01000`, which is 512 - is not in the pattern because it is a
+    // SyntaxError in a module, and every file walked here is one. `syntax-check` is what
+    // holds that.
+    const NUMERIC = new RegExp([
+      '(?<![\\w$.])(?:',
+      '0[xX][\\dA-Fa-f](?:_?[\\dA-Fa-f])*',       // hex
+      '|0[oO][0-7](?:_?[0-7])*',                  // octal
+      '|0[bB][01](?:_?[01])*',                    // binary
+      '|\\d(?:_?\\d)*(?:\\.(?:\\d(?:_?\\d)*)?)?(?:[eE][+-]?\\d(?:_?\\d)*)?', // decimal
+      ')n?',
+    ].join(''), 'g');
+    const declares = (source, n) => [...source.matchAll(NUMERIC)]
+      .some((m) => Number(m[0].replace(/n$/, '').replace(/_/g, '')) === n);
     const GRID = [['the depth width', 512], ['the depth height', 424]];
     // Relative paths under `base`, deepest last, as one flat list. Split out from the
     // row below so the falsification control underneath can run the same walker over a
@@ -1917,22 +1958,44 @@ async function runChecks() {
     // The control, run before the row it controls: a tree whose grids are one directory
     // down, one dimension per file. A walker that skips directories answers `[]` here
     // and this goes red, where against the real `web/` and `server/` it would answer
-    // exactly what the rows below want and pass. Two files rather than one so the
+    // exactly what the rows below want and pass. Separate files rather than one so the
     // per-dimension search is exercised separately as well - a probe that planted both
     // numbers together would be answered by either of them. Built under
     // `.library-check` and left there with the rest of the run's scratch.
+    //
+    // **Each dimension is planted twice, once in decimal and once in a spelling that is
+    // the same number**, because the walk is not the only thing this arm holds - it is
+    // also the only control the matcher has, and a matcher that reads digits passes a
+    // probe written in digits. Hex for the width and scientific notation for the height,
+    // so a matcher handling one spelling and not the other reddens one row rather than
+    // being covered by the dimension it does handle.
+    //
+    // And a file of near misses, which is what stops the value comparison from being
+    // *looser* than the regex it replaced: `1512` and `4.24` are the two the old guards
+    // existed for, and `0x201` is the same trap one spelling along. The rows below assert
+    // the whole matched list rather than membership in it, so this file appearing in one
+    // is a failure without needing a row of its own.
     const probeRoot = join(REPO, '.library-check', 'grid-probe');
     rmSync(probeRoot, { recursive: true, force: true });
     mkdirSync(join(probeRoot, 'web', 'nested', 'deeper'), { recursive: true });
     writeFileSync(join(probeRoot, 'web', 'flat.js'), 'export const NOTHING = 1;\n');
+    writeFileSync(join(probeRoot, 'web', 'near-misses.js'),
+      'export const WIDE = 1512;\nexport const SMALL = 4.24;\nexport const HEX = 0x201;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'buried.js'), 'export const W = 512;\n');
+    writeFileSync(join(probeRoot, 'web', 'nested', 'hexadecimal.js'), 'export const W = 0x200;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'further.js'), 'export const H = 424;\n');
+    writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'scientific.js'), 'export const H = 4.24e2;\n');
     const walked = sourcesUnder(probeRoot, 'web');
+    // Sorted per directory and depth-first, which is the order `sourcesUnder` produces
+    // and the order these are written in.
+    const WANT = {
+      512: ['web/nested/buried.js', 'web/nested/hexadecimal.js'],
+      424: ['web/nested/deeper/further.js', 'web/nested/deeper/scientific.js'],
+    };
     for (const [what, n] of GRID) {
-      const probed = walked.filter((rel) => literal(n).test(readFileSync(join(probeRoot, rel), 'utf8')));
-      const want = n === 512 ? ['web/nested/buried.js'] : ['web/nested/deeper/further.js'];
-      check(eq(probed, want),
-        `the walk this row uses reaches ${what} buried in a subdirectory rather than stopping at the top of the tree`,
+      const probed = walked.filter((rel) => declares(readFileSync(join(probeRoot, rel), 'utf8'), n));
+      check(eq(probed, WANT[n]),
+        `the walk this row uses reaches ${what} buried in a subdirectory, in every spelling of the number and in no near miss of it`,
         probed.join(' ') || 'the walk found nothing');
     }
 
@@ -1940,12 +2003,12 @@ async function runChecks() {
     // declared once" is two claims and only one of them can be answered by a match on
     // either number.
     const holdersOf = (n) => ['web', 'server'].flatMap(
-      (dir) => sourcesUnder(root, dir).filter((rel) => literal(n).test(withoutComments(shippedSource(rel)))),
+      (dir) => sourcesUnder(root, dir).filter((rel) => declares(withoutComments(shippedSource(rel)), n)),
     );
     for (const [what, n] of GRID) {
       const holders = holdersOf(n);
       check(eq(holders, ['web/format.js']),
-        `${n}, ${what}, appears as a literal in exactly one file across web/ and server/, and it is web/format.js`,
+        `${n}, ${what}, is a literal in exactly one file across web/ and server/ however it is spelled, and it is web/format.js`,
         holders.join(' ') || `nothing holds ${n}, which is half a grid that went missing rather than a grid stated once`);
     }
   }

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -2178,12 +2178,34 @@ async function runChecks() {
     // **Typed scripts are excluded by type and not by looking like data.** `index.html`
     // carries an importmap, which is JSON in a `<script>` tag - a version string in it is
     // not a declaration of anything, and it is skipped because its `type` says it is not
-    // JavaScript rather than because this guessed. An empty `type`, `module`, or a
-    // JavaScript mime are the three that count.
+    // JavaScript rather than because this guessed.
+    //
+    // **The list is HTML's and not a shape**, which is the correction: the first spelling
+    // matched `(text|application)/(java|ecma)script` and that is four of the sixteen
+    // essences the spec calls a JavaScript MIME type. A page written with
+    // `application/x-javascript` runs, and its body was being discarded - executable
+    // JavaScript dropped from a row about what the JavaScript declares, silently, which is
+    // the direction a missing spelling always fails in. There is no pattern behind the
+    // sixteen; `text/livescript` and `text/jscript` are there for reasons that are
+    // twenty-five years old, so the enumeration *is* the definition and a regex over it
+    // was a guess at one.
+    //
+    // Parameters are stripped before the comparison because the spec matches the essence,
+    // and that is also the safe way to be wrong: a `text/javascript; charset=utf-8` block
+    // read as JavaScript is scanned, and scanning something that is not code over-reports
+    // loudly, where skipping something that is code goes unseen.
+    const JS_MIME = new Set([
+      'application/ecmascript', 'application/javascript', 'application/x-ecmascript',
+      'application/x-javascript', 'text/ecmascript', 'text/javascript', 'text/javascript1.0',
+      'text/javascript1.1', 'text/javascript1.2', 'text/javascript1.3', 'text/javascript1.4',
+      'text/javascript1.5', 'text/jscript', 'text/livescript', 'text/x-ecmascript',
+      'text/x-javascript',
+    ]);
     const SCRIPT = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
     const isJs = (attrs) => {
-      const type = /\btype\s*=\s*["']?([^"'\s>]*)/i.exec(attrs)?.[1]?.toLowerCase();
-      return !type || type === 'module' || /^(text|application)\/(java|ecma)script$/.test(type);
+      const type = /\btype\s*=\s*["']?([^"'>]*)/i.exec(attrs)?.[1]?.trim().toLowerCase();
+      if (!type || type === 'module') return true;
+      return JS_MIME.has(type.split(';')[0].trim());
     };
     const javascriptIn = (rel, source) => {
       if (rel.endsWith('.js') || rel.endsWith('.mjs')) return source;
@@ -2275,6 +2297,15 @@ async function runChecks() {
       + '<script type="importmap">{"imports":{"x":"/x-512-424.js"}}</script>\n'
       + '<script type="module">const W = 512;</script>\n');
     writeFileSync(join(probeRoot, 'web', 'sheet.css'), '.rail { height: 424px; width: 512px; }\n');
+    // A second page whose executable code is under a `type` nobody writes any more and
+    // every browser still runs, beside a block of JSON under a `type` that is not code at
+    // all. It must be a holder of the height and not of the width, so a check that knows
+    // only the four modern essences loses the first and a check that reads anything in a
+    // `<script>` gains the second. The charset parameter is on it because the spec matches
+    // the essence and a check comparing the whole attribute would drop this too.
+    writeFileSync(join(probeRoot, 'web', 'legacy-page.html'),
+      '<script type="application/x-javascript; charset=utf-8">const H = 424;</script>\n'
+      + '<script type="application/json">{"width": 512}</script>\n');
     const walked = sourcesUnder(probeRoot, 'web');
     // Sorted per directory and depth-first, which is the order `sourcesUnder` produces
     // and the order these are written in.
@@ -2285,7 +2316,8 @@ async function runChecks() {
     // the 424 list and fails. One file, both directions.
     const WANT = {
       512: ['web/nested/buried.js', 'web/nested/edge-forms.js', 'web/nested/hexadecimal.js', 'web/page.html'],
-      424: ['web/nested/deeper/further.js', 'web/nested/deeper/scientific.js', 'web/nested/literals.js'],
+      424: ['web/legacy-page.html', 'web/nested/deeper/further.js', 'web/nested/deeper/scientific.js',
+        'web/nested/literals.js'],
     };
     for (const [what, n] of GRID) {
       const probed = walked.filter((rel) => declares(

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1324,9 +1324,19 @@ const numbersIn = (src) => {
     // perfectly good name; under the ASCII classes the `π` fell out of the identifier,
     // landed as punctuation, and the division behind it read as a regex that swallowed
     // the number - silently, and in a module the row is meant to be reading.
-    if (ID_START.test(c)) {
+    // **Walked by code point, not by code unit.** `𐐀` is `ID_Continue` and lives outside
+    // the basic plane, so a JavaScript string holds it as two surrogates - and a lone
+    // surrogate is not `ID_Continue`, so indexing one character at a time stopped the
+    // name in the middle of a letter. The rest of it then landed as punctuation and the
+    // division behind it opened a regex over the number, which is the same silent ending
+    // as every other way of not finishing a token.
+    if (ID_START.test(String.fromCodePoint(src.codePointAt(i)))) {
       let j = i;
-      while (j < src.length && ID_PART.test(src[j])) j++;
+      while (j < src.length) {
+        const letter = String.fromCodePoint(src.codePointAt(j));
+        if (!ID_PART.test(letter)) break;
+        j += letter.length;
+      }
       prevWord = src.slice(i, j);
       prev = 'a';
       i = j;

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1361,7 +1361,20 @@ const numbersIn = (src) => {
     // branch above has already taken it whole.
     if (/\d/.test(c) || (c === '.' && /\d/.test(src[i + 1] ?? ''))) {
       const [token] = NUM.exec(src.slice(i));
-      values.push(Number(token.replace(/n$/, '').replace(/_/g, '')));
+      // **Legacy octal, read as octal.** `01000` is 512 to a browser and 1000 to
+      // `Number`, and the comment that used to sit here said the form could be ignored
+      // because every file walked is a module and a module makes it a SyntaxError. That
+      // stopped being true when this began reading `<script>` bodies: an untyped script is
+      // a *classic* script, which is sloppy mode, where the form is legal and means 512.
+      // A comment asserting a property the code no longer has is the failure this file
+      // exists to refuse, so the form is handled rather than the sentence rewritten.
+      //
+      // Only a leading zero followed by octal digits: `08` and `09` are the legacy
+      // *decimal* forms and mean eight and nine, `0` alone is zero, and anything carrying
+      // a dot or an exponent is decimal - all three fall out of the pattern rather than
+      // needing a case.
+      const digits = token.replace(/n$/, '').replace(/_/g, '');
+      values.push(/^0[0-7]+$/.test(digits) ? parseInt(digits, 8) : Number(digits));
       i += token.length;
       prev = '0';
       prevWord = '';
@@ -2164,9 +2177,12 @@ async function runChecks() {
     // outside what this claims, and saying so is the difference between a bound and a
     // hole.
     //
-    // Legacy octal - `01000`, which is 512 - is not in the pattern because it is a
-    // SyntaxError in a module, and every file walked here is one. `syntax-check` is what
-    // holds that.
+    // Legacy octal - `01000`, which is 512 - **is** read, and this paragraph used to say
+    // the opposite: that the form could be ignored because a module makes it a SyntaxError
+    // and every file walked is a module. The second half stopped being true the day this
+    // began reading `<script>` bodies, because an untyped script is a classic script and
+    // classic scripts are sloppy mode. `numbersIn` handles it, and the case file records
+    // that the sentence outlived its reason by one commit.
     const declares = (source, n) => numbersIn(source).includes(n);
 
     // **The JavaScript in a file, because this is a claim about JavaScript.** The walk
@@ -2217,7 +2233,13 @@ async function runChecks() {
     // afterwards, because a quoted value may legitimately contain a space and an unquoted
     // one may not, and that is exactly the difference a shared pattern cannot carry.
     const SCRIPT = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
-    const TYPE_ATTR = /\btype\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]*))/i;
+    // **Anchored on an attribute boundary and not on `\b`**, because a word boundary sits
+    // between `-` and `type` as happily as it sits after `<script`. A page carrying
+    // `<script data-type="application/json">` has no `type` attribute at all, so the
+    // browser runs its body as a classic script - and the match found `data-type`, read
+    // JSON, and dropped it. An attribute starts at whitespace or at the start of the
+    // attribute list, and nowhere else.
+    const TYPE_ATTR = /(?:^|\s)type\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]*))/i;
     const isJs = (attrs) => {
       const m = TYPE_ATTR.exec(attrs);
       const type = (m?.[1] ?? m?.[2] ?? m?.[3] ?? '').trim().toLowerCase();
@@ -2330,9 +2352,17 @@ async function runChecks() {
     // The unquoted form with an attribute behind it is on the same page, because it fails
     // the same way and for the same reason - a value read past its end is a value that
     // matches nothing, and the body of a running script is dropped.
+    // Four scripts and one of them is not code. The two below the first are the ways a
+    // block that *runs* gets mistaken for one that does not: an attribute merely ending in
+    // `type`, which a word boundary matches and an attribute boundary does not, and no
+    // `type` at all, which is a classic script - sloppy mode, where `0650` is octal and
+    // means 424. Every one of them declares the height, so the page has to hold it, and
+    // the JSON block declares the width, so the page must not hold that.
     writeFileSync(join(probeRoot, 'web', 'legacy-page.html'),
       '<script type="application/x-javascript; charset=utf-8">const H = 424;</script>\n'
       + '<script type=text/javascript defer>const H2 = 424;</script>\n'
+      + '<script data-type="application/json">const H3 = 424;</script>\n'
+      + '<script>const H4 = 0650;</script>\n'
       + '<script type="application/json">{"width": 512}</script>\n');
     const walked = sourcesUnder(probeRoot, 'web');
     // Sorted per directory and depth-first, which is the order `sourcesUnder` produces

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -887,6 +887,40 @@ const MUTATIONS = {
   // the row a status code cannot carry, which is why the check reads the argv the
   // program was actually given rather than the answer the route wrote.
   'reveal-drops-the-path': { file: 'server/library.js', edits: [REVEAL_EDIT] },
+  // **The gallery goes back to composing its own refusal**, which is the shape that
+  // shipped: two derivations of one predicate twelve lines apart, disagreeing on the
+  // take with a hello and no whole frame. The historical body rather than a minimal
+  // edit, because what the row claims is that the page reads the reason it was sent
+  // rather than that one branch of it is right.
+  //
+  // Anchored on the *post-fix* text on purpose. A mutation written against the code
+  // the fix deletes matches nothing, the unmutated page loads, and the run is recorded
+  // as this check having missed a bug it was never shown.
+  'open-decides-its-own-reason': { file: 'web/library.js', edits: [[
+    "const cannotOpen = (take) => take.openRefusals[0]?.why ?? '';",
+    'const cannotOpen = (take) => {\n'
+      + '  if (take.recording === true) return warningsOf(take)[0].why;\n'
+      + "  if (take.hasHello === false) return 'this take carries no sensor hello, so its intrinsics are unknown';\n"
+      + "  if (take.frames !== null && take.frames < 2) return 'a take needs two frames to bracket a position';\n"
+      + "  return '';\n"
+      + '};',
+  ]] },
+  // **The monitor's cost line goes back to spelling the grid out inline**, which is
+  // where it was for as long as the comment above it promised the opposite. It
+  // computes exactly the same number, renders identical pixels and serves identical
+  // bytes, so the only thing it can move is the single-declaration row - which is what
+  // makes it a control for that row rather than for the gallery.
+  //
+  // Deliberately not written as an edit that replaces an import line. `web/main.js`
+  // reaches `PROJECT_VERSION`, `versionRefusal` and the grid through one import and
+  // `web/library.js` reaches `VALID_ID` and the grid through another, so a mutation
+  // swapping either for local declarations takes an unrelated binding out with it and
+  // reddens half the suite - a control that fails everything cannot say which row was
+  // carrying the claim.
+  'grid-declared-twice': { file: 'web/main.js', edits: [[
+    '  const depthKB = Math.ceil(DEPTH_W / state.divisor) * Math.ceil(DEPTH_H / state.divisor) * 2 / 1000;',
+    '  const depthKB = Math.ceil(512 / state.divisor) * Math.ceil(424 / state.divisor) * 2 / 1000;',
+  ]] },
   // The loopback gate comes off the one route in this program that starts a process,
   // so a browser across the link opens a window on a machine nobody is standing at.
   'reveal-answers-any-caller': { file: 'server/index.js', edits: [[
@@ -912,6 +946,44 @@ function mutatedSource(name) {
 const mutation = MUTATE ? mutatedSource(MUTATE) : null;
 const pageMutation = mutation && mutation.file.startsWith('web/') ? mutation : null;
 const serverMutation = mutation && mutation.file.startsWith('server/') ? mutation : null;
+
+/**
+ * A file of the staged tree as this run actually ships it.
+ *
+ * The staged copy for everything, and `mutation.body` for the one file a mutation
+ * replaces - which is not the same thing, and the difference is what lets a source row
+ * fail. `stageServer` writes only a *server* mutation into the tree; a page mutation is
+ * delivered by intercepting its route in `openPage`, so the staged `web/main.js` on a
+ * `--mutate grid-declared-twice` run is the clean file. A source row reading it would
+ * pass against every page mutation there is, which is the falsification control that
+ * cannot fire, arriving one layer further out than the match-exactly-once rule that
+ * guards the anchor.
+ *
+ * `root` is read at call time rather than closed over at declaration, which is why this
+ * can sit beside the mutation table it belongs to and above the tree it reads.
+ */
+const shippedSource = (rel) => (
+  mutation && mutation.file === rel ? mutation.body : readFileSync(join(root, rel), 'utf8')
+);
+
+/**
+ * Source with its comments taken out, so a row about what the code says is not
+ * answered by what the prose says.
+ *
+ * Four files in this tree name the grid in prose - `web/format.js` explaining why it
+ * lives there, `web/main.js` describing the band a mis-bound frame collapses into,
+ * `server/protocol.js` sizing a message and `server/webcam.js` explaining what the
+ * colour camera is not - and every one of them is a comment doing its job. A row that
+ * counted them would be unfalsifiable in the loud direction: permanently red, and
+ * therefore turned off.
+ *
+ * Block comments first, because a `//` inside one is not a line comment; and a `//`
+ * preceded by a colon is left alone, since that is a URL rather than the start of one.
+ */
+const withoutComments = (src) => src
+  .replace(/<!--[\s\S]*?-->/g, ' ')
+  .replace(/\/\*[\s\S]*?\*\//g, ' ')
+  .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
 
 // ----------------------------------------------------------------- the fixtures
 //
@@ -1039,6 +1111,15 @@ function buildFixture() {
   writeTake(macCaps, 'truncated-take', { frames: 6, truncate: true });
   writeTake(macCaps, 'no-hello-take', { frames: 6, withHello: false });
   writeTake(macCaps, 'one-frame-take', { frames: 1 });
+  // **A hello, and no whole frame - the one shape that could tell the gallery's two
+  // openability sentences apart, and the take nobody planted.** `three-warning-take`
+  // below reaches zero frames the same way but carries no hello, so the button's
+  // refusal answered on the hello branch and never reached the frame one;
+  // `one-frame-take` above has a hello and a frame, where the two sites agreed. Both
+  // observations skipped this object, which is why the button could say a take "needs
+  // two frames to bracket a position" - a sentence about a take with one - over a
+  // poster correctly badged as having none, for as long as it did.
+  writeTake(macCaps, 'hello-no-frames', { frames: 1, truncate: true });
   writeBadLengthTake(macCaps, 'bad-length-take');
   // **Three warnings at once, which is the tile the height rows need and none of the
   // takes above is.** Every fixture take carries at most one - truncated, or no
@@ -1478,6 +1559,38 @@ process.exit(failures ? 1 : skipped.length ? 2 : 0);
 async function runChecks() {
   checkLogPredicate();
 
+  // ------------------------------------------------- 0. one grid, one declaration
+  //
+  // **The sensor grid is one number in one file, and this asks the tree rather than
+  // the four places it used to be written.** It was declared four times in
+  // JavaScript - twice inside `web/main.js` alone, under two different names 1,646
+  // lines apart - and spelled out as bare literals a fifth time in the monitor's cost
+  // line, under a comment promising the number was stated from the grid so it could
+  // not drift. Nothing had bitten yet, which is the only reason this is a row and not
+  // a bug report.
+  //
+  // It walks the directories rather than a list of the files that hold it today, so a
+  // page or a server module added next year is asked by existing - the close-the-class
+  // rule, where the enumeration *is* the check. Scoped to `web/` and `server/` and
+  // deliberately not to `tools/`: every proof tool here states the grid independently,
+  // and that is correct rather than sloppy, because a check that imported the constant
+  // it asserts would be holding a `512` against itself.
+  console.log('\n[library] the sensor grid is declared once, and the tree is what says so');
+  {
+    const grid = /(?<![\d.])(?:512|424)(?![\d.])/;
+    const holders = [];
+    for (const dir of ['web', 'server']) {
+      for (const name of readdirSync(join(root, dir)).sort()) {
+        const rel = `${dir}/${name}`;
+        if (statSync(join(root, rel)).isDirectory()) continue;
+        if (grid.test(withoutComments(shippedSource(rel)))) holders.push(rel);
+      }
+    }
+    check(eq(holders, ['web/format.js']),
+      'the 512x424 grid appears as a literal in exactly one file across web/ and server/, and it is web/format.js',
+      holders.join(' ') || 'nothing holds it, which is a grid that went missing rather than a grid stated once');
+  }
+
   // ------------------------------------------------------------- 1. the manifest
   console.log('\n[library] the manifest carries step 2\'s hash, and stops carrying a stale one');
   {
@@ -1521,6 +1634,14 @@ async function runChecks() {
     check(byId['one-frame-take'].frames === 1 && byId['one-frame-take'].openable === false,
       'a one-frame take lists, and says it cannot be bracketed');
     check(byId['local-clip'].openable === true, 'and an ordinary take is openable');
+    // The fixture the openability rows in section 6 rest on, asserted here rather than
+    // assumed there: the truncation has to cut the single frame without cutting the
+    // hello, and a sample regenerated at a different frame size could leave the frame
+    // whole. A take that listed with one frame would send those rows looking at the
+    // shape that never disagreed.
+    check(byId['hello-no-frames'].hasHello === true && byId['hello-no-frames'].frames === 0,
+      'a take can carry a hello and no whole frame at all, which is the shape the two client derivations disagreed about',
+      `hasHello=${byId['hello-no-frames'].hasHello} frames=${byId['hello-no-frames'].frames}`);
     check(byId['local-clip'].dateSource === 'hello'
       && Math.abs(byId['local-clip'].capturedAt - Date.UTC(2026, 6, 15, 18, 5)) < 1,
       'the wall-clock capture date comes off the hello where the take carries one');
@@ -2036,6 +2157,28 @@ async function runChecks() {
       'the Open on a take with no hello is disabled rather than a throw waiting to happen');
     check(one('local-clip').acts.find((a) => a.label === 'Open')?.disabled === false,
       'and an ordinary take opens');
+
+    // **One take, one reason, whichever surface is asking.** The page used to derive
+    // this twice, twelve lines apart, and the two derivations disagreed on exactly one
+    // shape: a take with a hello and no whole frame. Measured on the build before the
+    // reason moved to the server, with this fixture: the badge read "the scan found no
+    // whole frame in this take, so there is nothing here to draw or to open" while the
+    // button beside it read "a take needs two frames to bracket a position" - a
+    // sentence about a take that has one, over a take that has none.
+    //
+    // Nothing had noticed because nothing had ever built this take. The zero-frame
+    // fixture carried no hello, so the button answered on its hello branch and never
+    // reached the frame one; the take with a hello had a frame, where the two agreed.
+    // Both observations skipped the one object that could tell them apart.
+    const refused = one('hello-no-frames');
+    const badgeWhy = refused.badges.find((b) => b.key === 'short')?.why ?? '';
+    const buttonWhy = refused.acts.find((a) => a.label === 'Open')?.why ?? '';
+    check(badgeWhy !== '' && badgeWhy === buttonWhy,
+      'a take with a hello and no whole frame is refused in one sentence, the same on its badge and on its button',
+      `badge ${JSON.stringify(badgeWhy)} vs button ${JSON.stringify(buttonWhy)}`);
+    check(/no whole frame/.test(buttonWhy) && !/bracket a position/.test(buttonWhy),
+      'and it is the sentence about the frame it does not have rather than the one about bracketing a position',
+      JSON.stringify(buttonWhy));
 
     // Marks on the tile's scrub bar, at their source fraction. The two that a
     // fraction gets wrong on its own are checked by name: source zero has to land

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -5143,6 +5143,19 @@ async function runChecks() {
       JSON.stringify({ recording: listed?.recording, hash: listed?.hash, frames: listed?.frames }));
     check(listed?.openable === false,
       'and it says it cannot be opened, so the tile has something to draw rather than zeros');
+    // **The missing hash is load-bearing on the menu, so it is asserted as that too.**
+    // `resolveResume` finds the take it was last opened on by hash and by nothing else,
+    // and `lastOpened` refuses a saved entry whose `takeHash` is not a non-empty string
+    // - so a take advertising no hash is one that lookup cannot reach, which is why the
+    // menu has no branch for a take being recorded and does not need one. That used to
+    // be a branch spelling its own sentence for the case, a third telling of a reason
+    // the server declares. Read off `/library/all`, which is the response the menu
+    // actually fetches, rather than off `/library/takes` above.
+    const resolvable = (await getJson(`${url}/library/all`)).takes;
+    const shooting = resolvable.filter((t) => t.recording === true);
+    check(shooting.length > 0 && shooting.every((t) => t.hash === null),
+      'and the response the menu resolves against gives it no hash, so nothing the menu can look up is a take being recorded',
+      `${shooting.length} recording, hashes ${JSON.stringify(shooting.map((t) => t.hash))}`);
 
     // Neither removal can verify anything about a file that is still arriving, and
     // unlinking one underneath a running write stream loses the shoot in progress.

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -931,6 +931,23 @@ const MUTATIONS = {
     'export const OPEN_REFUSALS = {\n'
       + "  'wrong-format': () => 'this take was written by a generation of the format this build cannot read',\n",
   ]] },
+  // **The scanner forgets to push a refusal it declares**, which leaves `no-hello` in
+  // `OPEN_REFUSALS`, in the page's `BADGES`, and on no take that exists - a reason and a
+  // badge for it that nothing can ever wear. It is the direction the containment row
+  // could not see while it only asked that what arrived was declared, and it is the
+  // ordinary way this breaks: a refusal is added to the table and to the page, and the
+  // branch that would produce it is written last or not at all.
+  //
+  // Aimed at the push rather than at the table. A mutation adding a key to the table
+  // reddens the badge row as well - `refusal-without-a-badge` does, measured, both rows
+  // - and two rows red for two different reasons cannot say which was carrying the
+  // claim. Neither control is isolated, and this one is not either: five rows go, and
+  // they are all one fact arriving in five places, which is the take with no hello no
+  // longer saying it cannot be opened. Read them as one.
+  'refusal-declared-but-never-pushed': { file: 'server/library.js', edits: [[
+    "  if (!index.hello) openRefusals.push(refusal('no-hello'));\n",
+    '',
+  ]] },
   // **One dimension of the grid stops being a literal while the other holds**, and the
   // value is deliberately unchanged - `DEPTH_W - 88` is still 424, so every page still
   // renders the same pixels and every message is still the same size. That is what
@@ -2501,14 +2518,33 @@ async function runChecks() {
     check(serverKeys.length > 0 && unbadged.length === 0,
       'every refusal the server can send has a badge on the page, so a reason added later is asked by existing',
       `server ${serverKeys.join(' ')} against page ${badgeKeys.join(' ')}`);
-    // And the declaration is not a list nothing reads: every key in it has to be a key
-    // the scanner can actually produce, or the row above is comparing the page against
-    // an enumeration that has drifted off the code the way the page's table did.
+    // **Both directions, because they are two different bugs and one of them was
+    // claimed rather than checked.** The comment here used to promise that every key in
+    // the table is one the scanner can produce and then assert the containment the
+    // other way round, which proves only that what arrived was declared. Under that
+    // row, a refusal added to `OPEN_REFUSALS` and to `BADGES` with the `describeTake`
+    // branch that pushes it forgotten stays green forever - a declared reason and a
+    // badge for it that no take can ever wear, which is the enumeration drifting off
+    // the code in the direction the row above cannot see either.
     const liveKeys = [...new Set((await getJson(`${macUrl}/library/takes`)).takes
       .flatMap((t) => t.openRefusals.map((r) => r.key)))];
     check(liveKeys.every((k) => k in OPEN_REFUSALS),
-      'and every refusal a take actually arrived with is one the table declares',
+      'every refusal a take actually arrived with is one the table declares',
       `${liveKeys.join(' ')} against ${Object.keys(OPEN_REFUSALS).join(' ')}`);
+    // And back the other way. `recording` is excluded by name and for a reason of fact
+    // rather than convenience: no take on this server is being written, so this
+    // response cannot carry that key however correct the scanner is. It is proven to
+    // arrive where it can arrive - the section that stands a recorder up and reads the
+    // tile it draws - and a row here pretending otherwise would be asserting against
+    // the fixture rather than against the code.
+    //
+    // What this puts on whoever adds the next refusal is a fixture take that provokes
+    // it, which is the intended cost: a reason nothing here can reach is a reason
+    // nothing here is testing.
+    const unreachable = Object.keys(OPEN_REFUSALS).filter((k) => k !== 'recording' && !liveKeys.includes(k));
+    check(unreachable.length === 0,
+      'and every refusal the table declares is one some take here actually arrives with, so a branch forgotten in the scanner is not a badge nobody can earn',
+      unreachable.length ? `declared and never produced: ${unreachable.join(' ')}` : liveKeys.join(' '));
 
     // Marks on the tile's scrub bar, at their source fraction. The two that a
     // fraction gets wrong on its own are checked by name: source zero has to land

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -707,8 +707,11 @@ const MUTATIONS = {
   ]] },
   // The manifest scans the take being written, which is a full read and a sha256 of
   // a growing multi-gigabyte file per request, against the recorder's own disk.
+  // Anchored on the branch's condition alone. It used to carry the `return {` two lines
+  // down with it, which put the refusal list between them the moment that was hoisted -
+  // and `syntax-check` refused the control rather than letting it silently match nothing.
   'manifest-scans-open-take': { file: 'server/library.js', edits: [[
-    '  if (recording) {\n    return {', '  if (false) {\n    return {',
+    '  if (recording) {\n', '  if (false) {\n',
   ]] },
   // The boot stops making the captures directory, which is the state a reflashed
   // node comes up in.
@@ -1010,6 +1013,19 @@ const MUTATIONS = {
     "  if (!index.hello) openRefusals.push(refusal('no-hello'));\n",
     '',
   ]] },
+  // **The take being written goes back to answering twice**, which is where it was: the
+  // list on one line and a hardcoded `openable: false` on the next. Both edits together,
+  // because a mutation that only hardcodes the boolean changes nothing observable - the
+  // list is non-empty, so `false` is what deriving would have given and the run would
+  // record a control that did nothing. Emptying the list beside it is what makes the two
+  // disagree, and disagreeing is the whole subject: the manifest goes on reporting a take
+  // that cannot be opened while `cannotOpen` has nothing to quote, so the Open button is
+  // disabled with an empty explanation.
+  'recording-decides-openable-itself': { file: 'server/library.js', edits: [
+    ["    const openRefusals = [refusal('recording')];", '    const openRefusals = [];'],
+    ['      openRefusals,\n      openable: openRefusals.length === 0,\n      recording: true,',
+      '      openRefusals,\n      openable: false,\n      recording: true,'],
+  ] },
   // **The capture-format band goes back to being a term in `openable` rather than a
   // refusal in the list**, which is the shape it arrived from `main` in and the shape the
   // merge changed. It is the control for that change, and the reason it needs one is that
@@ -1025,10 +1041,15 @@ const MUTATIONS = {
   //
   // Narrow on purpose: an empty `openRefusals` still satisfies `carriesRefusals`, so the
   // node link stays up and the rest of the suite still measures.
+  // The second edit carries `openRefusals,` above it and `recording: false,` below,
+  // because both branches of `describeTake` derive `openable` from the list now and the
+  // line on its own matches twice. `recording: false` is what says which branch this is.
   'openable-recomputes-the-band': { file: 'server/library.js', edits: [
     ["  if (captureFormatRefusal('this take', format) !== '') openRefusals.push(refusal('format', format));\n", ''],
-    ['    openable: openRefusals.length === 0,',
-      "    openable: Boolean(index.hello) && stamps.length >= 2 && captureFormatRefusal('this take', format) === '',"],
+    ['    openRefusals,\n    openable: openRefusals.length === 0,\n    recording: false,',
+      '    openRefusals,\n'
+      + "    openable: Boolean(index.hello) && stamps.length >= 2 && captureFormatRefusal('this take', format) === '',\n"
+      + '    recording: false,'],
   ] },
   // **One dimension of the grid stops being a literal while the other holds**, and the
   // value is deliberately unchanged - `DEPTH_W - 88` is still 424, so every page still
@@ -1488,6 +1509,22 @@ const portHeld = (port) => new Promise((done) => {
  * check. Exit 2 rather than 1: this is the suite declining to run, not a claim failing.
  */
 async function reservePorts() {
+  // **The node's port inside the mac span is a configuration this cannot serve**, and the
+  // `new Set` below used to swallow it: both ports are free, every check passes, and the
+  // run starts. The node comes up on it first and is still live when a section reaches
+  // that offset, so the claim-a-taken-offset path in `startServer` retires a server that
+  // is *running* - the replacement then dies on EADDRINUSE and the run ends on an error
+  // about a port, several sections in, naming neither the overlap nor the node.
+  //
+  // Refused here instead, because it is a fact about the arguments and can be known before
+  // anything spawns. Exit 2 with the other refusals: the suite declining to run.
+  if (NODE_PORT >= MAC_PORT && NODE_PORT <= MAC_PORT + PORT_SPAN) {
+    console.error(`[library] refusing to run: --node-port ${NODE_PORT} is inside the mac span `
+      + `${MAC_PORT}..${MAC_PORT + PORT_SPAN}, so the node and a section would claim one port.`);
+    console.error('[library] pass two ranges that do not overlap - the node needs one port and the mac side needs '
+      + `${PORT_SPAN + 1} from --mac-port.`);
+    process.exit(2);
+  }
   const wanted = [NODE_PORT, ...Array.from({ length: PORT_SPAN + 1 }, (_, i) => MAC_PORT + i)];
   const held = [];
   for (const port of new Set(wanted)) if (await portHeld(port)) held.push(port);
@@ -1973,6 +2010,36 @@ async function runChecks() {
     ].join(''), 'g');
     const declares = (source, n) => [...source.matchAll(NUMERIC)]
       .some((m) => Number(m[0].replace(/n$/, '').replace(/_/g, '')) === n);
+
+    // **The JavaScript in a file, because this is a claim about JavaScript.** The walk
+    // reaches every file under `web/` and `server/`, which is three HTML pages and a
+    // stylesheet as well as the modules - and asking "is 512 a literal here" of markup
+    // answers about prose and layout. A `width: 512px` in `nav.css`, or a paragraph in
+    // `index.html` mentioning a 424-line budget, is not a second declaration of the
+    // sensor's grid, and a row that failed on one would be blocking a copy change with a
+    // proof failure. Bad in both directions, too: the alternative of trusting it makes
+    // every future stylesheet a place the grid can hide.
+    //
+    // Restricting the *walk* to `.js` would close it by opening a hole, because the pages
+    // here carry real code - `menu.html` holds `resolveResume` inline, which is a module
+    // this suite mutates. So the walk stays wide and the question narrows: the whole of a
+    // module, and the `<script>` bodies of a page.
+    //
+    // **Typed scripts are excluded by type and not by looking like data.** `index.html`
+    // carries an importmap, which is JSON in a `<script>` tag - a version string in it is
+    // not a declaration of anything, and it is skipped because its `type` says it is not
+    // JavaScript rather than because this guessed. An empty `type`, `module`, or a
+    // JavaScript mime are the three that count.
+    const SCRIPT = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+    const isJs = (attrs) => {
+      const type = /\btype\s*=\s*["']?([^"'\s>]*)/i.exec(attrs)?.[1]?.toLowerCase();
+      return !type || type === 'module' || /^(text|application)\/(java|ecma)script$/.test(type);
+    };
+    const javascriptIn = (rel, source) => {
+      if (rel.endsWith('.js') || rel.endsWith('.mjs')) return source;
+      if (!rel.endsWith('.html')) return '';
+      return [...source.matchAll(SCRIPT)].filter((m) => isJs(m[1])).map((m) => m[2]).join('\n');
+    };
     const GRID = [['the depth width', 512], ['the depth height', 424]];
     // Relative paths under `base`, deepest last, as one flat list. Split out from the
     // row below so the falsification control underneath can run the same walker over a
@@ -2015,17 +2082,32 @@ async function runChecks() {
     writeFileSync(join(probeRoot, 'web', 'nested', 'hexadecimal.js'), 'export const W = 0x200;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'further.js'), 'export const H = 424;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'scientific.js'), 'export const H = 4.24e2;\n');
+    // A page and a stylesheet, which is what the tree actually holds beside the modules.
+    // The page states both numbers three times over and only one of them is a
+    // declaration: in prose, in a `<style>` rule, in an importmap that is a `<script>` of
+    // the wrong type, and then in a module script, which is the one that counts. The
+    // stylesheet states the height in a rule and must be found by nothing - a `424px`
+    // column is a layout decision, and a row that called it a second grid would fail a
+    // clean tree on a copy change.
+    writeFileSync(join(probeRoot, 'web', 'page.html'),
+      '<p>the sensor is 512 across and 424 down, which this paragraph says and does not declare</p>\n'
+      + '<style>.tile { width: 512px; height: 424px; }</style>\n'
+      + '<script type="importmap">{"imports":{"x":"/x-512-424.js"}}</script>\n'
+      + '<script type="module">const W = 512;</script>\n');
+    writeFileSync(join(probeRoot, 'web', 'sheet.css'), '.rail { height: 424px; width: 512px; }\n');
     const walked = sourcesUnder(probeRoot, 'web');
     // Sorted per directory and depth-first, which is the order `sourcesUnder` produces
     // and the order these are written in.
     const WANT = {
-      512: ['web/nested/buried.js', 'web/nested/hexadecimal.js'],
+      512: ['web/nested/buried.js', 'web/nested/hexadecimal.js', 'web/page.html'],
       424: ['web/nested/deeper/further.js', 'web/nested/deeper/scientific.js'],
     };
     for (const [what, n] of GRID) {
-      const probed = walked.filter((rel) => declares(readFileSync(join(probeRoot, rel), 'utf8'), n));
+      const probed = walked.filter((rel) => declares(
+        withoutComments(javascriptIn(rel, readFileSync(join(probeRoot, rel), 'utf8'))), n,
+      ));
       check(eq(probed, WANT[n]),
-        `the walk this row uses reaches ${what} buried in a subdirectory, in every spelling of the number and in no near miss of it`,
+        `the walk this row uses reaches ${what} buried in a subdirectory, in every spelling of the number, in a page's script and in no near miss, stylesheet or paragraph`,
         probed.join(' ') || 'the walk found nothing');
     }
 
@@ -2033,7 +2115,8 @@ async function runChecks() {
     // declared once" is two claims and only one of them can be answered by a match on
     // either number.
     const holdersOf = (n) => ['web', 'server'].flatMap(
-      (dir) => sourcesUnder(root, dir).filter((rel) => declares(withoutComments(shippedSource(rel)), n)),
+      (dir) => sourcesUnder(root, dir)
+        .filter((rel) => declares(withoutComments(javascriptIn(rel, shippedSource(rel))), n)),
     );
     for (const [what, n] of GRID) {
       const holders = holdersOf(n);
@@ -3102,6 +3185,27 @@ async function runChecks() {
     check(unreachable.length === 0,
       'and every refusal the table declares is one some take here actually arrives with, so a branch forgotten in the scanner is not a badge nobody can earn',
       unreachable.length ? `declared and never produced: ${unreachable.join(' ')}` : liveKeys.join(' '));
+
+    // **The predicate against the list, on every take rather than on the branches.** The
+    // whole argument for the table is that `openable` is "the list is empty" and not a
+    // second expression of the same thing - and `describeTake` has two branches, one of
+    // which derived it and one of which carried the list and a hardcoded `openable: false`
+    // beside it. They agreed, so nothing was wrong yet; the failure waiting there is a
+    // disabled Open button whose reason is the empty string, since `cannotOpen` quotes a
+    // list that had gone while the boolean stayed.
+    //
+    // Asked of every take in the listing, which is what makes it a claim about the scanner
+    // rather than about the takes this fixture happens to hold - a third branch added
+    // later is asked by existing. The two rows above cannot reach it from either
+    // direction: they compare *which keys* the tables know, and this is about a take whose
+    // keys are all perfectly declared and whose boolean stopped following them.
+    const disagreed = (await getJson(`${macUrl}/library/takes`)).takes
+      .filter((t) => t.openable !== (t.openRefusals.length === 0));
+    check(disagreed.length === 0,
+      'and every take\'s openable is its refusal list being empty, rather than a second answer to the same question',
+      disagreed.length
+        ? disagreed.map((t) => `${t.id} openable=${t.openable} with ${t.openRefusals.length} refusals`).join(', ')
+        : 'agreed on every take');
 
     // Marks on the tile's scrub bar, at their source fraction. The two that a
     // fraction gets wrong on its own are checked by name: source zero has to land
@@ -5806,6 +5910,22 @@ async function runChecks() {
       JSON.stringify({ recording: listed?.recording, hash: listed?.hash, frames: listed?.frames }));
     check(listed?.openable === false,
       'and it says it cannot be opened, so the tile has something to draw rather than zeros');
+    // **And it says *why*, which is the half a boolean cannot carry.** This branch of
+    // `describeTake` used to hold the refusal list and a hardcoded `openable: false` beside
+    // it - two answers to one question, written in by the commit whose whole subject is
+    // that there should be one. They agreed, so nothing was wrong yet, and what waits at
+    // the end of that is the quiet failure: `cannotOpen` quotes the list, so a list that
+    // went while the boolean stayed leaves a disabled Open button explaining nothing.
+    //
+    // The row is here rather than beside its two-table siblings because this is the only
+    // server in the suite with a take being written - those rows read a listing that
+    // cannot contain one, and skip `recording` by name for exactly that reason. A probe
+    // for this claim has to stand where the answer could be different.
+    check(listed?.openRefusals?.length === 1 && listed.openRefusals[0].key === 'recording'
+      && typeof listed.openRefusals[0].why === 'string' && listed.openRefusals[0].why !== ''
+      && listed.openable === (listed.openRefusals.length === 0),
+      'and the reason is on the take rather than only in the boolean, with openable following the list here too',
+      JSON.stringify(listed?.openRefusals));
     // **The missing hash is load-bearing on the menu, so it is asserted as that too.**
     // `resolveResume` finds the take it was last opened on by hash and by nothing else,
     // and `lastOpened` refuses a saved entry whose `takeHash` is not a non-empty string

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1342,7 +1342,11 @@ const numbersIn = (src) => {
         i++;
       }
       i++;
-      prev = '/';
+      // **A finished regex is a value**, and leaving `prev` as the slash that closed it
+      // said the opposite - so `/x/ / 512` read the second slash as another opener and
+      // swallowed the number. `)` stands for "a value ended here" the same way it does
+      // after a call, which is what the question below actually asks.
+      prev = ')';
       prevWord = '';
       continue;
     }
@@ -2232,7 +2236,13 @@ async function runChecks() {
     // The three quoting forms are matched as three alternatives rather than by stripping
     // afterwards, because a quoted value may legitimately contain a space and an unquoted
     // one may not, and that is exactly the difference a shared pattern cannot carry.
-    const SCRIPT = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+    // **A start tag ends at the first unquoted `>`.** Reading to the first `>` of any kind
+    // ends the tag inside `<script data-note=">">`, which leaves the attribute's closing
+    // quote at the head of the body - so the scan opens a string on it, runs to the next
+    // quote, and eats the declaration behind it. Quoted runs are matched as units for the
+    // same reason the type attribute is: a quoted value may contain the character that
+    // would otherwise terminate what it sits in.
+    const SCRIPT = /<script\b((?:"[^"]*"|'[^']*'|[^>"'])*)>([\s\S]*?)<\/script>/gi;
     // **Anchored on an attribute boundary and not on `\b`**, because a word boundary sits
     // between `-` and `type` as happily as it sits after `<script`. A page carrying
     // `<script data-type="application/json">` has no `type` attribute at all, so the
@@ -2308,7 +2318,11 @@ async function runChecks() {
       // value, and the division reads as a regex that swallows to the end of the line.
       // It sits in this file because that is the file whose 512 must be found - a scan
       // that swallows here loses the declaration two lines up as well.
-      + 'export const step = (counter) => counter++ / 512;\n');
+      + 'export const step = (counter) => counter++ / 512;\n'
+      // A finished regex divided by something, which is the third way the slash question
+      // gets answered wrongly: the slash that *closed* a pattern is not the slash that
+      // could open one, and treating it as the latter swallows what follows.
+      + 'export const ratio = /x/ / 512;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'further.js'), 'export const H = 424;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'scientific.js'), 'export const H = 4.24e2;\n');
     // **The literal text a module carries, which is the same fact as the paragraph in the
@@ -2363,6 +2377,10 @@ async function runChecks() {
       + '<script type=text/javascript defer>const H2 = 424;</script>\n'
       + '<script data-type="application/json">const H3 = 424;</script>\n'
       + '<script>const H4 = 0650;</script>\n'
+      // An attribute whose value contains the character that ends a start tag. A tag
+      // matcher stopping at the first `>` of any kind hands the body a leading quote,
+      // which opens a string that runs over the declaration behind it.
+      + '<script data-note=">">const H5 = 424;</script>\n'
       + '<script type="application/json">{"width": 512}</script>\n');
     const walked = sourcesUnder(probeRoot, 'web');
     // Sorted per directory and depth-first, which is the order `sourcesUnder` produces

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1318,6 +1318,14 @@ const numbersIn = (src) => {
       i = j;
       continue;
     }
+    // **`++` and `--` are transparent to the value question**, and taking them one
+    // character at a time got that wrong: each `+` left `prev` as `+`, which is not the
+    // end of a value, so the slash in `counter++ / 512` read as a regex and swallowed the
+    // rest of the line - the silent direction, and the whole point of a scan is that it is
+    // not doing that. Leaving `prev` alone is what makes it right in both positions:
+    // postfix keeps the value its operand already ended, and prefix keeps whatever came
+    // before it, since the operand it binds to sets `prev` a moment later anyway.
+    if ((c === '+' || c === '-') && src[i + 1] === c) { i += 2; continue; }
     // A regex only where a value cannot already have ended - or after one of the words
     // that cannot be followed by division, which is what makes `return /512/` a pattern
     // and `total / 512` a quotient. `}` stays the ambiguous case resolved toward
@@ -2201,9 +2209,18 @@ async function runChecks() {
       'text/javascript1.5', 'text/jscript', 'text/livescript', 'text/x-ecmascript',
       'text/x-javascript',
     ]);
+    // **An unquoted attribute value ends at whitespace, and reading it to the `>` swallows
+    // the attributes after it.** `<script type=text/javascript defer>` is valid markup that
+    // every browser runs, and a capture stopping only at a quote or a bracket answered
+    // `text/javascript defer`, which is in no list of anything - so the body was dropped.
+    // The three quoting forms are matched as three alternatives rather than by stripping
+    // afterwards, because a quoted value may legitimately contain a space and an unquoted
+    // one may not, and that is exactly the difference a shared pattern cannot carry.
     const SCRIPT = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+    const TYPE_ATTR = /\btype\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]*))/i;
     const isJs = (attrs) => {
-      const type = /\btype\s*=\s*["']?([^"'>]*)/i.exec(attrs)?.[1]?.trim().toLowerCase();
+      const m = TYPE_ATTR.exec(attrs);
+      const type = (m?.[1] ?? m?.[2] ?? m?.[3] ?? '').trim().toLowerCase();
       if (!type || type === 'module') return true;
       return JS_MIME.has(type.split(';')[0].trim());
     };
@@ -2262,7 +2279,14 @@ async function runChecks() {
     // one of those wrong.
     writeFileSync(join(probeRoot, 'web', 'nested', 'edge-forms.js'),
       'export const W = .512e3;\n'
-      + 'export const rows = () => { return /424/; };\n');
+      + 'export const rows = () => { return /424/; };\n'
+      // A postfix operator directly before a division, which is the other way the slash
+      // question gets answered by a character instead of a token: `++` taken one `+` at a
+      // time leaves the scan looking at an operator, an operator is not the end of a
+      // value, and the division reads as a regex that swallows to the end of the line.
+      // It sits in this file because that is the file whose 512 must be found - a scan
+      // that swallows here loses the declaration two lines up as well.
+      + 'export const step = (counter) => counter++ / 512;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'further.js'), 'export const H = 424;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'scientific.js'), 'export const H = 4.24e2;\n');
     // **The literal text a module carries, which is the same fact as the paragraph in the
@@ -2303,8 +2327,12 @@ async function runChecks() {
     // only the four modern essences loses the first and a check that reads anything in a
     // `<script>` gains the second. The charset parameter is on it because the spec matches
     // the essence and a check comparing the whole attribute would drop this too.
+    // The unquoted form with an attribute behind it is on the same page, because it fails
+    // the same way and for the same reason - a value read past its end is a value that
+    // matches nothing, and the body of a running script is dropped.
     writeFileSync(join(probeRoot, 'web', 'legacy-page.html'),
       '<script type="application/x-javascript; charset=utf-8">const H = 424;</script>\n'
+      + '<script type=text/javascript defer>const H2 = 424;</script>\n'
       + '<script type="application/json">{"width": 512}</script>\n');
     const walked = sourcesUnder(probeRoot, 'web');
     // Sorted per directory and depth-first, which is the order `sourcesUnder` produces

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -931,6 +931,27 @@ const MUTATIONS = {
     'export const OPEN_REFUSALS = {\n'
       + "  'wrong-format': () => 'this take was written by a generation of the format this build cannot read',\n",
   ]] },
+  // **One dimension of the grid stops being a literal while the other holds**, and the
+  // value is deliberately unchanged - `DEPTH_W - 88` is still 424, so every page still
+  // renders the same pixels and every message is still the same size. That is what
+  // makes it a control for the declaration rows and for nothing else: the only thing it
+  // can move is whether `424` is written down in the tree. A single regex over
+  // `512|424` is answered by the `512` still sitting two lines above and reports the
+  // grid as stated once, which is the row this splits in two.
+  'grid-loses-a-dimension': { file: 'web/format.js', edits: [[
+    'export const DEPTH_H = 424;',
+    'export const DEPTH_H = DEPTH_W - 88;',
+  ]] },
+  // **The link demands that every take name a refusal**, which refuses a node for being
+  // healthy: `openRefusals: []` is what an ordinary openable take sends, so this takes
+  // the link off for every library that has nothing wrong with it. It reddens the
+  // node's own rows and the arm holding the openable take, and it is the control for
+  // the fixture rather than for the gate - a positive arm carrying only a *refused*
+  // take passes this mutation while every real node goes dark.
+  'refusals-must-be-nonempty': { file: 'server/library.js', edits: [[
+    'const carriesRefusals = (take) => Array.isArray(take.openRefusals)\n',
+    'const carriesRefusals = (take) => Array.isArray(take.openRefusals)\n  && take.openRefusals.length > 0\n',
+  ]] },
   // **The link admits a manifest from the build before the refusals moved**, which is
   // the take that reconciles in looking like any other and then blanks the shelf while
   // the first remote tile paints. The gate rather than the sentence it sets, because
@@ -1629,9 +1650,21 @@ async function runChecks() {
   // grid under a row still printing green. That is the close-the-class rule failing in
   // the shape it is meant to catch: the enumeration was the files that exist rather
   // than the tree, and nothing about the row said which.
+  //
+  // **Each dimension asked for separately, because one regex over both cannot see one
+  // of them go missing.** A single `512|424` alternation answers "does this file
+  // mention the grid", and `web/format.js` mentions it as long as *either* number is
+  // still there - so a `DEPTH_H` that stopped being a literal, or drifted off 424 while
+  // `DEPTH_W` held, leaves the holder list reading exactly `['web/format.js']` and the
+  // row green over a build whose JavaScript no longer describes the sensor's frames.
+  // The duplication half was never at risk, since a file redeclaring either number
+  // lands in the list; it is the row's other half - its own failure message says "a
+  // grid that went missing" - that only fired when both went at once.
   console.log('\n[library] the sensor grid is declared once, and the tree is what says so');
   {
-    const grid = /(?<![\d.])(?:512|424)(?![\d.])/;
+    // A literal, with the guards that keep `512` out of `1512` and `4.24` alike.
+    const literal = (n) => new RegExp(`(?<![\\d.])${n}(?![\\d.])`);
+    const GRID = [['the depth width', 512], ['the depth height', 424]];
     // Relative paths under `base`, deepest last, as one flat list. Split out from the
     // row below so the falsification control underneath can run the same walker over a
     // tree it built, which is the only way to hold a traversal to its claim - a
@@ -1643,30 +1676,40 @@ async function runChecks() {
         ? sourcesUnder(base, `${dir}/${entry.name}`, `${prefix}${entry.name}/`)
         : [`${dir}/${entry.name}`]));
 
-    // The control, run before the row it controls: a tree whose only grid is one
-    // directory down. A walker that skips directories answers `[]` here and this goes
-    // red, where against the real `web/` and `server/` it would answer exactly what the
-    // row below wants and pass. Built under `.library-check` and left there with the
-    // rest of the run's scratch.
+    // The control, run before the row it controls: a tree whose grids are one directory
+    // down, one dimension per file. A walker that skips directories answers `[]` here
+    // and this goes red, where against the real `web/` and `server/` it would answer
+    // exactly what the rows below want and pass. Two files rather than one so the
+    // per-dimension search is exercised separately as well - a probe that planted both
+    // numbers together would be answered by either of them. Built under
+    // `.library-check` and left there with the rest of the run's scratch.
     const probeRoot = join(REPO, '.library-check', 'grid-probe');
     rmSync(probeRoot, { recursive: true, force: true });
-    mkdirSync(join(probeRoot, 'web', 'nested'), { recursive: true });
+    mkdirSync(join(probeRoot, 'web', 'nested', 'deeper'), { recursive: true });
     writeFileSync(join(probeRoot, 'web', 'flat.js'), 'export const NOTHING = 1;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'buried.js'), 'export const W = 512;\n');
-    const probed = sourcesUnder(probeRoot, 'web').filter((rel) => grid.test(readFileSync(join(probeRoot, rel), 'utf8')));
-    check(eq(probed, ['web/nested/buried.js']),
-      'the walk this row uses reaches a file one directory down, so a grid buried in a subdirectory is found',
-      probed.join(' ') || 'the walk found nothing, which is a walk that stops at the top of the tree');
-
-    const holders = [];
-    for (const dir of ['web', 'server']) {
-      for (const rel of sourcesUnder(root, dir)) {
-        if (grid.test(withoutComments(shippedSource(rel)))) holders.push(rel);
-      }
+    writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'further.js'), 'export const H = 424;\n');
+    const walked = sourcesUnder(probeRoot, 'web');
+    for (const [what, n] of GRID) {
+      const probed = walked.filter((rel) => literal(n).test(readFileSync(join(probeRoot, rel), 'utf8')));
+      const want = n === 512 ? ['web/nested/buried.js'] : ['web/nested/deeper/further.js'];
+      check(eq(probed, want),
+        `the walk this row uses reaches ${what} buried in a subdirectory rather than stopping at the top of the tree`,
+        probed.join(' ') || 'the walk found nothing');
     }
-    check(eq(holders, ['web/format.js']),
-      'the 512x424 grid appears as a literal in exactly one file across web/ and server/, and it is web/format.js',
-      holders.join(' ') || 'nothing holds it, which is a grid that went missing rather than a grid stated once');
+
+    // One row per dimension. The pair is what a grabber frame is, but "the grid is
+    // declared once" is two claims and only one of them can be answered by a match on
+    // either number.
+    const holdersOf = (n) => ['web', 'server'].flatMap(
+      (dir) => sourcesUnder(root, dir).filter((rel) => literal(n).test(withoutComments(shippedSource(rel)))),
+    );
+    for (const [what, n] of GRID) {
+      const holders = holdersOf(n);
+      check(eq(holders, ['web/format.js']),
+        `${n}, ${what}, appears as a literal in exactly one file across web/ and server/, and it is web/format.js`,
+        holders.join(' ') || `nothing holds ${n}, which is half a grid that went missing rather than a grid stated once`);
+    }
   }
 
   // ------------------------------------------------------------- 1. the manifest
@@ -1819,9 +1862,25 @@ async function runChecks() {
       hash: `sha256:${'cd'.repeat(32)}`,
       openRefusals: [{ key: 'short', why: 'a take needs two frames to bracket a position, so there is nothing here to play' }],
     };
+    // **And the take that carries none, which is nearly every take there is.** A
+    // refused take is the interesting shape and it is the wrong one to test a gate
+    // with: `openRefusals: []` is what an ordinary openable take from a current node
+    // sends, so a gate written as `length > 0` would take the link off for every
+    // healthy library while a positive arm holding only the refused take stayed green.
+    // The empty list is the case the code has to admit, so it is the case the fixture
+    // has to contain.
+    const openableShape = {
+      ...oldShape,
+      id: 'openable-on-this-build',
+      hash: `sha256:${'ef'.repeat(32)}`,
+      frames: 60,
+      durationSec: 4,
+      openable: true,
+      openRefusals: [],
+    };
 
     const old = await stub([oldShape]);
-    const current = await stub([newShape]);
+    const current = await stub([newShape, openableShape]);
     try {
       const oldLink = new NodeLink(old.url, 'old-node');
       const oldTakes = await oldLink.takes();
@@ -1836,9 +1895,16 @@ async function runChecks() {
       // entirely, which is the same failure one build further along.
       const currentLink = new NodeLink(current.url, 'current-node');
       const currentTakes = await currentLink.takes();
-      check(currentTakes?.length === 1 && currentTakes[0].id === 'shot-on-this-build',
+      check(eq((currentTakes ?? []).map((t) => t.id), ['shot-on-this-build', 'openable-on-this-build']),
         'a manifest that carries them passes, so the gate is a version band rather than the link switched off',
-        `${currentTakes === null ? 'null' : currentTakes.length} takes, error ${JSON.stringify(currentLink.lastError)}`);
+        `${currentTakes === null ? 'null' : currentTakes.map((t) => t.id).join(' ')}, error ${JSON.stringify(currentLink.lastError)}`);
+      // Named separately, because the two takes above fail for different reasons and a
+      // combined row would report the wrong one. An empty list is a *take with nothing
+      // wrong with it* rather than a take whose refusals went missing, and the gate has
+      // to tell those apart or a healthy node is refused for being healthy.
+      check(currentTakes?.some((t) => t.id === 'openable-on-this-build' && t.openRefusals.length === 0),
+        'and an openable take, whose refusal list is correctly empty, is not read as a manifest with none',
+        currentTakes === null ? `the whole manifest was refused: ${currentLink.lastError}` : 'it came through');
 
       // What the operator gets, which is the half a boundary test cannot see: the
       // gallery still paints, the local shelf is all there, and the line under the
@@ -2482,15 +2548,28 @@ async function runChecks() {
       `${at0.signature} then ${at90.signature}, means ${at0.mean.toFixed(2)} and ${at90.mean.toFixed(2)}`);
     const remoteHash = tiles.find((t) => t.state === 'remote')?.hash;
     check(remoteHash !== undefined, 'a remote take is present to skim');
-    await page.evaluate(`globalThis.__library.drawn(${JSON.stringify(remoteHash)})`);
-    const remote = await page.evaluate(`globalThis.__library.poster(${JSON.stringify(remoteHash)})`);
-    // Sixteen times fewer samples reach the canvas, so a decimated skim is
-    // measurably sparser rather than merely labelled as such. This is the arm the
-    // label alone cannot carry: a tile that said "decimated" and fetched a full
-    // frame would pass every assertion above it.
-    check(remote.mean > 0 && remote.mean < at0.mean * 0.5,
-      'a decimated skim is measurably sparser than a local one, not just labelled',
-      `local ${at0.mean.toFixed(1)} against remote ${remote.mean.toFixed(1)}`);
+    // **Skipped, with the row still counted, when the link is down**, the same shape
+    // the way-back anchor above already uses. Any mutation that takes the node off -
+    // `refusals-must-be-nonempty` is the one that found this - leaves the shelf with no
+    // remote tile, and `drawn(undefined)` then waits out its own timeout and throws
+    // `tile undefined never drew 1 frames`, which ended the run at 105 of 366 with
+    // eight rows correctly red and two hundred and sixty claims never measured. A
+    // control is supposed to redden what carries its claim; one that stops the run has
+    // the tool as its blast radius.
+    if (remoteHash !== undefined) {
+      await page.evaluate(`globalThis.__library.drawn(${JSON.stringify(remoteHash)})`);
+      const remote = await page.evaluate(`globalThis.__library.poster(${JSON.stringify(remoteHash)})`);
+      // Sixteen times fewer samples reach the canvas, so a decimated skim is
+      // measurably sparser rather than merely labelled as such. This is the arm the
+      // label alone cannot carry: a tile that said "decimated" and fetched a full
+      // frame would pass every assertion above it.
+      check(remote.mean > 0 && remote.mean < at0.mean * 0.5,
+        'a decimated skim is measurably sparser than a local one, not just labelled',
+        `local ${at0.mean.toFixed(1)} against remote ${remote.mean.toFixed(1)}`);
+    } else {
+      check(false, 'a decimated skim is measurably sparser than a local one, not just labelled',
+        'there is no remote tile to skim');
+    }
 
     // Every tab shows a count, and a count that disagreed with the tiles it filters
     // to would be the readout lying about the library rather than about a take.

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -2180,6 +2180,23 @@ async function runChecks() {
       'and it is the sentence about the frame it does not have rather than the one about bracketing a position',
       JSON.stringify(buttonWhy));
 
+    // **Every refusal the server can send has a badge on the page, asked of the two
+    // tables rather than of the refusals that exist today.** The page decides its own
+    // badge text - a 228px poster is a page constraint - so the two lists are
+    // genuinely separate and a key added to one and not the other is the failure. The
+    // first spelling of the page's side was a two-case conditional with an else, which
+    // would have badged a third refusal "no hello" over a take that has one, and a
+    // format-version band is exactly that third refusal arriving. `recording` is left
+    // out by name: `warningsOf` returns its own four-verb warning before it reaches
+    // this table, which is the one sentence the page still writes and why.
+    const badgeKeys = await page.evaluate('globalThis.__library.badgeKeys()');
+    const serverKeys = [...new Set((await getJson(`${macUrl}/library/takes`)).takes
+      .flatMap((t) => (t.openRefusals ?? []).map((r) => r.key)))].filter((k) => k !== 'recording');
+    const unbadged = serverKeys.filter((k) => !badgeKeys.includes(k));
+    check(serverKeys.length > 0 && unbadged.length === 0,
+      'every refusal the server can send has a badge on the page, so a reason added later is asked by existing',
+      `server ${serverKeys.join(' ')} against page ${badgeKeys.join(' ')}`);
+
     // Marks on the tile's scrub bar, at their source fraction. The two that a
     // fraction gets wrong on its own are checked by name: source zero has to land
     // at the left edge rather than being falsy-dropped, and one past the end has to

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1010,6 +1010,26 @@ const MUTATIONS = {
     "  if (!index.hello) openRefusals.push(refusal('no-hello'));\n",
     '',
   ]] },
+  // **The capture-format band goes back to being a term in `openable` rather than a
+  // refusal in the list**, which is the shape it arrived from `main` in and the shape the
+  // merge changed. It is the control for that change, and the reason it needs one is that
+  // the three rows `main` brought - the future-format take lists, names its generation and
+  // says it cannot be opened - are all still true here. `openable` is false either way, so
+  // every row asking `openable` passes a build where the band decides for itself again,
+  // and the difference only shows in what the take *carries*: a refusal with a sentence
+  // the tile can badge, or nothing, leaving a dead Open button with no reason on it.
+  //
+  // Two edits because the term and the push are two halves of one decision, and removing
+  // only the push would leave `openable` reading a list the band no longer writes to,
+  // which is a build that opens a take it cannot read rather than the one under test.
+  //
+  // Narrow on purpose: an empty `openRefusals` still satisfies `carriesRefusals`, so the
+  // node link stays up and the rest of the suite still measures.
+  'openable-recomputes-the-band': { file: 'server/library.js', edits: [
+    ["  if (captureFormatRefusal('this take', format) !== '') openRefusals.push(refusal('format', format));\n", ''],
+    ['    openable: openRefusals.length === 0,',
+      "    openable: Boolean(index.hello) && stamps.length >= 2 && captureFormatRefusal('this take', format) === '',"],
+  ] },
   // **One dimension of the grid stops being a literal while the other holds**, and the
   // value is deliberately unchanged - `DEPTH_W - 88` is still 424, so every page still
   // renders the same pixels and every message is still the same size. That is what
@@ -1445,6 +1465,10 @@ function stageServer() {
 }
 
 const servers = [];
+// Servers whose offset has since been claimed by another section. They are off `servers`
+// so that a lookup by port answers with whoever is on it, and they are still here so the
+// exit backstop has a list to walk rather than an argument to follow.
+const retired = [];
 
 /** Whether something already holds a port, asked of the kernel rather than of a fetch. */
 const portHeld = (port) => new Promise((done) => {
@@ -1499,8 +1523,14 @@ async function startServer(root, args, port) {
   // already rules out: the second would fail to bind, and the exit-instead-of-listening
   // throw below is what says so. Reaching here at all means the last holder let the port
   // go, which is the definition of it being the last one.
+  // Retired rather than forgotten. Every stop in this file is a SIGKILL, so the dropped
+  // child is genuinely dead and killing it again would be a no-op - but the exit backstop
+  // below exists because a server this run leaks holds its port and turns every later run
+  // in every worktree into an exit 2 naming an owner nobody can find, and "it is dead
+  // because every current caller kills it" is a reasoning step standing where a list
+  // would do.
   const stale = servers.findIndex((s) => s.port === port);
-  if (stale !== -1) servers.splice(stale, 1);
+  if (stale !== -1) retired.push(...servers.splice(stale, 1));
   const child = spawn(process.execPath, [join(root, 'server/index.js'), '--port', String(port), ...args], {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -1528,7 +1558,7 @@ async function startServer(root, args, port) {
 }
 
 function stopServers() {
-  for (const { child } of servers) child.kill('SIGKILL');
+  for (const { child } of [...servers, ...retired]) child.kill('SIGKILL');
 }
 
 // **The backstop for every way out that does not reach the `finally`.** A spawned server

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1205,23 +1205,114 @@ const serverMutation = mutation && mutation.file.startsWith('server/') ? mutatio
 const shippedSource = (rel) => readFileSync(join(root, rel), 'utf8');
 
 /**
- * Source with its comments taken out, so a row about what the code says is not
- * answered by what the prose says.
+ * Every number a piece of JavaScript states as code, by value.
  *
- * Four files in this tree name the grid in prose - `web/format.js` explaining why it
- * lives there, `web/main.js` describing the band a mis-bound frame collapses into,
- * `server/protocol.js` sizing a message and `server/webcam.js` explaining what the
- * colour camera is not - and every one of them is a comment doing its job. A row that
- * counted them would be unfalsifiable in the loud direction: permanently red, and
- * therefore turned off.
+ * **A scan rather than a pair of regexes, and it replaced two.** What a row about the
+ * sensor grid needs is the numbers the *code* says, and the two things that are not code
+ * are comments and literal text - so the question is what a JavaScript lexer would call a
+ * numeric token, and nothing else is a reliable way to ask it. Four files in this tree
+ * name the grid in prose (`web/format.js` explaining why it lives there, `web/main.js`
+ * describing the band a mis-bound frame collapses into, `server/protocol.js` sizing a
+ * message, `server/webcam.js` saying what the colour camera is not) and every one is a
+ * comment doing its job; the string half is the same fact one layer in, where an
+ * ordinary `throw new Error('expected 512 bytes')` added to any module would have been
+ * counted as a second declaration of the sensor's width.
  *
- * Block comments first, because a `//` inside one is not a line comment; and a `//`
- * preceded by a colon is left alone, since that is a URL rather than the start of one.
+ * The regexes this replaces each approximated one half and each carried a patch for the
+ * other's territory - the line-comment rule skipped a `//` preceded by a colon, so that a
+ * URL in a string would survive, which is a lexer being written one exception at a time.
+ * One pass that knows what a literal is has no exceptions to accumulate.
+ *
+ * **Template expressions are scanned and template text is not**, which is the one place
+ * the two can be interleaved: `${...}` is code by definition and the brace depth says
+ * where it ends.
+ *
+ * **Where it guesses, it guesses toward reporting.** A `/` is division or the start of a
+ * regex depending on what came before it, and there is no correct answer without a parse.
+ * The unambiguous cases are decided by the previous significant token and skipped whole -
+ * `= /[0-9a-f]{64}/` is a regex and its digits are not declarations of anything. What is
+ * left ambiguous is `}`, which ends a block (a regex may follow) or an object (division
+ * may), and this reads it as division. Wrong that way, a regex's contents get scanned as
+ * code and a digit inside one is a holder reported that is not one, which fails loudly and
+ * gets looked at. Wrong the other way, it skips to the next `/` and swallows whatever code
+ * is in between, which is a declaration going unseen under a green row. Only one of those
+ * two is safe to be wrong about.
  */
-const withoutComments = (src) => src
-  .replace(/<!--[\s\S]*?-->/g, ' ')
-  .replace(/\/\*[\s\S]*?\*\//g, ' ')
-  .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+const numbersIn = (src) => {
+  const values = [];
+  // One entry per literal we are inside, innermost last. A backtick pushes `template`;
+  // a `${` inside one pushes `code` remembering the brace depth to come back at.
+  const stack = [];
+  const inTemplate = () => stack[stack.length - 1]?.kind === 'template';
+  let depth = 0;
+  // The last significant character, which is what decides the `/` question. Not the last
+  // character: whitespace and comments do not answer it.
+  let prev = '';
+  let i = 0;
+  const NUM = /^(?:0[xX][\dA-Fa-f](?:_?[\dA-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?(?:[eE][+-]?\d(?:_?\d)*)?)n?/;
+  while (i < src.length) {
+    const c = src[i];
+    if (inTemplate()) {
+      if (c === '\\') { i += 2; continue; }
+      if (c === '`') { stack.pop(); prev = '`'; i++; continue; }
+      if (c === '$' && src[i + 1] === '{') { stack.push({ kind: 'code', depth }); depth++; prev = '{'; i += 2; continue; }
+      i++;
+      continue;
+    }
+    if (c === '/' && src[i + 1] === '/') { while (i < src.length && src[i] !== '\n') i++; continue; }
+    if (c === '/' && src[i + 1] === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      i++;
+      while (i < src.length && src[i] !== c) i += src[i] === '\\' ? 2 : 1;
+      i++;
+      prev = c;
+      continue;
+    }
+    if (c === '`') { stack.push({ kind: 'template' }); i++; continue; }
+    // A regex only where a value cannot already have ended. `}` counts as a value ending,
+    // which is the ambiguous case resolved toward division, as the comment above says.
+    if (c === '/' && !/[\w$)\]}'"`]/.test(prev)) {
+      i++;
+      let klass = false;
+      while (i < src.length) {
+        if (src[i] === '\\') { i += 2; continue; }
+        if (src[i] === '[') klass = true;
+        else if (src[i] === ']') klass = false;
+        else if (src[i] === '/' && !klass) break;
+        else if (src[i] === '\n') break;
+        i++;
+      }
+      i++;
+      prev = '/';
+      continue;
+    }
+    if (c === '{') { depth++; prev = c; i++; continue; }
+    if (c === '}') {
+      depth--;
+      const top = stack[stack.length - 1];
+      if (top?.kind === 'code' && top.depth === depth) { stack.pop(); i++; continue; }
+      prev = c;
+      i++;
+      continue;
+    }
+    // A number, but only where one can start - `a.512` is a property and `x512` a name.
+    if (/\d/.test(c) && !/[\w$.]/.test(prev)) {
+      const [token] = NUM.exec(src.slice(i));
+      values.push(Number(token.replace(/n$/, '').replace(/_/g, '')));
+      i += token.length;
+      prev = '0';
+      continue;
+    }
+    if (!/\s/.test(c)) prev = c;
+    i++;
+  }
+  return values;
+};
 
 // ----------------------------------------------------------------- the fixtures
 //
@@ -1987,14 +2078,14 @@ async function runChecks() {
   // grid that went missing" - that only fired when both went at once.
   console.log('\n[library] the sensor grid is declared once, and the tree is what says so');
   {
-    // **Every numeric literal, compared by value.** The first spelling of this searched
-    // for the decimal digits with guards either side - `(?<![\d.])512(?![\d.])`, which
-    // keeps `512` out of `1512` and `4.24` - and that is a matcher for one *spelling* of a
-    // number wearing the name of the number. A module redeclaring the width as `512.0` is
-    // rejected by the trailing guard, `0x200` and `5.12e2` are never looked at, and each
-    // of them is a second declaration of the grid sitting under a row reporting one. The
-    // guards are not needed once the comparison is by value, because `1512` tokenises as
-    // `1512` and answers 1512.
+    // **Every numeric literal, compared by value**, which `numbersIn` above is the scan
+    // for. The first spelling of this searched for the decimal digits with guards either
+    // side - `(?<![\d.])512(?![\d.])`, which keeps `512` out of `1512` and `4.24` - and
+    // that is a matcher for one *spelling* of a number wearing the name of the number. A
+    // module redeclaring the width as `512.0` is rejected by the trailing guard, `0x200`
+    // and `5.12e2` are never looked at, and each of them is a second declaration of the
+    // grid sitting under a row reporting one. The guards stopped being needed with the
+    // comparison by value, because `1512` is one token and answers 1512.
     //
     // Bounded on purpose, and the boundary is where a reader would otherwise assume more:
     // this sees a literal in any spelling and does not see an *expression* that computes
@@ -2007,16 +2098,7 @@ async function runChecks() {
     // Legacy octal - `01000`, which is 512 - is not in the pattern because it is a
     // SyntaxError in a module, and every file walked here is one. `syntax-check` is what
     // holds that.
-    const NUMERIC = new RegExp([
-      '(?<![\\w$.])(?:',
-      '0[xX][\\dA-Fa-f](?:_?[\\dA-Fa-f])*',       // hex
-      '|0[oO][0-7](?:_?[0-7])*',                  // octal
-      '|0[bB][01](?:_?[01])*',                    // binary
-      '|\\d(?:_?\\d)*(?:\\.(?:\\d(?:_?\\d)*)?)?(?:[eE][+-]?\\d(?:_?\\d)*)?', // decimal
-      ')n?',
-    ].join(''), 'g');
-    const declares = (source, n) => [...source.matchAll(NUMERIC)]
-      .some((m) => Number(m[0].replace(/n$/, '').replace(/_/g, '')) === n);
+    const declares = (source, n) => numbersIn(source).includes(n);
 
     // **The JavaScript in a file, because this is a claim about JavaScript.** The walk
     // reaches every file under `web/` and `server/`, which is three HTML pages and a
@@ -2089,6 +2171,25 @@ async function runChecks() {
     writeFileSync(join(probeRoot, 'web', 'nested', 'hexadecimal.js'), 'export const W = 0x200;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'further.js'), 'export const H = 424;\n');
     writeFileSync(join(probeRoot, 'web', 'nested', 'deeper', 'scientific.js'), 'export const H = 4.24e2;\n');
+    // **The literal text a module carries, which is the same fact as the paragraph in the
+    // page one layer in.** An ordinary `throw new Error('expected 512 bytes')` is a
+    // message and not a declaration, and a row that counted it would fail a clean suite
+    // on a debug string. Every kind that can hold text is here because they are scanned
+    // by different branches: a single-quoted string, a double-quoted one, an escaped
+    // quote inside a string, a comment, and template text.
+    //
+    // **The last line is the one that has to be found**, and it is here because skipping
+    // template *text* and skipping a template *expression* are one character apart in the
+    // scan. `${}` is code by definition, so a declaration hiding in one is a declaration -
+    // and a scan that swallowed the whole template would lose it silently, which is the
+    // direction that does not announce itself.
+    writeFileSync(join(probeRoot, 'web', 'nested', 'literals.js'),
+      "export const A = 'expected 512 bytes';\n"
+      + 'export const B = "a 424-line budget";\n'
+      + "export const C = 'it\\'s 512 wide, they said';\n"
+      + '// a comment saying 512 and 424\n'
+      + 'export const D = `the grid is 512 by 424`;\n'
+      + 'export const E = `computed ${424} rows`;\n');
     // A page and a stylesheet, which is what the tree actually holds beside the modules.
     // The page states both numbers three times over and only one of them is a
     // declaration: in prose, in a `<style>` rule, in an importmap that is a `<script>` of
@@ -2105,16 +2206,21 @@ async function runChecks() {
     const walked = sourcesUnder(probeRoot, 'web');
     // Sorted per directory and depth-first, which is the order `sourcesUnder` produces
     // and the order these are written in.
+    // **`literals.js` is on one list and not the other, which is the whole arm.** Its
+    // 512s are all text - two strings, an escaped quote, a comment, a template - and its
+    // 424 appears both as text and inside a `${}`. So a scan that reads strings puts it on
+    // the 512 list and fails, and a scan that swallows template expressions takes it off
+    // the 424 list and fails. One file, both directions.
     const WANT = {
       512: ['web/nested/buried.js', 'web/nested/hexadecimal.js', 'web/page.html'],
-      424: ['web/nested/deeper/further.js', 'web/nested/deeper/scientific.js'],
+      424: ['web/nested/deeper/further.js', 'web/nested/deeper/scientific.js', 'web/nested/literals.js'],
     };
     for (const [what, n] of GRID) {
       const probed = walked.filter((rel) => declares(
-        withoutComments(javascriptIn(rel, readFileSync(join(probeRoot, rel), 'utf8'))), n,
+        javascriptIn(rel, readFileSync(join(probeRoot, rel), 'utf8')), n,
       ));
       check(eq(probed, WANT[n]),
-        `the walk this row uses reaches ${what} buried in a subdirectory, in every spelling of the number, in a page's script and in no near miss, stylesheet or paragraph`,
+        `the walk this row uses reaches ${what} in every spelling and in a page's script, and in no string, comment, template text, stylesheet, paragraph or near miss`,
         probed.join(' ') || 'the walk found nothing');
     }
 
@@ -2123,7 +2229,7 @@ async function runChecks() {
     // either number.
     const holdersOf = (n) => ['web', 'server'].flatMap(
       (dir) => sourcesUnder(root, dir)
-        .filter((rel) => declares(withoutComments(javascriptIn(rel, shippedSource(rel))), n)),
+        .filter((rel) => declares(javascriptIn(rel, shippedSource(rel)), n)),
     );
     for (const [what, n] of GRID) {
       const holders = holdersOf(n);

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -63,6 +63,7 @@ import { createHash } from 'node:crypto';
 import { chmodSync, cpSync, mkdirSync, readdirSync, rmSync, symlinkSync, existsSync, readFileSync, writeFileSync, appendFileSync, statSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { createConnection } from 'node:net';
+import { createServer } from 'node:http';
 import { networkInterfaces } from 'node:os';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 import { WebSocket } from 'ws';
@@ -905,6 +906,40 @@ const MUTATIONS = {
       + "  return '';\n"
       + '};',
   ]] },
+  // **The menu goes back to naming both causes at once**, which is the sentence that
+  // shipped: a page holding an `openable` boolean and nothing telling it which half
+  // fired, so a take with a hello and one frame was told it might have neither. A
+  // second control beside `open-decides-its-own-reason` and not a widening of it,
+  // because the claim is that *whichever surface asks* gets the server's sentence, and
+  // a control that mutates only the gallery leaves the other surface free to derive its
+  // own with every row still green - which is what it was doing.
+  'menu-decides-its-own-reason': { file: 'web/menu.html', edits: [[
+    '  if (!take.openable) {\n'
+      + '    const why = take.openRefusals.map((r) => r.why).join(\'; \');\n'
+      + '    return gallery(`${take.id} cannot be opened: ${why}`);\n'
+      + '  }',
+    '  if (!take.openable) return gallery(`${take.id} cannot be opened: no sensor hello, or under two frames`);',
+  ]] },
+  // **A refusal the server declares and no page can badge**, which is the drift the
+  // two-table row exists to catch and could not see while it read the refusals a
+  // fixture take happened to carry. Nothing here provokes this key - that is the
+  // point: a reason that applies to a take shape this library does not hold is exactly
+  // the one that would arrive unbadged, and a row deriving its list from
+  // `/library/takes` would compare two keys against two keys and print green.
+  'refusal-without-a-badge': { file: 'server/library.js', edits: [[
+    'export const OPEN_REFUSALS = {\n',
+    'export const OPEN_REFUSALS = {\n'
+      + "  'wrong-format': () => 'this take was written by a generation of the format this build cannot read',\n",
+  ]] },
+  // **The link admits a manifest from the build before the refusals moved**, which is
+  // the take that reconciles in looking like any other and then blanks the shelf while
+  // the first remote tile paints. The gate rather than the sentence it sets, because
+  // what the row claims is that nothing without refusals reaches a surface - a mutation
+  // of the wording would redden a message row while the take still came through.
+  'node-admits-an-old-manifest': { file: 'server/library.js', edits: [[
+    '      const older = takes.find((t) => !carriesRefusals(t));\n      if (older) {',
+    '      const older = takes.find((t) => !carriesRefusals(t));\n      if (false) {',
+  ]] },
   // **The monitor's cost line goes back to spelling the grid out inline**, which is
   // where it was for as long as the comment above it promised the opposite. It
   // computes exactly the same number, renders identical pixels and serves identical
@@ -1480,15 +1515,26 @@ async function openPage(browser, url, viewport = { width: 1100, height: 760 }) {
     // exists for one layer up, arriving through the delivery instead of the anchor.
     const file = pageMutation.file.slice('web/'.length);
     const html = file.endsWith('.html');
-    const target = html ? '/gallery' : `/${file}`;
-    await page.route(`**${target}`, (route) => route.fulfill({
+    // The table rather than a conditional, for the reason the rule below already gives:
+    // a page is reached at the URL `PAGES` names it by, so the mapping is a fact about
+    // the server and a check that knew only one of them delivered nothing for the rest.
+    // It knew only `library.html` until the menu got a mutation of its own, and the
+    // shape of that miss is the throw underneath: loud, at the first page opened, and
+    // naming the file - never a silent fulfil of a route nothing requests.
+    const AT = { 'library.html': '/gallery', 'menu.html': '/' };
+    if (html && !(file in AT)) {
+      throw new Error(`no URL is known for web/${file}: this table knows ${Object.keys(AT).join(', ')}`);
+    }
+    // Matched on the pathname rather than by a `**${target}` glob. The menu is served
+    // at `/`, and `**/` matches every directory-shaped URL the page asks for - the
+    // mutated menu would have been fulfilled for requests that are not the menu. A
+    // predicate says the one thing meant: this exact path and nothing under it.
+    const target = html ? AT[file] : `/${file}`;
+    await page.route((url) => url.pathname === target, (route) => route.fulfill({
       status: 200,
       contentType: html ? 'text/html; charset=utf-8' : 'text/javascript; charset=utf-8',
       body: pageMutation.body,
     }));
-    if (html && file !== 'library.html') {
-      throw new Error(`no URL is known for web/${file}: only library.html is served, at /gallery`);
-    }
   }
   await page.goto(url, { waitUntil: 'domcontentloaded' });
   return { page, errors };
@@ -1575,14 +1621,46 @@ async function runChecks() {
   // deliberately not to `tools/`: every proof tool here states the grid independently,
   // and that is correct rather than sloppy, because a check that imported the constant
   // it asserts would be holding a `512` against itself.
+  //
+  // **It recurses, and the first spelling of it did not.** `web/` and `server/` are flat
+  // today, so a walk of their direct children found every file there is and read as a
+  // walk of the tree - with a `continue` on a directory that would have skipped the
+  // first subdirectory anybody made, silently, leaving a module free to redeclare the
+  // grid under a row still printing green. That is the close-the-class rule failing in
+  // the shape it is meant to catch: the enumeration was the files that exist rather
+  // than the tree, and nothing about the row said which.
   console.log('\n[library] the sensor grid is declared once, and the tree is what says so');
   {
     const grid = /(?<![\d.])(?:512|424)(?![\d.])/;
+    // Relative paths under `base`, deepest last, as one flat list. Split out from the
+    // row below so the falsification control underneath can run the same walker over a
+    // tree it built, which is the only way to hold a traversal to its claim - a
+    // recursion bug in this loop is invisible against a directory that has nothing in
+    // it to recurse into.
+    const sourcesUnder = (base, dir, prefix = '') => readdirSync(join(base, dir), { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .flatMap((entry) => (entry.isDirectory()
+        ? sourcesUnder(base, `${dir}/${entry.name}`, `${prefix}${entry.name}/`)
+        : [`${dir}/${entry.name}`]));
+
+    // The control, run before the row it controls: a tree whose only grid is one
+    // directory down. A walker that skips directories answers `[]` here and this goes
+    // red, where against the real `web/` and `server/` it would answer exactly what the
+    // row below wants and pass. Built under `.library-check` and left there with the
+    // rest of the run's scratch.
+    const probeRoot = join(REPO, '.library-check', 'grid-probe');
+    rmSync(probeRoot, { recursive: true, force: true });
+    mkdirSync(join(probeRoot, 'web', 'nested'), { recursive: true });
+    writeFileSync(join(probeRoot, 'web', 'flat.js'), 'export const NOTHING = 1;\n');
+    writeFileSync(join(probeRoot, 'web', 'nested', 'buried.js'), 'export const W = 512;\n');
+    const probed = sourcesUnder(probeRoot, 'web').filter((rel) => grid.test(readFileSync(join(probeRoot, rel), 'utf8')));
+    check(eq(probed, ['web/nested/buried.js']),
+      'the walk this row uses reaches a file one directory down, so a grid buried in a subdirectory is found',
+      probed.join(' ') || 'the walk found nothing, which is a walk that stops at the top of the tree');
+
     const holders = [];
     for (const dir of ['web', 'server']) {
-      for (const name of readdirSync(join(root, dir)).sort()) {
-        const rel = `${dir}/${name}`;
-        if (statSync(join(root, rel)).isDirectory()) continue;
+      for (const rel of sourcesUnder(root, dir)) {
         if (grid.test(withoutComments(shippedSource(rel)))) holders.push(rel);
       }
     }
@@ -1683,6 +1761,122 @@ async function runChecks() {
       `remaining space is reported as time, not bytes (${lib.storage.label})`);
     check(lib.storage.secondsLeft > 0 && Number.isFinite(lib.storage.bytesPerSec),
       'and it is a duration derived from a rate rather than a byte count');
+  }
+
+  // ------------------------------------------- 2b. a node from another build
+  //
+  // **Two machines on one network are two builds**, and every fixture above has them
+  // running the same one - which is the shape that cannot show this. The editing
+  // machine is upgraded first because it is the one somebody is standing at, and the
+  // node then answers `/library/takes` in the vocabulary of the build before: an
+  // `openable` boolean, a `hasHello`, a frame count, and no refusals at all. That
+  // manifest parses, survives the id and hash filters, and reconciles into the listing
+  // looking like any other take, so the failure lands where nothing is watching for it
+  // - the gallery iterating a field that is not there while painting the first remote
+  // tile, and the whole shelf blank on a `TypeError`.
+  //
+  // The node is a stub rather than a second server, because what has to be tested is a
+  // manifest this tree can no longer produce. Anything spawned out of `stageServer`
+  // runs the build under test and answers correctly by construction, which is the same
+  // trap as an oracle that agrees with itself.
+  //
+  // On a kernel-assigned port rather than one out of the reserved span. `reservePorts`
+  // exists because two worktrees sharing a fixed port shared a server and asserted
+  // against each other's fixtures; a port the kernel hands out on `listen(0)` cannot
+  // be held by anybody, which answers the same worry without widening the span.
+  console.log('\n[library] a node running an older build is refused at the link, not rendered');
+  {
+    const { NodeLink } = await import(pathToFileURL(join(root, 'server/library.js')).href);
+    const stub = (takes) => new Promise((done) => {
+      const srv = createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ takes }));
+      });
+      srv.listen(0, '127.0.0.1', () => done({ srv, url: `http://127.0.0.1:${srv.address().port}` }));
+    });
+    // The manifest the build before this one served, field for field. Written out here
+    // rather than generated, because a fixture derived from today's shape by deleting a
+    // key is a fixture that follows the code it is meant to outlive.
+    const oldShape = {
+      id: 'shot-on-an-old-node',
+      file: 'shot-on-an-old-node.knct',
+      bytes: 4096,
+      hash: `sha256:${'ab'.repeat(32)}`,
+      frames: 1,
+      durationSec: 0,
+      capturedAt: Date.UTC(2026, 5, 1),
+      dateSource: 'mtime',
+      truncated: false,
+      hasHello: true,
+      hello: { fx: 365, fy: 365, cx: 256, cy: 212 },
+      openable: false,
+      recording: false,
+      marks: [],
+    };
+    const newShape = {
+      ...oldShape,
+      id: 'shot-on-this-build',
+      hash: `sha256:${'cd'.repeat(32)}`,
+      openRefusals: [{ key: 'short', why: 'a take needs two frames to bracket a position, so there is nothing here to play' }],
+    };
+
+    const old = await stub([oldShape]);
+    const current = await stub([newShape]);
+    try {
+      const oldLink = new NodeLink(old.url, 'old-node');
+      const oldTakes = await oldLink.takes();
+      check(oldTakes === null, 'a manifest with no refusals on it is refused whole rather than admitted take by take',
+        oldTakes === null ? 'null' : `${oldTakes.length} takes came through`);
+      check(/older build/.test(oldLink.lastError ?? '') && /shot-on-an-old-node/.test(oldLink.lastError ?? ''),
+        'and the link says it is the node\'s build and which take arrived without them, rather than reporting a timeout',
+        JSON.stringify(oldLink.lastError));
+
+      // **The other arm, and the row is unfalsifiable without it.** A gate that
+      // refused every manifest would pass both rows above while taking the link off
+      // entirely, which is the same failure one build further along.
+      const currentLink = new NodeLink(current.url, 'current-node');
+      const currentTakes = await currentLink.takes();
+      check(currentTakes?.length === 1 && currentTakes[0].id === 'shot-on-this-build',
+        'a manifest that carries them passes, so the gate is a version band rather than the link switched off',
+        `${currentTakes === null ? 'null' : currentTakes.length} takes, error ${JSON.stringify(currentLink.lastError)}`);
+
+      // What the operator gets, which is the half a boundary test cannot see: the
+      // gallery still paints, the local shelf is all there, and the line under the
+      // header says what happened. With the gate off this is where the `TypeError`
+      // lands and every tile goes with it, so the arm is here rather than assumed.
+      const mixedUrl = await startServer(root, ['--captures', macCaps, '--name', 'mac', '--node', old.url,
+        '--node-name', 'old-node', '--presets', join(WORK, 'presets'), '--projects', join(WORK, 'projects'),
+        '--builtin-presets', join(WORK, 'builtin-presets')], MAC_PORT + 1);
+      const { page, errors } = await openPage(browser, galleryPage(mixedUrl));
+      // **Waited for behind a catch, because this is the arm the mutation kills.** With
+      // the gate off, the remote take reconciles in and the page throws inside its
+      // top-level paint, so `__library` is never assigned at all - and an unguarded
+      // wait is twenty seconds of Playwright and then a throw that ends the whole run
+      // at 29 of 363 assertions. Measured: that is what `--mutate
+      // node-admits-an-old-manifest` did before this catch. A control is supposed to
+      // redden the rows carrying its claim and leave every other claim still
+      // measurable; one whose blast radius is the tool measures nothing else.
+      const painted = await page.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 })
+        .then(() => true).catch(() => false);
+      const tiles = painted ? await page.evaluate('globalThis.__library.tiles()') : [];
+      check(painted && tiles.length > 0 && errors.length === 0,
+        'the gallery beside an older node still draws this machine\'s own takes, with no page error',
+        `${painted ? `${tiles.length} tiles` : 'the page never finished painting'}, ${errors.length} errors: ${errors.join(' | ')}`);
+      // `tiles.length > 0` and not just `every`, because an empty list satisfies every
+      // predicate there is - and an empty list is exactly what the arm above reports
+      // when the page has died.
+      check(tiles.length > 0 && tiles.every((t) => t.state !== 'remote'),
+        'and nothing from that node is on the shelf, because a shelf missing some of them silently is the worse answer',
+        `${tiles.length} tiles, ${tiles.filter((t) => t.state === 'remote').length} of them remote`);
+      const line = await page.evaluate('document.getElementById("note")?.textContent ?? ""');
+      check(/old-node/.test(line) && /older build/.test(line),
+        'and the page names the node and says its build is the reason', JSON.stringify(line));
+      await page.close();
+      for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
+    } finally {
+      old.srv.close();
+      current.srv.close();
+    }
   }
 
   // ----------------------------------------------------------- 3. decimation
@@ -2180,6 +2374,37 @@ async function runChecks() {
       'and it is the sentence about the frame it does not have rather than the one about bracketing a position',
       JSON.stringify(buttonWhy));
 
+    // **The same take, asked of the other surface**, because "whichever surface asks"
+    // is a claim about more than one of them and the two rows above are both the
+    // gallery. The menu resolves the Resume tile against `/library/all` and used to
+    // hold an `openable` boolean with nothing telling it which half had fired, so it
+    // named both causes at once - "no sensor hello, or under two frames" over a take
+    // with a hello and one of the two conditions. A reader of this file could have
+    // reverted that line and watched every row here stay green, which is a claim
+    // asserted rather than enforced; `--mutate menu-decides-its-own-reason` is the
+    // control that closes it.
+    const refusedHash = one('hello-no-frames').hash;
+    {
+      const { page: menu, errors: menuErrors } = await openPage(browser, `${macUrl}/`);
+      // Seeded and then reloaded, because the page resolves its tile once at load out
+      // of storage another surface writes. Setting it on a page already resolved would
+      // be asserting against the answer for an empty machine.
+      await menu.evaluate(`localStorage.setItem('kinect.lastOpened', ${JSON.stringify(JSON.stringify({
+        takeHash: refusedHash, takeId: 'hello-no-frames', project: null,
+      }))})`);
+      await menu.reload({ waitUntil: 'domcontentloaded' });
+      await menu.waitForFunction('globalThis.__menu !== undefined', null, { timeout: 20000 });
+      const resume = await menu.evaluate('globalThis.__menu.resume()');
+      check(resume.href === '/gallery' && (resume.reason ?? '').includes(buttonWhy),
+        'the menu refuses the same take in the same sentence the gallery put on its button',
+        `menu ${JSON.stringify(resume.reason)} against button ${JSON.stringify(buttonWhy)}`);
+      check(!/no sensor hello, or under two frames/.test(resume.reason ?? ''),
+        'and not in a sentence naming both causes over a take that has one of them',
+        JSON.stringify(resume.reason));
+      check(menuErrors.length === 0, 'and the menu raises no page error resolving it', menuErrors.join(' | '));
+      await menu.close();
+    }
+
     // **Every refusal the server can send has a badge on the page, asked of the two
     // tables rather than of the refusals that exist today.** The page decides its own
     // badge text - a 228px poster is a page constraint - so the two lists are
@@ -2189,13 +2414,35 @@ async function runChecks() {
     // format-version band is exactly that third refusal arriving. `recording` is left
     // out by name: `warningsOf` returns its own four-verb warning before it reaches
     // this table, which is the one sentence the page still writes and why.
+    //
+    // **Read off `OPEN_REFUSALS` and not off `/library/takes`**, because the fixture
+    // library is not an enumeration of anything. The first spelling of this row
+    // flattened the refusals the fixture takes happened to carry, which covers a key
+    // exactly as far as some take here provokes it - so the next refusal, which will
+    // apply to a take shape nothing in `buildFixture` writes, would be absent from the
+    // list, absent from the page's table, and the row would print green having compared
+    // two keys against two keys. The claim is that a reason added later is asked by
+    // existing, and only the server's own declaration can carry it.
+    //
+    // Imported out of the staged tree rather than through this file's static import of
+    // `server/library.js`, which reaches the repo: a server mutation is written into
+    // the stage, so a row reading the repo's copy would be answering about an
+    // unmutated build and `--mutate refusal-without-a-badge` would pass.
+    const { OPEN_REFUSALS } = await import(pathToFileURL(join(root, 'server/library.js')).href);
     const badgeKeys = await page.evaluate('globalThis.__library.badgeKeys()');
-    const serverKeys = [...new Set((await getJson(`${macUrl}/library/takes`)).takes
-      .flatMap((t) => (t.openRefusals ?? []).map((r) => r.key)))].filter((k) => k !== 'recording');
+    const serverKeys = Object.keys(OPEN_REFUSALS).filter((k) => k !== 'recording');
     const unbadged = serverKeys.filter((k) => !badgeKeys.includes(k));
     check(serverKeys.length > 0 && unbadged.length === 0,
       'every refusal the server can send has a badge on the page, so a reason added later is asked by existing',
       `server ${serverKeys.join(' ')} against page ${badgeKeys.join(' ')}`);
+    // And the declaration is not a list nothing reads: every key in it has to be a key
+    // the scanner can actually produce, or the row above is comparing the page against
+    // an enumeration that has drifted off the code the way the page's table did.
+    const liveKeys = [...new Set((await getJson(`${macUrl}/library/takes`)).takes
+      .flatMap((t) => t.openRefusals.map((r) => r.key)))];
+    check(liveKeys.every((k) => k in OPEN_REFUSALS),
+      'and every refusal a take actually arrived with is one the table declares',
+      `${liveKeys.join(' ')} against ${Object.keys(OPEN_REFUSALS).join(' ')}`);
 
     // Marks on the tile's scrub bar, at their source fraction. The two that a
     // fraction gets wrong on its own are checked by name: source zero has to land

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1181,21 +1181,28 @@ const serverMutation = mutation && mutation.file.startsWith('server/') ? mutatio
 /**
  * A file of the staged tree as this run actually ships it.
  *
- * The staged copy for everything, and `mutation.body` for the one file a mutation
- * replaces - which is not the same thing, and the difference is what lets a source row
- * fail. `stageServer` writes only a *server* mutation into the tree; a page mutation is
- * delivered by intercepting its route in `openPage`, so the staged `web/main.js` on a
- * `--mutate grid-declared-twice` run is the clean file. A source row reading it would
- * pass against every page mutation there is, which is the falsification control that
- * cannot fire, arriving one layer further out than the match-exactly-once rule that
- * guards the anchor.
+ * **One read, because there is one delivery.** This used to be a conditional -
+ * `mutation.body` for the mutated file and the staged copy for everything else - and the
+ * difference was load-bearing when `stageServer` wrote only *server* mutations into the
+ * tree and a page mutation was fulfilled by intercepting its route in the browser. The
+ * staged `web/main.js` on a `--mutate grid-declared-twice` run really was the clean file
+ * then, so a source row reading it would have passed against every page mutation there
+ * is: a falsification control that cannot fire, one layer further out than the
+ * match-exactly-once rule that guards the anchor.
+ *
+ * `stageServer` writes every mutation now, whichever side of the wire it is on, so the
+ * two branches returned identical bytes and the conditional was a second path that could
+ * only ever agree. Kept as a named helper rather than inlined, because a row wants to say
+ * it is reading what this run ships and not what the repo holds - but the answer to that
+ * is the staged tree and nothing else.
+ *
+ * What holds the staging is the source rows' own controls: remove that write and
+ * `grid-declared-twice` stops reddening, which is a mutation this suite already runs.
  *
  * `root` is read at call time rather than closed over at declaration, which is why this
  * can sit beside the mutation table it belongs to and above the tree it reads.
  */
-const shippedSource = (rel) => (
-  mutation && mutation.file === rel ? mutation.body : readFileSync(join(root, rel), 'utf8')
-);
+const shippedSource = (rel) => readFileSync(join(root, rel), 'utf8');
 
 /**
  * Source with its comments taken out, so a row about what the code says is not

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -99,6 +99,15 @@ const MAC_PORT = Number(flag('--mac-port', '8211'));
 // and the failure reads exactly like a finding about the recorder. The span is checked
 // end to end before anything spawns, and `startServer` asserts its port is inside it, so
 // a section added later at `+17` is caught by arithmetic rather than by a wrong reading.
+//
+// **The span stayed at 16 and the collision inside it was fixed instead**, which is worth
+// saying because widening was the first answer and it is the wrong one. Every worktree on
+// this machine has to find the whole span free, so two more ports is a cost paid by
+// everybody to route around a bug in the bookkeeping - and the bug is one offset naming
+// two servers in `servers`, which `startServer` now drops the stale half of. Reuse is
+// deliberate here rather than tolerated: `+14` is a rename server and later a
+// broken-preset one, and an offset with a live holder cannot be taken at all, because the
+// kernel refuses the bind.
 const PORT_SPAN = 16;
 const MUTATE = flag('--mutate');
 const HEADED = argv.includes('--headed');
@@ -1461,6 +1470,24 @@ async function startServer(root, args, port) {
     throw new Error(`port ${port} is outside the reserved span ${MAC_PORT}..${MAC_PORT + PORT_SPAN}: `
       + 'raise PORT_SPAN and the note beside it, or this server is one nothing checked was free');
   }
+  // **An offset this run has used before belongs to whoever is on it now**, and the entry
+  // for the last holder is dropped rather than left beside the new one. Sections reuse an
+  // offset on purpose - `+14` is a broken-preset server long after the rename server on it
+  // has been killed - and two entries for one port make every `servers.find((s) => s.port
+  // === n)` in this file answer with whichever was pushed first, which is the dead one.
+  //
+  // That is not hypothetical either: it read `0 exits` off a killed server's log while the
+  // live one under test had died twenty-two times, and reported three rows about a
+  // supervisor that was working. The reading was wrong rather than the code, which is the
+  // worst way for a proof tool to be wrong - so the ambiguity is removed rather than
+  // documented.
+  //
+  // Replaced and not refused, because two *live* servers on one port is a case the kernel
+  // already rules out: the second would fail to bind, and the exit-instead-of-listening
+  // throw below is what says so. Reaching here at all means the last holder let the port
+  // go, which is the definition of it being the last one.
+  const stale = servers.findIndex((s) => s.port === port);
+  if (stale !== -1) servers.splice(stale, 1);
   const child = spawn(process.execPath, [join(root, 'server/index.js'), '--port', String(port), ...args], {
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -931,6 +931,26 @@ const MUTATIONS = {
     'export const OPEN_REFUSALS = {\n'
       + "  'wrong-format': () => 'this take was written by a generation of the format this build cannot read',\n",
   ]] },
+  // **The badge table goes back to having a prototype**, which is where it was and
+  // which answers `BADGES['__proto__']` with `Object.prototype` instead of `undefined`.
+  // The `?.` then does not short-circuit and the call throws on a value that is not a
+  // function, so a refusal key chosen by another machine kills the shelf - through the
+  // one door the version gate is deliberately told to leave open, since the gate checks
+  // the shape of a manifest and not its vocabulary.
+  //
+  // The historical body rather than a minimal edit, for the same reason
+  // `open-decides-its-own-reason` uses one: what the row claims is that the table is
+  // safe to index with a string off the wire, not that one particular spelling of it is.
+  'badges-inherit-from-object': { file: 'web/library.js', edits: [[
+    'const BADGES = Object.assign(Object.create(null), {\n'
+      + "  'no-hello': () => 'no hello',\n"
+      + "  short: (take) => (take.frames === 0 ? 'no frames' : '< 2 frames'),\n"
+      + '});',
+    'const BADGES = {\n'
+      + "  'no-hello': () => 'no hello',\n"
+      + "  short: (take) => (take.frames === 0 ? 'no frames' : '< 2 frames'),\n"
+      + '};',
+  ]] },
   // **The scanner forgets to push a refusal it declares**, which leaves `no-hello` in
   // `OPEN_REFUSALS`, in the page's `BADGES`, and on no take that exists - a reason and a
   // badge for it that nothing can ever wear. It is the direction the containment row
@@ -1956,6 +1976,51 @@ async function runChecks() {
         'and the page names the node and says its build is the reason', JSON.stringify(line));
       await page.close();
       for (const p of servers.filter((sv) => sv.port === MAC_PORT + 1)) p.child.kill('SIGKILL');
+
+      // ---- and a node one build *ahead*, which is the door the gate leaves open
+      //
+      // **The gate is on the shape of a manifest and deliberately not on its
+      // vocabulary**, so that a newer node can name a reason this build has never heard
+      // of and have the tile badge the key as itself. That promise is what is tested
+      // here, and it had a hole in it: `BADGES[key]?.(take)` on an ordinary object
+      // literal answers `__proto__` with `Object.prototype`, so the `?.` does not
+      // short-circuit and the call throws on a value that is not a function. The
+      // gallery then dies painting the tile - the same blank shelf the version gate
+      // exists to prevent, arriving through the door the gate was told to leave open.
+      //
+      // `__proto__` because it is the one that throws. `constructor`, `toString` and
+      // `valueOf` are the quieter half of the same fault and badge a take
+      // `[object Object]`, so the second row asks what the badge actually says rather
+      // than only that the page survived.
+      const ahead = await stub([{
+        ...openableShape,
+        id: 'shot-on-a-newer-build',
+        hash: `sha256:${'12'.repeat(32)}`,
+        openable: false,
+        openRefusals: [{ key: '__proto__', why: 'this take is refused for a reason this build has never heard of' }],
+      }]);
+      try {
+        const aheadUrl = await startServer(root, ['--captures', macCaps, '--name', 'mac', '--node', ahead.url,
+          '--node-name', 'new-node', '--presets', join(WORK, 'presets'), '--projects', join(WORK, 'projects'),
+          '--builtin-presets', join(WORK, 'builtin-presets')], MAC_PORT + 8);
+        const { page: aheadPage, errors: aheadErrors } = await openPage(browser, galleryPage(aheadUrl));
+        const alive = await aheadPage.waitForFunction('globalThis.__library !== undefined', null, { timeout: 20000 })
+          .then(() => true).catch(() => false);
+        const aheadTiles = alive ? await aheadPage.evaluate('globalThis.__library.tiles()') : [];
+        const strange = aheadTiles.find((t) => t.id === 'shot-on-a-newer-build');
+        check(alive && strange !== undefined && aheadErrors.length === 0,
+          'a refusal key this build has never heard of paints its tile rather than killing the shelf',
+          `${alive ? `${aheadTiles.length} tiles` : 'the page never finished painting'}, `
+            + `${aheadErrors.length} errors: ${aheadErrors.join(' | ')}`);
+        const badge = strange?.badges.find((b) => b.key === '__proto__');
+        check(badge?.short === '__proto__',
+          'and the badge reads the key itself, which is what visibly unmapped was promised to mean',
+          JSON.stringify(strange?.badges ?? null));
+        await aheadPage.close();
+        for (const p of servers.filter((sv) => sv.port === MAC_PORT + 8)) p.child.kill('SIGKILL');
+      } finally {
+        ahead.srv.close();
+      }
     } finally {
       old.srv.close();
       current.srv.close();
@@ -2528,7 +2593,12 @@ async function runChecks() {
     // the code in the direction the row above cannot see either.
     const liveKeys = [...new Set((await getJson(`${macUrl}/library/takes`)).takes
       .flatMap((t) => t.openRefusals.map((r) => r.key)))];
-    check(liveKeys.every((k) => k in OPEN_REFUSALS),
+    // `Object.hasOwn` and not `in`, which walks the prototype chain and would call a
+    // take arriving with `toString` or `constructor` a declared refusal. The same
+    // reading that took the prototype off the page's table, applied to the row that
+    // checks it: an instrument asking `in` about keys that come off a wire is asking a
+    // question `Object.prototype` gets to answer.
+    check(liveKeys.every((k) => Object.hasOwn(OPEN_REFUSALS, k)),
       'every refusal a take actually arrived with is one the table declares',
       `${liveKeys.join(' ')} against ${Object.keys(OPEN_REFUSALS).join(' ')}`);
     // And back the other way. `recording` is excluded by name and for a reason of fact

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -1588,6 +1588,15 @@ const servers = [];
 // so that a lookup by port answers with whoever is on it, and they are still here so the
 // exit backstop has a list to walk rather than an argument to follow.
 const retired = [];
+// **Everything this run started, which is what anything sweeping rather than looking up
+// wants.** Splitting the list gave the *lookups* a right answer and quietly gave the
+// *sweeps* a short one: the end-of-run fatal-log scan read `servers` alone, so a server
+// whose offset was later reused - three of them on a full run - could log `cannot open`
+// and have it dropped from the verdict. A named set rather than `[...servers, ...retired]`
+// spelled at each site, because the sites are two today and the bug was one of them being
+// forgotten. `sweptEverything` below asserts this is still all of them.
+const everyServer = () => [...servers, ...retired];
+let serversStarted = 0;
 
 /** Whether something already holds a port, asked of the kernel rather than of a fetch. */
 const portHeld = (port) => new Promise((done) => {
@@ -1678,6 +1687,7 @@ async function startServer(root, args, port) {
   let exited = null;
   child.on('exit', (code, signal) => { exited = signal ?? code; });
   servers.push({ child, log, port });
+  serversStarted++;
   for (let i = 0; i < 200; i++) {
     await new Promise((done) => { setTimeout(done, 100); });
     if (exited !== null) {
@@ -1693,7 +1703,7 @@ async function startServer(root, args, port) {
 }
 
 function stopServers() {
-  for (const { child } of [...servers, ...retired]) child.kill('SIGKILL');
+  for (const { child } of everyServer()) child.kill('SIGKILL');
 }
 
 // **The backstop for every way out that does not reach the `finally`.** A spawned server
@@ -6155,7 +6165,29 @@ async function runChecks() {
     for (const p of servers.filter((sv) => sv.port === MAC_PORT + 13)) p.child.kill('SIGKILL');
   }
 
-  for (const { log } of servers) {
+  // **Every server this run started, and a row saying so.** The sweep read `servers`
+  // alone, which stopped being all of them when a reclaimed offset started moving the
+  // previous holder to `retired` - three servers on a full run, whose fatal lines were
+  // dropped from the verdict while the tool reported a pass. That is the worst shape a
+  // proof tool has: a detection it made and did not say.
+  //
+  // The count is checked rather than the collection, because what went wrong was not this
+  // loop reading the wrong variable - it was a list being split somewhere else and one of
+  // its two readers not being told. A row comparing what was swept against what was
+  // started is red for either mistake, including the next collection somebody adds.
+  //
+  // **It has no `--mutate` entry and the reason is a limit worth knowing**: this row is
+  // about the instrument, and the mutation machinery reaches only the subject. A spec
+  // writes its body into the staged tree, and the stage is `server/` and `web/` - a
+  // mutation naming a file under `tools/` would be delivered to a copy nothing runs, and
+  // would be recorded as a control that passed. So this one was mutation-tested by hand:
+  // `everyServer()` put back to `servers` reddens this row and nothing else, and the
+  // commit message carries the numbers.
+  const swept = everyServer();
+  check(swept.length === serversStarted,
+    'the fatal-log sweep reads every server this run started, including the ones whose port was later reclaimed',
+    `swept ${swept.length} of ${serversStarted} started`);
+  for (const { log } of swept) {
     const text = log.join('');
     const bad = text.split('\n').filter(looksFatal);
     if (bad.length) {

--- a/tools/monitor-check.mjs
+++ b/tools/monitor-check.mjs
@@ -195,8 +195,8 @@ const MUTATIONS = {
   // everything: a control that reddens every row cannot say which row is carrying the
   // claim, and the claim here is that a sample lands where it was measured.
   'expand-shifts-by-a-block': { file: 'web/main.js', edits: [[
-    'for (let col = 0; col < DW; col++) dst[to + col] = src[from + ((col / grid.k) | 0)];',
-    'for (let col = 0; col < DW; col++) dst[to + col] = src[from + Math.min(grid.w - 1, (((col / grid.k) | 0) + 1))];',
+    'for (let col = 0; col < DEPTH_W; col++) dst[to + col] = src[from + ((col / grid.k) | 0)];',
+    'for (let col = 0; col < DEPTH_W; col++) dst[to + col] = src[from + Math.min(grid.w - 1, (((col / grid.k) | 0) + 1))];',
   ]] },
 };
 if (MUTATE && !MUTATIONS[MUTATE]) {

--- a/tools/sensor-view-check.mjs
+++ b/tools/sensor-view-check.mjs
@@ -273,8 +273,8 @@ const MUTATIONS = {
   'tanv-uses-fx': {
     file: 'web/main.js',
     edits: [[
-      '  const tanV = (DH / 2) / fy;',
-      '  const tanV = (DH / 2) / fx;',
+      '  const tanV = (DEPTH_H / 2) / fy;',
+      '  const tanV = (DEPTH_H / 2) / fx;',
     ]],
   },
   // Navigation that leaves a trace. Modelled on the `key here` handler beside it

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -419,6 +419,44 @@ if (!existsSync(DOC)) {
     } else {
       console.log(`  format/ CAPTURE_FORMAT is ${inJs[1]} in both languages`);
     }
+
+    // **The sensor grid, in the two languages that have to agree about it and cannot share
+    // a declaration.** `library-check` proves the grid is stated once across `web/` and
+    // `server/`, and that row is structurally unable to see the other side of the wire:
+    // the grabber is C++ and cannot import `web/format.js`, so its `DW`/`DH` are a second
+    // declaration that has to exist. Two unavoidable declarations are not a drift problem
+    // solved by deleting one - they are a drift problem solved by comparing them, which is
+    // exactly what `CAPTURE_FORMAT` above already does and for the same reason.
+    //
+    // What drift costs is a node that starts and then serves nothing: the grabber would
+    // emit a depth block of its own size and `server/capture.js` measures every frame
+    // against `DEPTH_W * DEPTH_H`, so every frame is refused at the parser with the sensor
+    // working perfectly.
+    //
+    // Anchored on the declaration in each language and never on a mention, which matters
+    // more here than it did for the format: `grabber.cpp` also holds `char hello[512]`,
+    // a buffer that has nothing to do with the sensor and would answer a search for the
+    // number.
+    const GRID = [['DEPTH_W', 'DW'], ['DEPTH_H', 'DH']];
+    const grid = GRID.map(([js, cpp]) => {
+      const fromJs = readFileSync(join(ROOT, 'web/format.js'), 'utf8')
+        .match(new RegExp(`^export const ${js} = (\\d+);`, 'm'));
+      const fromCpp = grabber.match(new RegExp(`^static const int ${cpp} = (\\d+);`, 'm'));
+      return { js, cpp, fromJs, fromCpp };
+    });
+    const undeclared = grid.filter(({ fromJs, fromCpp }) => !fromJs || !fromCpp);
+    const disagreed = grid.filter(({ fromJs, fromCpp }) => fromJs && fromCpp && fromJs[1] !== fromCpp[1]);
+    if (undeclared.length) {
+      fail(`the sensor grid is not declared where this looked: ${undeclared
+        .map(({ js, cpp, fromJs }) => (fromJs ? `${cpp} in native/grabber.cpp` : `${js} in web/format.js`))
+        .join(', ')} - a declaration that moved cannot be compared with anything`);
+    } else if (disagreed.length) {
+      fail(`${disagreed.map(({ js, cpp, fromJs, fromCpp }) => `${js} is ${fromJs[1]} in web/format.js and ${cpp} is ${fromCpp[1]} in native/grabber.cpp`).join('; ')}`
+        + ' - the grabber would emit a depth block that server/capture.js measures against the other number and refuses, '
+        + 'so a node with a working sensor would serve no frames at all');
+    } else {
+      console.log(`  grid/   ${grid.map(({ fromJs }) => fromJs[1]).join('x')} in both languages`);
+    }
   }
 }
 

--- a/web/format.js
+++ b/web/format.js
@@ -118,3 +118,35 @@ export function versionRefusal(what, version) {
  * valid document name.
  */
 export const VALID_ID = /^[A-Za-z0-9_][A-Za-z0-9._-]*$/;
+
+/**
+ * The sensor's depth grid, and it is filed here for the delivery reason above rather
+ * than for the document-format one.
+ *
+ * Nothing about 512x424 is a property of the document format, so a reader arriving at
+ * the top of this file has every right to wonder what a sensor dimension is doing
+ * beside a version number. The answer is the second half of the header's argument and
+ * not the first: the browser can only import what the server serves, `web/` is what
+ * gets served, and Node has no such constraint and reaches for it by path. That is the
+ * whole of why this file exists as a shared home, and the grid needs exactly that home
+ * for exactly that reason - `web/main.js` and `web/library.js` are pages,
+ * `server/capture.js` is not, and all three have to mean the same grid.
+ *
+ * It was declared four times before this, twice inside `web/main.js` alone under two
+ * different names 1,646 lines apart, and spelled out as bare literals a fifth time in
+ * the monitor's cost line - under a comment promising the number was "stated from the
+ * grid rather than from a table, so the number cannot drift from what the sender is
+ * actually building". It was stated from two literals typed a third time, which is the
+ * duplication having already started saying something untrue.
+ *
+ * **`native/grabber.cpp` declares the pair a second time and that one is correct.** No
+ * JavaScript import reaches a C++ translation unit, so the grabber has no way to be a
+ * reader of this and is the one honest second declaration. It is what the hello
+ * carries, so a device with a different grid changes both files and nothing between
+ * them.
+ *
+ * The proof tools keep their own copies too, and deliberately: a check that imported
+ * the constant it asserts would be holding a `512` against itself.
+ */
+export const DEPTH_W = 512;
+export const DEPTH_H = 424;

--- a/web/library.js
+++ b/web/library.js
@@ -132,11 +132,27 @@ const post = (url, body) => jsonOf(url, {
  * would have been badged "no hello" over a take that has one. Visibly unmapped beats
  * confidently wrong, and `library-check` asserts the two tables agree rather than
  * leaving it to be noticed.
+ *
+ * **No prototype, because the keys come off the wire and `Object.prototype` answers to
+ * some of them.** A refusal key is a string another machine chose - `NodeLink` gates
+ * the *shape* of a manifest and deliberately not its vocabulary, so that a newer node
+ * can name a reason this build has never heard of and get the fallback above - and an
+ * ordinary object literal answers `BADGES['__proto__']` with its own prototype rather
+ * than with `undefined`. The `?.` then does not short-circuit, the call throws on a
+ * value that is not a function, and the gallery dies painting the tile: the same blank
+ * shelf the version gate exists to prevent, arriving through the door the gate was
+ * told to leave open. `constructor`, `toString` and `valueOf` do not throw and are
+ * worse, badging a take `[object Object]` under a promise that an unmapped key reads
+ * as itself.
+ *
+ * Fixed at the table rather than at the one lookup, because the lookup is one today
+ * and the property that makes it safe belongs to the table. `Object.keys` still sees
+ * exactly the two entries, which is what `badgeKeys()` reports.
  */
-const BADGES = {
+const BADGES = Object.assign(Object.create(null), {
   'no-hello': () => 'no hello',
   short: (take) => (take.frames === 0 ? 'no frames' : '< 2 frames'),
-};
+});
 
 /**
  * The warnings a take carries, short enough for a badge and long enough to act on.

--- a/web/library.js
+++ b/web/library.js
@@ -115,6 +115,30 @@ const post = (url, body) => jsonOf(url, {
 // -------------------------------------------------------------- what a take says
 
 /**
+ * The badge each refusal wears over a poster, as a table rather than a conditional
+ * with an else on the end.
+ *
+ * The sentence under a badge is the server's and this is the part that is not: a
+ * 228px poster is a page constraint, and "no frames" against "< 2 frames" is a
+ * distinction only something drawing the tile can be asked to make. Zero and one are
+ * different facts and the badge says which - a take cut before its first whole frame
+ * has no picture to show at all, which is why the skim never asks for one, where a
+ * single-frame take has exactly one and draws it. Reading `< 2 frames` on a tile with
+ * a blank poster would send somebody looking for the frame it has.
+ *
+ * **A key with no entry here reads as itself.** The first spelling of this was
+ * `key === 'short' ? … : 'no hello'`, which is a table of two wearing an else - so a
+ * third refusal, of the kind the server is free to add and which is being added,
+ * would have been badged "no hello" over a take that has one. Visibly unmapped beats
+ * confidently wrong, and `library-check` asserts the two tables agree rather than
+ * leaving it to be noticed.
+ */
+const BADGES = {
+  'no-hello': () => 'no hello',
+  short: (take) => (take.frames === 0 ? 'no frames' : '< 2 frames'),
+};
+
+/**
  * The warnings a take carries, short enough for a badge and long enough to act on.
  *
  * One list, read by the poster badges, by the ⋯ menu and by the viewer, because
@@ -155,13 +179,6 @@ function warningsOf(take) {
   // `VALID_ID`**: there is no local derivation left to fall back to, because a second
   // one is exactly what was wrong.
   //
-  // Zero and one are different facts and the badge says which. A take cut before its
-  // first whole frame has no picture to show at all - which is why the skim below
-  // never asks for one - where a single-frame take has exactly one and draws it. Both
-  // refuse to open, and reading `< 2 frames` on a tile with a blank poster would send
-  // somebody looking for the frame it has. That distinction is a 228px poster's
-  // problem rather than a library fact, which is why `short` is still written here
-  // while the sentence under it is not.
   // No `?? []` guarding this. `describeTake` sets the field in both its branches, so a
   // take that reached this page without one is a server this page cannot render
   // anyway, and a silent empty list would draw a tile claiming a take is fine - which
@@ -170,7 +187,7 @@ function warningsOf(take) {
   for (const refusal of take.openRefusals) {
     out.push({
       key: refusal.key,
-      short: refusal.key === 'short' ? (take.frames === 0 ? 'no frames' : '< 2 frames') : 'no hello',
+      short: BADGES[refusal.key]?.(take) ?? refusal.key,
       why: refusal.why,
     });
   }
@@ -1625,6 +1642,11 @@ globalThis.__library = {
     empty: false,
   })),
   emptyLine: () => grid.querySelector('.empty')?.textContent ?? null,
+  // Which refusal keys this page has a badge for, so a check can hold the two tables
+  // against each other rather than against the refusals that happen to exist today.
+  // A key the server can send and this page cannot badge is the next wrong label,
+  // and it is a row rather than something to notice.
+  badgeKeys: () => Object.keys(BADGES),
 
   /**
    * Every tile's geometry as it actually rendered, which is the only place the

--- a/web/library.js
+++ b/web/library.js
@@ -47,10 +47,7 @@
 // over the picture where they cost no height. See `library.html` for each of those in
 // the place it is enforced.
 
-import { VALID_ID } from '/format.js';
-
-const DEPTH_W = 512;
-const DEPTH_H = 424;
+import { DEPTH_H, DEPTH_W, VALID_ID } from '/format.js';
 
 // The depth divisor per state. A local take is read whole; a take that is only on
 // the node comes through the divisor, which is what turns a 486KB frame into about
@@ -129,6 +126,12 @@ const post = (url, body) => jsonOf(url, {
 function warningsOf(take) {
   const out = [];
   if (take.recording === true) {
+    // **The one sentence this page still writes, and it is a warning rather than a
+    // refusal.** It names four actions, so it is not an answer to "why is Open off" -
+    // the server carries that one, in a sentence about the hash a take being written
+    // does not have yet. The two are different claims about one take rather than two
+    // copies of one claim, which is why this did not move to the library scanner with
+    // the others: an action list is not something a scanner knows.
     out.push({
       key: 'recording',
       short: 'recording',
@@ -144,37 +147,44 @@ function warningsOf(take) {
       why: 'the writer stopped mid-frame, so the take is usable up to the cut and no further',
     });
   }
-  if (take.hasHello === false) {
+  // The reasons the take cannot be opened, in the server's words. This page used to
+  // write them again from `hasHello` and `frames`, which is how the badge and the
+  // Open button beside it ended up saying different things about one take - so the
+  // sentence arrives with the take now and the only thing decided here is the badge
+  // it goes under. **Not a courtesy copy in the sense `web/format.js` uses for
+  // `VALID_ID`**: there is no local derivation left to fall back to, because a second
+  // one is exactly what was wrong.
+  //
+  // Zero and one are different facts and the badge says which. A take cut before its
+  // first whole frame has no picture to show at all - which is why the skim below
+  // never asks for one - where a single-frame take has exactly one and draws it. Both
+  // refuse to open, and reading `< 2 frames` on a tile with a blank poster would send
+  // somebody looking for the frame it has. That distinction is a 228px poster's
+  // problem rather than a library fact, which is why `short` is still written here
+  // while the sentence under it is not.
+  // No `?? []` guarding this. `describeTake` sets the field in both its branches, so a
+  // take that reached this page without one is a server this page cannot render
+  // anyway, and a silent empty list would draw a tile claiming a take is fine - which
+  // is a second implementation wearing a fallback, and the fallback is the half that
+  // would be believed.
+  for (const refusal of take.openRefusals) {
     out.push({
-      key: 'no-hello',
-      short: 'no hello',
-      why: 'this take carries no sensor hello, so its intrinsics are unknown and it cannot be unprojected',
-    });
-  }
-  if (take.frames !== null && take.frames < 2) {
-    // Zero and one are different facts and the badge says which. A take cut before
-    // its first whole frame has no picture to show at all - which is why the skim
-    // below never asks for one - where a single-frame take has exactly one and draws
-    // it. Both refuse to open, for the same reason, and reading `< 2 frames` on a
-    // tile with a blank poster would send somebody looking for the frame it has.
-    out.push({
-      key: 'short',
-      short: take.frames === 0 ? 'no frames' : '< 2 frames',
-      why: take.frames === 0
-        ? 'the scan found no whole frame in this take, so there is nothing here to draw or to open'
-        : 'a take needs two frames to bracket a position, so there is nothing here to play',
+      key: refusal.key,
+      short: refusal.key === 'short' ? (take.frames === 0 ? 'no frames' : '< 2 frames') : 'no hello',
+      why: refusal.why,
     });
   }
   return out;
 }
 
-/** Why a take cannot be opened, or the empty string when it can. */
-const cannotOpen = (take) => {
-  if (take.recording === true) return warningsOf(take)[0].why;
-  if (take.hasHello === false) return 'this take carries no sensor hello, so its intrinsics are unknown';
-  if (take.frames !== null && take.frames < 2) return 'a take needs two frames to bracket a position';
-  return '';
-};
+/**
+ * Why a take cannot be opened, or the empty string when it can.
+ *
+ * Read rather than derived. The two sentences this used to compose disagreed with the
+ * badges over the same poster, and the fix is not a third careful copy - it is that
+ * the take carries its own reasons and every surface quotes them.
+ */
+const cannotOpen = (take) => take.openRefusals[0]?.why ?? '';
 
 // ------------------------------------------------------------------ the skim frame
 
@@ -1595,11 +1605,21 @@ globalThis.__library = {
     id: el.dataset.id,
     hash: el.dataset.hash,
     state: el.dataset.state,
-    acts: [...el.querySelectorAll('.acts .act')].map((b) => ({ label: b.textContent, disabled: b.disabled })),
+    // `why` off the rendered `title` rather than out of `availability`, so a row
+    // asking whether two surfaces say the same thing reads the sentence an operator
+    // would actually get rather than the one the function returned.
+    acts: [...el.querySelectorAll('.acts .act')].map((b) => ({ label: b.textContent, disabled: b.disabled, why: b.title })),
     menu: [...el.querySelectorAll('.menu .mi')].map((b) => ({
       item: b.dataset.item, label: b.textContent, disabled: b.disabled, why: b.title,
     })),
     flags: [...el.querySelectorAll('.skim .flag')].map((f) => f.dataset.flag),
+    // The same badges with the sentence each one is short for. A second field rather
+    // than a richer `flags`, because a dozen rows above read `flags` as a list of
+    // keys and a shape change there would be a rewrite of all of them to add one
+    // reading.
+    badges: [...el.querySelectorAll('.skim .flag')].map((f) => ({
+      key: f.dataset.flag, short: f.textContent, why: f.title,
+    })),
     marks: [...el.querySelectorAll('.bar .mk')].map((m) => Number.parseFloat(m.style.left)),
     coarse: el.querySelector('.coarse')?.textContent ?? null,
     empty: false,
@@ -1760,7 +1780,7 @@ globalThis.__library = {
       note: vNote.textContent,
       flags: [...document.querySelectorAll('#vFlags .flag')].map((f) => f.dataset.flag),
       marks: [...vBar.querySelectorAll('.mk')].map((m) => Number.parseFloat(m.style.left)),
-      acts: [...document.querySelectorAll('#vActs .act')].map((b) => ({ label: b.textContent, disabled: b.disabled })),
+      acts: [...document.querySelectorAll('#vActs .act')].map((b) => ({ label: b.textContent, disabled: b.disabled, why: b.title })),
       // Reported in the same shape `tiles()` reports a tile's, because what reads them
       // is one comparison: the two surfaces have to offer a take the same things, and a
       // reader that could see only one half of each would be comparing the halves that

--- a/web/main.js
+++ b/web/main.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { PROJECT_VERSION, versionRefusal } from './format.js';
+import { DEPTH_H, DEPTH_W, PROJECT_VERSION, versionRefusal } from './format.js';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
@@ -9,9 +9,7 @@ import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
 
-const DW = 512;
-const DH = 424;
-const POINTS = DW * DH;
+const POINTS = DEPTH_W * DEPTH_H;
 
 // Which of the two surfaces this page is, decided by the path. One document still
 // serves both, because there is one renderer and one image pipeline and splitting
@@ -211,7 +209,7 @@ const DEFAULT_POSE = poseLookingAt(new THREE.Vector3(0, 0.1, 1.6));
 // which is what makes an 8-15fps stream look fluid on a 120Hz display.
 const makeDepthTexture = () => {
   const tex = new THREE.DataTexture(
-    new Uint16Array(POINTS), DW, DH, THREE.RedIntegerFormat, THREE.UnsignedShortType,
+    new Uint16Array(POINTS), DEPTH_W, DEPTH_H, THREE.RedIntegerFormat, THREE.UnsignedShortType,
   );
   tex.internalFormat = 'R16UI';
   tex.minFilter = THREE.NearestFilter;
@@ -255,7 +253,7 @@ const stateType = renderer.getContext().getExtension('EXT_color_buffer_float')
   ? THREE.FloatType
   : THREE.HalfFloatType;
 
-const makeStateTarget = () => new THREE.WebGLRenderTarget(DW, DH, {
+const makeStateTarget = () => new THREE.WebGLRenderTarget(DEPTH_W, DEPTH_H, {
   type: stateType,
   minFilter: THREE.NearestFilter,
   magFilter: THREE.NearestFilter,
@@ -282,7 +280,7 @@ const MAX_AGE = 6.0;
 const stateUniforms = {
   depthCurr: { value: depthCurr },
   statePrev: { value: statePrev.texture },
-  resolution: { value: new THREE.Vector2(DW, DH) },
+  resolution: { value: new THREE.Vector2(DEPTH_W, DEPTH_H) },
   dt: { value: 1 / 30 },
   snapDelta: { value: 250 },
 };
@@ -353,8 +351,8 @@ const geometry = new THREE.BufferGeometry();
 const pixelCoords = new Float32Array(POINTS * 2 * 3);
 const slotAttr = new Float32Array(POINTS * 2);
 for (let slot = 0; slot < 2; slot++) {
-  for (let row = 0, i = 0; row < DH; row++) {
-    for (let col = 0; col < DW; col++, i++) {
+  for (let row = 0, i = 0; row < DEPTH_H; row++) {
+    for (let col = 0; col < DEPTH_W; col++, i++) {
       const k = slot * POINTS + i;
       pixelCoords[k * 3] = col;
       pixelCoords[k * 3 + 1] = row;
@@ -378,7 +376,7 @@ const uniforms = {
   interpolate: { value: 1 },
   focal: { value: new THREE.Vector2(366, 366) },
   center: { value: new THREE.Vector2(256, 212) },
-  resolution: { value: new THREE.Vector2(DW, DH) },
+  resolution: { value: new THREE.Vector2(DEPTH_W, DEPTH_H) },
   // The drawing buffer's height, which is what makes every screen-space term
   // below a fraction of the frame rather than a count of pixels. Written by
   // `resize` and by nothing else, so the one place the buffer can change is also
@@ -1084,8 +1082,8 @@ function setAdditive(on) {
 // here has to be told which one it is looking at.
 const DEPTH_GRIDS = new Map();
 for (let k = 1; k <= 16; k++) {
-  const w = Math.ceil(DW / k);
-  const h = Math.ceil(DH / k);
+  const w = Math.ceil(DEPTH_W / k);
+  const h = Math.ceil(DEPTH_H / k);
   DEPTH_GRIDS.set(w * h, { k, w, h });
 }
 
@@ -1114,7 +1112,7 @@ function expandDepth(src, dst) {
   const grid = DEPTH_GRIDS.get(src.length);
   if (!grid) {
     throw new Error(
-      `a depth block of ${src.length} samples is not the ${DW}x${DH} grid at any divisor this `
+      `a depth block of ${src.length} samples is not the ${DEPTH_W}x${DEPTH_H} grid at any divisor this `
       + 'build serves: refusing rather than filling the head of the texture with it and '
       + 'unprojecting whatever was already in the rest as though it were the scene',
     );
@@ -1123,10 +1121,10 @@ function expandDepth(src, dst) {
     dst.set(src);
     return;
   }
-  for (let row = 0; row < DH; row++) {
+  for (let row = 0; row < DEPTH_H; row++) {
     const from = ((row / grid.k) | 0) * grid.w;
-    const to = row * DW;
-    for (let col = 0; col < DW; col++) dst[to + col] = src[from + ((col / grid.k) | 0)];
+    const to = row * DEPTH_W;
+    for (let col = 0; col < DEPTH_W; col++) dst[to + col] = src[from + ((col / grid.k) | 0)];
   }
 }
 
@@ -1655,8 +1653,6 @@ function gradeNeeded() {
  * the take actually open rather than against the ones in this comment.
  */
 const CROP_LIMIT = 7;
-const DEPTH_W = 512;
-const DEPTH_H = 424;
 const cropReach = (maxDepth = 9.5) => {
   const { x: fx, y: fy } = uniforms.focal.value;
   const { x: cx, y: cy } = uniforms.center.value;
@@ -3673,8 +3669,9 @@ function showMonitor(state) {
   // A frame is 486KB at full rate; the depth block scales with the divisor squared
   // and the colour block does not move at all, which is why the saving flattens.
   // Stated from the grid rather than from a table, so the number cannot drift from
-  // what the sender is actually building.
-  const depthKB = Math.ceil(512 / state.divisor) * Math.ceil(424 / state.divisor) * 2 / 1000;
+  // what the sender is actually building - which this line promised for a while
+  // before it was true, having spelled the two numbers out inline as a third copy.
+  const depthKB = Math.ceil(DEPTH_W / state.divisor) * Math.ceil(DEPTH_H / state.divisor) * 2 / 1000;
   const perFrame = depthKB + 52;
   const rate = perFrame * (30 / state.stride) / 1000;
   const parts = [];
@@ -8803,9 +8800,9 @@ function drawPlanCloud(rect) {
   const far = uniforms.farClip.value;
   const s = planScale(rect);
   chromeCtx.fillStyle = 'rgba(232, 236, 241, 0.55)';
-  for (let row = 0; row < DH; row += PLAN_STRIDE) {
-    for (let col = 0; col < DW; col += PLAN_STRIDE) {
-      const mm = depth[row * DW + col];
+  for (let row = 0; row < DEPTH_H; row += PLAN_STRIDE) {
+    for (let col = 0; col < DEPTH_W; col += PLAN_STRIDE) {
+      const mm = depth[row * DEPTH_W + col];
       if (mm === 0) continue;
       const z = mm * 0.001;
       if (z < near || z > far) continue;
@@ -9171,8 +9168,8 @@ function sensorView() {
   const fx = uniforms.focal.value.x;
   const fy = uniforms.focal.value.y;
   // Half-angles as tangents, which is the form the containment test needs anyway.
-  const tanH = (DW / 2) / fx;
-  const tanV = (DH / 2) / fy;
+  const tanH = (DEPTH_W / 2) / fx;
+  const tanV = (DEPTH_H / 2) / fy;
   // Fit rather than fill. three's `fov` is the vertical angle and the horizontal one
   // follows from the aspect, so matching vertical on a stage narrower than the sensor
   // would crop the sides off the very thing the button exists to show. Whichever axis
@@ -9264,9 +9261,9 @@ function fitPatchNormal(col0, row0, depth, fx, fy, cx, cy, near, far) {
   const xs = [];
   const ys = [];
   const zs = [];
-  for (let row = Math.max(0, row0 - LEVEL_PATCH); row <= Math.min(DH - 1, row0 + LEVEL_PATCH); row++) {
-    for (let col = Math.max(0, col0 - LEVEL_PATCH); col <= Math.min(DW - 1, col0 + LEVEL_PATCH); col++) {
-      const mm = depth[row * DW + col];
+  for (let row = Math.max(0, row0 - LEVEL_PATCH); row <= Math.min(DEPTH_H - 1, row0 + LEVEL_PATCH); row++) {
+    for (let col = Math.max(0, col0 - LEVEL_PATCH); col <= Math.min(DEPTH_W - 1, col0 + LEVEL_PATCH); col++) {
+      const mm = depth[row * DEPTH_W + col];
       if (mm === 0) continue;
       const z = mm * 0.001;
       if (z < near || z > far) continue;
@@ -9370,9 +9367,9 @@ function levelAtStagePoint(stageX, stageY) {
   // through the one in front of the sensor, because the gesture names a surface by
   // where it sits in the picture and the picture is whatever the view happens to be.
   let best = null;
-  for (let row = 0; row < DH; row += LEVEL_PICK_STRIDE) {
-    for (let col = 0; col < DW; col += LEVEL_PICK_STRIDE) {
-      const mm = depth[row * DW + col];
+  for (let row = 0; row < DEPTH_H; row += LEVEL_PICK_STRIDE) {
+    for (let col = 0; col < DEPTH_W; col += LEVEL_PICK_STRIDE) {
+      const mm = depth[row * DEPTH_W + col];
       if (mm === 0) continue;
       const z = mm * 0.001;
       if (z < near || z > far) continue;
@@ -9968,12 +9965,12 @@ async function openTake(id) {
   // correct one, and pretending otherwise would be a threshold with no method
   // behind it.
   const usable = hello.fx > 0 && hello.fy > 0
-    && hello.cx > 0 && hello.cx < DW
-    && hello.cy > 0 && hello.cy < DH;
+    && hello.cx > 0 && hello.cx < DEPTH_W
+    && hello.cy > 0 && hello.cy < DEPTH_H;
   if (!usable) {
     throw new Error(
       `take ${id} has an unusable hello: ${JSON.stringify(hello)} - focal lengths must be `
-      + `positive and the centre must lie inside the ${DW}x${DH} depth frame`,
+      + `positive and the centre must lie inside the ${DEPTH_W}x${DEPTH_H} depth frame`,
     );
   }
   uniforms.focal.value.set(hello.fx, hello.fy);
@@ -10577,7 +10574,7 @@ globalThis.__kinect = {
   // noise rather than on motion.
   stateStats() {
     const buf = new Float32Array(POINTS * 4);
-    renderer.readRenderTargetPixels(statePrev, 0, 0, DW, DH, buf);
+    renderer.readRenderTargetPixels(statePrev, 0, 0, DEPTH_W, DEPTH_H, buf);
     let ghosts = 0, hard = 0, soft = 0, fresh = 0;
     const life = uniforms.fadeTime.value + uniforms.wakeTime.value;
     for (let i = 0; i < POINTS; i++) {

--- a/web/menu.html
+++ b/web/menu.html
@@ -195,7 +195,13 @@ async function resolveResume() {
   // gallery's job rather than something to do on the way past.
   if (take.state === 'remote') return gallery(`${take.id} is only on the node`);
   if (take.recording === true) return gallery(`${take.id} is still being recorded`);
-  if (!take.openable) return gallery(`${take.id} cannot be opened: no sensor hello, or under two frames`);
+  // The reason the take carries, rather than this page's own third spelling of it.
+  // It used to name both causes at once - "no sensor hello, or under two frames" -
+  // because it had the boolean and nothing telling it which one fired.
+  if (!take.openable) {
+    const why = take.openRefusals.map((r) => r.why).join('; ');
+    return gallery(`${take.id} cannot be opened: ${why}`);
+  }
 
   // Built a value at a time rather than by interpolation, because a project name is
   // whatever somebody typed and an ampersand in it would otherwise start a second

--- a/web/menu.html
+++ b/web/menu.html
@@ -194,7 +194,20 @@ async function resolveResume() {
   // A take only on the node has no local file to open, and downloading it is the
   // gallery's job rather than something to do on the way past.
   if (take.state === 'remote') return gallery(`${take.id} is only on the node`);
-  if (take.recording === true) return gallery(`${take.id} is still being recorded`);
+  // **A take being recorded needs no branch of its own here, and used to have one.** It
+  // spelled its own sentence - "is still being recorded" - for a case this lookup cannot
+  // produce: the match above is by hash, `describeTake` gives a take mid-write no hash
+  // on purpose, and `lastOpened` refuses a saved entry whose `takeHash` is not a
+  // non-empty string. So the branch was a third spelling of a reason the server now owns,
+  // guarding a take that cannot arrive. `library-check` asserts the hash half of that
+  // rather than leaving it as a reading, because a recording take that started carrying
+  // one would make this reachable again - and then it falls through to the block below
+  // and quotes the server, which is the right answer either way.
+  //
+  // The remote branch above stays, and the difference is the point: "only on the node"
+  // is a fact about reconciliation that no take carries in its refusals, where
+  // "recording" is a key the server declares.
+  //
   // The reason the take carries, rather than this page's own third spelling of it.
   // It used to name both causes at once - "no sensor hello, or under two frames" -
   // because it had the boolean and nothing telling it which one fired.


### PR DESCRIPTION
Closes #49.

Two facts in this program were stated several times over, and both of them are the second
path `CLAUDE.md` keeps rejecting. The sensor grid is one declaration now, and the server is
the only author of the sentence saying why a take will not open.

## The grid

Declared four times in JavaScript — twice inside `web/main.js` alone, as `DW`/`DH` at line
12 and again as `DEPTH_W`/`DEPTH_H` 1,646 lines below — and spelled out as bare literals a
fifth time in the monitor's cost line, under a comment promising the number was "stated
from the grid rather than from a table, so the number cannot drift from what the sender is
actually building". It was stated from two literals typed a third time, which is the
duplication having already started saying something untrue.

It lives in `web/format.js` now, for the delivery reason that file's header already gives
for `PROJECT_VERSION` and `VALID_ID`: the browser can only import what the server serves,
`web/` is served, and Node reaches for it by path. The comment says so explicitly, because
a sensor dimension filed beside a document version otherwise reads as a filing error.
`native/grabber.cpp` keeps its own declaration — no JavaScript import reaches a C++
translation unit — and so do the proof tools, deliberately: a check that imported the
constant it asserts would hold a `512` against itself.

## Openability

Derived three times: once on the server and twice more in `web/library.js`, twelve lines
apart, with `web/menu.html` inventing a third spelling of a sentence for a boolean it was
handed. The two client derivations disagreed, and the issue predicted exactly where.
Measured on the unmodified tree, driving the gallery with a take carrying a hello and no
whole frame:

| surface | string |
|---|---|
| `short` badge | `the scan found no whole frame in this take, so there is nothing here to draw or to open` |
| disabled Open | `a take needs two frames to bracket a position` |

A sentence about a take with one frame, on the button beside a poster correctly badged as
having none. Nothing had noticed because nothing had ever built that take: the zero-frame
fixture carried no hello, so the button answered on its hello branch and never reached the
frame one, and the take with a hello had a frame. Both observations skipped the one object
that could tell them apart.

`describeTake` carries a keyed `openRefusals` list beside the boolean now, and `openable`
is "the list is empty" rather than a second expression of the same predicate. `warningsOf`
quotes those sentences while still choosing its own badge text, since "no frames" against
"< 2 frames" is a 228px poster's problem rather than a library fact. `cannotOpen` is one
line that reads the first reason. `web/menu.html` shows the reasons the take carries.

**The recording take is the one sentence the page still writes**, and it is deliberate: it
names four actions — stop it before opening, downloading, renaming or removing it — so it
is a warning rather than an answer to "why is Open off", which the server gives in terms of
the hash a take being written does not have yet. Two claims about one take rather than two
copies of one claim. Before this the button showed the four-verb sentence, so a control
about one action named three it was not. Worth a reviewer's eye, since it is the one place
the diff makes two surfaces say different things rather than the same thing.

## Measured

Read as `docs/proof-tools.md` asks — failed assertions and *which* ones, never exit codes —
and every run below reached its full 351-assertion total, because a run that stops early is
not a result in either direction.

| run | assertions | failed |
|---|---|---|
| `library-check` clean, second commit | 352 | **0** |
| `library-check` clean, first commit | 351 | **0** |
| `--mutate grid-declared-twice` | 351 | 2 |
| `--mutate open-decides-its-own-reason` | 351 | 4 |

The totals differ by the one row the second commit adds. It passes reading
`server no-hello short against page no-hello short`, which is the two tables agreeing
rather than a list of keys agreeing with itself.

`grid-declared-twice` reddens the single-declaration row, naming both holders:
`web/format.js web/main.js`. `open-decides-its-own-reason` reddens the two openability
rows, with the mutated build's button reading `a take needs two frames to bracket a
position` — the historical wrong sentence. The two controls are independent in the
direction that matters: the constants row **passes** under `open-decides-its-own-reason`
and the openability rows pass under `grid-declared-twice`, so neither is a control that
reddens everything.

Also: `syntax-check` 39 files 0 failed, `npm test` 0 failed, and all three of the issue's
done-criteria greps come back as specified.

**Driven in a real browser rather than fetched.** `/gallery`, `/edit?take=…` and `/` all
load with zero page errors (one favicon 404). The editor renders its point cloud with a
populated top-down view, and `cropReach()` — the function that held the second declaration
— answers 6.690m across and 5.638m up, the values its own comment documents. With a
hello-and-no-frames take planted, the badge and the disabled Open now carry the same
string.

## What is not closed, stated rather than glossed

**This machine sat at load average ~500 for the whole session**, with two to four other
agents' proof-tool sweeps running continuously — the condition `docs/instruments.md`
records as failing in a way that reads as a finding. The extra reds in the two mutation
runs above are all from the recorder-respawn, mark-stamp and descriptor families, they vary
run to run, they are absent from the clean run, and no change in this diff can reach them —
a mutation that turns one arithmetic expression into an identical one cannot affect whether
a fake grabber respawned. They are reported rather than filtered out.

**The two re-anchored mutations are proven to resolve, not proven to still catch.**
`sensor-view-check` prints `MUTATED BUILD: tanv-uses-fx in web/main.js` and `monitor-check`
prints `MUTATED: expand-shifts-by-a-block (web/main.js)`, which is the property the rename
put at risk — both tools refuse a mutation whose anchor no longer matches exactly once, and
neither refused. The semantic edit each performs is unchanged apart from the renamed
identifier. Neither, though, completed a run, and **the two are blocked on different things,
which is worth separating because "wait for a quiet machine" only fixes one of them**:

- `monitor-check` is the load. It reported its own `DID NOT RUN — server never came up`,
  a 15-second boot timeout that nothing at load 500 was going to meet. Re-run as is.
- `sensor-view-check` is a fixture shortfall in how I ran it, not the load. I pointed it at
  an ad-hoc server whose captures directory held a single take, and it correctly failed
  "the library cannot distinguish a computed angle from a constant on its own — 1 takes,
  1 distinct fx/fy", which is the row saying why its anamorphic arm C has to be synthetic.
  It needs a captures directory with at least two takes of differing intrinsics.

Both want re-running before merge, on those terms.

## A second commit, from review

**The badge mapping was a table of two wearing an else.** `key === 'short' ? … : 'no hello'`
badges *any* other refusal key "no hello", so the capture-format version band being added in
separate work — the third refusal the issue's own STOP condition names — would have arrived
over a take that has a hello, labelled as one that does not. It is a `BADGES` table now and
an unmapped key renders as itself, because visibly unmapped beats confidently wrong. A row
holds the two tables against each other: every refusal key the server can send must have a
badge on the page, read through a new `badgeKeys()` hook rather than from a list of the keys
that exist today.

**`docs/instruments.md` gains the finding**, since `CLAUDE.md` says new lessons go there
rather than into a commit message — the staged-tree-versus-route-interception hole, filed
beside the rest of the falsification-control-that-cannot-fire family, with the measured half
and the code-fact half marked as which.

## Three deviations from the issue's scope, each called out

1. **`tools/monitor-check.mjs` is in the diff.** Its `expand-shifts-by-a-block` anchors on
   `for (let col = 0; col < DW; …)` in `web/main.js`, so the rename moves it — the issue's
   declared STOP condition for a second tool. Escalated rather than decided, and approved.
   The change is two identifiers in one anchor. Every other tool was checked: no third
   anchor holds `DW`/`DH` against `web/main.js`. #28's static anchor row is exactly what
   would have found this without a manual grep.
2. **The constants row reads the source the run ships, not the staged file.** Step 4 said to
   walk `join(root, 'web')` because "mutations are written into the copy", which holds only
   for server mutations — `stageServer` writes `serverMutation` alone and a page mutation is
   delivered by route interception in `openPage`. A row reading `root/web/main.js` could not
   have been falsified by any page mutation, so it reads `mutation.body` for the mutated
   file instead. That is the same failure the match-exactly-once rule guards, arriving
   through the delivery rather than the anchor.
3. **`CLAUDE.md` gains two lines**, naming the two new controls where that file names every
   other one, and `docs/instruments.md` gains the entry described above — both because this
   repo's rules say a tool nobody documented is a tool nobody runs and a lesson belongs
   beside its neighbours, rather than because the issue listed them.
