### PR TITLE
Keep the clip range inside the program, the stage drawn, and view tracks out of a project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,9 @@ node tools/editor-check.mjs --mutate pause-keeps-resume --no-render   # ... and 
 node tools/editor-check.mjs --mutate bounds-compare-off-grid --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate detent-in-rate-units --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate zoom-pans-at-the-clamp --no-render # ... and must FAIL
+node tools/editor-check.mjs --mutate clip-range-unclamped --no-render # ... a trim the program cannot hold
+node tools/editor-check.mjs --mutate resize-skips-repaint --no-render # ... and the picture a resize clears
+node tools/editor-check.mjs --mutate restore-accepts-view-track --no-render # ... and a track the writer never writes
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows
 node tools/monitor-check.mjs --mutate decimate-reaches-recorder  # ... and must FAIL mutated
 node tools/monitor-check.mjs --mutate bind-ignores-grid          # ... and must FAIL mutated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ node tools/editor-check.mjs --mutate bounds-compare-off-grid --no-render # ... a
 node tools/editor-check.mjs --mutate detent-in-rate-units --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate zoom-pans-at-the-clamp --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate clip-range-unclamped --no-render # ... a trim the program cannot hold
+node tools/editor-check.mjs --mutate clip-bound-coerces-nonnumeric --no-render # ... and a trim that is not a time at all
 node tools/editor-check.mjs --mutate resize-skips-repaint --no-render # ... and the picture a resize clears
 node tools/editor-check.mjs --mutate restore-accepts-view-track --no-render # ... and a track the writer never writes
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ node tools/editor-check.mjs --mutate detent-in-rate-units --no-render # ... and 
 node tools/editor-check.mjs --mutate zoom-pans-at-the-clamp --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate clip-range-unclamped --no-render # ... a trim the program cannot hold
 node tools/editor-check.mjs --mutate clip-bound-coerces-nonnumeric --no-render # ... and a trim that is not a time at all
+node tools/editor-check.mjs --mutate refusal-strands-the-picker --no-render # ... and the menu that named what was refused
 node tools/editor-check.mjs --mutate resize-skips-repaint --no-render # ... and the picture a resize clears
 node tools/editor-check.mjs --mutate restore-accepts-view-track --no-render # ... and a track the writer never writes
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -367,6 +367,40 @@ writer's own log rather than from an artifact the reader creates. **Before polli
 condition, ask what the polling call itself writes, opens or caches** - anything that lists,
 scans or indexes a directory something else is writing is a candidate.
 
+### A fix can be a probe with an observer effect, and the same rule catches it
+
+The section above is about an instrument that disturbs what it samples. The same failure has
+a second home nobody looks for it in — **a fix placed at a door, where the disturbance is the
+fix**. `resize()` reallocates the drawing buffer and never drew into it, so a parked editor's
+stage went black on every path that resized it, and the fix is a `requestRepaint()` on
+`resize()`'s last line: at the door rather than at the seven callers, which is this repo's own
+rule about closing the class.
+
+It was still wrong as first written, and by exactly the mechanism above. **Most calls to
+`resize()` do not resize anything.** `rebuildLanes` runs it on every lane rebuild, so every
+rate change reaches it through `timingChanged` -> `lanesChanged` with the strip the height it
+already was — and asking for a repaint there is a second accurate seek on top of the one the
+gesture's own release issues. Measured: 2 seeks for one held arrow key against 1, which is the
+seek storm the speed control was rewritten to avoid, arriving through a door opened for
+something else. It cost the take as well, three runs out of three, because the release resumes
+playback behind its seek and the repaint's seek put the playhead back on the frame the resume
+had just left.
+
+Two things are worth keeping from how it was found. The row that caught it was **not** either
+of the new rows written for the fix — it was section 4's existing play-intent row, which went
+red in a `--no-render` run and green in the full one, and read exactly like a flake. What
+settled it was the row *above* it printing a number rather than a verdict: `2 seeks for 6
+repeats` against HEAD's `1`. **A row that reports a count beside its pass is what lets the
+neighbouring boolean be diagnosed instead of re-run.**
+
+And the guard that fixed it rests on a fact about a browser rather than about this build — a
+same-size `setSize` reallocates nothing, so a conditional repaint is safe. That is the shape of
+premise that quietly stops being true, so it is asserted rather than trusted: `editor-check`
+section 13 fires a `resize` event with the window unchanged and requires the picture to still
+be there. Measured, 158,247 lit pixels before and exactly 158,247 after, against 0 across a
+resize that moved the buffer 1298x730 -> 1084x610. **When a fix is conditional on a platform
+behaviour, the condition is a claim and needs its own row.**
+
 **A fixture that has never held the shape under test cannot measure it, and the gallery's
 tile heights are the plainest case of that yet.** Every take in `library-check`'s fixture
 carried at most one warning — truncated, or no hello, or under two frames — so a
@@ -518,6 +552,24 @@ user-facing surface should have at least one arm pointed at that surface.** Sect
 browser; `bind-ignores-grid` and `expand-shifts-by-a-block` are one control each, and the
 second exists because the first reddens every row and a control that fails everything cannot
 say which row carries the claim.
+
+**A fourth, and this time the skipped object was reachable through a hook that answers a
+neighbouring question.** `editor-check`'s deliverable block drove exactly the shape that
+freezes the transport — a saved trim adopted from the menu — and asserted through
+`__kinect.editor.clipRange()`, which returns the raw `clipIn`/`clipOut` document fields. The
+transport does not move on those. It reads `clipInSec` and `clipOutSec`, two getters that were
+not symmetric, so a trim past the program's end made the pair cross and `frameAt` composed to a
+constant: every position the editor could ask for came back as one frame, and `exportClip`
+computed both of its bounds through it and wrote a one-frame file. The block passed identically
+either way, because the fields it read were the ones the document held rather than the ones the
+picture came from.
+
+The tell is that `clipRange()` is not wrong. It returns what it is named for, and the fix left
+it alone — the new rows read the transport instead, because the two are different questions.
+**A hook that answers a question adjacent to the claim is worse than no hook**, since it makes
+the row look grounded: the arm is reading live state through a real seam, and the state it
+reads simply is not the one the behaviour depends on. Ask what the *subject* reads, not what is
+convenient to read about it.
 
 ## Close the class, not the instance — and have the check enumerate it
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -547,6 +547,35 @@ every tab the key `''`: the sweep reported four controls it could not name and f
 naming nothing, both rows red, neither of them about the page. It looks exactly like a real
 enumeration failure.
 
+### A row that provokes a refusal writes into a channel a later row sweeps
+
+The third variant of the two sections above, and the one that arrives by post rather than in
+person: the probe does not disturb what *it* samples, it disturbs what something fifteen
+sections away samples. `editor-check` ends by asserting that the page said nothing at all -
+`errors.length === 0`, fed by both `pageerror` and `console` at type `error`. Section 7 then
+grew a block that hands the deliverable menu a document whose `in` point is not a time, which
+is the whole point of it, and `showTimelineError` writes every refusal it shows the operator to
+`console.error` as well. Every row the new block wrote was green and the sweep went red: 252
+assertions, one failure, and the failure quoting the string the new block had just planted.
+
+**The repair is a drain that asserts, not an exemption that does not.** A filter at the sweep is
+the obvious move and it is the one rule 5 is about - a deliberate exclusion, carrying its own
+justification, that stops anybody looking twice. It would also be *standing* rather than local:
+it would go on covering whatever the page said next that happened to match, and a build where
+the refusal stopped happening would take the exemption with it in complete silence, because a
+filter that removes nothing is indistinguishable from a filter that removed the thing it was
+written for. The block takes its own entry out instead and asserts that it took exactly one,
+which turns the noise into a claim about the refusal: `clip-bound-coerces-nonnumeric` reddens
+that row too, `0 drained: nothing`, because a build that does not refuse says nothing to the
+console.
+
+The temptation next door is to stop driving the door. Section 14 hands `restoreProject` a
+document it must reject from inside a page-side `try`/`catch`, so the throw never reaches the
+console at all - and copying that here would have made the problem disappear along with the
+test. The menu is the door a document from another build actually arrives through, and writing
+to the console is part of what arriving through it does. **When an instrument's own noise
+collides with a sweep, move the noise, never the sweep.**
+
 ## What do my arms agree about
 
 **When one probe turns out to be blind to something, ask what all of them are blind to

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -155,6 +155,23 @@ the editor is *reachable* rather than merely present. Its own two flaws — a pr
 and a probe that moved the page it measured — are in `docs/instruments.md`, because both are
 instances of rules that were already written down.
 
+**Sections 13 and 14 need the state the sections before them leave, and both say so in their
+own terms.** Section 13 counts lit pixels across a resize, and it presses "sensor view" first
+rather than measuring whatever twelve sections of orbiting and exporting happened to leave —
+inherited, the same claim measured 1543 lit pixels on one run and 89,625 on another, which is a
+row whose margin depends on what ran before it. It also takes the chrome off, because the camera
+path and the top-down inset live on a second canvas that `placeChrome` repaints regardless, and
+those are exactly the pixels a blank-stage build still has. Section 14 hands documents to
+`restoreProject` and asserts its own cleanup landed, because the build it matters on is the one
+that accepts what it should refuse: a `renderScale` track surviving into section 15 is
+`resize()` once per rendered frame there, which arrives as a hang rather than as a row.
+
+**Its deliverable rows size their fixtures off the take rather than writing numbers down.** The
+block used to plant a trim at a flat `in: 20, out: 40`, which the clip clamp holds inside a
+30.362s sample — so the row meaning to assert that the menu applies a trim would have been
+asserting the clamp instead. They are now read off the measured duration, and the one deliberate
+exception is `editor-check-past`, planted at 1.5x the duration precisely so that it misses.
+
 **`vendor-check` reads the built artifact as well as the source.** Sections 1-4 prove
 `third_party/` is upstream plus the declared edits; section 5 asserts the library actually
 installed at `vendor/prefix` carries `LIBFREENECT2_REG_THREADS`, the env override the threading

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -59,6 +59,9 @@
 //   node tools/editor-check.mjs --mutate orbit-arms-stale-position --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate release-seeks-past-target --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate pin-keeps-orbit-armed  --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate clip-range-unclamped   --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate resize-skips-repaint   --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate restore-accepts-view-track --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate export-ignores-name              # must FAIL
 //
 // `--no-render` drops the real-export rows and says so in the verdict, the way
@@ -607,6 +610,79 @@ const MUTATIONS = {
   // The clip bounds go back to being compared in seconds against a playhead that is a
   // frame, so a playhead sitting on a cut reads as outside it after every rescale.
   // Reddens the boundary seek-count row and leaves the interior one green.
+  // The clip range goes back to being written through unchecked, so a deliverable whose
+  // `in` lands past the end of the program leaves `clipInSec` above `clipOutSec` and
+  // `frameAt` composing to a constant. Reddens the three rows in section 7's deliverable
+  // block that adopt `editor-check-past` and read the pair off the transport. The three
+  // rows above them stay green on purpose: they are about the menu applying a trim and
+  // about a held gesture, both of which this leaves working, and a control that reddened
+  // them too would be naming a different defect. Rows further down the file can go red
+  // behind it - a frozen `frameAt` is frozen for whatever seeks next - which is why the
+  // rows are read rather than counted.
+  'clip-range-unclamped': {
+    file: 'web/main.js',
+    edits: [[
+      '  if (timeline) {\n'
+      + '    const dur = timeline.duration;\n'
+      + '    clipIn = Math.max(0, Math.min(clipIn, dur));\n'
+      + '    // `null` still means "to the end", which is a different statement from a number that\n'
+      + '    // happens to equal the duration: "whole clip" has to survive a retime that lengthens\n'
+      + '    // the program, and a duration written in here would freeze it at today\'s length.\n'
+      + '    if (clipOut !== null) clipOut = Math.max(clipIn, Math.min(clipOut, dur));\n'
+      + '  }\n',
+      '',
+    ]],
+  },
+
+  // `resize()` goes back to reallocating the drawing buffer and drawing nothing into it,
+  // which leaves a parked stage black behind the chrome overlay. Reddens the three
+  // resize rows in section 13 and nothing in section 9 or 11 - and that pair staying
+  // green is the point of the control rather than a bonus: green section 9 says the call
+  // did not become a per-frame pump, and green section 11 says it did not un-throttle
+  // the splitter drag. Section 13's same-size row stays green too, and that is the third
+  // thing this separates: a `resize()` that reallocates nothing needs no repaint either
+  // way, so a control that reddened that row would be naming the guard rather than the
+  // repaint.
+  'resize-skips-repaint': {
+    file: 'web/main.js',
+    edits: [[
+      '  const buffer = renderer.getDrawingBufferSize(new THREE.Vector2());\n'
+      + '  if (buffer.x !== wasBuffer.x || buffer.y !== wasBuffer.y) requestRepaint();\n',
+      '',
+    ]],
+  },
+
+  // `restoreProject` goes back to calling `params.spec` for its throw and discarding the
+  // spec, so a document carrying a track on a view parameter opens - and `evaluateTracks`
+  // has no tag filter, so that track calls `resize()` once per rendered frame. Reddens
+  // only the first row of section 14. The look-track row beside it stays green, which is
+  // what separates "the reader now reads the tag" from "the reader stopped taking
+  // tracks", and the unknown-name refusal is untouched.
+  //
+  // Anchored on the `const spec =` binding and the `if` that reads it rather than on
+  // the bare call the revert produces: `params.spec(name);` on its own appears twice in
+  // `main.js` - once here and once in the parameter-value walk below it - so a mutation
+  // written the other way round would match twice and refuse to run.
+  'restore-accepts-view-track': {
+    file: 'web/main.js',
+    edits: [
+      [
+        '    const spec = params.spec(name);',
+        '    params.spec(name);',
+      ],
+      [
+        "    if (spec.tag !== 'look') {\n"
+        + '      throw new Error(\n'
+        + '        `the track on ${JSON.stringify(name)} is on a ${spec.tag} parameter: a project carries `\n'
+        + "        + 'look tracks only, which is what this build writes and the only kind it can evaluate '\n"
+        + "        + 'without resizing the drawing buffer from inside the render loop',\n"
+        + '      );\n'
+        + '    }\n',
+        '',
+      ],
+    ],
+  },
+
   'bounds-compare-off-grid': {
     file: 'web/main.js',
     edits: [[
@@ -2514,9 +2590,28 @@ try {
   await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
   await page.evaluate(`__kinect.keyframes.setTracks({ bloom: [{ t: 2, value: 0.2 }, { t: 6, value: 0.9 }] })`);
   await settle();
+  // **The far trim is read off the take rather than written down, and the third one is
+  // written to miss it deliberately.** `setClipInOut` holds a trim inside the program
+  // that is open, so the flat 20s..40s this block used to plant came back as
+  // 20s..30.362s on the sample and the row below would have been asserting the clamp
+  // where it means to assert the menu. Two thirds and nine tenths of the way along keep
+  // it as far from the near one's 2s..8s as the old pair were - which is all the swap
+  // rows need of it - and keep it inside the program at every rate this block reaches,
+  // including the 2x the gesture holds, where 40s would have been clamped mid-gesture.
+  //
+  // `editor-check-past` is the one that misses: a trim starting half a program past the
+  // end, which is what a deliverable authored against a longer take or a slower rate
+  // looks like when it arrives here. It is planted with the other two rather than in a
+  // block of its own so that it is cleaned up by the same loop.
+  const takeDur = (await read()).duration;
+  const farIn = takeDur * (2 / 3);
+  const farOut = takeDur * 0.9;
+  const pastIn = takeDur * 1.5;
+  const pastOut = takeDur * 2;
   const baseDeliverable = await page.evaluate('({ ...__kinect.library.activeDeliverable() })');
   await putDeliverable('editor-check-near', { ...baseDeliverable, name: 'editor-check-near', in: 2, out: 8 });
-  await putDeliverable('editor-check-far', { ...baseDeliverable, name: 'editor-check-far', in: 20, out: 40 });
+  await putDeliverable('editor-check-far', { ...baseDeliverable, name: 'editor-check-far', in: farIn, out: farOut });
+  await putDeliverable('editor-check-past', { ...baseDeliverable, name: 'editor-check-past', in: pastIn, out: pastOut });
   await page.evaluate('__kinect.editor.refreshDeliverables?.()');
   // What the menu looked like before this block touched it. Restored at the end, because
   // the selected name is drawn in a chip on the two-row bar and a longer one reflows it -
@@ -2528,10 +2623,10 @@ try {
     return { value: el.value, options: [...el.options].map((o) => o.value) };
   })()`);
   // And where the playhead was. `setClipInOut` seeks when the new trim excludes it, so
-  // choosing a deliverable at 20s..40s moves it - and section 8 renders its crop rows at
-  // the playhead, so a different frame there is a different depth slab and its numbers
-  // move. They moved: the near-slab row printed 0.337 before this block existed and 0.123
-  // after, on a build whose cropping had not changed at all.
+  // choosing a deliverable two thirds of the way along moves it - and section 8 renders
+  // its crop rows at the playhead, so a different frame there is a different depth slab
+  // and its numbers move. They moved: the near-slab row printed 0.337 before this block
+  // existed and 0.123 after, on a build whose cropping had not changed at all.
   const playheadBefore = await page.evaluate('__kinect.timeline.transport().programSec');
   const pick = async (name) => {
     await page.evaluate(`(() => {
@@ -2548,8 +2643,9 @@ try {
   };
 
   const far = await pick('editor-check-far');
-  check(near(far.in ?? -1, 20, 1e-6) && near(far.out ?? -1, 40, 1e-6),
-    'choosing a deliverable puts its trim on the clip', JSON.stringify(far));
+  check(near(far.in ?? -1, farIn, 1e-6) && near(far.out ?? -1, farOut, 1e-6),
+    'choosing a deliverable puts its trim on the clip',
+    `${JSON.stringify(far)}, wanted in ${farIn.toFixed(4)} out ${farOut.toFixed(4)}`);
   // The gesture begins here, holding `far`'s cuts, and the near one lands under it.
   await page.evaluate(`(() => {
     const el = document.getElementById('tRate');
@@ -2588,9 +2684,68 @@ try {
     '  and the gesture that continues rescales that trim rather than writing the old one back',
     `${JSON.stringify(afterSwap)}, wanted in ${wantIn.toFixed(4)} out ${wantOut.toFixed(4)}`);
 
+  // **A trim the program cannot hold, read off the transport rather than off the
+  // document.** `clipRange()` returns the raw `clipIn`/`clipOut` fields, and those are
+  // not what the transport moves on: it reads `clipInSec` and `clipOutSec`, and those
+  // two getters were not symmetric. `clipOutSec` was held down to the take's duration
+  // and `clipInSec` was held up to zero and to nothing else, so a deliverable whose
+  // `in` landed past the program's end made the pair cross - and `frameAt`, which is
+  // `frameOf(max(clipInSec, min(clipOutSec, t)))`, then composed to a constant. Every
+  // position the editor can ask for came back as one frame, and `exportClip` computed
+  // both of its bounds through it, so the file it wrote was one frame long with the
+  // `if (to < from)` guard unable to fire and the readout still naming a range.
+  //
+  // The rows below therefore go through `transport()` for the pair and through
+  // `clipRange()` only where the raw field is the thing being asserted. The old rows in
+  // this block pass identically on a build with the clamp removed, which is what makes
+  // this one worth its own three assertions rather than an extra term on one of theirs.
+  //
+  // The rate goes back to 1 first so the numbers are about the take rather than about
+  // the gesture two rows above: a slower rate only makes the program shorter, so the
+  // trim would miss either way, but a row whose precondition depends on where the last
+  // one left the slider is a row that reads as a different failure when it moves.
+  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await settle();
+  const pastDur = (await read()).duration;
+  check(pastIn > pastDur,
+    'the planted trim really does begin past the end of the program, or nothing below is about it',
+    `in ${pastIn.toFixed(3)}s against a ${pastDur.toFixed(3)}s program`);
+  await pick('editor-check-past');
+  const adopted = await page.evaluate(`(() => {
+    const t = __kinect.timeline.transport();
+    return {
+      in: t.clipInSec,
+      out: t.clipOutSec,
+      duration: t.duration,
+      readout: document.getElementById('tInOut').textContent.trim(),
+    };
+  })()`);
+  check(adopted.in <= adopted.out,
+    '  and adopting it leaves the transport a range that runs forwards, which is the pair frameAt reads',
+    `clipInSec ${adopted.in.toFixed(3)}s, clipOutSec ${adopted.out.toFixed(3)}s, program ${adopted.duration.toFixed(3)}s`);
+  const pastRange = await range();
+  check((pastRange.in ?? -1) <= adopted.duration + 1e-6 && (pastRange.out ?? -1) <= adopted.duration + 1e-6,
+    '  and the document it wrote names times the take has, both ends of it',
+    `${JSON.stringify(pastRange)} against a ${adopted.duration.toFixed(3)}s program`);
+  // The operator's half of the same fact. `paintStripPositions` clamps where it *draws*
+  // the two markers, so both of them sit at the right-hand end either way and the strip
+  // cannot tell you which build you are on - the numeric readout beside it is the one
+  // surface where the document's claim is printed rather than clipped.
+  const readoutSec = (text) => {
+    const [m, s] = text.split(':');
+    return Number(m) * 60 + Number(s);
+  };
+  // A millisecond of slack rather than a float epsilon: `timecode` rounds to three
+  // decimals, so a duration that rounds *up* would fail an exact comparison against a
+  // build doing exactly the right thing. The number this separates from is fifteen
+  // seconds away.
+  check(readoutSec(adopted.readout) <= adopted.duration + 1e-3,
+    '  and the readout beside the markers names a time the take has, rather than one it does not',
+    `#tInOut reads ${adopted.readout} of a ${adopted.duration.toFixed(3)}s program`);
+
   await focusStage();
   await page.evaluate(`(async () => {
-    for (const n of ['editor-check-near', 'editor-check-far']) {
+    for (const n of ['editor-check-near', 'editor-check-far', 'editor-check-past']) {
       // The content type is required on every write route, delete included - the origin
       // rule refuses a request that does not declare one, which is a 200 carrying an
       // error rather than a network failure, so a cleanup without it fails silently.
@@ -4183,9 +4338,211 @@ try {
     await cleanupPresets();
   }
 
-  // ================================ 13. the pinned drive takes the loop away with it
+  // ================================ 13. a reallocated drawing buffer still has a picture in it
 
-  console.log('\n[13] pinning the drive drops what the loop was going to serve');
+  console.log('\n[13] resizing the stage while the playhead is parked leaves a picture on it');
+
+  // **`resize()` reallocates the drawing buffer, which clears it, and a parked editor
+  // has no clock that would draw into it again.** `tickNow` returns immediately on
+  // `!playing` and `pumpParkedDraft` returns with nothing armed, so the stage stayed
+  // black until something unrelated happened to seek - the window resize, the three
+  // splitter entries, the render-scale slider, the export-size menu and `rebuildLanes`
+  // all reached it, and none of them asked for a repaint. `resize-skips-repaint` is the
+  // control, and it deletes the one call at the end of `resize()` rather than any
+  // caller, because the fix is at the door.
+  //
+  // **Chrome is taken off first, and that is the row rather than tidiness.** The camera
+  // path and the top-down inset live on a separate 2D canvas that `placeChrome` goes on
+  // repainting perfectly happily, which is exactly what the operator sees on the broken
+  // build: an overlay floating over an opaque black stage. Left on, that overlay is lit
+  // pixels inside the stage's box and it would carry this row on a build whose picture
+  // is gone. Section 8 already left it off; this says so rather than inheriting it.
+  //
+  // Measured as a density rather than a count, because the two arms change the box: a
+  // narrower window is a smaller letterbox, so the same picture is fewer pixels and a
+  // raw count would read the shrink as a loss. Against the pre-resize frame rather than
+  // for bit-equality, for the reason section 8 records - two screenshots of one clip are
+  // not bit-identical, and asserting that they are would be asserting determinism, which
+  // is another tool's claim.
+  {
+    await page.evaluate('__kinect.keyframes.chrome.set(false)');
+    await page.evaluate('__kinect.timeline.transport().pause()');
+    await page.evaluate('__kinect.timeline.transport().seek(12)');
+    // The picture this section counts is put there rather than inherited, and pressing
+    // "sensor view" is how: it poses the camera at the sensor's own origin with a
+    // frustum fitted to the sensor's rectangle, so the whole cloud is in frame by
+    // construction. Inherited, it was whatever twelve sections of orbiting, exporting
+    // and preset importing happened to leave - 1543 lit pixels of 947 thousand on one
+    // run against 89 thousand on another, which is a row whose margin depends on what
+    // ran before it rather than on the claim it makes.
+    await page.locator('#camSensor').click();
+    await settle();
+    await new Promise((r) => setTimeout(r, 150));
+    const density = async () => {
+      const box = await page.locator('#stage').boundingBox();
+      const n = await lit();
+      return { all: n.all, per: n.all / Math.max(1, box.width * box.height), box };
+    };
+    // Waited on rather than slept through: `setViewportSize` returns before the page's
+    // own `resize` listener has run, and a `settled()` that arrives first finds nothing
+    // scheduled and reports an idle page one macrotask before the work starts. Watching
+    // the counter the door increments is what closes that, and it doubles as evidence
+    // the arm went through the door it names.
+    const throughResize = async (label, act) => {
+      const was = await page.evaluate('__kinect.editor.stageResizes()');
+      await act();
+      await page.waitForFunction(`__kinect.editor.stageResizes() > ${was}`, null, { timeout: 15000 })
+        .catch(() => { throw new Error(`${label} never reached resize()`); });
+      await settle();
+      await new Promise((r) => setTimeout(r, 150));
+    };
+
+    // The bar is set from measurement rather than from what a full frame would look
+    // like, and it is set low on purpose. **The blank build measures exactly 0.00%**, so
+    // the separation this row needs is not a matter of degree - what the threshold is
+    // for is that a section arriving on an empty view reports the absence as its own
+    // precondition failing rather than as the stage rows passing on nothing. Measured
+    // from the sensor-view pose at 12s: 0.84% on a full run and 9.46% under
+    // `--no-render`, where section 7's export has not been through the look. The order
+    // of magnitude between those two is why this is not written any tighter.
+    const beforeResize = await density();
+    check(beforeResize.per > 0.001,
+      'the parked stage carries a picture before anything resizes, or nothing below is about a resize',
+      `${beforeResize.all} lit pixels at ${(beforeResize.per * 100).toFixed(2)}% of `
+      + `${Math.round(beforeResize.box.width)}x${Math.round(beforeResize.box.height)}, `
+      + `on the ${await page.evaluate('__kinect.viewCamera() === __kinect.freeCamera ? "free" : "program"')} camera`);
+
+    // **The premise the repaint's guard rests on, asserted rather than trusted.**
+    // `resize()` only asks for the picture back when the drawing buffer's size actually
+    // moved, because most calls do not move it - `rebuildLanes` runs it on every lane
+    // rebuild, so every rate change reaches it with the strip the height it already was,
+    // and a repaint there is a second accurate seek on top of the one the gesture's own
+    // release issues. That guard is only safe while a same-size `setSize` reallocates
+    // nothing, which is a fact about `WebGLRenderTarget` and about Chrome's canvas
+    // rather than about this build. So it is measured here: a `resize` event with the
+    // window unchanged, and the picture has to still be there afterwards. The day this
+    // row goes red the guard is wrong and the stage goes black on the paths nothing
+    // else covers.
+    const bufferOf = () => page.evaluate(`(() => {
+      const gl = __kinect.renderer.getContext();
+      return { w: gl.drawingBufferWidth, h: gl.drawingBufferHeight, resizes: __kinect.editor.stageResizes() };
+    })()`);
+    const bufBefore = await bufferOf();
+    await page.evaluate('window.dispatchEvent(new Event("resize"))');
+    await settle();
+    await new Promise((r) => setTimeout(r, 150));
+    const bufSame = await bufferOf();
+    const sameSize = await density();
+    check(bufSame.resizes > bufBefore.resizes && bufSame.w === bufBefore.w && bufSame.h === bufBefore.h
+      && sameSize.all === beforeResize.all,
+      '  and a resize that reallocates nothing leaves it alone, which is what lets the repaint be conditional',
+      `${bufSame.resizes - bufBefore.resizes} resizes, buffer ${bufBefore.w}x${bufBefore.h} -> `
+      + `${bufSame.w}x${bufSame.h}, lit ${beforeResize.all} -> ${sameSize.all}`);
+
+    await throughResize('the window resize', () => page.setViewportSize({
+      width: VIEWPORT.width - 220, height: VIEWPORT.height - 120,
+    }));
+    const afterWindow = await density();
+    check(afterWindow.per > beforeResize.per * 0.5,
+      'a window resize with the playhead parked leaves the stage drawn rather than blank',
+      `${afterWindow.all} lit pixels at ${(afterWindow.per * 100).toFixed(2)}% density `
+      + `against ${beforeResize.all} at ${(beforeResize.per * 100).toFixed(2)}%`);
+    await throughResize('the window restore', () => page.setViewportSize(VIEWPORT));
+
+    // The render-scale slider, and it is the subtle half. It is tagged `view`, and
+    // `paramWritten` deliberately withholds the repaint every other parameter gets -
+    // so the registry's single write path ran `apply`, which destroyed the buffer, and
+    // then took the early return that was written on the premise that resizing the
+    // buffers was already the work. Driven through `params.set` because that is the
+    // door the slider's own `input` listener uses.
+    const scaleWas = await page.evaluate("__kinect.params.get('renderScale')");
+    await throughResize('the render-scale write', () => page.evaluate("__kinect.params.set('renderScale', 130)"));
+    const afterScale = await density();
+    check(afterScale.per > beforeResize.per * 0.5,
+      '  and so does a render-scale write, which is the one door that asks for no repaint of its own',
+      `${afterScale.all} lit pixels at ${(afterScale.per * 100).toFixed(2)}% density, render % 130`);
+    await throughResize('the render-scale restore',
+      () => page.evaluate(`__kinect.params.set('renderScale', ${scaleWas})`));
+    const restored = await density();
+    check(restored.per > beforeResize.per * 0.5,
+      '  and the stage the next section inherits is a drawn one',
+      `${restored.all} lit pixels at ${(restored.per * 100).toFixed(2)}%, render % back to ${scaleWas}`);
+  }
+
+  // ================================ 14. a project carries look tracks and nothing else
+
+  console.log('\n[14] a project is refused a track on a parameter it must not carry');
+
+  // **The writer filtered the track set and the reader did not, and the tag was sitting
+  // in the reader's hand unread.** `serialiseProjectBody` writes
+  // `params.names('look').filter(...)`, so a track on `renderScale` or `spin` is a shape
+  // no build of this program has ever written - but `restoreProject` called
+  // `params.spec(name)` purely for its throw-on-unknown side effect and discarded the
+  // spec it got back, and both of those are names the registry knows.
+  //
+  // What accepting one cost is why this row exists rather than a note about tidiness.
+  // `evaluateTracks` has no tag filter and runs inside `renderProgramFrame`, so a
+  // `renderScale` track is `resize()` once per rendered frame - and where the value
+  // moves, `composer.setSize` disposes and recreates the render targets and, through
+  // `AfterimagePass`, the trails accumulator, between two consecutive frames of a
+  // pre-roll that exists to build exactly that accumulator up. The seek stops
+  // reproducing the playback it is defined to reproduce, and the document quietly stops
+  // round-tripping at the same time, because the serialiser filters the track back out
+  // on the next commit.
+  //
+  // Driven straight at `restoreProject`, which is exposed raw and deliberately for this:
+  // reaching it through a successful save-and-load could never hand it a document the
+  // serialiser refuses to write. The body is the *current* document with one track added
+  // rather than a fixture built here, so that a build which accepts it is left holding
+  // the clip it already had plus the track - which is the damage this names, and nothing
+  // else that a later section would report as its own failure.
+  {
+    const original = await page.evaluate('JSON.stringify(__kinect.library.serialiseProjectBody())');
+    const handTo = (name) => page.evaluate(`(() => {
+      const body = JSON.parse(${JSON.stringify(original)});
+      body.look.tracks[${JSON.stringify(name)}] = [{ t: 0, value: 100 }, { t: 4, value: 140 }];
+      try {
+        __kinect.library.restoreProject(body);
+        return { threw: false, message: null };
+      } catch (err) {
+        return { threw: true, message: String(err?.message ?? err) };
+      }
+    })()`);
+    const viewTrack = await handTo('renderScale');
+    check(viewTrack.threw && /view/.test(viewTrack.message ?? ''),
+      'a project carrying a track on a view parameter is refused, and the refusal names the tag',
+      viewTrack.threw ? `"${viewTrack.message}"` : 'it was accepted');
+    // The other half of the same claim, and the reason the refusal reads the tag rather
+    // than a list of names: a track on a look parameter is the shape the serialiser
+    // writes, and it has to keep loading. A build that had simply stopped accepting
+    // tracks would pass the row above and fail this one.
+    const look = await handTo('bloom');
+    check(!look.threw, '  and one on a look parameter still loads, which is the shape the serialiser writes',
+      look.threw ? `"${look.message}"` : 'accepted');
+    // Whatever the two above left behind, put back - and asserted rather than assumed,
+    // because the build this matters on is the one that is deliberately wrong. On this
+    // build the first is refused with nothing touched and the second replaces the
+    // document with itself plus a bloom track; on the mutated build the first one lands
+    // too, and a `renderScale` track surviving into the next section is `resize()` once
+    // per rendered frame there. A cleanup that silently failed would hand that to
+    // section 15 as a hang nobody could attribute to this block.
+    const cleaned = await page.evaluate(`(() => {
+      try {
+        __kinect.library.restoreProject(JSON.parse(${JSON.stringify(original)}));
+        return { threw: null, tracks: __kinect.keyframes.names() };
+      } catch (err) {
+        return { threw: String(err?.message ?? err), tracks: __kinect.keyframes.names() };
+      }
+    })()`);
+    await settle();
+    check(cleaned.threw === null && !cleaned.tracks.includes('renderScale'),
+      '  and the document this section handed over is put back, carrying neither track it planted',
+      cleaned.threw ? `the restore threw "${cleaned.threw}"` : `tracks: ${cleaned.tracks.join(', ') || 'none'}`);
+  }
+
+  // ================================ 15. the pinned drive takes the loop away with it
+
+  console.log('\n[15] pinning the drive drops what the loop was going to serve');
 
   // The third state that strands an armed position, and the only one `pumpParkedDraft`
   // cannot notice on its own: `drive.pin` calls `setAnimationLoop(null)`, so that

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -686,9 +686,11 @@ const MUTATIONS = {
   // `restoreProject` goes back to calling `params.spec` for its throw and discarding the
   // spec, so a document carrying a track on a view parameter opens - and `evaluateTracks`
   // has no tag filter, so that track calls `resize()` once per rendered frame. Reddens
-  // only the first row of section 14. The look-track row beside it stays green, which is
-  // what separates "the reader now reads the tag" from "the reader stopped taking
-  // tracks", and the unknown-name refusal is untouched.
+  // the first row of section 14 and the empty-view-track row below it, which is the same
+  // claim asked about the shape that used to walk past the check entirely. The two look
+  // rows beside them stay green, which is what separates "the reader now reads the tag"
+  // from "the reader stopped taking tracks", and the two unknown-name refusals stay green
+  // too because this mutation leaves `params.spec`'s own throw where it is.
   //
   // Anchored on the `const spec =` binding and the `if` that reads it rather than on
   // the bare call the revert produces: `params.spec(name);` on its own appears twice in
@@ -4605,9 +4607,13 @@ try {
   // else that a later section would report as its own failure.
   {
     const original = await page.evaluate('JSON.stringify(__kinect.library.serialiseProjectBody())');
-    const handTo = (name) => page.evaluate(`(() => {
+    // The keys are a parameter rather than a literal because the shape that walked past
+    // both refusals is an *empty* track, and a helper that can only plant a populated one
+    // cannot ask about it. Defaulted to the populated pair so the rows written before this
+    // was known say exactly what they said.
+    const handTo = (name, keys = [{ t: 0, value: 100 }, { t: 4, value: 140 }]) => page.evaluate(`(() => {
       const body = JSON.parse(${JSON.stringify(original)});
-      body.look.tracks[${JSON.stringify(name)}] = [{ t: 0, value: 100 }, { t: 4, value: 140 }];
+      body.look.tracks[${JSON.stringify(name)}] = ${JSON.stringify(keys)};
       try {
         __kinect.library.restoreProject(body);
         return { threw: false, message: null };
@@ -4626,6 +4632,30 @@ try {
     const look = await handTo('bloom');
     check(!look.threw, '  and one on a look parameter still loads, which is the shape the serialiser writes',
       look.threw ? `"${look.message}"` : 'accepted');
+    // **The same document with no keys in it, which is the shape that walked past both
+    // refusals.** `restoreProject` skipped an empty track before it asked the two
+    // questions, so `{"renderScale": []}` and a track under a name the registry has never
+    // heard of were both accepted by a reader that had just promised to refuse them - and
+    // accepted is the wrong word for what happened to them, because `serialiseProjectBody`
+    // filters the entry back out on the next commit. The document stopped saying what it
+    // said when it was opened, through the one shape with no edit in it to notice missing.
+    //
+    // Three rows rather than one, because "refuses an empty view track" on its own is also
+    // satisfied by a build that refuses every empty track: the name row says the older
+    // refusal still reaches this shape too, and the look row says empty is not itself what
+    // is being refused.
+    const emptyView = await handTo('renderScale', []);
+    check(emptyView.threw && /view/.test(emptyView.message ?? ''),
+      '  and an empty track on a view parameter is refused too, rather than skipped for being cheap to skip',
+      emptyView.threw ? `"${emptyView.message}"` : 'it was accepted');
+    const emptyUnknown = await handTo('notAParameterThisBuildKnows', []);
+    check(emptyUnknown.threw,
+      '  and so is an empty one under a name the registry has never heard of',
+      emptyUnknown.threw ? `"${emptyUnknown.message}"` : 'it was accepted');
+    const emptyLook = await handTo('bloom', []);
+    check(!emptyLook.threw,
+      '  while an empty one on a look parameter still loads, because empty is not what is being refused',
+      emptyLook.threw ? `"${emptyLook.message}"` : 'accepted');
     // Whatever the two above left behind, put back - and asserted rather than assumed,
     // because the build this matters on is the one that is deliberately wrong. On this
     // build the first is refused with nothing touched and the second replaces the

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -61,6 +61,7 @@
 //   node tools/editor-check.mjs --mutate pin-keeps-orbit-armed  --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate clip-range-unclamped   --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate clip-bound-coerces-nonnumeric --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate refusal-strands-the-picker --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate resize-skips-repaint   --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate restore-accepts-view-track --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate export-ignores-name              # must FAIL
@@ -663,6 +664,27 @@ const MUTATIONS = {
         + '  if (out !== undefined) clipOut = out;\n',
       ],
     ],
+  },
+
+  // The refusal goes back to leaving the picker on the document it just refused, so the menu
+  // names a configuration the clip is not on while the readout beside it names the one it is.
+  // Reddens *both* picker rows in section 7, and the first draft of this comment claimed it
+  // reddened only the first - measured 2 assertions, not 1, which is worth leaving written
+  // down. Removing the revert leaves the picker sitting on the refused name, and that fails
+  // both questions at once: it is the refused one, and it is not the adopted one. The second
+  // row still earns its place, because it is aimed at a different wrong build - one that
+  // reverts the picker to *something*, which would pass the first row while naming a
+  // deliverable the clip is not on. No mutation here produces that build; the row is the
+  // standing guard against a fix written that way later.
+  //
+  // The five `editor-check-bad` rows above stay green, because the refusal itself still
+  // happens - this control removes what the page *says* about it, not the refusing.
+  'refusal-strands-the-picker': {
+    file: 'web/main.js',
+    edits: [[
+      "    ui.deliverable.value = ui.deliverable.dataset.adopted ?? '';\n",
+      '',
+    ]],
   },
 
   // `resize()` goes back to reallocating the drawing buffer and drawing nothing into it,
@@ -2846,6 +2868,24 @@ try {
   // `applyDeliverable` behind it the way section 14 drives `restoreProject`. The menu is the
   // door a document from another build actually arrives through, and the console write is
   // part of what arriving through it does.
+  // **And the control that names the selection is put back on what the clip is on.** The
+  // refusal happens before `applyDeliverable` replaces anything, so the trim, the export size
+  // and the readout beside the picker all still describe the deliverable that was already
+  // there - which left the picker as the one surface naming the refused one. Two surfaces
+  // disagreeing is worse than either being wrong: a render afterwards matches the readout
+  // while the menu shows the name of a configuration that was never adopted.
+  //
+  // Read off `#tDeliverable` rather than off any hook, because the element is the claim.
+  const picker = await page.evaluate(`(() => {
+    const el = document.getElementById('tDeliverable');
+    return { value: el.value, adopted: el.dataset.adopted ?? '' };
+  })()`);
+  check(picker.value !== 'editor-check-bad',
+    '  and the picker is not left naming the deliverable that was refused',
+    `#tDeliverable reads ${JSON.stringify(picker.value)}`);
+  check(picker.value === picker.adopted,
+    '  and it names the one the clip is actually on, rather than merely something else',
+    `#tDeliverable ${JSON.stringify(picker.value)} against the adopted ${JSON.stringify(picker.adopted)}`);
   const drained = errors.filter((e) => /not a program time/.test(e));
   for (const e of drained) errors.splice(errors.indexOf(e), 1);
   check(drained.length === 1,

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -60,6 +60,7 @@
 //   node tools/editor-check.mjs --mutate release-seeks-past-target --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate pin-keeps-orbit-armed  --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate clip-range-unclamped   --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate clip-bound-coerces-nonnumeric --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate resize-skips-repaint   --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate restore-accepts-view-track --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate export-ignores-name              # must FAIL
@@ -632,6 +633,36 @@ const MUTATIONS = {
       + '  }\n',
       '',
     ]],
+  },
+
+  // The program stops asking what a clip bound is, at both of the places that ask, so a
+  // bound that is not a number is clamped instead of refused - which is arithmetic, so it
+  // spreads: the in point becomes NaN and the `Math.max` holding the out point up carries
+  // it into that one too. Reddens the five `editor-check-bad` rows in section 7 and nothing
+  // else in the block - the fifth being the drain, which finds nothing to take out of the
+  // page-error sweep because a build that does not refuse says nothing to the console.
+  // The three `editor-check-past` rows above them stay green on purpose,
+  // and that is the separation this control exists to make: the clamp itself still works,
+  // and what is missing is the refusal in front of it. Both edits are needed for the defect
+  // to come back at all - either question on its own still catches the document - which is
+  // why this is one mutation rather than two.
+  'clip-bound-coerces-nonnumeric': {
+    file: 'web/main.js',
+    edits: [
+      [
+        "  clipBoundOrThrow(deliverable.in, 'in');\n"
+        + "  clipBoundOrThrow(deliverable.out, 'out');\n",
+        '',
+      ],
+      [
+        "  const nextIn = inn === undefined ? undefined : clipBoundOrThrow(inn, 'in');\n"
+        + "  const nextOut = out === undefined ? undefined : clipBoundOrThrow(out, 'out');\n"
+        + '  if (nextIn !== undefined) clipIn = nextIn;\n'
+        + '  if (nextOut !== undefined) clipOut = nextOut;\n',
+        '  if (inn !== undefined) clipIn = inn;\n'
+        + '  if (out !== undefined) clipOut = out;\n',
+      ],
+    ],
   },
 
   // `resize()` goes back to reallocating the drawing buffer and drawing nothing into it,
@@ -2612,6 +2643,12 @@ try {
   await putDeliverable('editor-check-near', { ...baseDeliverable, name: 'editor-check-near', in: 2, out: 8 });
   await putDeliverable('editor-check-far', { ...baseDeliverable, name: 'editor-check-far', in: farIn, out: farOut });
   await putDeliverable('editor-check-past', { ...baseDeliverable, name: 'editor-check-past', in: pastIn, out: pastOut });
+  // And one whose `in` is not a time at all, which is the other thing a document written by
+  // a build this one cannot read looks like. It carries a *valid* `out` on purpose: the
+  // failure this separates is not that a bad bound is bad, it is that clamping one spreads
+  // it - `Math.max(clipIn, ...)` holds the out point up against the in point, so a single
+  // unusable field takes a perfectly good one with it.
+  await putDeliverable('editor-check-bad', { ...baseDeliverable, name: 'editor-check-bad', in: 'start', out: farOut });
   await page.evaluate('__kinect.editor.refreshDeliverables?.()');
   // What the menu looked like before this block touched it. Restored at the end, because
   // the selected name is drawn in a chip on the two-row bar and a longer one reflows it -
@@ -2743,9 +2780,79 @@ try {
     '  and the readout beside the markers names a time the take has, rather than one it does not',
     `#tInOut reads ${adopted.readout} of a ${adopted.duration.toFixed(3)}s program`);
 
+  // **A bound that is not a program time, refused rather than clamped into one.** The clamp
+  // above is arithmetic, and arithmetic does not refuse a value that is not a number - it
+  // spreads it. An `in` of `"start"` clamps to NaN, the `Math.max` that holds the out point
+  // up against it carries the NaN into a bound that was good, and `clipOutSec` and `frameAt`
+  // both stop answering with numbers. That is worse than the getter the clamp was put in
+  // front of, which coerced a malformed `in` to zero and left `out` alone, so the clamp had
+  // to learn to refuse before it clamps.
+  //
+  // The range is cleared first because the block above deliberately leaves it collapsed at
+  // the end of the program, where `frameAt` is a constant for a reason that is correct. A
+  // row about a frozen `frameAt` run from there would be green on every build.
+  await page.locator('#tClearRange').click();
+  await settle();
+  const beforeBad = await page.evaluate(`(() => {
+    const t = __kinect.timeline.transport();
+    return { in: t.clipInSec, out: t.clipOutSec };
+  })()`);
+  await pick('editor-check-bad');
+  // The two probe positions come off the *duration*, not off the clip range, so they are
+  // still two distinct program times on a build where the range has gone to NaN. Reading
+  // them off `clipOutSec` would have made the row assert nothing there: NaN times anything
+  // is NaN, and both probes would land on the same non-answer for the same reason.
+  const bad = await page.evaluate(`(() => {
+    const t = __kinect.timeline.transport();
+    return {
+      in: t.clipInSec,
+      out: t.clipOutSec,
+      early: t.frameAt(t.duration * 0.25),
+      late: t.frameAt(t.duration * 0.75),
+      note: document.getElementById('tNote').textContent.trim(),
+    };
+  })()`);
+  check(Number.isFinite(bad.in) && Number.isFinite(bad.out),
+    '  and a deliverable whose in point is not a number leaves the transport a range that is still two times',
+    `clipInSec ${bad.in}, clipOutSec ${bad.out}`);
+  check(near(bad.out, beforeBad.out, 1e-6),
+    '  and the out point it keeps is the one the clip already had, so the document was refused rather than repaired',
+    `clipOutSec ${bad.out} against ${beforeBad.out} before the document was chosen`);
+  // The composed function rather than its inputs, because that is what the transport moves
+  // on and it is what a bound reading NaN actually breaks. Two positions half a program
+  // apart resolving to one frame is the freeze this whole block is named for.
+  check(Number.isFinite(bad.early) && Number.isFinite(bad.late) && bad.early !== bad.late,
+    '  and frameAt still resolves two positions half a program apart to two different frames',
+    `frameAt(0.25) ${bad.early}, frameAt(0.75) ${bad.late}`);
+  // The operator's half. A document that is refused and says nothing is a menu selection
+  // that appears to have worked, which is the same silence the clamp itself was fixing.
+  check(/not a program time/.test(bad.note),
+    '  and the refusal is said out loud rather than leaving the menu looking like it took',
+    `#tNote reads ${JSON.stringify(bad.note)}`);
+  // `showTimelineError` also writes the refusal to `console.error`, and the sweep at the end
+  // of this file asserts the page said nothing at all - so this block has to take its own
+  // noise back out or it reddens a row fifteen sections away that is about something else.
+  //
+  // **Drained here and asserted on the way out, rather than excused at the sweep.** A filter
+  // added down there would be a standing exemption: it would go on covering whatever the
+  // page said next that happened to match, and a refusal that stopped happening would take
+  // the exemption with it silently. Taking exactly what this block provoked, and failing if
+  // that is not exactly one thing, means the drain is a claim about the refusal rather than
+  // a hole in the sweep - and everything else the page said stays in for the sweep to find.
+  //
+  // This is also why the block drives the deliverable menu rather than calling
+  // `applyDeliverable` behind it the way section 14 drives `restoreProject`. The menu is the
+  // door a document from another build actually arrives through, and the console write is
+  // part of what arriving through it does.
+  const drained = errors.filter((e) => /not a program time/.test(e));
+  for (const e of drained) errors.splice(errors.indexOf(e), 1);
+  check(drained.length === 1,
+    '  and it reaches the console exactly once, which is what this block takes back out of the page-error sweep',
+    `${drained.length} drained: ${drained.map((e) => e.slice(0, 60)).join(' | ') || 'nothing'}`);
+
   await focusStage();
   await page.evaluate(`(async () => {
-    for (const n of ['editor-check-near', 'editor-check-far', 'editor-check-past']) {
+    for (const n of ['editor-check-near', 'editor-check-far', 'editor-check-past', 'editor-check-bad']) {
       // The content type is required on every write route, delete included - the origin
       // rule refuses a request that does not declare one, which is a 200 carrying an
       // error rather than a network failure, so a cleanup without it fails silently.

--- a/web/main.js
+++ b/web/main.js
@@ -3408,7 +3408,6 @@ function restoreProject(project) {
   const restoredLook = [];
   for (const [name, keys] of Object.entries(project.look.tracks)) {
     if (!Array.isArray(keys)) throw new Error(`look track ${name} is not an array of keys`);
-    if (keys.length === 0) continue;
     // Names the registry does not know are refused rather than dropped. A track
     // silently discarded is an edit silently lost, and the file is more likely to
     // be from a build this one cannot read than to be harmlessly extra.
@@ -3438,6 +3437,18 @@ function restoreProject(project) {
         + 'without resizing the drawing buffer from inside the render loop',
       );
     }
+    // **Skipped only after it has been asked about, and the order is the whole of it.**
+    // This shortcut used to stand above both refusals, so `{"renderScale": []}` and a
+    // track under a name the registry has never heard of both walked straight past a
+    // reader that had just promised to refuse them. Nothing threw and nothing was kept:
+    // `serialiseProjectBody` filters the entry back out on the next commit, so the
+    // document quietly stopped saying what it said when it was opened - which is the
+    // "an edit silently lost" the comment above is about, arriving through the one shape
+    // that has no edit in it to notice missing.
+    //
+    // An empty track is still nothing to restore, so it is still skipped. The change is
+    // that it is skipped for being empty rather than for being cheap to skip.
+    if (keys.length === 0) continue;
     restoredLook.push([name, keys.map((k) => {
       const key = restoreKey(`track ${name}`, k);
       key.value = params.normalise(name, key.value);

--- a/web/main.js
+++ b/web/main.js
@@ -1407,6 +1407,16 @@ function setViewCamera(cam) {
 // in its temporal dead zone on the `resize()` that runs at boot.
 let stageResizes = 0;
 
+// The transport, or null until a take is open. Declared here rather than beside the
+// class it is built from four thousand lines below, and for the same reason the counter
+// above is: `resize()` ends by asking for a repaint, `requestRepaint` reads this binding
+// first, and the `resize()` that runs at boot would be reading a `let` in its temporal
+// dead zone - a ReferenceError before the page has drawn anything, on the one path
+// nothing recovers from. That it is read there is deliberate rather than incidental:
+// null is the honest answer at boot, and it is the answer that makes the repaint stand
+// down until there is something to repaint.
+let timeline = null;
+
 /**
  * Who owns the transport's play state right now.
  *
@@ -1479,6 +1489,10 @@ const pauseTransport = () => {
 
 function resize() {
   stageResizes++;
+  // What the drawing buffer measured on the way in, so the repaint at the bottom can
+  // ask whether this call actually reallocated it. See the comment there for why the
+  // question is worth asking rather than assuming the answer is always yes.
+  const wasBuffer = renderer.getDrawingBufferSize(new THREE.Vector2());
   // The stage is the window less whatever the timeline strip is taking, which is
   // nothing at all while it is hidden. Overlaying it on the image instead would
   // have cost nothing here and hidden the bottom of every frame being graded.
@@ -1571,6 +1585,53 @@ function resize() {
   bloom.setSize(Math.max(1, refWidth / 2), 300);
   grade.uniforms.resolution.value.set(buf.x, buf.y);
   uniforms.bufferHeight.value = buf.y;
+  // And then ask for the picture back, because everything above reallocates the drawing
+  // buffer and nothing above draws into it again. A parked editor has no clock of its
+  // own - `tickNow` returns immediately on `!playing` and `pumpParkedDraft` returns with
+  // nothing armed - so the stage stays black until something unrelated happens to seek,
+  // with the chrome overlay floating over it because that is a separate 2D canvas
+  // `placeChrome` goes on repainting. Every path that resizes a parked stage had it: the
+  // window listener below, the three splitter entries, the render-scale slider, the
+  // export-size menu through `setTargetSize`, and `rebuildLanes` reaching this
+  // indirectly - which is the argument for the repaint being here, at the door, rather
+  // than at a caller list the seventh path would be added outside of.
+  //
+  // **This is not the pump section 9 of `editor-check` forbids.** That rule is about a
+  // redraw asking for the next redraw: `renderProgramFrame` moves the camera, so a
+  // handler that renders on a control's `change` has armed its own successor and a
+  // parked drag runs at whatever rate the machine can rebuild a frame. Nothing of that
+  // shape is here. `requestRepaint` stands down while playing, scrubbing, orbiting or
+  // exporting, and coalesces through `queueMicrotask`, so a splitter drag costs one
+  // accurate seek per settled state rather than one per pointer move.
+  //
+  // What keeps it that way is that nothing in the render path reaches this function, and
+  // that is a property to hold rather than one to assume. A `renderScale` track would
+  // have been exactly that path - `evaluateTracks` has no tag filter and runs per
+  // rendered frame - so the refusal `restoreProject` now makes is what stops this line
+  // becoming a repaint requested once per frame of every pre-roll.
+  //
+  // **Only when the buffer actually moved, and that condition was measured rather than
+  // reasoned about.** Most calls here change nothing: `rebuildLanes` runs this whenever
+  // the lane set is rebuilt, so every rate change reaches it through
+  // `timingChanged` -> `lanesChanged` with the strip the same height it already was.
+  // Asking for a repaint there is asking for a second accurate seek on top of the one
+  // the gesture's own release is about to issue - measured at 2 seeks for one held
+  // arrow key against 1, which is the seek storm the speed control was rewritten to
+  // avoid, coming back through a door that was opened for something else. It cost the
+  // take as well: the release resumes playback behind its seek, and the repaint's seek
+  // landed on top of that and put the playhead back on the frame the resume had just
+  // left, so a held key stopped the take three runs out of three.
+  //
+  // The condition is safe because a `setSize` to the size something already has does
+  // not reallocate anything: `WebGLRenderTarget.setSize` returns early on an unchanged
+  // size, and Chrome's canvas does the same for an unchanged `width`/`height`. Measured
+  // on this build rather than read off a specification - a stage carrying 158,247 lit
+  // pixels carried exactly 158,247 across a same-size `resize()`, and 0 across one that
+  // moved the buffer 1298x730 -> 1084x610. `editor-check` section 13 asserts both
+  // halves, because the premise this guard rests on is a fact about a browser and the
+  // day it stops being true is the day the stage goes black with nothing saying so.
+  const buffer = renderer.getDrawingBufferSize(new THREE.Vector2());
+  if (buffer.x !== wasBuffer.x || buffer.y !== wasBuffer.y) requestRepaint();
 }
 addEventListener('resize', () => {
   // The ceiling is a share of the window, so a window that got shorter can put the
@@ -2663,6 +2724,40 @@ function setClipInOut(values) {
   const { in: inn, out } = values;
   if (inn !== undefined) clipIn = inn;
   if (out !== undefined) clipOut = out;
+  // **Held inside the program that is open, because the two getters the transport reads
+  // this through are not symmetric.** `clipOutSec` is bounded above by the take's
+  // duration and `clipInSec` is bounded below by zero and above by nothing, so an `in`
+  // past the program's end makes `clipInSec` the larger of the two and `frameAt`
+  // composes to a constant: its inner `Math.min` can never exceed the out point, so its
+  // outer `Math.max` always answers the in point. Every position the editor can ask for
+  // then comes back as the same frame - seek, draft, redraw, `goTo`, Home, End, the
+  // arrow steps and the scrubber's release alike - while the readout goes on naming a
+  // range that has nothing in it.
+  //
+  // A deliverable is how that arrives. `applyDeliverable` writes a saved document's
+  // program times as they stand rather than into the rate the clip happens to be in, so
+  // a trim authored at 1x lands past the end of the same take played at 2x, and nothing
+  // upstream of here compares it against the take that is open.
+  //
+  // **Here rather than in the getters, and here rather than at `applyDeliverable`.**
+  // This is the one door every writer already passes - the two marker drags, the rate
+  // rescale in `reparameteriseProgramTime` and the deliverable - so there is no second
+  // clamp to keep in step with this one, and the writer added next year is held by
+  // existing. The markers already clamp themselves this way at their own ends; this is
+  // that same rule said once, where it covers the door a document comes through.
+  //
+  // What it deliberately does not do is make an empty range usable. A trim that lands
+  // wholly past the end has nothing in it, so it collapses to a point at the end - which
+  // is the state the two markers dragged together already reach, and it is explained by
+  // the same picture rather than by a frozen transport nothing on screen accounts for.
+  if (timeline) {
+    const dur = timeline.duration;
+    clipIn = Math.max(0, Math.min(clipIn, dur));
+    // `null` still means "to the end", which is a different statement from a number that
+    // happens to equal the duration: "whole clip" has to survive a retime that lengthens
+    // the program, and a duration written in here would freeze it at today's length.
+    if (clipOut !== null) clipOut = Math.max(clipIn, Math.min(clipOut, dur));
+  }
   ensureActiveDeliverable();
   activeDeliverable.in = clipIn;
   activeDeliverable.out = clipOut;
@@ -3275,7 +3370,32 @@ function restoreProject(project) {
     // Names the registry does not know are refused rather than dropped. A track
     // silently discarded is an edit silently lost, and the file is more likely to
     // be from a build this one cannot read than to be harmlessly extra.
-    params.spec(name);
+    const spec = params.spec(name);
+    // And a name it does know but does not tag `look` is refused for a harder reason
+    // than tidiness. `serialiseProjectBody` filters the track set down to look
+    // parameters, so this is a shape no build of this program has ever written - the
+    // reader was simply not making the demand the writer already meets, and the tag was
+    // sitting here unread while the throw above was taken for the whole check.
+    //
+    // What accepting one cost is the part worth naming. `evaluateTracks` has no tag
+    // filter and runs inside `renderProgramFrame`, so a track on `renderScale` is
+    // `resize()` called once per rendered frame - and where the value genuinely moves
+    // across a ramp, `composer.setSize` disposes and recreates the render targets and,
+    // through `AfterimagePass`, the trails accumulator. That is the accumulator
+    // destroyed between two consecutive frames of a pre-roll whose entire purpose is to
+    // build it up, so an accurate seek stops reproducing the playback it is defined to
+    // reproduce. The document stops round-tripping at the same time and just as quietly,
+    // because the serialiser filters the track back out on the next commit.
+    //
+    // Read off the spec rather than checked against a list of view parameter names, so
+    // a parameter retagged later is refused by existing rather than by being remembered.
+    if (spec.tag !== 'look') {
+      throw new Error(
+        `the track on ${JSON.stringify(name)} is on a ${spec.tag} parameter: a project carries `
+        + 'look tracks only, which is what this build writes and the only kind it can evaluate '
+        + 'without resizing the drawing buffer from inside the render loop',
+      );
+    }
     restoredLook.push([name, keys.map((k) => {
       const key = restoreKey(`track ${name}`, k);
       key.value = params.normalise(name, key.value);
@@ -5935,8 +6055,6 @@ const sayExport = (text) => {
   ui.exportNote.title = text;
 };
 
-let timeline = null;
-
 const timecode = (sec) => {
   const s = Math.max(0, sec);
   const m = Math.floor(s / 60);
@@ -6424,9 +6542,15 @@ paramWritten = (name, tag) => {
   // business on their window, but a source has its own buffer and its own reason to
   // be told what scale to draw at.
   sendProgramOut({ params: { [name]: params.get(name) } });
-  // View state changes what you are looking at rather than what the clip is, and
-  // both of today's view parameters already do their own work: render scale
-  // resizes the buffers, and auto-orbit only means anything with a clock running.
+  // View state changes what you are looking at rather than what the clip is, and both
+  // of today's view parameters already do their own work: auto-orbit only means
+  // anything with a clock running, and render scale resizes the buffers - which is
+  // `resize()`, and `resize()` asks for its own repaint on its last line because
+  // reallocating a buffer clears it. The premise this comment used to carry was that
+  // resizing the buffers was the work, so a repaint here would be a second one. It is
+  // not: resizing a buffer is not drawing into it, and withholding the repaint here
+  // while nothing else asked for one is what left the stage black behind the chrome
+  // after every move of the render-scale slider.
   if (tag === 'view' || transportWriting) return;
   requestRepaint();
 };

--- a/web/main.js
+++ b/web/main.js
@@ -8438,6 +8438,24 @@ async function refreshDeliverables() {
   return list;
 }
 
+/**
+ * Moves the picker and the record of what it is naming together.
+ *
+ * **Because a refusal has to be able to put the picker back, and there is nothing else
+ * that knows where back is.** A `change` event arrives with `value` already moved, so the
+ * previous selection is gone by the time anything can object to the new one - and
+ * `activeDeliverable` cannot stand in for it, since `saveDeliverable` PUTs the document as
+ * it is and stamps no name into it. Kept on the element rather than in a module binding so
+ * there is one object holding both halves and no second copy to fall out of step.
+ *
+ * Every adoption goes through here, which is what makes the revert below mean "the one the
+ * clip is actually on" rather than "the one somebody remembered to record".
+ */
+function showAdoptedDeliverable(name) {
+  ui.deliverable.value = name;
+  ui.deliverable.dataset.adopted = name;
+}
+
 async function saveDeliverable(name, deliverable) {
   const res = await fetch(`/deliverables/${encodeURIComponent(name)}`, {
     method: 'PUT',
@@ -9903,8 +9921,20 @@ ui.deliverable.addEventListener('change', async () => {
     if (doc.error) throw new Error(doc.error);
     applyDeliverable(doc.body);
     history.commit();
+    showAdoptedDeliverable(name);
     ui.note.textContent = `deliverable ${name}`;
   } catch (err) {
+    // **Put the picker back on what the clip is actually on.** `applyDeliverable` refuses a
+    // document whose cuts are not program times, and it refuses it before it has replaced
+    // anything - so the clip, the export size and the readout beside the picker all still
+    // describe the deliverable that was there before. The picker was the one surface left
+    // naming the refused one, and the two disagreeing is worse than either: the readout says
+    // one thing, the control says another, and the file that comes out of a render afterwards
+    // matches the readout while carrying the name the operator can see in the menu.
+    //
+    // The message stays on `#tNote` either way, so this is not a refusal being swallowed - it
+    // is the refusal being told in one place instead of contradicted in a second.
+    ui.deliverable.value = ui.deliverable.dataset.adopted ?? '';
     showTimelineError(err);
   }
 });
@@ -9916,7 +9946,9 @@ ui.deliverableNew.addEventListener('click', async () => {
   try {
     await saveDeliverable(name, activeDeliverable);
     await refreshDeliverables();
-    ui.deliverable.value = name;
+    // Through the same door as the menu's own adoption: what was just saved *is* what the
+    // clip is on, so this is the selection a later refusal has to be able to come back to.
+    showAdoptedDeliverable(name);
     ui.note.textContent = `saved deliverable ${name}`;
   } catch (err) {
     showTimelineError(err);

--- a/web/main.js
+++ b/web/main.js
@@ -2705,7 +2705,34 @@ function setActiveDeliverable(deliverable) {
   activeDeliverable = deliverable;
 }
 
+// What a clip bound is allowed to be, asked in one place because two callers need the
+// same answer and a second copy of it is the drift this design keeps refusing.
+//
+// `null` is a statement rather than a time, and it is only ever legal at the out point:
+// there it means "to the end", which has to survive a retime that lengthens the program
+// and so cannot be written down as a number. At the in point, and for anything else that
+// is not a finite number, there is no reading to recover - so it is refused.
+function clipBoundOrThrow(value, which) {
+  if (value === null && which === 'out') return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  throw new Error(
+    `the clip's ${which} point is ${JSON.stringify(value) ?? String(value)}, which is not a program `
+    + 'time: a trim carries finite seconds, and holding a value that is not one inside the program '
+    + 'spreads it through both bounds and leaves the transport no range at all',
+  );
+}
+
 function applyDeliverable(deliverable) {
+  // **Asked before anything is touched, so a document this program cannot read is refused
+  // whole rather than half-adopted.** `setClipInOut` below is the door that refuses a
+  // bound, and refusing there is what covers the marker drags and the rate rescale too -
+  // but by the time it runs, `setActiveDeliverable` has already made this document the
+  // active one, so a throw from inside it would leave a refused document's output size
+  // and codec sitting on a clip whose cuts it never got to write. Asking the same
+  // predicate here first is a second call site rather than a second rule, which is the
+  // distinction that matters: there is still one answer to what a clip bound is.
+  clipBoundOrThrow(deliverable.in, 'in');
+  clipBoundOrThrow(deliverable.out, 'out');
   // Before anything is written, because what follows replaces the cuts and the output
   // rate wholesale - see `dropRateGesture` for why this is not `takeTransport`.
   dropRateGesture();
@@ -2722,8 +2749,23 @@ function applyDeliverable(deliverable) {
 
 function setClipInOut(values) {
   const { in: inn, out } = values;
-  if (inn !== undefined) clipIn = inn;
-  if (out !== undefined) clipOut = out;
+  // **Refused before either binding is written, because the clamp below is arithmetic and
+  // arithmetic on something that is not a number does not fail - it spreads.** An `in` of
+  // `"start"` makes `Math.min(clipIn, dur)` NaN, and the `Math.max(clipIn, ...)` that holds
+  // the out point up then carries that NaN into a bound which was perfectly good: both ends
+  // are gone, `clipOutSec` answers NaN, and `frameAt` resolves every position to NaN. The
+  // getter this clamp was put in front of coerced instead - `Number(clipIn) || 0` read a
+  // malformed `in` as zero and left a valid `out` alone - so clamping without refusing first
+  // is strictly worse than what it replaced, on exactly the documents it exists to survive.
+  //
+  // `undefined` is not that case and must not be refused: it is how the two marker drags say
+  // which end they mean, and a drag writes one bound while the other keeps whatever it held.
+  // A document has no such reading, which is why `applyDeliverable` asks the same question
+  // about both of its fields and gets a refusal where this gets a pass.
+  const nextIn = inn === undefined ? undefined : clipBoundOrThrow(inn, 'in');
+  const nextOut = out === undefined ? undefined : clipBoundOrThrow(out, 'out');
+  if (nextIn !== undefined) clipIn = nextIn;
+  if (nextOut !== undefined) clipOut = nextOut;
   // **Held inside the program that is open, because the two getters the transport reads
   // this through are not symmetric.** `clipOutSec` is bounded above by the take's
   // duration and `clipInSec` is bounded below by zero and above by nothing, so an `in`


### PR DESCRIPTION
Closes #43. Three defects, all in `web/main.js`, all silent — nothing on screen named the cause and `editor-check` passed identically through every one of them.

## One — an adopted deliverable could invert the clip range

The two getters the transport reads its range from were not symmetric: `clipOutSec` was held down to the take's duration and `clipInSec` was held up to zero and to nothing else. So a deliverable whose `in` landed past the program's end made `clipInSec` the larger of the two, and `frameAt` composed to a constant — every position the editor could ask for came back as one frame, and `exportClip` computed both of its bounds through it and wrote a one-frame file with the `if (to < from)` guard unable to fire.

`setClipInOut` now holds the range inside the program that is open. That is the one door every writer already passes — both marker drags, `reparameteriseProgramTime` and the deliverable — so there is no second clamp to keep in step, and the two getters are untouched.

**One thing to know before reviewing, because the issue asked for something impossible.** Step 3 wanted a row asserting that two seeks to different program times land on different frames after the clamp. No clamp can deliver that: a trim landing wholly past the end has nothing in it, so it collapses to a point at the end whatever order the two ends are clamped in, and `frameAt` stays constant there. That state is also already reachable by dragging the two markers together, so it is explained by the same picture rather than by a frozen transport. Raised through AskUserQuestion and settled as clamp-only. What the fix buys is that the document stops being invertible and the readout stops lying — `#tInOut` read `00:45.543` on a 30.362s take before it and reads `00:30.362` after — and the new rows assert exactly that.

## Two — every path that resized the drawing buffer while parked left the stage blank

`resize()` reallocates the buffer, which clears it, and a parked editor has no clock: `tickNow` returns on `!playing` and `pumpParkedDraft` returns with nothing armed. So the stage stayed black behind a chrome overlay that `placeChrome` went on repainting on its own 2D canvas. `resize()` now asks for the picture back, at the door rather than at the seven callers that reach it.

**The repaint is conditional on the drawing buffer's size having actually moved, and that condition is the part worth reviewing hardest.** Most calls to `resize()` change nothing — `rebuildLanes` runs it on every lane rebuild, so every rate change reaches it through `timingChanged` → `lanesChanged` with the strip the height it already was. Repainting there cost a second accurate seek on top of the one the gesture's own release issues: measured at 2 seeks for one held arrow key against HEAD's 1, which is the seek storm the speed control was rewritten to avoid arriving through a door opened for something else. It lost the take three runs out of three, because the release resumes playback behind its seek and the repaint's seek put the playhead back on the frame the resume had just left.

The guard rests on a same-size `setSize` reallocating nothing, which is a fact about a browser rather than about this build — so section 13 asserts it rather than trusting it. Measured: a stage carrying 158,247 lit pixels carried exactly 158,247 across a same-size `resize()`, and 0 across one that moved the buffer 1298x730 → 1084x610.

The `tag === 'view'` early return at `paramWritten` is left alone as the issue asked; only its comment changed, since resizing a buffer is why render scale needs a repaint rather than why it does not.

## Three — `restoreProject` accepted tracks the serialiser can never write

`serialiseProjectBody` filters the track set to look parameters; the reader called `params.spec(name)` for its throw-on-unknown and discarded the spec, so `renderScale` and `spin` were names it knew and let through. `evaluateTracks` has no tag filter and runs inside `renderProgramFrame`, so such a track is `resize()` once per rendered frame — and where the value moves, `composer.setSize` disposes the render targets and, through `AfterimagePass`, the trails accumulator, between two frames of a pre-roll that exists to build it. The reader now reads the tag it was already fetching. Nothing on disk changes meaning, so no version bump is owed.

## Method

Fixture is `captures/sample.knct`, 284 frames, program duration **30.362s** at 1x, read from `GET /library/takes` on the running server.

**One existing row is re-anchored in the same commit.** The deliverable block planted `editor-check-far` at a flat `in: 20, out: 40`, which on this take comes back clamped at 20..30.362 — so the row "choosing a deliverable puts its trim on the clip" would have been asserting the clamp where it means to assert the menu. The far trim is now read off the take at two thirds and nine tenths of its duration, which keeps it as far from the near one's 2s..8s as the old pair were and keeps it inside the program at every rate the block reaches, including the 2x the gesture holds. No other row moved, and every mutation anchor in the suite still matches exactly once — checked by walking every tool's table against its target file, with only issue #28's two known-stale anchors failing, as they do at HEAD.

| Run | Result |
|---|---|
| `editor-check --take sample` | 248 assertions, 0 failed |
| `editor-check --take sample --no-render` | 242 assertions, 0 failed |
| `--mutate clip-range-unclamped` | caught — the three new transport rows; deliverable rows green |
| `--mutate resize-skips-repaint` | caught, 3 fired — the three resize rows only; sections 9 and 11 green, and section 13's same-size row green with them |
| `--mutate restore-accepts-view-track` | caught, 1 fired — the refusal row and nothing else |
| `--mutate orbit-pumps-on-change` | still caught, section 9's redraw-per-frame row |
| `--mutate bounds-compare-off-grid` | still caught, 1 fired — not exit 2 on a stale anchor |
| `syntax-check` | 39 files, 0 failed |
| `npm test` | exit 0 |

Four runs during this work reddened one unrelated row apiece and none reproduced — a section 4 play-intent row, a section 5 double-click row, a section 7 deliverable row and a section 9 orbit-drift precondition row, a different one each time, the last firing against two different mutations in succession. Every mutation above was re-run on an idle machine before its verdict was recorded.

## Review notes

Worth the most scrutiny: that the clamp lives in exactly one place and the two getters were left alone; that the new `requestRepaint()` is genuinely coalesced rather than merely cheap, which sections 9 and 11 answer together; and that each new mutation reddens one row rather than several. The buffer-size guard on the repaint is the piece that was not in the issue — it came out of a regression this branch introduced and then measured, and section 13's same-size row exists to keep its premise honest.

Two lessons went to `docs/instruments.md` beside their neighbours: a fix placed at a door is a probe with an observer effect, and the same rule catches it; and a hook answering a question adjacent to the claim is worse than no hook, because it makes the row look grounded.
