### PR TITLE
Let a preset name part of a look, and a group derive whether it is shown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,12 @@ node tools/editor-check.mjs --mutate lanes-clear-siblings --no-render  # ... and
 node tools/editor-check.mjs --mutate plant-unswept-control --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate import-skips-normalise --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate import-saves-before-validating --no-render # ... and must FAIL
+node tools/editor-check.mjs --mutate picker-ignores-the-boxes --no-render # ... the subset a preset is written with
+node tools/editor-check.mjs --mutate readings-tick-alone --no-render   # ... and the five weights that move as one
+node tools/editor-check.mjs --mutate group-never-reveals --no-render      # ... a panel group is open because the clip says so
+node tools/editor-check.mjs --mutate reveal-ignores-tracks --no-render    # ... and a keyframe counts where the value does not
+node tools/editor-check.mjs --mutate detail-ignores-the-reading --no-render # ... the group that answers for another group's values
+node tools/editor-check.mjs --mutate override-prunes-only-on-toggle --no-render # ... and the override the document, not the toggle, has caught up with
 node tools/editor-check.mjs --mutate panel-row-skips-parameter --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate nav-at-the-foot --no-render       # ... and must FAIL
 node tools/editor-check.mjs --mutate orbit-pumps-on-change --no-render # ... and must FAIL
@@ -174,6 +180,9 @@ node tools/editor-check.mjs --mutate pause-keeps-resume --no-render   # ... and 
 node tools/editor-check.mjs --mutate bounds-compare-off-grid --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate detent-in-rate-units --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate zoom-pans-at-the-clamp --no-render # ... and must FAIL
+node tools/editor-check.mjs --mutate prune-ignores-movement --no-render # ... a stored collapse, against the boot it has to survive
+node tools/editor-check.mjs --mutate panel-rederives-per-write --no-render # ... and what the panel costs the render path
+node tools/editor-check.mjs --mutate envelope-unchecked --no-render     # ... the half of a preset document nothing used to read
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows
 node tools/monitor-check.mjs --mutate decimate-reaches-recorder  # ... and must FAIL mutated
 node tools/monitor-check.mjs --mutate bind-ignores-grid          # ... and must FAIL mutated

--- a/README.md
+++ b/README.md
@@ -316,27 +316,65 @@ else, so applying one never moves your camera.
 
 ### Presets
 
-A preset is a document: `{ version, values }`, one number per look parameter. The five
-that ship are served read-only from `presets-builtin/` beside your own library in
-`presets/`, and they are marked with a `·` in the picker.
+A preset is a document: `{ version, values }`, and the keys it names are its scope. The
+five that ship are served read-only from `presets-builtin/` beside your own library in
+`presets/`, and they are marked with a `·` in the picker. Each of them names the whole
+look tag, which is one shape a preset can take rather than the only one — "just my grain
+and bloom" is a document naming two values, and applying it leaves everything it does not
+name where the grade left it.
+
+Saving and exporting both ask which values go in, with every box ticked, so the gesture
+that existed before that dialog writes what it always wrote and a sparse preset is
+something you go out of your way to author. The boxes carry the same headings the panel
+uses and are derived from the registry rather than listed beside it, so a parameter added
+later appears under its own heading by existing. A second statement of which parameter
+sits under which heading is the copy that drifts, and it would drift silently, because a
+parameter missing from that dialog is not an error anywhere — it is a value you can no
+longer choose to leave out.
+
+**The five reading weights tick and untick together, and the format refuses the document
+that would otherwise be assembled.** A file naming any reading has to name all five,
+because the ones it leaves out do not arrive as anything: they stay at whatever the clip
+was already wearing, so two fifths of a blend renders as a mixture nobody authored and
+nothing on screen says it is a mixture. A file naming none of them is the other case and
+is not a hole in a look — it is a look that is not about the reading, so what is on screen
+afterwards is the blend whoever was grading had already chosen. That is `format.js`'s
+argument for refusing a version 3 document, asked again of a document that passes the
+version gate.
+
+**A preset that describes part of a look does not stamp the clip.** Applying one writes
+its values and leaves the provenance where it was, and saving one does the same, because
+the stamp answers "what look is this clip wearing" and a document that set three of the
+fifty-four look values did not answer it. Recording it as the clip's origin would put a
+set of clips on one revision of a look they agree about only in the three values that file
+happened to carry — the drift the stamp exists to make visible, arriving as something the
+stamp says itself. A whole look stamps exactly as it always did, and the two surfaces that
+report an apply say which of the two happened instead of printing a revision either way.
 
 **Saving over a shipped name forks it rather than overwriting it.** The write lands in
 your library and shadows the built-in; delete the fork and the shipped look comes back.
 So the five are starting points you cannot damage, and re-grading one in a later release
 reaches everybody rather than only people who had not run the program yet.
 
-`export` writes the look on screen — not the document the picker happens to name, which
-are the same thing only until you move a slider — as `<name>.braindance-preset.json`.
-`import` reads one back. The bytes are the document, so a look is something you can keep
-in a repository, mail to somebody, or edit in a text editor.
+`export` goes through that same dialog and writes the look on screen — not the document
+the picker happens to name, which are the same thing only until you move a slider — as
+`<name>.braindance-preset.json`. `import` reads one back. The bytes are the document, so a
+look is something you can keep in a repository, mail to somebody, or edit in a text
+editor — and it is one dialog rather than two because a subset you could put in your
+library and not into a file would be a document shape that exists on one side of the
+export and not the other.
 
 An imported file is checked against the registry before it is saved and applied only
 after, which is what makes that safe: a scalar carrying a string fails at the key that is
 wrong instead of writing a plausible-looking look, and a file carrying `__proto__` is
 refused as an unknown parameter — and neither ever reaches the library, because the
 refusal happens before the write rather than after it. A file is the one door into the program that nothing upstream validates, so
-nothing about it is taken on trust — `editor-check` section 9 drives the whole round trip
-in a browser, and `import-skips-normalise` is the mutation that must break it.
+nothing about it is taken on trust — `editor-check` section 12 drives the whole round trip
+in a browser, and `import-skips-normalise` is the mutation that must break it. The subset
+half of that round trip is driven there too, through the rendered controls rather than
+through the function behind them: `picker-ignores-the-boxes` writes the whole look tag
+whatever was ticked, and `readings-tick-alone` gives each reading weight a box of its own,
+which authors a file this program then refuses to read.
 
 Documents from before the readings landed are version 3 and will not open. The
 conversion is total and lossless, so it is a one-shot over files rather than a second

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -26,6 +26,36 @@ growth bound. When you write a proof tool, ask what a broken implementation woul
 to still pass it, and close that. **Every proof tool needs a falsification control**:
 something that must FAIL if the thing under test were not actually doing the work.
 
+### A rule with two terms, driven only through the term the code already handled
+
+The sharpest version of "an instrument must enforce its claims" yet, because the row was
+honest, the gesture was real, and the check was still blind by construction.
+
+The panel's store rule is a comparison: an override is kept where it disagrees with what the
+document derives, and dropped where the two agree. Two terms, and either can move. The check
+drove one of them — press a toggle to collapse a live group, press it again to reopen it,
+assert the entry is gone — and reported the rule holding. It did hold, on that path, because
+`toggleGroup` compares the two *at the instant of the press* and pressing back is the one
+gesture where they agree by construction. **The path the check drove was the only path that
+never needed the fix.** The other term moves without anybody pressing anything — a value set,
+a look applied, a project opened — and nothing in the section moved it, so a build whose prune
+lived entirely inside the toggle passed 22 assertions with a group pinned open over an empty
+document, and the comment beside that code claimed self-healing behaviour the code had never
+had.
+
+Two things generalise. **When a claim is a comparison, ask which side your fixture moves**, and
+write a row for each — a check that only ever changes the term the handler is written around is
+asserting the handler rather than the rule. And the tell was in the prose before it was in the
+behaviour: the section's own comment said the entry goes "the moment the derivation catches up",
+while every gesture under it moved the *override* and left the derivation alone. A sentence
+naming a term no arm touches is a hole with a label on it.
+
+`override-prunes-only-on-toggle` is the control, and it restores the pre-fix build exactly
+rather than breaking the feature some other way — the prune moves out of `refreshGroups` and
+back into `toggleGroup` in one edit. That matters for the reason the whole document keeps
+repeating: a mutation that also failed the toggle rows would redden a path this build gets
+right, and a control that fails everything cannot say which question it was asking.
+
 ### The passthrough row that hashed a served part against the set of served parts
 
 `vcam-check` section 2 claimed "the bytes served are the bytes emitted", with a comment above
@@ -138,6 +168,86 @@ accurate seek to the same moment on the worst of the forty tiles, where a seek o
 sits 4.48 — an eighteen-fold separation, and the claim row asks for a fourfold one.
 `release-seeks-past-target` is the control, and it moves that worst tile to 4.50.
 
+### A floor stated in the wrong units stops being able to fail when the selector under it widens
+
+`editor-check` section 1 sweeps the controls the editor renders and demands a driver for each,
+and the row under it is what stops that claim being satisfied by having nothing left to cover:
+`check(sweep.length > 60, 'and the sweep found the panel, not an empty page')`. It meant what it
+said for as long as everything the selector could reach was the strip or the panel.
+
+The preset subset dialog is a body-level `<dialog>`, so the sweep was widened to
+`dialog input, dialog select, dialog button, dialog a` — correctly, because a modal outside every
+observation is the deliberate exclusion this document already records costing three holes. That
+put 68 more controls inside the same count. **68 clears 60 on its own**, so from that commit a
+build whose panel had gone entirely would have passed a row whose entire sentence is that the
+panel was found, and passed it green, in a run with nothing else red. Measured either side: 160
+controls at the commit before, of which 131 were the panel; 228 after, of which 131 are still the
+panel and 68 are the dialog.
+
+**And the same failure has a second form, where the population does not grow but the thing being
+counted stops being the thing the sentence is about.** `sensor-view-check` section 6 asserted
+"and open on the editor, where grading is the job - 9 look groups, all 9 visible", counting group
+*nodes* through `checkVisibility`. Then the panel learned to collapse a group that the document
+says nothing is in — and collapse hides a group's **rows**, not the box around them, so the node
+goes on answering `true` with nothing gradeable underneath it. The row passed, correctly by its
+own arithmetic, on a recorder showing four of its nine look groups as a heading and a chevron.
+It was found by pressing `extended settings` on the recorder, which nothing else in the pass
+covered: every screenshot and every `editor-check` row is `/edit`, and a recorder has no clip, so
+every look parameter sits at its default and all four collapsible groups derive shut at once.
+
+The repair is to count the controls rather than the containers — `input, select` inside each
+block, hit-tested the same way — and to say which groups the collapse rule shut in the detail
+line, so the split between "hidden by the surface" and "collapsed by the document" is legible
+instead of averaged away. **A container is visible for a different reason than its contents
+are**, so a row about whether something is on screen has to name which of the two it means and
+count that one. Which groups collapse stays `editor-check` section 13's subject, because a
+collapse derived from the document is a different feature from a surface that hides the grade,
+and one row asserting both would go red for either.
+
+Nothing would have caught it. The row it protects — every control has a driver — went on working
+perfectly, because that one ranges over the same widened set and *should*; only the floor was
+stated in units of what the selector happened to return rather than in units of the thing it
+protects. The repair is one line, `sweep.filter((r) => r.groups.includes('#panel')).length > 60`,
+and it reports `131 of 228 controls are the panel's` so the two numbers stay visible.
+
+**When you widen what a count ranges over, re-read every threshold on that count against its own
+sentence.** A floor is denominated in the thing it is defending, and a selector is not. This is
+the vacuous-conjunction failure at the top of this document arriving from the other direction:
+there, a row compared a quantity against a set containing it; here, a row kept comparing the same
+quantity while the set underneath it grew a second population that satisfies the comparison alone.
+
+**And the repair for that second form arrived carrying the first failure this document names,
+which is the part worth reading twice.** The row that replaced it read
+`edFixed.length > 0 && edFixed.every((b) => b.controls > 0 && b.controlsOnScreen === b.controls)
+&& sum(edLook, 'controlsOnScreen') > 0` — and the last conjunct cannot fail while the one before
+it holds, since a group showing all of its controls with a positive control count *is* a positive
+sum. A vacuous conjunction, written into the change whose commit message cites the vacuous
+conjunction at the top of this file. The floor beside it was denominated wrongly in the same way
+the `sweep.length > 60` one was: `edFixed` is the look groups that do not declare `collapses`, so
+it narrows towards one as more of them do and would reach zero without a word, while the claim
+underneath it is about the grade being reachable at all.
+
+The repair is to partition rather than to floor. The look groups are split by the `shut` class
+the panel sets, every group the collapse rule leaves open has to show *all* of its controls,
+every group it has shut has to show none, and there has to be at least one of the first — which
+is checked from both sides, so a build marking everything shut fails the floor and one marking
+everything open fails the controls. **A conjunct earns its place by being able to fail while its
+neighbours hold**, and the cheapest way to find out is to ask what would have to break for that
+term alone to go red. The same row on the recorder had the weaker version of the same problem:
+`after.controlsOnScreen > before.controlsOnScreen` with the row above pinning `before` at zero,
+so "controls included" was graded at one control appearing anywhere on a surface with fifty of
+them, and it now asks the recorder's revealed groups exactly what the editor's row asks.
+
+Two smaller things from the same change, recorded because each is a rule already here landing
+somewhere new. The dialog's rule in `covered()` has to be tested **before** the panel's, since the
+panel rule matches any `#panel` checkbox and would have credited 54 dialog checkboxes to
+`registry-check`'s drop-one slider sweep, which has never heard of them — the misattribution the
+`DRIVER_RULES` re-keying was done to stop, reappearing as an ordering rather than as an index. And
+the row asserting that unticking a group heading takes its whole group out was first written as
+`after.length === before.length - off.length`, which is true by construction of a set difference:
+a row that cannot fail, in the middle of a section about rows that cannot fail. It reads the
+panel's own group out of the DOM now and requires the two groupings to be the same grouping.
+
 ## Mutation-test the instrument, don't just reason about it
 
 Deliberately break the thing under test, run the check, and confirm it fails on the
@@ -152,6 +262,35 @@ result, and it has now caught two flaws that reading the code did not:
 
 Report which mutations you ran and what each one caught. A check nobody has broken on purpose
 is a check nobody knows the sensitivity of.
+
+### A mutation that removes a precondition reddens the rows built on it, and that is the mutation working
+
+The rule above says to report which rows fired, and the rule two sections down says the next
+agent re-derives that set from scratch rather than trusting a docstring. Put together they make
+an undocumented extra red row read as a second defect to investigate — so a `Must redden` line
+that undercounts costs somebody a hunt for a bug that is not there.
+
+The shape that produces the undercount is always the same. A section builds a fixture with one
+gesture and then asserts several things about it; a mutation that destroys the *gesture*
+destroys the fixture, and every row standing on it goes red for a reason that is about the
+fixture rather than about that row's own claim. `editor-check`'s preset section has three
+mutations of exactly this shape and only one of them said so: `picker-ignores-the-boxes` was
+documented at two rows and fires three, `readings-tick-alone` at one and fires three, while
+`detail-ignores-the-reading` carried the sentence "three more go with it and they are the
+fixture rather than the claim" from the day it was written. Nothing was wrong with any of the
+three mutations. Two docstrings were wrong about them.
+
+So a `Must redden` line has two parts and needs both: **the rows carrying the claim, and the
+rows that redden because the mutation took their fixture away.** Naming the first without the
+second is not brevity, because the reader's job is to check the set they got against the set
+they were promised, and a promise that is a subset fails that check every time it is kept.
+
+The tell that a red row is a cascade rather than a finding is that it asserts about a state the
+section had to *establish* — a partial document, a live reading, a value planted off its
+default — and the mutation is what establishes it. Where the two cannot be told apart by
+reading, the discriminator is the same one this document keeps returning to: read the detail
+line, which prints the quantity, and ask whether it moved in the direction the mutation moves it
+or simply went absent.
 
 ### A mutation that does nothing reads as a check that found nothing
 
@@ -519,6 +658,55 @@ mutation was re-run rather than reasoned about and reddens both geometric rows, 
 the scrolling body: true` — which is what says it failed for its own reason rather than a
 neighbouring one.
 
+### A persistence row that went red because it had found the bug, and was re-polarised instead
+
+**This entry previously drew the opposite conclusion and was wrong. It is kept with the
+correction on it rather than replaced, because the wrong reading is the one that recurs.**
+
+`editor-check` 13i asks whether a collapsed panel group survives a reload. It shut `Reading ·
+detail` while a reading was live, reloaded, put the reading back, and read the group. It went
+red the round the override's prune moved into `refreshGroups`, reporting `shut=false, 7 of 7
+rows on screen`, as the only red row in the run.
+
+The reading taken at the time was that the row had become ambiguous. On a document at its
+defaults the group derives shut; the page boots *before* the reading goes back; so at the
+instant the store is read the stored `false` and the derived `false` agree, and an entry that
+agrees is indistinguishable from one that was forgotten. Every sentence of that is true, and
+the conclusion drawn from it — reverse the polarity to a group pinned *open* on a quiet
+document, which is a disagreement nothing can prune — does not follow, because **the row does
+not read its answer at that instant.** It puts the value back afterwards, and with the value
+back the two builds part company: the entry kept renders the group shut, the entry pruned
+renders it open. The row was discriminating, it was red, and the thing it had found was a real
+defect in the code the same change had just written — the prune comparing two terms for
+equality on the boot pass, where the derivation is not a statement about the document but about
+there not being one yet. Collapsing a group that was in use never survived a reload. Pinning
+one open always did, so re-polarising the row onto the pin moved it onto the one direction the
+defect cannot reach, and the suite went green over a shipped bug for a second round.
+
+Three things to carry, in the order they bite.
+
+**A row that goes red on a build you have just changed is evidence about the change first.**
+This is the same failure the review found in `library-check`'s route sweep and it has now cost
+two rounds here: the instrument was adjusted to accommodate the code rather than the code
+fixed, and the adjustment came with a written justification, which is what stopped anybody
+looking twice. Before re-polarising, re-weakening or re-siting a red row, work out what the
+build would have to be doing for it to be red, and check whether that is happening.
+
+**The general form is still sound; the answer to it was wrong.** *Ask what the page would do
+with the entry missing, and if the answer is the same thing, the row is not about the entry* —
+ask it of the moment the row **reads**, not of the moment the page boots. A fixture rebuilt
+after the reload is not automatically a tell that the row is reaching: here it is the step that
+creates the difference, because the stored opinion only becomes visible once the document
+disagrees with it again.
+
+**Both polarities are worth a row and they are not the same claim.** The pin proves an override
+survives a reload at all; the collapse proves nothing pruned it against a document that had not
+loaded yet. 13i drives both across one reload now, and its strongest row is neither of those —
+it reads `kinect.panelGroupsOpen` straight back after the reload and before anything touches
+the panel, which is the defect at its own scale rather than through its consequence.
+`prune-ignores-movement` is the control, restoring the equality comparison and reddening those
+two rows and no others.
+
 ### A probe that changes the state it samples proves whatever it did to it
 
 This is a distinct failure from the two above - not a probe in a dead zone and not a vacuous
@@ -786,6 +974,56 @@ different from grain that has not as grain that has thinned, so both grade mutat
 every difference-based threshold the sampling residual left room for. What catches them is a
 correlation: high-pass both images and correlate, and a structure quantised onto a shared
 reference grid correlates 0.94 where a continuously sampled one correlates 0.77.
+
+**A feature that serialises gestures makes every driver's press conditional, and the DOM
+observable for "the last one finished" is a task early.** The preset controls grew an
+in-flight guard, so a press landing while the previous gesture is still unwinding is
+correctly ignored — which turns four existing lines of `editor-check` from "click the
+button" into "click the button and hope". The wait that looks right is the one already
+beside them, `dialog.open === false`, and it is wrong by construction: `close()` clears
+`open` synchronously and fires its `close` event in a later task, and the promise the
+handler awaits settles from that event. So a driver can pass the wait, do a whole
+Node-side `fetch` round trip, and still press into a gesture that has not finished. It
+arrives as a ten-second `waitForFunction` timeout with **zero failed assertions** — a
+crash wearing the shape of a catch, which is the outcome this document already names
+twice. Measured once, at 238 of 274 on a mutation run whose own rows had not been reached.
+
+Two things to carry. **When a build learns to refuse a repeated gesture, every driver of
+that gesture becomes a race**, and the fix is not more waiting but waiting on the right
+thing: the guard's own state, published for the purpose, because nothing in the DOM is
+that state. And the repair goes to **all** the call sites rather than the one that failed
+— `openPicker` is now the only way this section presses either control, so the fifth
+gesture somebody adds inherits the wait by existing instead of by being remembered.
+
+**And it came back a round later at the other end: the guard was scoped to the controls
+that share the dialog rather than to the value it protects.** Its own docstring named the
+failure — "a second door added later would otherwise be a second way in with no guard on
+it" — and then listed two of the four doors onto `appliedPreset`. Press save, confirm, and
+apply a whole-look preset while the PUT is unanswered: the apply stamps first and the save
+lands on top of it with the older revision, which is the same corruption the guard exists
+to close arriving through a door outside it. **A guard named after a gesture drifts from
+the value it defends; ask which writes it, not which controls look alike.** The choice
+against the obvious alternative is worth recording too — a sequence number on the stamp
+would be a second gate agreeing with the first, and this document already has the entry
+about two gates that cannot be tested apart.
+
+Two things the fix needed that the shape did not make obvious. The guard belongs on the
+**handlers** and not inside `applyStoredPreset`, because that function and `restoreProject`
+beside it are exposed raw for the proof tools to drive, and a guard pushed down there
+starts silently dropping calls that are not gestures. And each door keeps **its own
+`catch`**: the recorder's apply writes `ui.recLookNote` deliberately, since
+`showTimelineError` targets a strip that surface does not show, so a shared catch in the
+wrapper would move that sentence somewhere nobody can see it.
+
+**The same guard stranded the caret its comment said it preserved**, which is the smaller
+half and the one a row can hold. `pickPresetSubset` hands focus to the control that opened
+the dialog on the `close` event and resolves in the same breath, so the button is holding
+the caret when the write span disables that same button a microtask later — which blurs it
+onto the body, and re-enabling does not undo that. The comment argued that the narrow span
+avoided exactly this, and the ordering made it false. Measuring it needs the driver
+changed as well: a programmatic `element.click()` leaves the caret on the body, where a
+build that stranded it and a build that never had it read identically, so `openPicker`
+focuses before it clicks.
 
 **A contended machine fails a check in a way that reads as a finding.** Two worktrees running
 proof tools at once produced four failed runs, and the quiet one is the dangerous one: under

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -130,6 +130,18 @@ per frame, each of which renders a pre-roll which evaluates, so the page never a
 never errors - it runs out of memory some minutes later, somewhere else. A bounded probe turns
 that into a sentence.
 
+**Its section 6e stands on something nobody wrote down until it nearly broke.** The two
+`page.click('.kf[aria-label="bloom keyframe"]')` calls need that diamond *visible*, and `bloom`
+lives in the `optical` panel group, which collapses when every parameter in it is at its
+default. They work only because 6e applies the Blackwall look first and that look moves `bloom`,
+`rgbSplit`, `scanlines` and `grain` off their defaults, so the group has derived itself open by
+the time the click lands. Nothing in either file says so, and the two ends can move
+independently: a look re-graded to leave `optical` alone, or a change to the reveal predicate,
+turns those clicks into thirty-second timeouts - which arrive as a crash with **zero failed
+assertions**, the shape this repo has twice recorded being written down as a bug found. If you
+touch either end, run `keyframe-check`; `editor-check` section 13c is the row that grades the
+mechanism itself.
+
 **`jobs-check`** spawns its own server and renders two real jobs through
 `tools/render-worker.mjs`, so it needs a GPU browser and ffprobe. `--no-render` drops both rows
 and says so - the queue rows are seconds, each render is about a minute.
@@ -390,10 +402,121 @@ and the two misses are recorded in the file** because each was NOT CAUGHT agains
 a fix removed: the rule they named had been made redundant by the two-row bar, which is worth
 knowing about the fix as well as about the check.
 
+**That sweep reaches into `<dialog>` as well as the strip and the panel, and what an uncovered
+control means depends on knowing it.** The selector names the element rather than any dialog's
+id, so a modal added later is asked about by existing rather than sitting outside every
+observation — which is what a body-level `<dialog>` does by default, since it is a sibling of
+`#panel` and not a descendant. **The load-bearing part is not visible from the selector: the
+dialog's rule is tested *ahead* of the panel's inside `covered()`.** The panel rule matches any
+checkbox under `#panel` and credits it to `registry-check`'s drop-one sweep, which drives
+sliders and knows nothing about a preset dialog, so the two rules in the other order hand the
+dialog's 54 checkboxes to a driver that never touches them and section 1 goes green over an
+untested surface. That is the misattribution the `DRIVER_RULES` array was re-keyed to prevent,
+arriving as an ordering rather than as an index. A row that reddens for a control inside a
+dialog is therefore a coverage failure like any other and not an artifact of the widening.
+
 Its `nav-at-the-foot` mutation is the control for section 1's second claim, that the way out of
 the editor is *reachable* rather than merely present. Its own two flaws — a probe in a dead zone
 and a probe that moved the page it measured — are in `docs/instruments.md`, because both are
 instances of rules that were already written down.
+
+**Section 13 grades a feature whose whole design is that it stores almost nothing**, and its
+five controls exist because most of the ways it can be wrong are invisible from the panel.
+Whether a parameter group is open is derived — a group is open when any parameter in it carries
+keyframes or holds a value off its own default — and the only thing written down is a person
+disagreeing with that, in `localStorage` under `kinect.panelGroupsOpen`, deleted again the
+moment the derivation catches up with them.
+
+- **`group-never-reveals`** is the falsification control for the derived half: the predicate
+  answers "nobody has been here" whatever the document holds, so a group carrying live values
+  renders shut. It reddens **14 rows** and the shape of that set is what to read. The rows that
+  move a value, key a parameter or move a reading and expect the group to open carry the claim.
+  **The mark rows go red with them, and that is correct rather than collateral** — the mark is
+  keyed on the same rule the open state is, so a build that cannot tell whether a group is in
+  use cannot mark it as in use either. This document said the opposite for a while, describing
+  an abandoned draft that widened the mark to a condition of its own; those rows stayed green
+  under it, which read as precision and was really the second rule covering for the first. The
+  two store rows in 13f-bis go red as well, because both halves of the store rule are
+  comparisons against a derivation this build has frozen. What stays green is the toggle itself
+  — it still presses, the rows still hide and show — and the count on a shut header, which
+  walks `paramTouched` rather than this predicate. 13i's three go red for the reason one step
+  further out: that block needs a group that is genuinely in use and then shut, and on a build
+  where nothing is ever in use that fixture cannot be built at all. Its pinned-open half stays
+  green, which is what says the three are about the predicate rather than about reloading.
+- **`override-prunes-only-on-toggle`** is the control for the *stored* half, and it exists
+  because that half had none. `toggleGroup` compares what a person asked for against what the
+  document derives at the instant of the press, so pressing a toggle back is the one gesture
+  where the two agree by construction — and 13f pressed exactly that, then reported the whole
+  rule. The term that moves afterwards is the derivation, and nothing drove it: a group pinned
+  open while quiet stayed open forever with nothing in it, through a green section. This
+  mutation restores the pre-fix build exactly — the prune comes out of `refreshGroups` and goes
+  back into `toggleGroup` in one edit — so the toggle path keeps working and only 13f-bis's two
+  rows go red. A break that also failed 13f would not say which question was being asked.
+- **`prune-ignores-movement`** is the other half of the same control set, and it restores the
+  build the first attempt at that prune shipped: the comparison stays where it is and loses only
+  its condition that one of the two terms has *moved*. That condition is what the state a page
+  boots into needs. Before the take is open every look parameter sits at its default and there
+  are no tracks, so the derivation answers `false` for every group — a statement about there
+  being no document yet rather than about the document — and a build pruning on agreement alone
+  deletes every stored collapse on its way past that reading and writes the pruned map back. It
+  fails one-directionally and in the direction people use: a pin stores `true` against a derived
+  `false`, which is a disagreement at boot and survives, while a collapse stores `false` against
+  the same `false` and does not. It reddens **2 rows**, both in 13i, and the pin row beside them
+  stays green — a control that reddened both could not say which of the two it was asking about.
+- **`panel-rederives-per-write`** is the control for 13k, which is the one cost row in this file.
+  It takes the gate off in both places it lives, which between them are the build from before it
+  existed: `params.set` announces every write to the panel unconditionally again, and
+  `withoutRepaint` stops asking once on the way out. Both edits or neither — removing only the
+  condition would leave the `finally` asking as well, at one pass per frame more than any build
+  that ever shipped, and the arm would then be about a build nobody has. Measured, two rounds per
+  arm: **1.00 re-derivation per rendered frame at four keyed parameters and 1.00 at eight, against
+  4.00 and 8.00 mutated.** Those exact figures are what say the arm is the pre-gate build rather
+  than the condition alone, since the latter would answer 9 at eight keys.
+- **`reveal-ignores-tracks`** drops the keyframe term alone, and it is the one worth reading
+  twice. A parameter that is keyed *and* off its default opens the group either way, so this
+  mutation is invisible to every other row in the section: the fixture has to plant a track
+  whose keys are all at the parameter's own default, and assert the parked value really is
+  there, before the row means anything. Without the term the groups breathe open and shut as
+  the playhead crosses a curve's default, because the evaluator writes through `params.set` and
+  `params.get` therefore answers the evaluated value.
+- **`detail-ignores-the-reading`** puts `Reading · detail` back onto the default rule. It takes
+  the *reading* terms out of that group's closure and leaves `revealsItself('detail')` standing,
+  so tuning a parameter inside the group still opens it exactly as before — the loss is narrower
+  than this document once claimed, and precisely so: the group's seven parameters sit at the
+  shader literals they replaced, so on the default rule alone it stays shut whichever reading is
+  live, which is the one case its closure exists for. It reddens **three rows**; the first
+  carries the claim and the two below it are the fixture saying it could not establish a live
+  `detail` to test the store rule against. It was four until 13i stopped needing a `detail` that a
+  reading had opened: that block pins `detail` open while it is *quiet* now, which is a
+  disagreement whether or not the closure reads the readings.
+
+Two things about the section that are not obvious from reading it. **It reloads the page rather
+than opening a second one**, because `page.route` is installed per page — a second page would
+take the tree's own `main.js` and put two builds inside one measurement. That reload carries both
+polarities at once and they are not the same claim: the pin proves an override survives a reload
+at all, the collapse proves nothing pruned it against a document that had not loaded yet, and the
+row between them reads `kinect.panelGroupsOpen` straight back before anything touches the panel.
+`docs/instruments.md` carries why that row was once re-polarised onto the pin alone and why that
+was the wrong call. And **every press is conditional on the state the group is actually in**: under `group-never-reveals` every group is
+already shut, so a blind "press to collapse" would open one instead and the row would fail for a
+reason that has nothing to do with the mutation.
+
+**The rows are hidden with CSS and never removed from the document**, which is what keeps the
+panel checkable at all: section 1 counts a control per registry parameter with a plain
+`querySelectorAll`, blind to visibility by construction, so a build that collapsed by rebuilding
+the panel would pass every row above it and quietly stop being the registry. Each row in section
+13 reads the count in the document beside the count on the screen for that reason. The same rule
+is why `framing` is not collapsible and why section 13 spends an assertion saying so: its
+`after()` emits `#cropReset`, section 8 clicks it, and Playwright's click waits for visibility —
+so a collapsible `framing` turns a row eight sections back into a thirty-second timeout, which
+arrives as a crash carrying no failed assertion rather than as a finding.
+
+**`keyframe-check` depends on this feature without mentioning it.** Its section 6e clicks
+`.kf[aria-label="bloom keyframe"]`, `bloom` is in the `optical` group, and that click needs the
+group open. It works because 6e applies the Blackwall look first, which moves `bloom`, `rgbSplit`,
+`scanlines` and `grain` off their defaults — so the per-write refresh that opens a group is
+load-bearing for another tool's actionability and not only for the panel looking right. Run
+`keyframe-check` after touching the predicate.
 
 **`vendor-check` reads the built artifact as well as the source.** Sections 1-4 prove
 `third_party/` is upstream plus the declared edits; section 5 asserts the library actually
@@ -407,6 +530,19 @@ builds from upstream's own registration.cpp, rather than a doctored copy of ours
 FAIL. **What is still source-only is the sub-9 fix**, whose `& 0x1ff` compiles to an immediate
 and leaves nothing in the binary to look for; the tool says so rather than implying it covers
 both. Exit 2 where no prefix exists.
+
+**`sensor-view-check` exits 2 on a machine with no sensor attached, and that is the tool
+working rather than a regression** — worth writing down because it reads like one. Its section 5
+arm waits for `uniforms.focal.value.x !== 366`, which is a hello arriving over the socket, so a
+server whose grabber will not spawn leaves the boot default standing and the wait times out at
+25s. The tool answers `untested` and says "no sensor, no claim" instead of failing, which is the
+right reading and still exits 2. Everything else in the file runs: **section 6 is the only arm
+in the suite pointed at the recorder's panel** — 20 blocks, 54 parameters on both surfaces, the
+nine look groups hidden and then revealed by `extended settings` — so a change to the panel is
+still graded on both surfaces on a sensorless rig, and that section is what to read. One row in
+section 3 goes red there for a second environmental reason: it needs **two or more takes** with
+a hello to say that the library cannot tell a computed angle from a constant, and a `captures/`
+holding only `sample.knct` reports `1 takes`.
 
 **`level-check` needs no sensor and no capture, and that is a claim about what it can grade
 rather than a convenience.** It writes analytic planes — `z = c / (u . n)` along each pixel's

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -153,8 +153,13 @@ const MUTATIONS = {
   // second copy of `import-skips-normalise`, which removes validation altogether and
   // therefore reddens the note rows instead.
   //
-  // Must redden: section 9's "a refused file never reaches the library", and that row
-  // alone.
+  // Must redden: the two rows that ask the store after a refusal - "a refused file never
+  // reaches the library" for the malformed one, and the same question asked of the file
+  // carrying a stray top-level key. Both, and only those. The second arrived with the
+  // envelope check and is the same claim at a second door rather than a cascade: this
+  // mutation moves the refusal after the PUT for every refused file at once, so a row
+  // that asks the store about any of them has to notice. Measured: `caught, as required
+  // (2 assertions fired)`.
   // The second anchor is the whole three-line tail rather than the `res.json()` line it
   // used to name: that line appears four times in `main.js` and the tool refused the
   // mutation outright, which is the refusal doing its job and worth not weakening.
@@ -172,6 +177,295 @@ const MUTATIONS = {
         + '  applyStoredPreset({ name: saved.name, rev: saved.rev, body });',
       ],
     ],
+  },
+
+  // The control for section 12's subset rows, and it is the shape the feature had
+  // before the dialog existed rather than an invention: a preset is the whole look tag
+  // whatever anybody ticked. The boxes still tick, the headings still go
+  // indeterminate, the count still counts - everything you can see about the dialog is
+  // correct - and the document written behind it names all fifty-odd values. That is
+  // the reason it anchors on the *answer* rather than on either writer: one edit takes
+  // the save and the export together, which is the class, where mutating the export's
+  // own call would leave a build whose library and whose files disagree about what a
+  // preset can be and would still pass the save half by never being asked.
+  //
+  // Must redden: **five rows - two claims, one at each door, and three standing on the
+  // fixture the mutation destroys.** The claims are the row reading the exported
+  // document's keys and the row reading what the *save* put in the library: both ask
+  // whether what came out is what was left ticked, and they are separate rows because
+  // they are separate writers over one picker. The three that follow are provenance rows,
+  // and they go red for a reason about the fixture rather than about themselves - a
+  // picker ignoring the boxes writes the *whole* look, so the sparse document those rows
+  // exist to reason about no longer exists, the import stamps the clip, the apply note
+  // names a revision, and the save moves the stamp it should have left alone. None is a
+  // second defect. `detail-ignores-the-reading` below has the identical shape and has
+  // always said so; this said "the two rows that read the exported document's keys" and
+  // undercounted, which under this suite's rule that the next agent re-derives the fired
+  // set from scratch reads as a bug to chase. Measured, settled machine, 278 assertions:
+  // `caught, as required (5 assertions fired)`.
+  //
+  // The rows about what the dialog offers and how it ticks stay green, deliberately -
+  // they are about the control and this mutation does not touch it.
+  'picker-ignores-the-boxes': {
+    file: 'web/main.js',
+    edits: [[
+      '      picked = { name: chosen, names: presetPickNames() };',
+      "      picked = { name: chosen, names: params.names('look') };",
+    ]],
+  },
+
+  // The reading rule, put back to the state a per-parameter checkbox has by default:
+  // each box writes itself and nothing else, so unticking `depth` authors a document
+  // naming four of the five weights. It is the sharper half of the same claim the
+  // format makes - `refusePresetBody` refuses that file on the way back in, so a build
+  // with this mutation lets you assemble a preset it will then refuse to read, and the
+  // gesture is only discovered to be impossible after it is finished.
+  //
+  // Must redden: **three rows - two claims and one that stands on what they broke.** The
+  // control's own row is the first: untick one weight and count what came off with it.
+  // The second is the format's opinion of the document that came out, which is a claim of
+  // its own rather than a cascade and is why that row exists at all - a file naming four
+  // of the five weights is exactly what `refusePresetBody` refuses, so the import is
+  // refused and the row reading the note says so. The third follows from the second
+  // mechanically: with the import refused the sparse document was never written, so the
+  // apply pointed at it comes back "could not apply" and the row asking what the note
+  // says goes red about a preset that does not exist. That one is the fixture, not a
+  // finding. Measured on an idle machine: `caught, as required (3 assertions fired)`,
+  // against a docstring that had promised one.
+  'readings-tick-alone': {
+    file: 'web/main.js',
+    edits: [[
+      '  for (const n of (PARAMS[name].reading ? READINGS : [name])) presetPickBoxes.get(n).checked = on;',
+      '  presetPickBoxes.get(name).checked = on;',
+    ]],
+  },
+
+  // The falsification control for the derived half of section 13: every collapsible
+  // group answers "nobody has been here" whatever the document holds, so a group
+  // carrying live values renders shut and stays shut.
+  //
+  // Written as a branch at the head of the predicate rather than as `return false` in
+  // place of its body, because the body is what the second control below edits and two
+  // mutations rewriting one region cannot both be anchored. `key` is always a truthy
+  // string here - every caller passes a group key - so the branch is unconditional in
+  // practice while leaving the loop underneath it intact and readable.
+  //
+  // Must redden: 14 rows, and the shape of that set is the thing to read rather than the
+  // count. The three carrying the claim are the ones that move a value, key a parameter,
+  // or move a reading and expect the group to open. **The mark rows go with them**, and
+  // that is right rather than collateral: the mark is keyed on the same rule the open
+  // state is, so a build that cannot tell whether a group is in use cannot mark it as in
+  // use either. An earlier draft widened the mark to a condition of its own and those
+  // rows stayed green here, which read as precision and was really the second rule
+  // covering for the first.
+  //
+  // **The store rows go with them too, for the same reason one link further out.** Both
+  // halves of the store rule are comparisons against the derivation - an entry is written
+  // where it disagrees and pruned where the document has caught up - so a predicate that
+  // answers `false` whatever the document holds makes the second comparison unreachable
+  // and the first one always true. On this build a group pinned open is never overtaken,
+  // so it never decays and never shuts again, and 13f-bis's two claim rows say so. They
+  // are the decay's own claim rather than a cascade, which is why the precondition row
+  // above them - that pinning a quiet group open is a disagreement at all - stays green
+  // and is what says the fixture was built.
+  //
+  // **And 13i's three go with them, for the reason one step further out still.** That
+  // block needs a group that is *in use* and then shut, which is the disagreement a person
+  // actually forms - and on a build where nothing is ever in use, that fixture cannot be
+  // built at all: the group is already shut, the conditional press does nothing, and no
+  // override is written. Its precondition row says so, and the two rows across the reload
+  // go with it. The pinned-open half of the same block stays green throughout, because
+  // pinning a quiet group open is a disagreement on this build too - which is what says
+  // these three are about the predicate rather than about reloading.
+  //
+  // It reddened one more for one round, and that one was a leak rather than a finding:
+  // 13f-bis left `optical` pinned open on this build, and 13g four rows later asks every
+  // collapsible group but `detail` to be shut. The block puts the pin back now, so this
+  // control fails rows about the predicate and none about a neighbour's fixture.
+  //
+  // The rows that stay green are the ones about the toggle itself - it still presses, and
+  // the rows still hide and show - and the count on a shut header, which walks
+  // `paramTouched` rather than this predicate. That is what says this mutation is about
+  // the predicate and not about the panel having stopped working.
+  'group-never-reveals': {
+    file: 'web/main.js',
+    edits: [[
+      'function revealsItself(key) {\n  return (panelGroupParams.get(key) ?? []).some(paramTouched);',
+      'function revealsItself(key) {\n  if (key) return false;\n  return (panelGroupParams.get(key) ?? []).some(paramTouched);',
+    ]],
+  },
+
+  // The control for the keyframe term, and it is the whole reason that term exists.
+  // The evidence test keeps its value half and loses its track half, so a group whose
+  // only evidence is a keyed parameter sitting on its own default at the parked frame
+  // reads as untouched and stays shut - which is the state the panel would be in for
+  // every frame a curve happens to cross its default, and a group that breathes open and
+  // shut under a moving playhead is unreadable while anything is playing.
+  //
+  // It edits `paramTouched`, which is the one place that test lives, so the count on a
+  // shut header loses the same half with it. That is the honest shape of this bug rather
+  // than a widening: a build that had never learned to read a track would not read one
+  // for the mark either. It reddens no mark row all the same, because every mark row
+  // here is set up with a value off its default rather than with a key.
+  //
+  // The sharper half is that this mutation is invisible to every other row here: a
+  // parameter that is keyed *and* off its default opens the group either way, so the
+  // section has to plant a track whose keys are all at the default and assert the value
+  // really is there before the row means anything.
+  //
+  // Must redden: the keyed-at-default row, and that row alone.
+  'reveal-ignores-tracks': {
+    file: 'web/main.js',
+    edits: [[
+      '  if ((tracks.get(name)?.keys.length ?? 0) > 0) return true;\n'
+      + '  return params.get(name) !== groupDefaults.get(name);',
+      '  return params.get(name) !== groupDefaults.get(name);',
+    ]],
+  },
+
+  // The third control, and it takes the widening off the one group that has one.
+  // `Reading · detail` keeps its own parameters and loses the readings, which is the
+  // state the feature has with no `reveals` at all - and because its seven parameters
+  // sit at the shader literals they replaced, that means the group stays shut whichever
+  // reading is live. A build with this mutation is not obviously broken from the panel:
+  // three groups open and close correctly, this one opens correctly when you tune
+  // something inside it, and the only thing missing is the case its closure exists for.
+  //
+  // It is the *narrowing* direction on purpose. The opposite defect - a closure that
+  // replaced the default rule instead of widening it - is caught by 13c-bis rather than
+  // by a mutation, because that row is the one place the two spellings differ and it
+  // fails on any build that drops the self term.
+  //
+  // Must redden: the row that moves a reading and expects `detail` to open, which is the
+  // row carrying the claim. Two more go with it and they are the fixture rather than the
+  // claim - a `detail` that cannot be made live by a reading is a `detail` the store-rule
+  // rows below it have nothing to establish their state on, so they measure a group in
+  // the wrong condition and say so. It used to redden a fourth in 13i, which asserted
+  // about a `detail` that a reading had opened; that block pins `detail` open while it is
+  // *quiet* now, which is a disagreement whether or not the closure reads the readings, so
+  // a narrowing here no longer decides what the reloaded page shows. The rows about the
+  // other three groups stay green throughout, which is what says this control is about
+  // the closure and not about the predicate under it.
+  'detail-ignores-the-reading': {
+    file: 'web/main.js',
+    edits: [[
+      "    reveals: () => revealsItself('detail') || revealsItself('source') || revealsItself('treatment'),",
+      "    reveals: () => revealsItself('detail'),",
+    ]],
+  },
+
+  // The store rule's own control, and the reason it exists is that the section did not
+  // have one and could not have noticed. 13f pressed a toggle, pressed it back, and
+  // reported that an override agreeing with the derivation stops existing - which is a
+  // true sentence about the only path that never needed the fix. `toggleGroup` compares
+  // the two terms at the moment of the press, so re-pressing is the one gesture where
+  // they agree by construction. The term that actually moves afterwards is the
+  // *derivation*, and nothing drove that: a value set, a look applied, a project opened
+  // never touched the store, so a group pinned open while quiet stayed open forever with
+  // nothing in it and 22 assertions in the section went green over it.
+  //
+  // This mutation is the pre-fix build restored exactly rather than a break invented for
+  // the occasion, which is what makes it say something: the prune comes out of
+  // `refreshGroups` and goes back into `toggleGroup` in the same edit, so the toggle path
+  // keeps working perfectly. A build that only removed the first half would also fail
+  // 13f, and a control that reddens the rows a working feature would pass cannot say
+  // which question it was asking.
+  //
+  // Must redden: 2 rows, both in 13f-bis, and no others. The one that reads the store
+  // after a value moves into the group, and the one that resets the look afterwards and
+  // finds the group still pinned open with nothing inside it. 13f above stays green,
+  // which is the whole point - it is the path this mutation leaves intact - and so does
+  // 13f-bis's own first row, because pinning a quiet group open is a disagreement on
+  // either build.
+  'override-prunes-only-on-toggle': {
+    file: 'web/main.js',
+    edits: [
+      [
+        '    const pair = `${want}/${inUse}`;\n'
+        + '    const settled = groupSeen.get(key);\n'
+        + '    if (settled !== undefined && settled !== pair && want === inUse) {\n'
+        + '      groupOverride.delete(key);\n'
+        + '      groupOverrideDirty = true;\n'
+        + '    }\n'
+        + '    groupSeen.set(key, `${groupOverride.get(key)}/${inUse}`);\n',
+        '',
+      ],
+      [
+        '  groupOverride.set(key, !groupIsOpen(entry.group));\n',
+        '  const want = !groupIsOpen(entry.group);\n'
+        + '  if (want === groupRevealed(entry.group)) groupOverride.delete(key);\n'
+        + '  else groupOverride.set(key, want);\n',
+      ],
+    ],
+  },
+
+  // The other half of the store rule's control set, and it restores the build the *first*
+  // attempt at the prune shipped rather than a break invented for the occasion: the
+  // comparison of the two terms stays where it is and loses only its condition that one
+  // of them has moved.
+  //
+  // That condition is what the state a page boots into needs. Before the take is open
+  // every look parameter sits at its default and `tracks` is empty, so the derivation
+  // answers `false` for every group - a statement about there being no document yet
+  // rather than about the document - and a build pruning on agreement alone deletes every
+  // stored collapse on its way past that reading, then lets the take load and derive the
+  // group open again. It is one-directional and it fails in the direction people use: a
+  // pin stores `true` against a derived `false`, which is a disagreement at boot and
+  // survives, while a collapse stores `false` against the same `false` and does not.
+  //
+  // Must redden: 2 rows, both in 13i, and no others. The one that reads the store back
+  // after the reload and finds the collapse gone, and the one that puts the value back and
+  // finds the group open. 13i's pin row stays green on this build, which is the whole
+  // point - it is the direction this defect cannot touch, and a control that reddens both
+  // could not say which of the two was being asked about. 13f and 13f-bis stay green as
+  // well, because pruning *more* eagerly is still pruning where those rows press.
+  'prune-ignores-movement': {
+    file: 'web/main.js',
+    edits: [[
+      '    if (settled !== undefined && settled !== pair && want === inUse) {\n',
+      '    if (want === inUse) {\n',
+    ]],
+  },
+
+  // The gate on the panel's re-derivation, taken off in the two places it lives, which
+  // between them are the build from before it existed. `params.set` announces every write
+  // to the panel unconditionally again, and `withoutRepaint` stops asking once on the way
+  // out - so the evaluator's per-frame bulk write costs one re-derivation per keyed
+  // parameter instead of one for the whole write.
+  //
+  // Both edits or neither, and that is what makes the arm measurable rather than
+  // approximate. Removing only the condition would leave the `finally` asking as well, at
+  // one more pass per frame than the build this restores, and the figure would then be
+  // about a build nobody ever shipped.
+  //
+  // Must redden: 13k's cost row, and that row alone. Nothing else in the file counts
+  // re-derivations, and the panel goes on deriving correctly - this is a mutation about
+  // what a feature costs rather than about whether it works, which is the only kind of
+  // mutation a performance row can have.
+  'panel-rederives-per-write': {
+    file: 'web/main.js',
+    edits: [
+      ['    if (!transportWriting) groupRevealChanged();\n', '    groupRevealChanged();\n'],
+      ['    if (!outer) groupRevealChanged();\n', ''],
+    ],
+  },
+
+  // The envelope check, removed while everything inside `values` goes on being validated.
+  // A version 3 document's `mode` field then walks straight through: it is semantically
+  // active in the version it belongs to, the file's author believes this build reads it,
+  // and answering that file with silence is the failure the version gate one line above
+  // exists to prevent arriving through the one part of the document nobody was reading.
+  //
+  // Must redden: 2 rows, both about the stray key - that it is refused by name, and that
+  // it never became a document. The `__proto__` row is untouched on purpose and is what
+  // says this mutation is about the envelope: that fixture puts its key inside `values`,
+  // where the registry walk refuses it on either build.
+  'envelope-unchecked': {
+    file: 'web/main.js',
+    edits: [[
+      '  const stray = Object.keys(body).filter((k) => !PRESET_KEYS.includes(k));\n',
+      '  const stray = [];\n',
+    ]],
   },
 
   'plant-unswept-control': {
@@ -956,6 +1250,31 @@ const DRIVER_RULES = [
     match: (el) => el.closest('#navRow'),
   },
   {
+    key: 'subset',
+    what: 'a control in the dialog that asks which look values a preset carries',
+    // Named because section 12 drives it end to end - it opens the dialog from export,
+    // reads what it offers against the registry, unticks a heading and a reading,
+    // confirms, and reads the keys of the file the browser wrote - and because it
+    // presses cancel and asserts nothing was written. A rule naming a control nobody
+    // touches is the coverage claim this section exists to refuse.
+    by: 'section 12 opens it from export and from save, unticks, confirms, cancels, '
+      + 'and reads the document that came out',
+    match: (el) => el.closest('#presetPick'),
+  },
+  {
+    key: 'groupreveal',
+    what: 'the control that shuts or opens a panel group',
+    // Named because section 13 enumerates them off the page and presses every one it
+    // finds, rather than pressing the four that exist today. That distinction is the
+    // whole value of the rule: a group gains a toggle by declaring `collapses` in
+    // `PANEL_GROUPS`, so a fifth one appears here without anybody editing this file,
+    // and a rule crediting a control no section drives is `plant-unswept-control`
+    // wearing a rule's clothes.
+    by: 'section 13 reads every collapsible group off the page, presses each one, and '
+      + 'asserts the rows under it changed visibility',
+    match: (el) => Boolean(el.dataset?.groupToggle),
+  },
+  {
     key: 'output',
     what: 'a program-out control',
     // Named because it is driven, not because it is exempt. `vcam-check` section 5
@@ -1153,16 +1472,29 @@ try {
     // head, and a selector naming only the form controls would have watched them
     // leave the sweep rather than fail - the "passes by disappearing" shape this
     // file's own section 1 exists to refuse.
+    // Dialogs are in the list by element rather than by id, which is the difference
+    // between covering the one this editor has and covering the ones it grows. A modal
+    // is in neither `.tbar` nor `#panel` - it is a child of the body - so a selector
+    // naming only those two watches every control inside one escape the sweep while
+    // reporting a clean row, which is the deliberate-exclusion shape `docs/instruments.md`
+    // records costing three separate holes.
     const els = [...document.querySelectorAll('.tbar input, .tbar select, .tbar button, .tbar a, '
-      + '#panel input, #panel select, #panel button, #panel a')];
+      + '#panel input, #panel select, #panel button, #panel a, '
+      + 'dialog input, dialog select, dialog button, dialog a')];
     return els.map((el) => ({
       id: el.id || null,
       tag: el.tagName,
       type: el.type || null,
       ease: el.dataset ? el.dataset.ease ?? null : null,
+      // Serialised for the same reason `ease` above is: attribution happens out here
+      // on these fields alone, so a rule that wanted to recognise a group toggle by
+      // its class or by a `closest()` would have nothing to recognise it with. The
+      // group key rather than a boolean, so the row below can say which group had no
+      // driver instead of saying that one of them did not.
+      groupToggle: el.dataset ? el.dataset.groupToggle || null : null,
       inTbar: Boolean(el.closest('.tbar')),
       groups: ['#panel', '#cameraGroup', '#navRow', '#recordGroup', '#recLookGroup',
-        '#sensorGroup', '#monitorGroup', '#extendedRow', '#programOutGroup']
+        '#sensorGroup', '#monitorGroup', '#extendedRow', '#programOutGroup', '#presetPick']
         .filter((g) => el.closest(g)),
       kf: el.classList.contains('kf'),
       label: (el.getAttribute('aria-label') || el.textContent || '').trim().slice(0, 24),
@@ -1175,6 +1507,20 @@ try {
     if (row.id && DRIVER_IDS[row.id]) return `named: ${DRIVER_IDS[row.id]}`;
     if (row.ease) return 'rule: an ease preset, section 5 presses all five';
     if (row.kf && row.id !== 'tRateKey') return RULE.keyframe;
+    // Ahead of the panel rule below rather than beside it. The dialog's fifty-odd
+    // checkboxes are the same element type as the panel's step parameters, and the
+    // panel rule credits any checkbox it matches to registry-check's drop-one sweep -
+    // which drives sliders and has never heard of this dialog. A control attributed to
+    // a driver that does not touch it is a green row over an untested surface, which
+    // is the misattribution this array was re-keyed to stop.
+    if (inGroup(row, '#presetPick')) return RULE.subset;
+    // Ahead of the panel rule for the same reason the dialog is: a group toggle sits
+    // inside `#panel`, and while it is a button rather than a range or a checkbox the
+    // panel rule below would not reach it today, that rule is one edit from widening.
+    // Attributed on what the element declares about itself rather than on where it
+    // happens to sit, which is what lets a toggle keep its driver if the panel is ever
+    // rearranged around it.
+    if (row.groupToggle) return RULE.groupreveal;
     if (inGroup(row, '#recordGroup', '#recLookGroup', '#sensorGroup', '#monitorGroup', '#extendedRow')) return RULE.recorder;
     if (inGroup(row, '#programOutGroup')) return RULE.output;
     if (inGroup(row, '#cameraGroup') || row.id === 'camSensor') return RULE.camera;
@@ -1184,8 +1530,14 @@ try {
   };
 
   const unknown = sweep.filter((row) => !covered(row));
+  // Counted in three places rather than two, because the third arrived and the line
+  // went on saying "in the panel" about sixty-odd controls in a modal - a diagnostic
+  // that names the wrong surface is how a reader stops being able to tell a sweep that
+  // grew from one that moved.
+  const inDialog = sweep.filter((r) => r.groups.includes('#presetPick')).length;
+  const inTbar = sweep.filter((r) => r.inTbar).length;
   note(`${sweep.length} interactive controls on the editor`,
-    `${sweep.filter((r) => r.inTbar).length} in the strip, ${sweep.length - sweep.filter((r) => r.inTbar).length} in the panel`);
+    `${inTbar} in the strip, ${sweep.length - inTbar - inDialog} in the panel, ${inDialog} in a dialog`);
   for (const row of unknown) {
     note('  no driver for', `${row.tag}${row.id ? `#${row.id}` : ''} "${row.label}"`);
   }
@@ -1194,7 +1546,26 @@ try {
     unknown.length ? `${unknown.length} uncovered: ${unknown.map((r) => r.id || r.label).join(', ')}` : `${sweep.length} controls`);
   // The rule half of the claim, so a build that removed every panel control could not
   // satisfy the row above by having nothing left to cover.
-  check(sweep.length > 60, 'and the sweep found the panel, not an empty page', `${sweep.length} controls`);
+  //
+  // **Counted over the panel rather than over the sweep, which is a repair the subset
+  // dialog forced.** The floor was `sweep.length > 60` while everything swept was the
+  // strip or the panel; the dialog put 68 more controls in reach of the same selector,
+  // and 68 clears 60 on its own - so a build whose panel had gone entirely would have
+  // passed a row whose whole sentence is that the panel was found. The number the claim
+  // is about is the panel's, so that is the number the floor reads.
+  //
+  // Measured at each step rather than at two, because a recorded number that has since
+  // moved reads as a baseline and is worse than none: **160 swept and 131 in the panel**
+  // before the subset dialog, **228 and the same 131** with it, and **232 and 135** once
+  // the panel groups grew a collapse toggle each. The dialog added 68 controls and no
+  // panel control; the toggles added four of both, which is why only the second step
+  // leaves the panel count alone. What has not moved at any step is the number of *rows*
+  // in the panel - 66 throughout - and that is the one to reach for when asking whether a
+  // change to this surface dropped a control, because a collapsed group hides its rows
+  // with CSS and every one of them is still in the document and still swept here.
+  const inPanel = sweep.filter((r) => r.groups.includes('#panel')).length;
+  check(inPanel > 60, 'and the sweep found the panel, not an empty page',
+    `${inPanel} of ${sweep.length} controls are the panel's`);
 
   // The other direction, and the panel being generated is what makes it necessary. Every
   // row above asks whether the controls the page renders are driven; none of them can ask
@@ -4071,7 +4442,31 @@ try {
   const NAME_EDITED = `${nonce}-edited-outside`;
   const NAME_BAD = `${nonce}-not-a-look`;
   const NAME_PROTO = `${nonce}-proto`;
-  const MADE = [NAME_EDITED, NAME_BAD, NAME_PROTO];
+  // The sparse look this run authors through the dialog. It is a name of its own rather
+  // than a reuse of the one above because it becomes a document - the import path PUTs
+  // what it reads - and a run that wrote two different shapes under one name would be
+  // asserting about whichever landed last.
+  const NAME_PART = `${nonce}-part-of-a-look`;
+  // The document the two-saves-at-once rows write. It is a whole look, so its own save
+  // stamps the clip - which is the value the race corrupts and therefore the one those
+  // rows have to be able to read afterwards.
+  const NAME_RACE = `${nonce}-two-at-once`;
+  // The sparse look the *save* button authors, which is a different door from the one
+  // `NAME_PART` goes through and needs a name of its own so the store can be asked what
+  // each of them actually wrote.
+  const NAME_SAVED_PART = `${nonce}-saved-part`;
+  // The five documents that must never become documents. They are named here with the
+  // rest rather than left anonymous because the free-before-the-run check and the cleanup
+  // are what make "a refused file never reaches the library" a statement about this run -
+  // and `envelope-unchecked` is a mutation that makes one of them land, so the cleanup
+  // has to know about it.
+  const NAME_NO_VALUES = `${nonce}-no-values`;
+  const NAME_EMPTY_VALUES = `${nonce}-empty-values`;
+  const NAME_LIST_VALUES = `${nonce}-list-values`;
+  const NAME_PART_READINGS = `${nonce}-part-readings`;
+  const NAME_STRAY_KEY = `${nonce}-stray-key`;
+  const MADE = [NAME_EDITED, NAME_BAD, NAME_PROTO, NAME_PART, NAME_RACE, NAME_SAVED_PART,
+    NAME_NO_VALUES, NAME_EMPTY_VALUES, NAME_LIST_VALUES, NAME_PART_READINGS, NAME_STRAY_KEY];
   for (const n of MADE) {
     const r = await fetch(`${URL_BASE}/presets/${n}`);
     check(!r.ok, `the fixture name ${n} is free before the run, or nothing below is about this run`,
@@ -4105,9 +4500,77 @@ try {
     await page.evaluate(`globalThis.__kinect.params.set('bloom', ${onlyOnScreen})`);
     await settle();
 
+    // **The dialog stands between the button and the file now, so this drives it rather
+    // than reaching past it.** Everything below goes through the rendered controls -
+    // the export button, the checkboxes, the confirm - because the picker is a seam
+    // with two sides, and a probe that called `pickPresetSubset` or handed a name list
+    // to `presetFromCurrentLook` would attach below it and pass on a build whose boxes
+    // are wired to nothing. That is `level-check` section 5's lesson arriving in a
+    // different instrument: arms that all attach on the same side of a seam measure one
+    // of them.
+    //
+    // **Every one of those gestures starts through `openPicker`, and the waiting it does
+    // first is not politeness.** These controls hold one gesture at a time now, so a
+    // press that lands while the previous one is still unwinding is correctly dropped -
+    // and the obvious thing to wait for, the dialog reporting `open === false`, is a
+    // task too early: `close()` clears that flag synchronously and queues its `close`
+    // event, and the promise the handler is awaiting settles from that event. So a
+    // driver can be past the wait, through a Node-side fetch, and still pressing into a
+    // gesture that has not finished. It cost a whole run to find - `detail-ignores-the-
+    // reading` died at 238 of 274 with zero failed assertions, which is a crash reading
+    // as a catch. The page publishes the guard's own state and this waits on that, which
+    // is the only observable that means what the sentence means.
+    //
+    // **And the guard covers every preset control now, not only the two that share the
+    // dialog**, because the value it protects is the provenance stamp and the apply and
+    // the import write that too. So the same wait goes in front of the file input and the
+    // apply button as well - `presetIdle` below - or a driver that pressed straight after
+    // an import would be dropped by a build that is working exactly as designed.
+    const presetIdle = () => page.waitForFunction(
+      '!globalThis.__kinect.library.presetGestureRunning()', null, { timeout: 15000 });
+    // Focused before it is clicked, which is what a hand does and what a programmatic
+    // `click()` does not - and the caret has to start on the control or the row below
+    // asserting it comes back is asserting that the body still has it.
+    const openPicker = async (id) => {
+      await presetIdle();
+      await page.focus(`#${id}`);
+      await page.evaluate(`document.getElementById(${JSON.stringify(id)}).click()`);
+      await page.waitForFunction("document.getElementById('presetPick').open === true", null, { timeout: 10000 });
+    };
+    // Every import in this section goes through here for the same reason.
+    const importFile = async (path) => {
+      await presetIdle();
+      await page.setInputFiles('#tPresetFile', path);
+    };
+    await openPicker('tPresetExport');
+    const offered = await page.evaluate(`(() => {
+      const boxes = [...document.querySelectorAll('#ppGroups input[id^="pp-"]')];
+      const heads = [...document.querySelectorAll('#ppGroups input[id^="ppg-"]')];
+      return {
+        named: boxes.map((b) => b.id.slice(3)),
+        ticked: boxes.filter((b) => b.checked).length,
+        heads: heads.length,
+        whole: heads.filter((h) => h.checked && !h.indeterminate).length,
+      };
+    })()`);
+    const lookNames = await page.evaluate("globalThis.__kinect.params.names('look')");
+    const noBox = lookNames.filter((n) => !offered.named.includes(n));
+    const extraBox = offered.named.filter((n) => !lookNames.includes(n));
+    // Recomputed from the registry rather than read off the dialog's own count, for the
+    // reason section 1 recomputes the panel's: the failure being guarded against is a
+    // build whose idea of the look tag is what went wrong, and a count it reports about
+    // itself agrees with it by construction.
+    check(noBox.length === 0 && extraBox.length === 0,
+      `the dialog offers every look parameter and only those (${lookNames.length})`,
+      noBox.length || extraBox.length ? `no box for ${noBox.join(', ') || 'none'}; not a look value: ${extraBox.join(', ') || 'none'}`
+        : `${offered.named.length} boxes`);
+    check(offered.ticked === offered.named.length && offered.whole === offered.heads,
+      'and every box starts ticked, so the gesture that existed before this dialog writes what it wrote before',
+      `${offered.ticked} of ${offered.named.length} ticked, ${offered.whole} of ${offered.heads} headings whole`);
+
     const [download] = await Promise.all([
       page.waitForEvent('download'),
-      page.evaluate("document.getElementById('tPresetExport').click()"),
+      page.evaluate("document.getElementById('ppGo').click()"),
     ]);
     const saved = join(TMP, download.suggestedFilename());
     await download.saveAs(saved);
@@ -4129,7 +4592,7 @@ try {
     writeFileSync(edited, `${JSON.stringify(nextBody, null, 2)}\n`);
     await page.evaluate("globalThis.__kinect.params.reset(globalThis.__kinect.params.names('look'))");
     await settle();
-    await page.setInputFiles('#tPresetFile', edited);
+    await importFile(edited);
     await page.waitForFunction("document.getElementById('tNote').textContent.startsWith('imported')", null, { timeout: 15000 });
     await settle();
     const back = await page.evaluate("(() => { const k = globalThis.__kinect; return JSON.stringify({ bloom: k.params.get('bloom'), grain: k.params.get('grain'), readBlackwall: k.params.get('readBlackwall'), stamp: k.library.appliedPreset() }); })()");
@@ -4139,13 +4602,336 @@ try {
     check(landed.stamp?.name === NAME_EDITED,
       'and stamps the clip with where it came from', JSON.stringify(landed.stamp?.name));
 
+    // ---- a look that is deliberately part of one
+    //
+    // The same door again with boxes unticked, and the rows below are the three claims
+    // a subset makes: what the boxes said is what the file carries, the five reading
+    // weights move as one, and a document that does not say what the whole look is
+    // cannot claim to be where the clip came from. The stamp row is the one that needs
+    // the ordering above - the clip is wearing `NAME_EDITED` at this point, so "the
+    // stamp did not move" is a statement about a value that is there to move, where the
+    // same row taken on a fresh page would pass on a build that had simply not stamped
+    // anything yet.
+    const ticksNow = `(() => [...document.querySelectorAll('#ppGroups input[id^="pp-"]')]
+      .filter((b) => b.checked).map((b) => b.id.slice(3)))()`;
+    await openPicker('tPresetExport');
+    await page.fill('#ppName', NAME_PART);
+    // A heading, pressed as the control it is: one press has to take its whole group
+    // out, or the affordance is decoration over fifty individual boxes.
+    //
+    // **Graded against the panel's own group rather than against a count**, and the
+    // first version of this row was the count - `after.length === before.length -
+    // off.length`, which is true by construction of a set difference and was therefore
+    // a row that could not fail. What "its whole group" means is the parameters the
+    // panel puts under that heading, so that is what is read: the two groupings have to
+    // be the same grouping, which is the whole reason the dialog derives its headings
+    // from `PANEL_GROUPS` instead of listing them again.
+    const panelPoints = await page.evaluate(`(() => {
+      const group = [...document.querySelectorAll('#panel .group')]
+        .find((g) => g.querySelector('label')?.textContent.trim() === 'Points');
+      return group ? [...group.querySelectorAll('input')].map((i) => i.id).filter(Boolean).sort() : null;
+    })()`);
+    const beforeGroup = await page.evaluate(ticksNow);
+    await page.click('#ppg-points');
+    const afterGroup = await page.evaluate(ticksNow);
+    const groupOff = beforeGroup.filter((n) => !afterGroup.includes(n)).sort();
+    check(panelPoints !== null && panelPoints.length > 0 && groupOff.join() === panelPoints.join(),
+      'unticking a group heading takes exactly the parameters the panel puts under that heading',
+      `${groupOff.length} off: ${groupOff.join(', ')}; the panel's Points holds ${(panelPoints ?? ['(no such group)']).join(', ')}`);
+    // And one reading, which has to take four others with it. The count is the row's
+    // claim; `readings-tick-alone` reduces it to one.
+    await page.click('#pp-readDepth');
+    const afterReading = await page.evaluate(ticksNow);
+    const readingOff = afterGroup.filter((n) => !afterReading.includes(n));
+    check(readingOff.length === 5 && readingOff.includes('readDepth'),
+      'and unticking one reading weight unticks all five, because half a blend is not a look',
+      `${readingOff.length} off: ${readingOff.join(', ')}`);
+
+    const [partDownload] = await Promise.all([
+      page.waitForEvent('download'),
+      page.evaluate("document.getElementById('ppGo').click()"),
+    ]);
+    const partFile = join(TMP, partDownload.suggestedFilename());
+    await partDownload.saveAs(partFile);
+    const partBody = JSON.parse(readFileSync(partFile, 'utf8'));
+    // Compared against what the boxes actually said rather than against a list of group
+    // members kept here, which is the same reasoning the dialog itself is built on: a
+    // tool holding its own copy of which parameter sits under which heading is a copy
+    // that goes stale, and it would fail looking exactly like the feature breaking.
+    const wroteExtra = Object.keys(partBody.values ?? {}).filter((n) => !afterReading.includes(n));
+    const wroteNone = afterReading.filter((n) => !Object.hasOwn(partBody.values ?? {}, n));
+    check(wroteExtra.length === 0 && wroteNone.length === 0,
+      'and the file that comes out names exactly the values that were left ticked',
+      wroteExtra.length || wroteNone.length
+        ? `${wroteExtra.length} it should not name (${wroteExtra.slice(0, 4).join(', ')}), ${wroteNone.length} missing`
+        : `${Object.keys(partBody.values).length} of ${lookNames.length} look values`);
+
+    // Back in through the file input, which is where the format meets the document this
+    // dialog just authored. A build whose reading boxes move one at a time writes four
+    // of the five weights, and `refusePresetBody` refuses exactly that file - so this
+    // row is the format's own opinion of what came out, taken without this file needing
+    // to know which parameters are readings.
+    //
+    // **Waited for as a change rather than for the word `imported`, and the wait cannot
+    // end the run.** A build whose reading boxes move one at a time writes a file this
+    // program refuses, so waiting for the success message is waiting for something that
+    // is never going to arrive - fifteen seconds and a throw, which arrives as `DID NOT
+    // RUN` and reports nothing about a mutation that had already reddened the row above
+    // it. Measured on exactly that: `readings-tick-alone` crashed the run at 231 of 241
+    // assertions before this was a catch and a row.
+    const noteBeforeImport = (await text('#tNote')) ?? '';
+    await importFile(partFile);
+    await page.waitForFunction(`document.getElementById('tNote').textContent !== ${JSON.stringify(noteBeforeImport)}`,
+      null, { timeout: 15000 }).catch(() => {});
+    await settle();
+    const importNote = (await text('#tNote')) ?? '';
+    check(importNote.startsWith('imported'),
+      'and the format accepts the document this dialog authored, which is the file rule reading back what the control wrote',
+      `"${importNote}"`);
+    const afterPart = await page.evaluate("(() => { const k = globalThis.__kinect; return JSON.stringify({ stamp: k.library.appliedPreset(), grain: k.params.get('grain') }); })()");
+    const part = JSON.parse(afterPart);
+    check(part.stamp?.name === NAME_EDITED,
+      'a preset that is part of a look leaves the clip\'s provenance alone - it did not say what the look is',
+      `stamp ${JSON.stringify(part.stamp?.name)}, where the file just imported was ${NAME_PART}`);
+    check(part.grain === 0.13,
+      'while the values it does name are applied like any other look',
+      `grain ${part.grain}`);
+
+    // The same document through the apply button, because that is the surface the stamp
+    // is reported on and it used to report it by reading `appliedPreset.rev` whatever
+    // had happened. On a partial apply that names a revision this gesture did not apply,
+    // and on a clip with no stamp at all it throws inside the handler - which the
+    // surrounding catch turns into "could not apply" over an apply that worked.
+    await page.evaluate(`(() => { document.getElementById('tPreset').value = ${JSON.stringify(NAME_PART)}; })()`);
+    await presetIdle();
+    await page.evaluate("document.getElementById('tPresetApply').click()");
+    await page.waitForFunction("document.getElementById('tNote').textContent.startsWith('applied')", null, { timeout: 15000 })
+      .catch(() => {});
+    await settle();
+    const partNote = await text('#tNote');
+    check(partNote.startsWith('applied') && !/·\s*[0-9a-f]{8}\s*$/.test(partNote) && partNote.includes(NAME_PART),
+      'and the note for it says what was applied rather than naming a revision this gesture did not apply',
+      `"${partNote}"`);
+
+    // ---- the same subset through the *save*, read back out of the library
+    //
+    // **Every row above about a sparse document went through the export button**, which
+    // downloads a file, and the only thing the save button had been asked to do was open
+    // the dialog and be cancelled. The two share `pickPresetSubset` and nothing else: one
+    // hands its names to `presetFromCurrentLook` and builds a blob, the other hands the
+    // same names to the same function and PUTs the result. A regression in which saved
+    // library presets carried the whole look while exported files stayed correct would
+    // have passed this entire section, and `picker-ignores-the-boxes` does not close it -
+    // that mutation changes the shared answer, so both doors move together and neither is
+    // proved against the other.
+    //
+    // Read back out of the store rather than off the note, for the reason the cancel row
+    // below gives about the same store: a build that said "saved" and wrote something
+    // else satisfies every row that reads the strip. And graded against the boxes as they
+    // stood rather than a list kept here, which is the rule the export rows already
+    // follow - a tool holding its own copy of which parameter sits under which heading is
+    // a copy that goes stale and fails looking like the feature breaking.
+    const stampBeforeSave = await page.evaluate('globalThis.__kinect.library.appliedPreset()');
+    await openPicker('tPresetSave');
+    await page.fill('#ppName', NAME_SAVED_PART);
+    await page.click('#ppg-points');
+    await page.click('#pp-readDepth');
+    const savedTicks = await page.evaluate(ticksNow);
+    await page.evaluate("document.getElementById('ppGo').click()");
+    await page.waitForFunction(
+      `document.getElementById('tNote').textContent.startsWith('saved ${NAME_SAVED_PART}')`,
+      null, { timeout: 15000 }).catch(() => {});
+    await settle();
+    const savedDoc = await (await fetch(`${URL_BASE}/presets/${encodeURIComponent(NAME_SAVED_PART)}`)).json();
+    const savedKeys = Object.keys(savedDoc.body?.values ?? {});
+    const savedExtra = savedKeys.filter((n) => !savedTicks.includes(n));
+    const savedMissing = savedTicks.filter((n) => !savedKeys.includes(n));
+    check(savedTicks.length > 0 && savedTicks.length < lookNames.length
+      && savedExtra.length === 0 && savedMissing.length === 0,
+      'saving a subset puts exactly the ticked values in the library, which no export row can say',
+      savedExtra.length || savedMissing.length
+        ? `${savedExtra.length} it should not name (${savedExtra.slice(0, 4).join(', ')}), ${savedMissing.length} missing`
+        : `${savedKeys.length} of ${lookNames.length} look values, matching the ${savedTicks.length} boxes left ticked`);
+    // And the stamp, which is the save path's own half of the whole-look rule and the
+    // half the export cannot have: a file that leaves the program stamps nothing, while
+    // a save writes the clip's provenance whenever the document describes the whole
+    // look. This one does not, so the clip has to be wearing what it was wearing.
+    const stampAfterSave = await page.evaluate('globalThis.__kinect.library.appliedPreset()');
+    check(stampAfterSave?.name === stampBeforeSave?.name && stampAfterSave?.rev === stampBeforeSave?.rev,
+      'and saving part of a look leaves the clip\'s provenance where it was, because the file does not say what the look is',
+      `stamp ${JSON.stringify(stampBeforeSave?.name)} before, ${JSON.stringify(stampAfterSave?.name)} after`);
+
+    // Cancelling writes nothing, and the library is what is asked rather than the note:
+    // a build that wrote the document and then said nothing about it would satisfy any
+    // row reading the strip.
+    const presetsBefore = (await (await fetch(`${URL_BASE}/presets`)).json()).presets.map((d) => d.name);
+    await openPicker('tPresetSave');
+    await page.fill('#ppName', `${nonce}-never-written`);
+    await page.click('#ppCancel');
+    await page.waitForFunction("document.getElementById('presetPick').open === false", null, { timeout: 10000 });
+    const presetsAfter = (await (await fetch(`${URL_BASE}/presets`)).json()).presets.map((d) => d.name);
+    check(presetsAfter.length === presetsBefore.length && !presetsAfter.includes(`${nonce}-never-written`),
+      'and cancelling the dialog writes nothing at all',
+      `${presetsBefore.length} documents before, ${presetsAfter.length} after`);
+
+    // ---- two saves at once, which the dialog made possible and the `prompt` had not
+    //
+    // `pickPresetSubset` closes before the PUT it authorised has been answered, so from
+    // that instant both controls are live with a write still in flight. Two saves whose
+    // responses come back out of order run the stale handler last and leave
+    // `appliedPreset` naming the older revision - the provenance stamp saying a look
+    // this clip is not wearing, which is the one thing the stamp exists to be right
+    // about.
+    //
+    // **The window is held open rather than aimed at.** `docs/instruments.md` records
+    // the rename race measured through its HTTP route coming back one winner and three
+    // refusals on a build with the hole, because every await between the driver and the
+    // interval widens it - four Playwright clicks would be that mistake again with more
+    // moving parts. So the PUT is intercepted and parked, which makes the in-flight
+    // state last as long as these rows need instead of microseconds, and the second
+    // gesture is attempted inside a state the build cannot get out of on its own.
+    //
+    // **And the second gesture is tried at every door rather than only at the one that
+    // races itself.** Four controls write the provenance stamp - save, apply, import, and
+    // the apply on the recorder - and a guard scoped to the two that share the dialog
+    // leaves the other two live with the write unanswered. That is the same corruption
+    // through a door the guard does not cover: press save, confirm, and apply a whole
+    // look while the PUT is parked, and the apply's stamp lands first with the save's
+    // overwriting it, so the clip ends up wearing the older revision. Each door needs an
+    // observable of its own, so the reads are the requests each one would have to make -
+    // a GET for the apply, a second PUT for the import.
+    let releasePut = () => {};
+    let putsSeen = 0;
+    let getsSeen = 0;
+    const holdPut = async (route) => {
+      if (route.request().method() !== 'PUT') {
+        if (route.request().method() === 'GET') getsSeen += 1;
+        await route.continue();
+        return;
+      }
+      putsSeen += 1;
+      if (putsSeen === 1) await new Promise((resolve) => { releasePut = resolve; });
+      await route.continue();
+    };
+    await page.route('**/presets/**', holdPut);
+    try {
+      const until = async (ready, what, ms = 15000) => {
+        const began = Date.now();
+        while (!ready()) {
+          if (Date.now() - began > ms) throw new Error(what);
+          await new Promise((r) => { setTimeout(r, 20); });
+        }
+      };
+      await openPicker('tPresetSave');
+      await page.fill('#ppName', NAME_RACE);
+      await page.evaluate("document.getElementById('ppGo').click()");
+      await page.waitForFunction("document.getElementById('presetPick').open === false", null, { timeout: 10000 });
+      await until(() => putsSeen === 1, 'the save never reached the network, so nothing below is about a write in flight');
+
+      const busy = await page.evaluate(`(() => ({
+        save: document.getElementById('tPresetSave').disabled,
+        exported: document.getElementById('tPresetExport').disabled,
+        applied: document.getElementById('tPresetApply').disabled,
+        imported: document.getElementById('tPresetImport').disabled,
+        dialog: document.getElementById('presetPick').open,
+      }))()`);
+      check(busy.save && busy.exported && busy.applied && busy.imported && !busy.dialog,
+        'a preset write in flight disables every control that could start a second one, with the dialog already gone',
+        `save disabled=${busy.save}, export disabled=${busy.exported}, apply disabled=${busy.applied}, `
+        + `import disabled=${busy.imported}, dialog open=${busy.dialog}`);
+
+      // The disabled attribute taken off by hand, which is the row that is about the
+      // rule rather than about the paint. A guard that lives only on the control is one
+      // `removeAttribute` from being absent, and it says nothing about a third writer
+      // added later - so what has to hold is that the *gesture* refuses to start.
+      const second = await page.evaluate(`(() => {
+        const button = document.getElementById('tPresetSave');
+        button.disabled = false;
+        button.click();
+        return { dialog: document.getElementById('presetPick').open, note: document.getElementById('tNote').textContent };
+      })()`);
+      check(!second.dialog && putsSeen === 1,
+        'and a second save pressed with the disable removed opens no dialog and puts no second write on the wire',
+        `dialog open=${second.dialog}, ${putsSeen} PUT reached the network`);
+
+      // The apply door, which is the one the finding came in through: a whole-look
+      // document applied while the save is unanswered stamps `appliedPreset`, and the
+      // save's own stamp then lands on top of it carrying the older revision. Graded on
+      // the request rather than on the stamp, because both builds end this block with the
+      // save's name on the clip and only one of them fetched a second document to get
+      // there - the corruption is transient and the gesture is what the rule is about.
+      const stampMidRace = await page.evaluate('globalThis.__kinect.library.appliedPreset()');
+      const getsBefore = getsSeen;
+      const applyPressed = await page.evaluate(`(() => {
+        const select = document.getElementById('tPreset');
+        select.value = ${JSON.stringify(NAME_EDITED)};
+        const button = document.getElementById('tPresetApply');
+        button.disabled = false;
+        button.click();
+        return { named: select.value };
+      })()`);
+      await settle();
+      const stampAfterApply = await page.evaluate('globalThis.__kinect.library.appliedPreset()');
+      check(applyPressed.named === NAME_EDITED && getsSeen === getsBefore
+        && stampAfterApply?.rev === stampMidRace?.rev,
+        'and an apply pressed with the disable removed fetches no document and moves no stamp, so the write in flight cannot be overtaken',
+        `${getsSeen - getsBefore} GET on the wire, stamp ${JSON.stringify(stampMidRace?.name)} before `
+        + `and ${JSON.stringify(stampAfterApply?.name)} after, offering ${applyPressed.named}`);
+
+      // And the import door, on the same reasoning. Its observable is a second PUT: an
+      // import writes the file into the library before it applies it, so a build that let
+      // this gesture start would have two writes in flight at once and stamp from
+      // whichever answered last.
+      await page.setInputFiles('#tPresetFile', edited);
+      await settle();
+      check(putsSeen === 1,
+        'and a file chosen with a write in flight starts no second one either, which is the third door onto the same stamp',
+        `${putsSeen} PUT reached the network, note "${await text('#tNote')}"`);
+
+      releasePut();
+      await page.waitForFunction(
+        `document.getElementById('tNote').textContent.startsWith('saved ${NAME_RACE}')`,
+        null, { timeout: 15000 }).catch(() => {});
+      await settle();
+      const done = await page.evaluate(`(() => ({
+        note: document.getElementById('tNote').textContent,
+        save: document.getElementById('tPresetSave').disabled,
+        exported: document.getElementById('tPresetExport').disabled,
+        applied: document.getElementById('tPresetApply').disabled,
+        imported: document.getElementById('tPresetImport').disabled,
+        focus: document.activeElement ? document.activeElement.id || document.activeElement.tagName : null,
+        stamp: globalThis.__kinect.library.appliedPreset(),
+      }))()`);
+      check(done.note.startsWith(`saved ${NAME_RACE}`) && done.stamp?.name === NAME_RACE,
+        'the write the guard let through finishes and stamps the clip, so the guard refuses a second gesture rather than the first',
+        `"${done.note}" with the stamp naming ${JSON.stringify(done.stamp?.name)}`);
+      check(!done.save && !done.exported && !done.applied && !done.imported,
+        'and every control comes back the moment the write is answered, so the guard is a span rather than a state to get stuck in',
+        `save disabled=${done.save}, export disabled=${done.exported}, apply disabled=${done.applied}, import disabled=${done.imported}`);
+      // The caret, which the guard's own comment claimed it never took and did.
+      // `pickPresetSubset` hands focus back to the control that opened the dialog on the
+      // `close` event and resolves in the same breath, so the button is holding it when
+      // the write span disables that same button a microtask later - which blurs it onto
+      // the body, and re-enabling does not undo that. `openPicker` focuses before it
+      // clicks for this row's sake: a programmatic `click()` leaves the caret on the body,
+      // where a build that stranded it and a build that never had it read identically.
+      check(done.focus === 'tPresetSave',
+        'and the caret is back on the control that opened the dialog rather than on the body the disable dropped it to',
+        `focus is on ${JSON.stringify(done.focus)}`);
+    } finally {
+      // Unrouted whatever happened above, because a parked PUT handler left installed
+      // would hold the first write of every row after this one.
+      releasePut();
+      await page.unroute('**/presets/**', holdPut);
+    }
+
     // The refusal, and it is the row that matters most: a file is the one door into
     // this program that nothing else validates. `params.apply` meets every value, so a
     // scalar carrying a string throws at that key rather than writing a plausible look
     // - and the image must not have moved on the way to finding out.
     const bad = join(TMP, `${NAME_BAD}.braindance-preset.json`);
     writeFileSync(bad, `${JSON.stringify({ version: PROJECT_VERSION, values: { bloom: 'loud' } }, null, 2)}\n`);
-    await page.setInputFiles('#tPresetFile', bad);
+    await importFile(bad);
     await page.waitForFunction("document.getElementById('tNote').textContent.includes('bloom')", null, { timeout: 15000 })
       .catch(() => {});
     const afterBad = await page.evaluate("(() => ({ note: document.getElementById('tNote').textContent, bloom: globalThis.__kinect.params.get('bloom') }))()");
@@ -4176,22 +4962,664 @@ try {
     writeFileSync(proto, `{ "version": ${PROJECT_VERSION}, "values": { "__proto__": { "polluted": true }, "bloom": 1 } }\n`);
     const parsedHasOwn = Object.keys(JSON.parse(readFileSync(proto, 'utf8')).values).includes('__proto__');
     check(parsedHasOwn, 'the probe really contains __proto__ as an own key, or the row below tests nothing');
-    await page.setInputFiles('#tPresetFile', proto);
+    await importFile(proto);
     await page.waitForFunction("document.getElementById('tNote').textContent.includes('__proto__')", null, { timeout: 15000 })
       .catch(() => {});
     const afterProto = await page.evaluate("(() => ({ note: document.getElementById('tNote').textContent, polluted: ({}).polluted ?? null, bloom: globalThis.__kinect.params.get('bloom') }))()");
     check(/__proto__/.test(afterProto.note) && afterProto.polluted === null && afterProto.bloom === 4.4,
       'and a file carrying __proto__ is refused as an unknown parameter, polluting nothing',
       `"${afterProto.note}" polluted=${afterProto.polluted}`);
+
+    // ---- the refusals whose *words* are the feature, driven at last
+    //
+    // Every row above about a refusal reads that a refusal happened - the note names
+    // `bloom`, the note names `__proto__` - and three of this program's refusals were
+    // rewritten on the strength of an argument about what they say, with no fixture
+    // anywhere driving the shapes they were rewritten for. A message is the whole of what
+    // a hand-edited file gets back, so a sentence that fits one document and is read by
+    // three is a defect this suite could not see. These rows send the documents and read
+    // the sentences.
+    //
+    // Sent as files rather than as objects handed to a page function, for the reason the
+    // `__proto__` row states one direction and this states the other: the import path is
+    // the door, and a probe attaching below it measures a build whose file input is
+    // wired to nothing.
+    const refuse = async (label, body) => {
+      const path = join(TMP, `${label}.braindance-preset.json`);
+      writeFileSync(path, `${body}\n`);
+      const was = (await text('#tNote')) ?? '';
+      await importFile(path);
+      await page.waitForFunction(`document.getElementById('tNote').textContent !== ${JSON.stringify(was)}`,
+        null, { timeout: 15000 }).catch(() => {});
+      await settle();
+      return (await text('#tNote')) ?? '';
+    };
+
+    // Three documents with no look in them, and they are three different mistakes. One
+    // sentence used to serve all three: a file with no `values` key, a file whose `values`
+    // is empty, and a file with a list where the object belongs all came back "carries no
+    // values object", which is accurate for the first and false on its face for the
+    // second. Somebody who has just deleted the last entry out of `values` was sent
+    // looking for a key that is in front of them.
+    const noValues = await refuse(NAME_NO_VALUES, `{ "version": ${PROJECT_VERSION} }`);
+    const emptyValues = await refuse(NAME_EMPTY_VALUES, `{ "version": ${PROJECT_VERSION}, "values": {} }`);
+    const listValues = await refuse(NAME_LIST_VALUES, `{ "version": ${PROJECT_VERSION}, "values": [1, 2, 3] }`);
+    const distinct = new Set([noValues, emptyValues, listValues]).size === 3;
+    check(distinct
+      && /no values object/.test(noValues)
+      && /nothing in it/.test(emptyValues) && /scope is nothing/.test(emptyValues)
+      && /a list where its values should be/.test(listValues),
+      'three documents with no look in them get three sentences, each about the shape that arrived',
+      `no values key: "${noValues}" | empty values: "${emptyValues}" | a list: "${listValues}"`);
+
+    // The reading rule, whose refusal names *both* ways out. A file carrying two of the
+    // five weights can name the other three or delete the two it has, and for a while the
+    // sentence named only the exit that adds keys - so somebody who had deliberately cut
+    // the blend down to two was told to put three back rather than told that taking two
+    // out is the other answer and probably the one they meant. Which readings this build
+    // has is read off the page, so the row does not carry a copy of the five names.
+    const readings = await page.evaluate('__kinect.readings()');
+    const namedTwo = readings.slice(0, 2);
+    const missingThree = readings.slice(2);
+    const partReadings = await refuse(NAME_PART_READINGS,
+      JSON.stringify({
+        version: PROJECT_VERSION,
+        values: { bloom: 1.2, ...Object.fromEntries(namedTwo.map((n) => [n, 1])) },
+      }));
+    check(missingThree.every((n) => partReadings.includes(n))
+      && namedTwo.every((n) => partReadings.includes(n))
+      && partReadings.includes(`Name the other ${missingThree.length}`)
+      && partReadings.includes(`take all ${namedTwo.length} it has out`),
+      'a file naming some of the reading weights is refused with both ways out of it, not only the one that adds keys',
+      `"${partReadings}" against ${namedTwo.join(', ')} named and ${missingThree.join(', ')} missing`);
+
+    // The envelope, which is the half of the document nothing used to read. Every key
+    // inside `values` is put to the registry and the keys *around* them were never looked
+    // at, so a version 3 field walks through: `mode` is exactly what version 4 dissolved
+    // into the five reading weights, it means something specific in the version it
+    // belongs to, and answering a file that carries it with silence is the failure the
+    // version gate one line above exists to prevent. `bloom` is what it names, at the
+    // value already on screen, so a build that accepts it moves no pixel and this row is
+    // about the envelope rather than about a look changing.
+    const strayKey = await refuse(NAME_STRAY_KEY,
+      JSON.stringify({ version: PROJECT_VERSION, mode: 4, values: { bloom: 4.4 } }));
+    check(/mode/.test(strayKey) && /preset/.test(strayKey),
+      'a document carrying a key beside version and values is refused by name, so a field an older version had is answered rather than ignored',
+      `"${strayKey}"`);
+    // And it never became a document, which the sentence above cannot tell you: the
+    // refusal happens before the PUT, so a build without the envelope check leaves the
+    // file in the library looking like a look until somebody picks it.
+    const storeAfterStray = await (await fetch(`${URL_BASE}/presets`)).json();
+    const landedStray = storeAfterStray.presets.find((d) => d.name === NAME_STRAY_KEY && !d.builtin);
+    check(!landedStray,
+      'and it never reached the library either, because the envelope is read before the store is touched',
+      landedStray ? `${NAME_STRAY_KEY} is in /presets` : `${NAME_STRAY_KEY} is absent from /presets`);
   } finally {
     // In a `finally` rather than after the last row, because a section that threw is
     // exactly when the library is most likely to be left with a fixture in it.
     await cleanupPresets();
   }
 
-  // ================================ 13. the pinned drive takes the loop away with it
+  // ================================ 13. a panel group is open because the clip says so
 
-  console.log('\n[13] pinning the drive drops what the loop was going to serve');
+  console.log('\n[13] which panel groups are open is derived, and only disagreements are stored');
+
+  // The claim is that no group carries a stored open/closed state: it is open when the
+  // document holds evidence that somebody has been inside it, and shut otherwise, with
+  // a person's disagreement the only thing written down. So every row here reads a
+  // consequence - which rows are on the screen, what the header says, what came back
+  // out of storage - rather than reading a flag the page keeps about itself.
+  //
+  // **The rows are still in the document while they are hidden**, which is the half a
+  // sweep cannot notice and the half that keeps this feature checkable. Section 1 counts
+  // a control per registry parameter with a plain `querySelectorAll`, blind to
+  // visibility by construction, so a build that collapsed by *rebuilding* the panel
+  // would pass every row above and quietly stop being the registry. Each row below reads
+  // the count in the document beside the count on the screen for that reason.
+  {
+    const GROUP_STATE = `(() => {
+      const vis = (el) => Boolean(el) && el.checkVisibility({ checkVisibilityCSS: true });
+      const rows = (g) => [...g.querySelectorAll('.row, .checkrow, .check')];
+      return [...document.querySelectorAll('#panel .group[data-group]')].map((g) => {
+        const toggle = g.querySelector(':scope > .grouphead > .grouptoggle');
+        const mark = g.querySelector(':scope > .grouphead > .groupmark');
+        return {
+          key: g.dataset.group,
+          collapsible: Boolean(toggle),
+          shut: g.classList.contains('shut'),
+          expanded: toggle ? toggle.getAttribute('aria-expanded') : null,
+          markVisible: vis(mark),
+          mark: mark ? mark.textContent : null,
+          inDom: rows(g).length,
+          onScreen: rows(g).filter(vis).length,
+        };
+      });
+    })()`;
+    const groups = () => page.evaluate(GROUP_STATE);
+    const groupOf = async (key) => (await groups()).find((g) => g.key === key);
+    const stored = () => page.evaluate("localStorage.getItem('kinect.panelGroupsOpen')");
+    // Back to a document nobody has touched. `params.reset` over the look tag is what
+    // `restoreProject` itself uses, so this is the state a fresh project arrives in
+    // rather than an approximation of it.
+    const freshLook = async () => {
+      await page.evaluate("__kinect.keyframes.setTracks({})");
+      await page.evaluate("__kinect.params.reset(__kinect.params.names('look'))");
+      await settle();
+    };
+
+    // The registry's own answer for what a fresh project holds, so every row below
+    // compares against the same number the page derives from rather than against a
+    // literal copied out of `PARAMS` that would go stale the day somebody re-grades a
+    // default. `normalise` is in it because that is what the predicate compares
+    // against - a default off its own step would be a value the slider cannot express.
+    const defaultOf = (name) => page.evaluate(
+      `__kinect.params.normalise(${JSON.stringify(name)}, __kinect.params.spec(${JSON.stringify(name)}).default)`);
+
+    // The store cleared once, here, where it is the only safe place to do it: nothing has
+    // pressed a toggle yet, so the page is holding no overrides in memory and the two
+    // cannot come apart. Later in the section they would - clearing the entry behind the
+    // page's back leaves the in-memory map intact, and the next write puts the leftovers
+    // straight back - so every row below establishes the state it needs by pressing.
+    await freshLook();
+    await page.evaluate("localStorage.removeItem('kinect.panelGroupsOpen')");
+    await page.evaluate('__kinect.timeline.transport().seek(3)');
+    await settle();
+
+    // ---- 13a. the set of collapsible groups, off the page rather than out of a list
+    //
+    // Enumerated because the driver rule above claims this section presses *every*
+    // group toggle the editor renders, and a rule crediting four ids while a section
+    // pressed three of them is the coverage claim `plant-unswept-control` exists to
+    // refuse. The names are printed and not asserted: which groups collapse is a design
+    // decision that may gain a fifth member, where "the ones on the page are the ones
+    // driven" is the invariant.
+    const all = await groups();
+    const collapsible = all.filter((g) => g.collapsible);
+    note(`${collapsible.length} of ${all.length} generated groups collapse`,
+      collapsible.map((g) => g.key).join(', '));
+    check(collapsible.length > 0 && collapsible.every((g) => g.inDom > 0),
+      'every collapsible group is a group that actually holds rows',
+      collapsible.map((g) => `${g.key}:${g.inDom}`).join(' '));
+
+    // `framing` by name, and it is the one group this row is worth spending an
+    // assertion on. Its `after()` emits `#cropReset`, section 8 clicks that button, and
+    // Playwright's click waits for the element to be visible - so a `framing` that
+    // could be shut turns a row eight sections back into a thirty-second timeout, which
+    // arrives as a crash carrying no failed assertion rather than as a finding.
+    const framing = all.find((g) => g.key === 'framing');
+    check(Boolean(framing) && !framing.collapsible && framing.onScreen === framing.inDom,
+      'framing is not collapsible, because the crop button under it is one section 8 has to click',
+      framing ? `collapsible: ${framing.collapsible}, ${framing.onScreen} of ${framing.inDom} rows on screen` : 'no framing group');
+
+    // ---- 13b. a document nobody has touched renders them shut
+    const fresh = (await groups()).filter((g) => g.collapsible);
+    check(fresh.every((g) => g.shut && g.expanded === 'false' && g.onScreen === 0),
+      'a project at its defaults renders every collapsible group shut',
+      fresh.map((g) => `${g.key}:${g.shut ? 'shut' : 'OPEN'}/${g.onScreen}`).join(' '));
+    // The other half, and the one that separates hiding from rebuilding. A build that
+    // emitted a subset would satisfy the row above perfectly.
+    check(fresh.every((g) => g.inDom > 0),
+      'and their rows are hidden rather than absent, so the panel is still the whole registry',
+      `${fresh.reduce((n, g) => n + g.inDom, 0)} rows in the document, ${fresh.reduce((n, g) => n + g.onScreen, 0)} on screen`);
+    check(fresh.every((g) => !g.markVisible),
+      'with nothing marked, because a group at its defaults has nothing to announce',
+      fresh.map((g) => `${g.key}:${g.markVisible}`).join(' '));
+
+    // ---- 13c. moving a value opens the group that holds it
+    //
+    // `bloom` because it is in `optical`, which is one of the four, and because
+    // `keyframe-check` clicks its keyframe diamond - a control Playwright will only
+    // press when it is visible. That tool applies a look that moves `bloom` before it
+    // clicks, so the group is open by the time it gets there; this row is what says the
+    // mechanism it relies on is working.
+    await page.evaluate("__kinect.params.set('bloom', 1.5)");
+    await settle();
+    const opened = await groupOf('optical');
+    check(!opened.shut && opened.expanded === 'true' && opened.onScreen === opened.inDom,
+      'moving one parameter off its default opens the group that holds it',
+      `optical: shut=${opened.shut}, ${opened.onScreen} of ${opened.inDom} rows on screen`);
+    // And its neighbours did not move, because a build that opened everything the
+    // moment anything changed would satisfy the row above while saying nothing.
+    const neighbours = (await groups()).filter((g) => g.collapsible && g.key !== 'optical');
+    check(neighbours.every((g) => g.shut),
+      'and only that group, so the rule is about the parameter rather than about the write',
+      neighbours.map((g) => `${g.key}:${g.shut ? 'shut' : 'OPEN'}`).join(' '));
+
+    // ---- 13c-bis. a `reveals` closure widens the default rule and does not replace it
+    //
+    // The row that holds the invariant the whole feature rests on: which groups are open
+    // is the look's diff against its defaults, so what a look is made of is a thing you
+    // read off the panel. `Reading · detail` is the one group with a rule of its own, and
+    // a closure written to *replace* the default rather than widen it would break that
+    // invariant on this group alone - a preset naming `contourBands` and no reading would
+    // leave a live value behind a closed heading with the panel's own rule agreeing that
+    // there was nothing to show.
+    //
+    // It is a row rather than a comment because nothing else here can see it. Every other
+    // group derives from its own parameters by construction, so this is the only place
+    // the two spellings of the rule differ, and the difference is invisible until a
+    // parameter in this group moves with the readings left alone.
+    await freshLook();
+    await settle();
+    const rimDefault = await defaultOf('ghostRim');
+    const rimSpec = await page.evaluate("__kinect.params.spec('ghostRim')");
+    // Whichever end of the travel the default is not, so this cannot become a write of
+    // the value that was already there - which would leave the group untouched and the
+    // row below asserting the state it started in.
+    await page.evaluate(`__kinect.params.set('ghostRim', ${rimDefault === rimSpec.max ? rimSpec.min : rimSpec.max})`);
+    await settle();
+    const rimNow = await page.evaluate("__kinect.params.get('ghostRim')");
+    // Off `__kinect.readings()` rather than a list spelled out here, so this asks about
+    // the readings this build has rather than the ones whoever wrote the row remembered.
+    const readingsQuiet = await page.evaluate(`__kinect.readings().every((n) =>
+      __kinect.params.get(n) === __kinect.params.normalise(n, __kinect.params.spec(n).default))`);
+    check(rimNow !== rimDefault && readingsQuiet,
+      'one detail parameter moved with every reading left at its default, or the row below tests nothing',
+      `ghostRim reads ${rimNow} against a default of ${rimDefault}, readings untouched: ${readingsQuiet}`);
+    const tuned = await groupOf('detail');
+    check(!tuned.shut && tuned.onScreen === tuned.inDom,
+      'a group with a rule of its own still opens for its own parameters, so the open set is the whole diff',
+      `detail: shut=${tuned.shut}, ${tuned.onScreen} of ${tuned.inDom} rows on screen`);
+
+    // ---- 13d. a keyframe counts even where the value does not
+    //
+    // The whole reason the predicate has a keyframe term, and the one row
+    // `reveal-ignores-tracks` can reach. The track's keys are all at `grain`'s own
+    // default, so the evaluator writes the default into the registry at every position
+    // and the value test says untouched at every frame - a parameter that is being
+    // animated, on a curve, with the group holding it shut.
+    await freshLook();
+    const grainDefault = await defaultOf('grain');
+    await page.evaluate(`__kinect.keyframes.setTracks({ grain: [
+      { t: 1, value: ${grainDefault} }, { t: 6, value: ${grainDefault} }] })`);
+    await page.evaluate('__kinect.timeline.transport().seek(3)');
+    await settle();
+    // The probe's own control, and without it the row below is an assertion about
+    // nothing: if the planted keys had moved the value off its default, the group would
+    // open through the term this row is trying to isolate and `reveal-ignores-tracks`
+    // would come back NOT CAUGHT for a reason that is about the fixture.
+    const parked = await page.evaluate("__kinect.params.get('grain')");
+    check(parked === grainDefault,
+      'the keyed parameter really is sitting on its default at the parked frame, or the row below tests nothing',
+      `grain reads ${parked} against a default of ${grainDefault}`);
+    const keyed = await groupOf('optical');
+    check(!keyed.shut && keyed.onScreen === keyed.inDom,
+      'a keyframe opens the group even where the value it holds is the default',
+      `optical: shut=${keyed.shut}, ${keyed.onScreen} of ${keyed.inDom} rows on screen`);
+
+    // ---- 13e. a shut group that is in use says so
+    //
+    // Pressed rather than assumed shut, because the state it starts in is exactly what
+    // `group-never-reveals` changes: on that build every group is already shut and a
+    // blind press would open one, which is a row failing for the wrong reason and a
+    // section that stops measuring what it is named for.
+    await freshLook();
+    await page.evaluate("__kinect.params.set('bloom', 1.5)");
+    await settle();
+    const shut = async (key) => {
+      if (!(await groupOf(key)).shut) await page.click(`[data-group-toggle=${key}]`);
+      await settle();
+      return groupOf(key);
+    };
+    const marked = await shut('optical');
+    check(marked.shut && marked.markVisible && marked.mark === '1',
+      'a shut group carrying a value says how many of its parameters are set',
+      `optical: shut=${marked.shut}, mark visible=${marked.markVisible}, reads "${marked.mark}"`);
+    // Two parameters, so the mark is a count rather than a light that came on. A mark
+    // reading "1" whatever is underneath it would pass the row above on every build.
+    await page.evaluate("__kinect.params.set('grain', 0.4)");
+    await settle();
+    const marked2 = await groupOf('optical');
+    check(marked2.mark === '2',
+      'and it is a count of them rather than a lamp, so the header says how much is hidden',
+      `two parameters set, the mark reads "${marked2.mark}"`);
+
+    // ---- 13f. the override is a disagreement, and a toggle that agrees writes none
+    //
+    // Half of the store rule, and **only the half a toggle can reach** - which is worth
+    // stating plainly because for a while this block claimed the whole of it. The group
+    // above was collapsed while its values justified being open, so that disagreement is
+    // written down; opening it again puts the two back into agreement, and what has to
+    // happen then is that the entry *goes*, not that it flips to true.
+    //
+    // What that cannot see is the other term. A toggle compares the two at the instant
+    // it is pressed, so pressing it back is the one gesture where they agree by
+    // construction - a build that only ever pruned there would pass every row here while
+    // an override the *document* had caught up with sat pinning a group open forever.
+    // That is exactly the build this repo shipped, through a green suite. 13f-bis below
+    // is the other term, and `override-prunes-only-on-toggle` is what makes the pair
+    // falsifiable rather than asserted.
+    const disagreeing = JSON.parse((await stored()) ?? '{}');
+    check(disagreeing.optical === false,
+      'collapsing a group that derives open writes the disagreement down',
+      JSON.stringify(disagreeing));
+    await page.click('[data-group-toggle=optical]');
+    await settle();
+    const agreeing = JSON.parse((await stored()) ?? '{}');
+    const reopened = await groupOf('optical');
+    check(!reopened.shut && !Object.hasOwn(agreeing, 'optical'),
+      'and opening it again removes the entry rather than storing the agreement',
+      `open=${!reopened.shut}, stored ${JSON.stringify(agreeing)}`);
+
+    // ---- 13f-bis. the term that moves afterwards is the document, not the toggle
+    //
+    // The row above presses the same control twice, so the two sides agree at the
+    // instant a toggle is pressed and the entry can go on the way past. That is the
+    // easy half and for a while it was the only half implemented, while the comment
+    // beside it claimed the whole rule: an override "decays instead of accumulating".
+    // It did not. The other term of the comparison is the *derivation*, and the
+    // derivation moves without anybody pressing anything - a value set, a look applied,
+    // a project opened - so an override that the document has caught up with sat there
+    // winning over a rule it now agreed with.
+    //
+    // These three rows are that failure in the order it happens to somebody. Pin a
+    // group open while it is quiet, put something in it, take that something away
+    // again: on a build whose prune only runs at the toggle, the last row finds a group
+    // held open by an opinion the person formed about a different document. That is the
+    // stored panel layout this whole design exists to refuse, arriving through the one
+    // door left open.
+    //
+    // `optical` because 13f just left it with no entry, so this establishes its own
+    // state by pressing rather than by clearing the store behind the page's back.
+    await freshLook();
+    await settle();
+    const quiet = await groupOf('optical');
+    if (quiet.shut) await page.click('[data-group-toggle=optical]');
+    await settle();
+    const pinned = await groupOf('optical');
+    const pinnedStore = JSON.parse((await stored()) ?? '{}');
+    check(!pinned.shut && pinned.onScreen === pinned.inDom && pinnedStore.optical === true,
+      'pinning a quiet group open is a disagreement and is written down, or the two rows below test nothing',
+      `open=${!pinned.shut}, ${pinned.onScreen} of ${pinned.inDom} rows on screen, stored ${JSON.stringify(pinnedStore)}`);
+    await page.evaluate("__kinect.params.set('bloom', 1.5)");
+    await settle();
+    const caughtUp = await groupOf('optical');
+    const caughtStore = JSON.parse((await stored()) ?? '{}');
+    check(!caughtUp.shut && !Object.hasOwn(caughtStore, 'optical'),
+      'and the document catching up with it takes the entry away, with nothing on screen changing',
+      `open=${!caughtUp.shut}, stored ${JSON.stringify(caughtStore)}`);
+    await freshLook();
+    await settle();
+    const decayed = await groupOf('optical');
+    check(decayed.shut && decayed.onScreen === 0,
+      'so taking the value away again shuts it, rather than leaving it pinned open with nothing in it',
+      `shut=${decayed.shut}, ${decayed.onScreen} of ${decayed.inDom} rows on screen, stored ${await stored()}`);
+    // Put back as it was found, and this is the fixture rather than a claim. On a build
+    // that prunes, the group is already shut and this presses nothing; on
+    // `override-prunes-only-on-toggle` it is still pinned, and a pin that outlived this
+    // block is a group the rows below would read as in use - 13g asks every collapsible
+    // group but `detail` to be shut. Without this the control reddens its own two rows
+    // *and* a neighbour's fixture, and a mutation that fails a row it has nothing to say
+    // about cannot tell you which question it was answering.
+    if (!(await groupOf('optical')).shut) await page.click('[data-group-toggle=optical]');
+    await settle();
+
+    // ---- 13g. detail is governed by the readings as well as by its own parameters
+    //
+    // The other half of its widened rule, and 13c-bis above is the first. Its seven
+    // parameters sit at the shader literals they replaced, so on the default rule alone
+    // the group would stay shut whichever reading is live - and
+    // `detail-ignores-the-reading` is exactly that build.
+    //
+    // `readGhost` rather than `readRgb`, and the difference is the whole trap: `readRgb`
+    // defaults to 1, so "open when a reading is non-zero" fires on a page nobody has
+    // touched. Comparing against the defaults is what keeps a fresh project shut, and
+    // 13b above is the row that says it does.
+    // No `localStorage.removeItem` here, deliberately. Clearing the store behind the
+    // page's back desynchronises it from the overrides the page is holding in memory, so
+    // the next write puts the leftovers back and the rows below would be reading a state
+    // this section did not establish. Nothing has pressed `detail` yet, so it has no
+    // override to clear.
+    await freshLook();
+    await settle();
+    const detailQuiet = await groupOf('detail');
+    await page.evaluate("__kinect.params.set('readGhost', 0.7)");
+    await settle();
+    const detailLive = await groupOf('detail');
+    check(detailQuiet.shut && !detailLive.shut && detailLive.onScreen === detailLive.inDom,
+      'moving a reading opens Reading · detail, with every one of its own parameters still at its default',
+      `shut with the readings at their defaults: ${detailQuiet.shut}, after readGhost moved: ${detailLive.shut}`);
+    // The other direction, and it is what makes the row above about `detail`'s own
+    // rule rather than about any parameter write opening any group: the reading that
+    // opened `detail` belongs to `treatment`, which is not collapsible, and the three
+    // groups that are collapsible have to be unmoved by it.
+    const untouched = (await groups()).filter((g) => g.collapsible && g.key !== 'detail');
+    check(untouched.every((g) => g.shut),
+      'and leaves the three groups the reading has nothing to do with shut',
+      untouched.map((g) => `${g.key}:${g.shut ? 'shut' : 'OPEN'}`).join(' '));
+
+    // ---- 13h. shutting a live detail group sticks
+    //
+    // The row that separates the store rule from the obvious spelling of it. Comparing
+    // what a person asked for against `revealsItself('detail')` - the group's own
+    // parameters - finds the two already agreeing on false, deletes the override and
+    // re-derives the group open, so the collapse would not survive the repaint it
+    // caused. Compared against what the group *derives*, which for this one is a
+    // different question, the disagreement is real and gets written down.
+    await page.click('[data-group-toggle=detail]');
+    await settle();
+    const detailShut = await groupOf('detail');
+    const detailStored = JSON.parse((await stored()) ?? '{}');
+    check(detailShut.shut && detailStored.detail === false,
+      'shutting a group whose rule reads another group stays shut and is written down',
+      `shut=${detailShut.shut}, stored ${JSON.stringify(detailStored)}`);
+    // And it is marked, because it is still in use - the reading that opened it has not
+    // moved. This is the mark answering a wider question than the open rule does: none
+    // of `detail`'s own parameters is off its default, so the header carries the dot
+    // with no number rather than a misleading zero.
+    check(detailShut.markVisible && detailShut.mark === '',
+      'and it is marked as in use with nothing of its own to count',
+      `mark visible=${detailShut.markVisible}, reads "${detailShut.mark}"`);
+
+    // ---- 13i. the override outlives the page that wrote it
+    //
+    // This page reloaded rather than a second page opened beside it, and the reason is
+    // the mutated module: `page.route` is installed per page, so a second page would
+    // take the tree's own `main.js` and put two different builds inside one
+    // measurement. Reloading re-runs the interception `openEditor` already proved held,
+    // and a reload is a fresh module evaluation either way - the store is read back
+    // from scratch rather than answered by anything the page was holding.
+    //
+    // **Both directions across one reload, and the collapse is the one that matters.**
+    // A round of this suite had the collapse row go red on a build whose panel was
+    // working, diagnosed the ambiguity correctly, and then reversed the row's polarity to
+    // pin-open - the one direction the defect underneath it cannot reach. The reasoning
+    // written down at the time was that a page booting with a stored `false` against a
+    // document at its defaults reads two terms that agree, and an entry that agrees is
+    // indistinguishable from one that was forgotten. That is true of the instant the page
+    // boots and it is not true of the row, because the row *re-establishes the value
+    // afterwards*: with the entry gone the group opens, with the entry kept it stays shut.
+    // The red row had found the bug. `docs/instruments.md` carries the correction.
+    //
+    // So the fixture is a group shut while it is genuinely in use - the disagreement
+    // somebody actually forms - plus a quiet group pinned open beside it, which is the
+    // direction that always worked and is kept because a reload that carried neither
+    // would fail this section for a reason that is about reloading.
+    await freshLook();
+    await page.evaluate("__kinect.params.set('bloom', 1.5)");
+    await settle();
+    if (!(await groupOf('optical')).shut) await page.click('[data-group-toggle=optical]');
+    if ((await groupOf('detail')).shut) await page.click('[data-group-toggle=detail]');
+    await settle();
+    const beforeReload = JSON.parse((await stored()) ?? '{}');
+    check(beforeReload.optical === false && beforeReload.detail === true,
+      'a group shut while it is in use and a quiet one pinned open are two disagreements to survive, or the rows below test nothing',
+      `stored ${JSON.stringify(beforeReload)}`);
+    await page.reload({ waitUntil: 'load' });
+    await page.waitForFunction('!!globalThis.__kinect.timeline.transport()', null, { timeout: 30000 });
+    await settle();
+    // Read straight out of storage, before anything else touches the page. This is the
+    // defect at its own scale rather than through its consequence: a build that prunes on
+    // agreement rather than on movement deletes the collapse during the boot pass, when
+    // the look is at its defaults because no document has arrived yet, and writes the
+    // pruned map back. The entry is gone from `localStorage` at this line on that build
+    // and present on this one, with nothing about the panel involved either way.
+    const carriedStore = JSON.parse((await stored()) ?? '{}');
+    check(carriedStore.optical === false && carriedStore.detail === true,
+      'the store the page booted from still holds both, so nothing pruned them against a document that had not loaded yet',
+      `stored ${JSON.stringify(carriedStore)}`);
+    // The pin, read off the page: it is open on a document holding nothing that would
+    // open it, so it is open *because of the store*. A group whose parameters had come
+    // back off their defaults would derive open on its own and pass on a build that had
+    // forgotten the entry entirely.
+    const pinCarried = await groupOf('detail');
+    const quietAfter = await page.evaluate(`(() => {
+      const k = globalThis.__kinect;
+      const known = new Set(k.params.names());
+      const group = [...document.querySelectorAll('#panel .group[data-group]')].find((g) => g.dataset.group === 'detail');
+      const names = [...group.querySelectorAll('input')].map((i) => i.id).filter((n) => known.has(n));
+      return { names: names.length, quiet: names.every((n) => k.params.get(n) === k.params.normalise(n, k.params.spec(n).default)) };
+    })()`);
+    check(!pinCarried.shut && pinCarried.onScreen === pinCarried.inDom
+      && quietAfter.names > 0 && quietAfter.quiet,
+      'and the page reloaded still finds the pinned one open, on a document holding nothing that would open it',
+      `open=${!pinCarried.shut}, ${pinCarried.onScreen} of ${pinCarried.inDom} rows on screen, `
+      + `${quietAfter.names} parameters in the group and all at their defaults: ${quietAfter.quiet}`);
+    // And the collapse, read the way it is felt: the value goes back, the document says
+    // the group is in use, and the group stays shut with the mark saying what is hidden.
+    // The reload does not restore the look - this page is opened on a take with no
+    // project - so putting the value back is what makes the derivation `true` again and
+    // the stored `false` a disagreement again. That is the step whose absence made the
+    // earlier reading of this row ambiguous, and it is the step that discriminates: with
+    // the entry pruned at boot the group opens here.
+    await page.evaluate("__kinect.params.set('bloom', 1.5)");
+    await settle();
+    const collapseCarried = await groupOf('optical');
+    check(collapseCarried.shut && collapseCarried.onScreen === 0
+      && collapseCarried.markVisible && collapseCarried.mark === '1',
+      'and the collapse survives it too, so a group shut while it was in use is still shut when the value comes back',
+      `shut=${collapseCarried.shut}, ${collapseCarried.onScreen} of ${collapseCarried.inDom} rows on screen, `
+      + `mark visible=${collapseCarried.markVisible} reading "${collapseCarried.mark}", stored ${await stored()}`);
+
+    // ---- 13j. every toggle the page renders is one this section has driven
+    //
+    // The reverse of the driver rule above, asked of the page rather than of this file.
+    // The rule claims section 13 presses every collapsible group; this presses whatever
+    // is left and asserts the rows under it answered, so a group declared after today is
+    // driven by existing rather than by being remembered here.
+    //
+    // **What it asserts is that the press changed something and that the header agrees
+    // with what it changed - never that the group ends up open.** Which way a press goes
+    // depends on the state the group was in, and that state is exactly what
+    // `group-never-reveals` alters: the first version of this row demanded
+    // `aria-expanded=true` after every press, so on that build the two groups that
+    // happened to start open failed a row about the *toggle* while the toggle was
+    // working perfectly. A row whose answer depends on the mutation it is not the
+    // control for is a row that cannot say what it found.
+    await freshLook();
+    await settle();
+    const driven = [];
+    for (const g of (await groups()).filter((x) => x.collapsible)) {
+      const before = await groupOf(g.key);
+      await page.click(`[data-group-toggle=${g.key}]`);
+      await settle();
+      const after = await groupOf(g.key);
+      driven.push({
+        key: g.key,
+        from: before.onScreen,
+        to: after.onScreen,
+        moved: before.onScreen !== after.onScreen,
+        // The header and the rows have to be telling the same story, which is the half
+        // a screen reader gets and a pixel comparison cannot see.
+        honest: after.expanded === String(after.onScreen > 0),
+      });
+    }
+    check(driven.length === collapsible.length && driven.every((d) => d.moved && d.honest),
+      'every collapsible group the page renders was pressed here and its rows answered',
+      driven.map((d) => `${d.key}:${d.from}->${d.to}${d.honest ? '' : ' (aria disagrees)'}`).join(' '));
+
+    // ---- 13k. one re-derivation per bulk write, not one per value in it
+    //
+    // The panel is re-derived from `params.set`, which is the door the evaluator writes
+    // every keyed parameter through on every rendered frame - so without a gate the cost
+    // of this feature scales with the number of keys on the clip, on the render path,
+    // where this repo has been bitten before. `paramWritten` beside it has skipped
+    // itself during a transport write since it existed; this is the same skip, with
+    // `withoutRepaint` asking once on the way out for the whole write.
+    //
+    // **Counted rather than timed**, because a duration taken around a gesture
+    // Playwright is pacing is a measurement of Playwright - `docs/measurement.md` states
+    // that about the paused orbit and it applies unchanged here. The page keeps the
+    // count and this reads a delta across a seek.
+    //
+    // **The claim is that the cost is fixed rather than proportional, so the arm varies
+    // the thing it would be proportional to.** A single arm can only be graded against a
+    // threshold somebody chose, and the threshold this row started with was
+    // `perFrame < keyedLook.length` - fewer than 8, against an ungated build measured at
+    // 8.02. A quarter of one percent of margin on a figure the machine has no say in is
+    // luck rather than a gate, and anything between 1.02 and 8.02 would have satisfied it
+    // equally. Keying four parameters and then eight and comparing the two per-frame
+    // counts asks the question the sentence asks: a gated build answers the same number
+    // twice, an ungated one answers half as much for half as many keys.
+    //
+    // The ceiling stays beside it and both conjuncts carry weight, which is the thing to
+    // check before adding a second term to a row. The proportionality test alone passes a
+    // build costing a constant eight passes per frame; the ceiling alone is the chosen
+    // threshold again. Neither implies the other.
+    //
+    // Measured over two rounds per arm, four arms, one seek of four program seconds each
+    // and five rendered frames per seek: **1.00 per frame at four keys and 1.00 at eight,
+    // against 4.00 and 8.00 under `panel-rederives-per-write`.** Every figure came out
+    // exact and repeated, which is the property that makes a count worth reading where a
+    // rate is not - the two mutated rounds were taken at load average 8.8 and reported the
+    // same numbers as the clean rounds taken at 6.6.
+    //
+    // **Those figures are also what reconciles the arithmetic**, and the earlier reading
+    // of this row did not. An ungated build costing one pass per keyed parameter *and* one
+    // for `withoutRepaint`'s way out would answer 9 at eight keys; it answers 8.00, so the
+    // arm is the build from before the gate existed - `params.set` announcing every write
+    // with no `finally` beside it - rather than the condition alone removed. The mutation
+    // makes both edits for that reason, and the gated arm's 1.00 is exactly the `finally`
+    // it takes away. An earlier figure of 8.02 against 1.02 came from a window that
+    // included the seek's own re-derivation spread across 121 frames; this one starts
+    // after the seek has settled, so the remainder is zero.
+    //
+    // **Counted rather than timed**, for the reason stated above.
+    const costOfKeying = async (count) => {
+      await freshLook();
+      const names = (await page.evaluate("__kinect.params.names('look')")).slice(0, count);
+      const spec = Object.fromEntries(await Promise.all(names.map(async (name) => {
+        const at = await defaultOf(name);
+        return [name, [{ t: 0, value: at }, { t: 8, value: at }]];
+      })));
+      await page.evaluate(`__kinect.keyframes.setTracks(${JSON.stringify(spec)})`);
+      await page.evaluate('__kinect.timeline.transport().seek(1)');
+      await settle();
+      const before = await page.evaluate(
+        '({ refreshes: __kinect.groupRefreshes(), renders: __kinect.timeline.counters.renders })');
+      await page.evaluate('__kinect.timeline.transport().seek(5)');
+      await settle();
+      const after = await page.evaluate(
+        '({ refreshes: __kinect.groupRefreshes(), renders: __kinect.timeline.counters.renders })');
+      await page.evaluate('__kinect.keyframes.setTracks({})');
+      const frames = after.renders - before.renders;
+      return { keys: names.length, frames, perFrame: frames > 0 ? (after.refreshes - before.refreshes) / frames : NaN };
+    };
+    // Interleaved rather than one after the other, because a sequential pair on a machine
+    // that got busy between them is a comparison of the machine. Two rounds is enough
+    // here - the quantity is a count the page keeps rather than a rate, so it does not
+    // move - and the detail line prints both rounds so a pair that disagreed is visible.
+    const cheap = [await costOfKeying(4), await costOfKeying(4)];
+    const dear = [await costOfKeying(8), await costOfKeying(8)];
+    const worst = (runs) => Math.max(...runs.map((r) => r.perFrame));
+    const ran = [...cheap, ...dear].every((r) => r.frames > 0 && Number.isFinite(r.perFrame));
+    check(ran && worst(dear) <= worst(cheap) + 0.5 && worst(dear) < 2,
+      'a rendered frame re-derives the panel a fixed number of times rather than once per keyed parameter',
+      `${cheap.map((r) => r.perFrame.toFixed(2)).join('/')} per frame with ${cheap[0].keys} parameters keyed, `
+      + `${dear.map((r) => r.perFrame.toFixed(2)).join('/')} with ${dear[0].keys}, `
+      + `over ${[...cheap, ...dear].map((r) => r.frames).join('/')} rendered frames`);
+
+    // Put the panel and the document back. The rows after this drive a pointer over the
+    // stage and pin the drive, and a panel left with four groups open is a different
+    // page from the one they were measured on - this is the same rule section 1's nav
+    // probe follows about the scroll position it moves.
+    await page.evaluate("localStorage.removeItem('kinect.panelGroupsOpen')");
+    await freshLook();
+  }
+
+  // ================================ 14. the pinned drive takes the loop away with it
+
+  console.log('\n[14] pinning the drive drops what the loop was going to serve');
 
   // The third state that strands an armed position, and the only one `pumpParkedDraft`
   // cannot notice on its own: `drive.pin` calls `setAnimationLoop(null)`, so that

--- a/tools/sensor-view-check.mjs
+++ b/tools/sensor-view-check.mjs
@@ -670,6 +670,24 @@ const PROBE = `(() => {
         visible: vis(el),
         display: getComputedStyle(el).display,
         look: el.classList.contains('lookgroup'),
+        // **The block's own controls, because a block is visible for a different reason
+        // than its controls are.** Collapse puts \`shut\` on the group and the rule under
+        // it hides the *rows*, so the node goes on passing \`checkVisibility\` with
+        // nothing gradeable underneath it - which is what let "all 9 visible" mean "all
+        // 9 have a heading" for a while. Counted off \`input, select\` rather than off
+        // the row classes so this holds no second copy of a class list that could drift
+        // from the generator's.
+        controls: el.querySelectorAll('input, select').length,
+        controlsOnScreen: [...el.querySelectorAll('input, select')].filter(vis).length,
+        // Whether the collapse rule governs this one at all, so a group with no rows on
+        // screen can be told from a group that has been shut.
+        collapsible: !!el.querySelector(':scope > .grouphead > .grouptoggle'),
+        // And whether it has been. Read off the class the panel sets rather than inferred
+        // from the count, which is what lets the rows below partition the look groups and
+        // then assert about the controls in each half - a build lying about this fails
+        // both halves at once, since a group claiming to be open has to show its controls
+        // and a group claiming to be shut has to show none.
+        shut: el.classList.contains('shut'),
       }));
       const look = k.params.names('look');
       // A keyframe control belongs to a parameter when it shares a row with that
@@ -698,16 +716,42 @@ const PROBE = `(() => {
     /** The extended toggle, driven as a user drives it and read back both ways. */
     extended() {
       const btn = document.getElementById('extended');
+      const vis = (el) => !!el && el.checkVisibility({ checkVisibilityCSS: true });
       const groups = [...document.querySelectorAll('#panel .lookgroup')];
-      const read = () => ({
-        visible: groups.filter((el) => el.checkVisibility({ checkVisibilityCSS: true })).length,
-        pressed: btn.getAttribute('aria-pressed'),
-        label: btn.textContent.trim(),
-        // Read at every state, because "the recorder has no keyframe controls" is a
-        // claim about the surface rather than about what happens to be on screen -
-        // and the toggle is the one gesture that could plausibly conjure some.
-        kfButtons: document.querySelectorAll('#panel .kf').length,
-      });
+      const controlsIn = (el) => [...el.querySelectorAll('input, select')];
+      // **Per group as well as summed, and the sums are taken from the same array.** A
+      // total is what a row about "controls included" was graded on for a round, and a
+      // total answers "did anything at all appear" - which is one control out of fifty on
+      // one group out of nine. The editor's row next door asks every group the collapse
+      // rule leaves open to show all of its controls, and this is what lets the recorder's
+      // ask the same thing rather than a weaker cousin of it.
+      const each = () => groups.map((el) => ({
+        key: el.id || \`label:\${el.querySelector('label')?.textContent.trim() ?? '(unlabelled)'}\`,
+        visible: vis(el),
+        controls: controlsIn(el).length,
+        controlsOnScreen: controlsIn(el).filter(vis).length,
+        shut: el.classList.contains('shut'),
+      }));
+      const read = () => {
+        // The same distinction \`panel()\` above draws, for the same reason: this button
+        // reveals the group nodes, and whether a revealed group has anything gradeable
+        // under it is the collapse rule's answer rather than this one's. A row asserting
+        // only the first would go on passing on a build where pressing it showed nine
+        // headings and no control.
+        const blocks = each();
+        return {
+          blocks,
+          visible: blocks.filter((b) => b.visible).length,
+          controls: blocks.reduce((n, b) => n + b.controls, 0),
+          controlsOnScreen: blocks.reduce((n, b) => n + b.controlsOnScreen, 0),
+          pressed: btn.getAttribute('aria-pressed'),
+          label: btn.textContent.trim(),
+          // Read at every state, because "the recorder has no keyframe controls" is a
+          // claim about the surface rather than about what happens to be on screen -
+          // and the toggle is the one gesture that could plausibly conjure some.
+          kfButtons: document.querySelectorAll('#panel .kf').length,
+        };
+      };
       const before = read();
       btn.click();
       const after = read();
@@ -1373,14 +1417,55 @@ try {
       'the recorder hides the composition block', `still visible: ${on(rec.blocks, EDITOR_ONLY).join(' ') || 'none'}`);
     check(off(ed.blocks, EDITOR_ONLY).length === 0,
       'and the editor shows it', `visible: ${on(ed.blocks, EDITOR_ONLY).join(' ')}`);
+    // **Counted in controls as well as in headings, and the pair is the point.** A
+    // group's node stays visible when the collapse rule shuts it - `shut` hides the
+    // rows, not the box around them - so "9 look groups, all 9 visible" went on being
+    // true of a panel with four of the nine showing nothing gradeable at all. That is
+    // the `sweep.length > 60` failure this repo already records, arriving in a second
+    // instrument: the sentence stayed still while the population under it grew a way of
+    // satisfying the comparison without satisfying the claim.
+    //
+    // Which groups are shut is `editor-check` section 13's subject and deliberately not
+    // asserted here, because a collapse that derives from the document is a different
+    // feature from a surface that hides the grade. What this row owes is that the two
+    // surfaces differ in the *controls* on screen and not merely in their furniture, so
+    // the non-collapsible look groups carry the assertion and the collapsible ones are
+    // named in the detail where a change in them is visible rather than silent.
+    //
+    // **Partitioned by the collapse rule rather than floored at one group**, and the
+    // difference is what a floor is denominated in. `every non-collapsible group shows
+    // all its controls` was the first repair, and its guard against having nothing left
+    // to say was `edFixed.length > 0` - a count of the groups that happen not to declare
+    // `collapses`, which narrows towards one as more of them do and would reach zero
+    // without a word. It sat beside `sum(edLook, 'controlsOnScreen') > 0`, which the
+    // conjunct before it already implies: a group showing all of its controls, with a
+    // positive control count, is a positive sum. That is the vacuous conjunction this
+    // document opens with, added by the change that cites it.
+    //
+    // So the look groups are split by the `shut` class the panel itself sets, and both
+    // halves are asserted: every group the rule leaves open shows *all* of its controls,
+    // every group it has shut shows none, and at least one is open. The floor is now
+    // about the claim - that the grade is reachable on this surface - rather than about
+    // which groups happen to be collapsible, and the partition is checked from both sides,
+    // so a build that marked everything shut fails the floor and one that marked
+    // everything open fails the controls.
+    const sum = (list, key) => list.reduce((n, b) => n + b[key], 0);
     const recLook = rec.blocks.filter((b) => b.look);
     const edLook = ed.blocks.filter((b) => b.look);
-    check(recLook.length > 0 && recLook.every((b) => !b.visible),
-      'the grade is hidden on the recorder, which is what the extended button is for',
-      `${recLook.length} look groups, ${recLook.filter((b) => b.visible).length} visible`);
-    check(edLook.length > 0 && edLook.every((b) => b.visible),
-      'and open on the editor, where grading is the job',
-      `${edLook.length} look groups, all ${edLook.filter((b) => b.visible).length} visible`);
+    const edOpen = edLook.filter((b) => !b.shut);
+    const edShut = edLook.filter((b) => b.shut);
+    check(recLook.length > 0 && recLook.every((b) => !b.visible) && sum(recLook, 'controlsOnScreen') === 0,
+      'the grade is hidden on the recorder, down to the last control, which is what the extended button is for',
+      `${recLook.length} look groups, ${recLook.filter((b) => b.visible).length} visible, `
+      + `${sum(recLook, 'controlsOnScreen')} of ${sum(recLook, 'controls')} controls on screen`);
+    check(edLook.length > 0 && edLook.every((b) => b.visible)
+      && edOpen.length > 0 && edOpen.every((b) => b.controls > 0 && b.controlsOnScreen === b.controls)
+      && edShut.every((b) => b.controlsOnScreen === 0),
+      'and open on the editor, where grading is the job - measured in controls on screen rather than in headings',
+      `${edLook.length} look groups, all ${edLook.filter((b) => b.visible).length} visible, `
+      + `${sum(edLook, 'controlsOnScreen')} of ${sum(edLook, 'controls')} controls on screen; `
+      + `${edOpen.length} left open by the collapse rule show ${sum(edOpen, 'controlsOnScreen')} of `
+      + `${sum(edOpen, 'controls')}; shut by it: ${edShut.map((b) => b.key).join(' ') || 'none'}`);
     // The closer. Everything the rules above do not name is common furniture and has
     // to be on both surfaces, so a block added later is covered without being listed.
     const commonRec = rec.blocks.filter((b) => !named.has(b.key) && !b.look);
@@ -1395,16 +1480,40 @@ try {
       `recorder ${rec.recRange}, editor ${ed.recRange}`);
 
     // (d) the extended toggle, driven rather than reasoned about
-    check(ext.total > 0 && ext.before.visible === 0,
-      'the look groups start hidden on the recorder', `${ext.before.visible} of ${ext.total} visible`);
-    check(ext.after.visible === ext.total,
-      'and one press of `extended settings` reveals all of them',
-      `${ext.after.visible} of ${ext.total} visible`);
+    check(ext.total > 0 && ext.before.visible === 0 && ext.before.controlsOnScreen === 0,
+      'the look groups start hidden on the recorder, with none of their controls on screen',
+      `${ext.before.visible} of ${ext.total} visible, `
+      + `${ext.before.controlsOnScreen} of ${ext.before.controls} controls on screen`);
+    // The press has to put controls on screen and not only headings, and it is asked the
+    // same way the editor's row above asks it. `after.controlsOnScreen >
+    // before.controlsOnScreen` was what this said for a round, with the row above it
+    // pinning `before` at zero - so "controls included" was graded at *one control
+    // appearing anywhere*, on a surface with nine groups and fifty of them. A recorder has
+    // no clip, so every look parameter sits at its default and every collapsible group
+    // derives shut, which makes the groups the collapse rule leaves open exactly the ones
+    // this claim is about: each of them has to show all of its controls, the shut ones
+    // have to show none, and there has to be at least one of the first.
+    //
+    // This is the surface F6 was found on and the one nothing else in the suite covers -
+    // every screenshot and every `editor-check` row is `/edit` - so a weak floor here is a
+    // weak floor everywhere.
+    const extOpen = ext.after.blocks.filter((b) => !b.shut);
+    const extShut = ext.after.blocks.filter((b) => b.shut);
+    check(ext.after.visible === ext.total
+      && extOpen.length > 0 && extOpen.every((b) => b.controls > 0 && b.controlsOnScreen === b.controls)
+      && extShut.every((b) => b.controlsOnScreen === 0),
+      'and one press of `extended settings` reveals all of them, every group the collapse rule leaves open showing all its controls',
+      `${ext.after.visible} of ${ext.total} visible, `
+      + `${ext.after.controlsOnScreen} of ${ext.after.controls} controls on screen, `
+      + `${extOpen.length} left open showing ${sum(extOpen, 'controlsOnScreen')} of ${sum(extOpen, 'controls')}, `
+      + `shut by the collapse rule: ${extShut.map((b) => b.key).join(' ') || 'none'}`);
     check(ext.before.pressed === 'false' && ext.after.pressed === 'true',
       'and the button says so', `aria-pressed ${ext.before.pressed} then ${ext.after.pressed}, label "${ext.after.label}"`);
-    check(ext.back.visible === 0 && ext.back.pressed === 'false',
+    check(ext.back.visible === 0 && ext.back.controlsOnScreen === 0 && ext.back.pressed === 'false',
       'and a second press puts them away, so the toggle is tested in both directions',
-      `${ext.back.visible} of ${ext.total} visible, aria-pressed ${ext.back.pressed}`);
+      `${ext.back.visible} of ${ext.total} visible, `
+      + `${ext.back.controlsOnScreen} of ${ext.back.controls} controls on screen, `
+      + `aria-pressed ${ext.back.pressed}`);
     // Revealing the grade is not the same act as gaining a clip, and the count has to
     // hold at every state of the toggle or "the recorder has no keyframe control" is
     // a claim about a moment rather than about the surface.

--- a/web/index.html
+++ b/web/index.html
@@ -73,8 +73,56 @@
   #status b { color: var(--accent); font-weight: 500; }
 
   .group { border-top: 1px solid var(--line); padding-top: 10px; margin-top: 10px; }
-  .group > label { display: block; color: var(--dim); margin-bottom: 6px;
+  .group > label, .grouphead > label { display: block; color: var(--dim); margin-bottom: 6px;
     letter-spacing: 0.08em; text-transform: uppercase; font-size: 10px; }
+  /* Every group's heading is in a head, whether or not the group can be shut, because
+     two shapes of header is two sets of rules and the forgotten one is always the one
+     nobody is looking at. The heading takes the spare width so the mark and the button
+     sit against the right edge at every panel width. */
+  .grouphead { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
+  .grouphead > label { flex: 1; min-width: 0; margin-bottom: 0; }
+
+  /* A group collapses by hiding its rows, never by leaving them out of the document,
+     and the argument is the one written above `.lookgroup` below: the generator emits a
+     row per registry parameter and refuses to boot when the count comes out short, so a
+     panel that built a subset would stop being checkable against the registry at all.
+     `editor-check` sweeps `#panel` with a plain `querySelectorAll`, which is blind to
+     visibility, so every row a shut group holds is still found, still counted against
+     the registry and still driveable. The head is what survives the rule - a group whose
+     own name you cannot see is a group nobody can open again.
+
+     Written as a child selector against the head rather than against `.row`, so a note
+     or a button row a collapsible group grows later is shut with the rest of it instead
+     of being left hanging under a closed heading. */
+  .group.shut > *:not(.grouphead) { display: none; }
+
+  /* The chevron is the whole control: a caret rotated a quarter turn, pointing down when
+     the group is open and right when it is shut, which is the direction convention every
+     disclosure control on this machine already uses. */
+  .grouptoggle {
+    flex: 0 0 16px; width: 16px; height: 16px; display: grid; place-items: center;
+    border: 0; background: transparent; padding: 0; cursor: pointer;
+  }
+  .grouptoggle i {
+    width: 5px; height: 5px; border-right: 1px solid var(--faint);
+    border-bottom: 1px solid var(--faint); transform: rotate(45deg) translate(-1px, -1px);
+  }
+  .grouptoggle:hover i { border-color: var(--ink); }
+  .grouptoggle[aria-expanded=false] i { transform: rotate(-45deg) translate(-1px, -1px); }
+
+  /* A shut group that is carrying something has to say so, or the panel is quietly
+     lying about what is shaping the frame - which is the exact worry this feature
+     exists to answer, inverted. It carries a count where the group's own parameters are
+     what moved, and stands as a plain dot where the group is relevant because another
+     group's values made it so, which is `Reading · detail` and nothing else. */
+  .groupmark {
+    flex: 0 0 auto; min-width: 14px; height: 14px; padding: 0 4px; border-radius: 7px;
+    display: grid; place-items: center; background: var(--accent-low);
+    color: var(--accent); font-size: 9px; font-variant-numeric: tabular-nums;
+  }
+  .groupmark[hidden] { display: none; }
+  .groupmark:empty { min-width: 6px; width: 6px; height: 6px; padding: 0; border-radius: 3px;
+    background: var(--accent); }
 
   .row { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
   .row span { flex: 0 0 74px; color: var(--dim); }
@@ -300,6 +348,50 @@
   .tchip button[disabled] { color: var(--dim); cursor: default; }
   .tchip.warn, #tNote { border-color: var(--warn); color: var(--warn); }
   #tNote:empty, #tBehind:empty, #tExportNote:empty { display: none; }
+
+  /* The dialog that asks which look values a preset is written with. A `<dialog>`
+     rather than a positioned div, for the reason `library.js` gives beside the
+     gallery's ⋯ menus: modality, a backdrop and an Escape that closes are behaviours
+     a browser already has, and the gallery had to write the Escape half by hand twice
+     before it stayed written. What this file owns is only how it looks. */
+  dialog { border: 1px solid var(--line-2); border-radius: 10px; background: var(--paper-1);
+    color: var(--ink); font: inherit; padding: 18px; width: min(460px, calc(100vw - 32px)); }
+  dialog::backdrop { background: rgba(0, 0, 0, 0.6); }
+  dialog h2 { margin: 0 0 8px; font-size: 11px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; }
+  dialog p { margin: 0 0 10px; color: var(--dim); font-size: 10px; line-height: 1.5; }
+  #ppName {
+    width: 100%; padding: 6px 8px; border: 1px solid var(--line); border-radius: 5px;
+    background: var(--paper-2); color: var(--ink); font: inherit; margin-bottom: 12px;
+  }
+  #ppName:focus-visible { outline: 1px solid var(--accent); outline-offset: 0; }
+  /* Scrolls rather than growing. The look tag is fifty-odd parameters, so a box sized
+     to its contents is taller than the window on a laptop and puts its own confirm
+     button below the bottom of the screen - which is the render button's old failure
+     in a container nothing can scroll to, since the page behind a modal does not
+     scroll for it. Two columns because one makes even the scrolling version long
+     enough that the groups at the end are a discovery. */
+  #ppGroups {
+    max-height: min(46vh, 360px); overflow-y: auto;
+    display: grid; grid-template-columns: 1fr 1fr; gap: 0 16px; align-content: start;
+  }
+  .ppgroup { margin-bottom: 10px; }
+  .ppgroup .pphead { margin-bottom: 4px; color: var(--dim); font-size: 10px;
+    letter-spacing: 0.08em; text-transform: uppercase; }
+  .ppgroup .check { font-size: 11px; margin-bottom: 3px; padding-left: 12px; }
+  .ppacts { display: flex; gap: 8px; margin-top: 14px; align-items: center; }
+  #ppCount { flex: 1; color: var(--dim); font-size: 10px; }
+  /* `:disabled` last and every other state written as `:not(:disabled)`, because this
+     is exactly where the gallery's stylesheet went wrong: `dialog .row .act.go` is
+     three classes and an element, so it beat a plain `.act:disabled` on specificity
+     and a disabled confirm went on looking pressable. */
+  .ppacts button {
+    padding: 6px 14px; border: 1px solid var(--line); border-radius: 5px;
+    background: transparent; color: var(--dim); font: inherit; font-size: 10px; cursor: pointer;
+  }
+  .ppacts button:hover:not(:disabled) { border-color: var(--line-3); color: var(--ink); }
+  .ppacts button.go { border-color: var(--accent); color: var(--accent); background: var(--accent-low); }
+  .ppacts button.go:hover:not(:disabled) { background: var(--accent); color: #04231f; }
+  .ppacts button:disabled { opacity: 0.4; cursor: default; }
 
   .tlanes { flex: 1; min-height: 0; display: grid; grid-template-columns: 96px minmax(0, 1fr); }
   .tcol { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
@@ -753,6 +845,30 @@
       </div>
     </div>
   </section>
+
+  <!-- Which look values the preset about to be written is going to carry, asked before
+       it is written rather than after. Both doors a look leaves by come through here -
+       the save into the library and the export to a file - because they are one
+       question with two destinations, and a subset offered on one of them would be a
+       shape of document you can author one way and not the other.
+
+       The boxes are not here. They are built at boot from the registry, so a parameter
+       added later appears under the same heading the panel gives it without this markup
+       knowing anything about it; `main.js` carries the rest of that argument. What is
+       written here is the furniture the generator hangs them on. -->
+  <dialog id="presetPick" aria-labelledby="ppTitle">
+    <h2 id="ppTitle">Save this look</h2>
+    <p>A preset carries the values you tick and nothing else, so a clip it is applied to
+      keeps everything left out. The five reading weights tick and untick together,
+      because a look naming some of them renders as a blend nobody authored.</p>
+    <input id="ppName" type="text" autocomplete="off" spellcheck="false" aria-label="Preset name" />
+    <div id="ppGroups"></div>
+    <div class="ppacts">
+      <span id="ppCount"></span>
+      <button type="button" id="ppCancel">cancel</button>
+      <button type="button" class="go" id="ppGo">save</button>
+    </div>
+  </dialog>
 
   <script type="importmap">
   {

--- a/web/main.js
+++ b/web/main.js
@@ -1689,6 +1689,26 @@ const cropReach = (maxDepth = 9.5) => {
 // straight down the panel: `Reading · detail` sits beside the two groups it belongs
 // with here and renders first among the grade's, because it is a look group and they
 // are not.
+//
+// `collapses` is the second such property, and it is declared here for the same reason
+// `lookgroup` is: a group added next year answers the question by existing rather than
+// by somebody remembering to put its key in a list somewhere else, which is the list
+// that would go stale. It says only that the group *may* be shut - whether it is shut
+// right now is derived from the document by `revealsItself` below and overridden only
+// where a person has disagreed, so there is no stored open/closed state to keep in step
+// with the values. Everything without it always renders open, and `framing` is the one
+// where that matters beyond taste: its `after()` emits `#cropReset`, which `editor-check`
+// clicks, and Playwright's click waits for visibility - so a collapsible `framing` would
+// turn that row into a thirty-second timeout, which is a crash carrying no failed
+// assertion rather than a finding.
+//
+// `reveals` is the escape hatch beside it, and exactly one group needs one. A group's
+// default rule is that it is in use when its own parameters are, and `Reading · detail`
+// is *also* governed by another group's values - so the rule lives on the entry with the
+// group it is about rather than as a branch inside the predicate that would have to name
+// it. A closure widens the default rule and must not replace it: which groups are open
+// is the look's diff against its defaults, and a group that dropped its own parameters
+// out of its rule would be carrying values the panel had stopped accounting for.
 const PANEL_GROUPS = [
   // The five readings of the take, which were five buttons and one integer uniform
   // until they became five look parameters. They mix rather than exclude, so this is
@@ -1712,7 +1732,35 @@ const PANEL_GROUPS = [
   // the bottom of a laptop panel to buy nothing anybody needs before a take. Which
   // reading you are shooting against is a shooting decision; how wide its bands are is
   // grading.
-  { key: 'detail', label: 'Reading · detail', lookgroup: true },
+  {
+    key: 'detail',
+    label: 'Reading · detail',
+    lookgroup: true,
+    collapses: true,
+    // The one group the default rule is not enough for, and it *widens* that rule rather
+    // than replacing it. Every one of these seven sits at the shader literal it replaced,
+    // so a fresh project has them all at their defaults - and choosing a reading writes
+    // `source` and `treatment` and never these, so on the default rule alone the group
+    // would stay shut whichever reading is live. Which reading you are shooting is
+    // exactly when these constants become worth reading, so the readings are a second
+    // way in and not a different door.
+    //
+    // **The `revealsItself('detail')` term is the load-bearing half of the widening.**
+    // Without it this group stops answering the question every other group answers -
+    // which groups are open is the look's diff against its defaults, so "what is this
+    // look made of" is a thing you can read off the panel - and a preset naming
+    // `contourBands` and no reading would leave a live value behind a closed heading
+    // while the panel had room to show it. Keeping the term is what holds that invariant
+    // across all four groups instead of three, and it is what lets the in-use mark be
+    // keyed on this rule alone rather than on a wider condition of its own.
+    //
+    // The obvious phrasing is wrong and is worth naming so nobody writes it back: "open
+    // when a reading is non-zero" fires on a page nobody has touched, because `readRgb`
+    // defaults to 1 and a default reading is the absence of a decision. Comparing
+    // against the defaults is the whole of what keeps a fresh project shut, on this
+    // group exactly as on the other three.
+    reveals: () => revealsItself('detail') || revealsItself('source') || revealsItself('treatment'),
+  },
   // Framing: what you can see, and where you are seeing it from. `sensor view` is
   // navigation and writes nothing - distinct from `look through it` in the camera
   // group, which adopts the program camera whose pose is document state.
@@ -1743,21 +1791,21 @@ const PANEL_GROUPS = [
   // what colour they take, what persists between frames, and what the optics do to
   // the result.
   { key: 'conditioning', label: 'Depth conditioning', lookgroup: true },
-  { key: 'displacement', label: 'Displacement', lookgroup: true },
+  { key: 'displacement', label: 'Displacement', lookgroup: true, collapses: true },
   // One region in the room, read three ways: it displaces, it scrambles, and it
   // masks. Everything here is metres in the sensor frame, so a look holds at any
   // output size without being referred to 1080p the way the screen-space terms are.
   // Half-extents at zero with a radius is a sphere; raise them and it becomes a
   // rounded box; take two to zero and it is a capsule. No shape selector, because an
   // enum could not keyframe and these sliders can.
-  { key: 'region', label: 'Region (metres)', lookgroup: true },
+  { key: 'region', label: 'Region (metres)', lookgroup: true, collapses: true },
   { key: 'points', label: 'Points', lookgroup: true },
   { key: 'colour', label: 'Colour & tone', lookgroup: true },
   // The three terms that accumulate across frames, together. Fade and wake are the
   // surface memory and trails is the afterimage buffer; they were two groups apart
   // while doing one thing, which is how a look gets tuned twice.
   { key: 'time', label: 'Time (ms)', lookgroup: true },
-  { key: 'optical', label: 'Optical', lookgroup: true },
+  { key: 'optical', label: 'Optical', lookgroup: true, collapses: true },
   // The two parameters that are not part of the clip, in the one group that says so.
   // They are tagged `view` in the registry, they get no keyframe control and no
   // preset carries them - and while they sat inside look groups that read as an
@@ -2079,8 +2127,16 @@ const PARAMS = {
 const READINGS = Object.keys(PARAMS).filter((n) => PARAMS[n].reading);
 
 /**
- * Which of the five readings a document does not name, which is a refusal at both
- * doors a document arrives through rather than at one of them.
+ * Which of the five readings a document does not name, asked at both doors a document
+ * arrives through and answered differently by them.
+ *
+ * A project is refused for missing any of them, because `serialiseProjectBody` writes
+ * the whole look tag every time and a project that is short of one is truncated. A
+ * preset is refused only for missing *some* of them, because a preset may deliberately
+ * be about part of a look - see `refusePresetBody` for why naming none is a scope and
+ * naming two is a blend nobody authored. The count is the same question; what differs
+ * is what each kind of document is allowed to leave out, which is a fact about the two
+ * doors rather than about this list.
  *
  * **The defaults are what make a partial document dangerous rather than incomplete.**
  * Every loader resets to defaults first so that a key a file omits means the default
@@ -2234,6 +2290,42 @@ function writeControl(name, value) {
 // would be machinery for a problem nobody has.
 let paramWritten = () => {};
 
+// The other announcement a write has to make, and it is separate from the one above
+// because it has a second sender: whether a panel group is worth showing is decided by
+// a parameter's value *and* by whether it carries keys, so a track appearing has to
+// reach this too and a track appearing is not a registry write.
+//
+// A no-op that gets replaced, like `paramWritten`, and here that shape is load-bearing
+// rather than stylistic. The predicate reads `tracks`, which is declared several hundred
+// lines below this - so `params.reset()` further down, which writes every parameter
+// while the module is still evaluating, would reach `tracks` in its temporal dead zone
+// and throw. A module that throws while evaluating publishes no `__kinect` at all, so
+// every proof tool in the suite reports DID NOT RUN and the exit code has no assertion
+// behind it, which is the outcome this repo has twice written down as a bug found.
+let groupRevealChanged = () => {};
+
+// Registry writes the transport makes on its own behalf, rather than on a user's: the
+// camera pose every render poses, and the three parameters a draft borrows for one frame
+// and hands back. Neither may ask for a repaint, and neither may re-derive the panel. A
+// render that scheduled another render would never stop, and a draft would be chased by
+// the accurate seek it exists to postpone - so the drag would pay for both.
+//
+// This is a separate flag from `evaluating` rather than a widening of it, and the two
+// mean different things: `evaluating` says a preset is not a track, this says a write
+// came from the renderer rather than from a hand. Nesting is real - a draft's suppression
+// spans a render that suppresses in turn - so `withoutRepaint` saves and restores instead
+// of clearing.
+//
+// **Declared up here rather than beside `withoutRepaint`, which is the same dead zone the
+// no-op above records and the second time this file has been caught by it.** `params.set`
+// consults it now, and `params.reset()` further down writes every parameter while the
+// module is still evaluating - so a `let` sitting beside its function four thousand lines
+// later is read before it exists, and the page throws during module evaluation. That
+// publishes no `__kinect` at all: every tool in the suite reports DID NOT RUN with no
+// assertion behind the exit code, measured exactly once and immediately. A flag the
+// registry reads is declared before the registry.
+let transportWriting = false;
+
 /**
  * The registry's door, and every way in goes through it.
  *
@@ -2289,6 +2381,18 @@ const params = {
     // write path at all: a preset, a slider, a mode and step 5's tracks all end up
     // on this line, so nothing can change the image without saying that it did.
     paramWritten(name, spec.tag);
+    // Beside it rather than folded into it, because the two answer different
+    // questions: `paramWritten` is "the image changed, rebuild it", and this is "the
+    // evidence a group is in use changed, so re-derive which groups are open". A
+    // parameter written back to the value it already held moves the first and not
+    // the second, which is why the refresh compares before it touches the panel.
+    //
+    // Skipped under the same flag `paramWritten` skips under, and for the same reason
+    // rather than by analogy: the transport's own writes arrive one per keyed parameter
+    // per rendered frame, and every one of them would walk every group's evidence to
+    // re-derive a panel the bulk write has not finished changing yet. `withoutRepaint`
+    // asks once on the way out, which is the answer for the whole write.
+    if (!transportWriting) groupRevealChanged();
     return v;
   },
   /**
@@ -2471,11 +2575,67 @@ function panelPlace(group, groupNode) {
   panelTail.set(anchor, groupNode);
 }
 
+// What the collapse rule below needs to find again after this pass has run: the group's
+// node, the parameters it emitted rows for, and the two elements in its head that say
+// what state it is in. Taken from the pass that *built* the rows rather than from a
+// second walk of the registry, because a group revealing itself over a parameter it
+// does not show would be a header answering for a control somewhere else - and two walks
+// of one table is exactly the drift this generator exists to remove.
+const panelGroupNodes = new Map();
+const panelGroupParams = new Map();
+
+// One head per group, whether or not the group can be shut, because two shapes of
+// header is two sets of CSS and the one that gets forgotten is the one nobody is
+// looking at. Only a collapsible group gets a button and a mark inside it.
+//
+// The heading stays the first element in the head and the only `<label>` there:
+// `sensor-view-check` names a group by the text of the first label it can find inside
+// it, so a head that put anything labelled ahead of the heading would rename thirteen
+// groups at once in a tool that has nothing to do with this feature.
+function panelHead(group) {
+  const head = panelNode('div', 'grouphead');
+  head.append(panelNode('label', null, group.label));
+  if (!group.collapses) return { head, button: null, mark: null };
+
+  // A count of the parameters in this group that are carrying something, shown only
+  // while the group is shut. Without it a collapsed group in use is the panel lying
+  // about what is shaping the frame, which is the exact fear this feature answers,
+  // inverted - the values would still be applied to every pixel with nothing on
+  // screen saying so.
+  const mark = panelNode('span', 'groupmark');
+  const button = panelNode('button', 'grouptoggle');
+  button.type = 'button';
+  // The key rather than a position, and on the button rather than only on the group,
+  // so `editor-check`'s sweep can credit *any* group toggle by the attribute instead
+  // of naming the four that exist today - a rule listing four ids stops covering the
+  // fifth the moment somebody declares `collapses` on another entry.
+  button.dataset.groupToggle = group.key;
+  button.id = `${group.key}Toggle`;
+  button.append(panelNode('i', 'groupchevron'));
+  button.addEventListener('click', () => toggleGroup(group.key));
+  head.append(mark, button);
+  return { head, button, mark };
+}
+
 let panelRowsEmitted = 0;
 for (const group of PANEL_GROUPS) {
   const groupNode = panelNode('div', group.lookgroup ? 'group lookgroup' : 'group');
-  groupNode.append(panelNode('label', null, group.label));
+  // A data attribute and not an id, because the six hand-written groups in the markup
+  // are already `#cameraGroup`, `#sensorGroup`, `#monitorGroup`, `#programOutGroup`,
+  // `#recordGroup` and `#recLookGroup`, and a generated group minting ids in the same
+  // shape is one registry key away from colliding with one of them silently.
+  groupNode.dataset.group = group.key;
+  // Named apart from the keyframe button the row loop below declares, which is a
+  // different button in a narrower scope: one `button` meaning two things in one loop
+  // is how the wrong element ends up registered.
+  const { head, button: headButton, mark: headMark } = panelHead(group);
+  groupNode.append(head);
   if (group.before) groupNode.append(...group.before());
+  const names = [];
+  panelGroupParams.set(group.key, names);
+  if (group.collapses) {
+    panelGroupNodes.set(group.key, { group, node: groupNode, button: headButton, mark: headMark });
+  }
 
   let rows = 0;
   for (const [name, spec] of Object.entries(PARAMS)) {
@@ -2520,6 +2680,11 @@ for (const group of PANEL_GROUPS) {
     }
     rows++;
     panelRowsEmitted++;
+    // The evidence set for this group, recorded here because here is where the row was
+    // emitted. A group asks whether anybody has touched it by walking exactly the
+    // parameters it put on screen, so the header and the rows under it cannot come to
+    // disagree about which parameters the group is.
+    names.push(name);
   }
   // A heading with nothing under it is a group key that got misspelled on one side,
   // which is the only way a group can end up empty and is worth a sentence rather
@@ -2582,19 +2747,9 @@ params.reset();
 // does not exist yet.
 let evaluating = false;
 
-// Registry writes the transport makes on its own behalf, rather than on a user's:
-// the camera pose every render poses, and the three parameters a draft borrows for
-// one frame and hands back. Neither may ask for a repaint. A render that scheduled
-// another render would never stop, and a draft would be chased by the accurate
-// seek it exists to postpone - so the drag would pay for both.
-//
-// This is a separate flag from `evaluating` rather than a widening of it, and the
-// two mean different things: `evaluating` says a preset is not a track, this says
-// a write came from the renderer rather than from a hand. Nesting is real - a
-// draft's suppression spans a render that suppresses in turn - so it saves and
-// restores instead of clearing.
-let transportWriting = false;
-
+// `transportWriting` is declared above the registry rather than here, where it would
+// otherwise belong: `params.set` reads it and the boot writes run long before this line.
+// The note on the declaration carries the rest.
 function withoutRepaint(write) {
   const outer = transportWriting;
   transportWriting = true;
@@ -2602,6 +2757,14 @@ function withoutRepaint(write) {
     return write();
   } finally {
     transportWriting = outer;
+    // The panel asked once for the whole write rather than once per value in it, and
+    // only at the outermost of a nest - a draft's suppression spans a render that
+    // suppresses in turn, so an inner `finally` firing here would be the per-write
+    // recompute again wearing a different name. This is not the repaint's twin: a
+    // repaint is deliberately *not* requested on the way out, because these writes are
+    // the renderer's own and asking for another render is the loop the flag exists to
+    // stop. Re-deriving which groups are open renders nothing.
+    if (!outer) groupRevealChanged();
   }
 }
 
@@ -3002,6 +3165,290 @@ function dropTrackIfEmpty(name) {
   const track = tracks.get(name);
   if (track && track.keys.length === 0) tracks.delete(name);
 }
+
+// ------------------------------------------------- which panel groups are open
+//
+// Whether a group is open is *derived from the document*, and only a disagreement is
+// stored. The alternative - a stored open/closed flag per group - is a second copy of
+// something the values already say, and a second copy drifts: a look applied from the
+// library would put values into three groups and leave all three shut, because nothing
+// in a preset knows about panel furniture. Deriving means the panel opens at whatever
+// the clip is actually using without anybody teaching every writer about it.
+//
+// This lives here rather than beside the generator because the predicate reads both of
+// the stores a parameter's evidence can be in, and `tracks` is the one declared just
+// above. See `groupRevealChanged`, which is the no-op the generator's pass calls and
+// which the last line of this block replaces.
+
+// Which groups you have overruled, and nothing else - the group key against the state
+// you asked for. It is client state and not document state, for the reason the `viewer`
+// group's own note gives about the two parameters in it: this changes what you are
+// looking at, not what the frame is. So it is out of the project, out of undo, out of
+// every export, and stored per browser like `kinect.lastOpened` and `kinect.lanesHeight`.
+const PANEL_GROUPS_OPEN = 'kinect.panelGroupsOpen';
+
+const groupOverride = new Map();
+try {
+  // The string is checked before the parse, which is the same lesson `kinect.lanesHeight`
+  // records one line at a time: `getItem` answers null when nothing was ever stored, and
+  // `JSON.parse(null)` answers null rather than throwing, so a missing entry and a stored
+  // `null` would arrive as one reading. `JSON.parse('')` does throw, and landing in the
+  // catch would be right by accident rather than by having asked.
+  const saved = localStorage.getItem(PANEL_GROUPS_OPEN);
+  if (saved !== null && saved.trim() !== '') {
+    const parsed = JSON.parse(saved);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      // Each entry checked rather than the object adopted, because this is a file a
+      // person can edit and a `null` or a string here would make `override ?? derived`
+      // answer with a truthy non-boolean and pin a group open forever. A `Map` is what
+      // holds them, so the `__proto__` key that `JSON.parse` creates as an own property
+      // is an ordinary entry here rather than a prototype write.
+      for (const [key, want] of Object.entries(parsed)) {
+        if (typeof want === 'boolean') groupOverride.set(key, want);
+      }
+    }
+  }
+} catch {
+  // Private browsing, storage disabled by policy, or an entry somebody has damaged.
+  // Every group answering for itself is a good state to arrive in.
+}
+
+function storeGroupOverride() {
+  try {
+    localStorage.setItem(PANEL_GROUPS_OPEN, JSON.stringify(Object.fromEntries(groupOverride)));
+  } catch {
+    // Private browsing or policy again. The panel still collapses and still opens; it
+    // just will not remember which way across a reload.
+  }
+}
+
+// What each parameter is worth in a project nobody has touched, computed once.
+//
+// **Through `normalise`, not against `PARAMS[n].def` raw**, and the difference is a
+// class rather than a case. `normalise` clamps, snaps to a grid anchored at `min` and
+// rounds to the decimals `min` and `step` imply, and every scalar default this build
+// declares happens to land on its own grid - so raw equality is correct today and
+// would go on being correct right up until somebody adds a parameter whose default is
+// not on its step. That group would then read as touched from boot, on a fresh page,
+// with nothing anywhere saying why. Doing it once at module scope is what keeps the
+// arithmetic off the evaluator's path, where this is asked several times a frame.
+const groupDefaults = new Map();
+for (const names of panelGroupParams.values()) {
+  for (const name of names) groupDefaults.set(name, params.normalise(name, PARAMS[name].def));
+}
+
+/**
+ * Whether one parameter carries evidence that somebody has been here: a keyframe track
+ * with keys on it, or a value sitting off the default a fresh project would hold. The
+ * whole rule is this line and a half, and both the group's open state and the count on
+ * a shut header are asked of it rather than of a copy.
+ *
+ * **The keyframe term is not decoration.** During playback the evaluator writes every
+ * keyed parameter through `params.set`, so `params.get` answers the *evaluated* value -
+ * and a curve that happens to cross its own default at the parked frame would make the
+ * value test say "untouched" for that one frame. Without this term the groups would
+ * breathe open and shut as the playhead moved, which is a panel that cannot be read
+ * while anything is playing. `valueAtProgram` answers the un-evaluated question, and it
+ * is deliberately not what this asks: a parameter with keys is in use at every position,
+ * including the ones its curve passes through on the way somewhere else.
+ *
+ * **`keys.length > 0`, never `tracks.has(name)`.** `restoreProject` does
+ * `trackFor('camera').keys = restoredCamera` with no `dropTrackIfEmpty` after it and
+ * `trackFor` inserts on a miss, so a zero-key entry survives in the map for the rest of
+ * the session after any project open or undo. No panel group holds `camera`, so
+ * membership would answer correctly here today and be wrong the first time an empty
+ * track outlives a name a group does show - and the length is what every other has-keys
+ * test in this file already asks.
+ *
+ * **And `tracks.get`, never `trackFor`.** `trackFor` is a creating accessor. A
+ * predicate built on it would author a keyframe track as a side effect of drawing a
+ * panel header, which is a document that changed because somebody looked at it.
+ */
+function paramTouched(name) {
+  if ((tracks.get(name)?.keys.length ?? 0) > 0) return true;
+  return params.get(name) !== groupDefaults.get(name);
+}
+
+/**
+ * The default rule: a group is in use when any parameter it shows is. Named rather than
+ * inlined because a `reveals` closure on a `PANEL_GROUPS` entry is written in terms of
+ * it - `Reading · detail` asks it about two other groups - so this is the vocabulary
+ * those closures are written in and not an internal step of the one below.
+ */
+function revealsItself(key) {
+  return (panelGroupParams.get(key) ?? []).some(paramTouched);
+}
+
+/**
+ * What the document says about a group, which is the derived half of "is it open" and
+ * the thing a toggle is measured against.
+ *
+ * Kept apart from `revealsItself` rather than folded into it, and the store rule below
+ * is why the two cannot be one function. A group carrying a `reveals` closure answers a
+ * wider question than its own parameters do, so a store rule comparing a collapse
+ * against `revealsItself` would find the two agreeing on a `Reading · detail` that a
+ * live reading had opened, drop the override, and re-derive the group open - a collapse
+ * that does not survive the repaint it caused. `detail`'s closure also calls
+ * `revealsItself` on two other groups, which is the second reason the names have to stay
+ * distinguishable at a call site.
+ */
+function groupRevealed(group) {
+  return group.reveals ? group.reveals() : revealsItself(group.key);
+}
+
+/** The predicate: what the document derives, unless a person has said otherwise. */
+function groupIsOpen(group) {
+  return groupOverride.get(group.key) ?? groupRevealed(group);
+}
+
+/**
+ * How many of a group's own parameters are carrying something, for the shut header.
+ *
+ * Over the same `paramTouched` the predicate walks rather than a second copy of the
+ * test, because two spellings of "has anybody been here" is two things to keep in step
+ * and the header would be the one that quietly stopped agreeing with the rule that
+ * opened the group above it.
+ */
+function groupTouchedCount(key) {
+  return (panelGroupParams.get(key) ?? []).filter(paramTouched).length;
+}
+
+/**
+ * What the panel shows, re-derived. Called after every registry write and after every
+ * change to the set of tracks, which between them are both terms of the predicate.
+ *
+ * Each group is painted only where the answer moved. The evaluator writes one value per
+ * keyed parameter per frame and every one of them arrives here, so an unconditional
+ * write would put a `textContent` assignment and an attribute write per group into the
+ * render path to say what the panel already said.
+ */
+const groupPainted = new Map();
+// How often the panel has been re-derived, for the one question a tool cannot answer
+// from outside: whether a bulk write costs one pass or one per value in it. A count the
+// page keeps rather than a duration a driver times, because a rate taken around a
+// gesture Playwright is pacing is a measurement of Playwright.
+let groupRefreshes = 0;
+// Whether the map has moved since it was last written down. It is a flag rather than a
+// second `storeGroupOverride()` call at the toggle because there is exactly one rule
+// about what may be in that store, and a rule with two enforcement sites is the shape
+// `docs/instruments.md` records the rename refusal having: no mutation can reach one of
+// them without the other covering, so one of the two is doing all the work and nothing
+// can say which.
+let groupOverrideDirty = false;
+// Where the two terms of the store rule last stood, keyed by group and read as
+// `override/derived`. It exists so a pass can tell an agreement that was just *arrived
+// at* from one that has been true since the page opened, which is the whole of what the
+// prune below turns on. Empty at boot on purpose.
+const groupSeen = new Map();
+function refreshGroups() {
+  groupRefreshes++;
+  for (const [key, { group, node, button, mark }] of panelGroupNodes) {
+    // The same rule that decides whether the group opens, and not a wider one of its
+    // own. That is a property of every `reveals` closure including its own parameters
+    // rather than a coincidence: a group with something touched inside it always
+    // derives open, so a shut group that is in use is always one a person shut, and the
+    // mark is telling them what they hid. A closure that *replaced* the default rule
+    // would break that - the group could be quietly carrying a value with nothing on
+    // screen saying so - and the fix belongs in the closure rather than here, because a
+    // mark widened to cover it would be a second rule drifting from the first.
+    const inUse = groupRevealed(group);
+    const want = groupOverride.get(key);
+    // **The decay the store rule claims, and for a while it was only a claim.**
+    // `toggleGroup` drops an entry that agrees with the derivation *at the moment the
+    // toggle is pressed*, which closes nothing on its own, because the term that moves
+    // afterwards is the other one. A group pinned open while it was quiet stores `true`
+    // against a derived `false`, and then a value set, a look applied or a project
+    // opened moves the derivation onto it with nothing looking - so reset the look and
+    // the group is still open with nothing inside it, which is the stored panel layout
+    // this whole design exists to refuse. The derivation is read here, on every write
+    // and every change to the tracks, so this is where an override that has been
+    // overtaken can be seen to have been.
+    //
+    // **What it may not do is prune on agreement alone, and the state that says so is
+    // the one this page boots into.** Before the take is open and before a project has
+    // been restored every look parameter sits at its default and `tracks` is empty, so
+    // the derivation answers `false` for every group - which is not a statement about
+    // the document, it is a statement about there not being one yet. A build comparing
+    // the two terms for equality deleted every stored collapse on its way past that
+    // reading, wrote the pruned map straight back, and then let the take load and derive
+    // the group open again. Collapsing a group that was in use never survived a reload
+    // while pinning one open always did, and the direction that failed is the one people
+    // reach for, because a quiet group is already shut. The same window is open for as
+    // long as the load takes rather than only at module evaluation, so a flag raised
+    // until boot finishes would close half of it: `openTake` derives against a default
+    // look before the project that fills it has arrived.
+    //
+    // So the pair is remembered and the prune fires where it has *changed* into
+    // agreement - the derivation arriving on the opinion, or a toggle putting the
+    // opinion on the derivation. Both terms are covered by one comparison rather than
+    // two rules, which is the same reason `toggleGroup` does not prune on its own way
+    // past. At boot nothing has changed into anything and the map is empty, so the page
+    // reads the store and leaves it alone. An entry that agreed from the first frame and
+    // never moved is kept, which costs a group rendering exactly as it would have
+    // anyway, and it decays the first time the document uses that group and stops.
+    //
+    // `get` answers `undefined` for a group nobody has overruled and no comparison
+    // against a boolean can match that, so the untouched case costs two Map lookups.
+    const pair = `${want}/${inUse}`;
+    const settled = groupSeen.get(key);
+    if (settled !== undefined && settled !== pair && want === inUse) {
+      groupOverride.delete(key);
+      groupOverrideDirty = true;
+    }
+    groupSeen.set(key, `${groupOverride.get(key)}/${inUse}`);
+    const open = groupIsOpen(group);
+    const touched = groupTouchedCount(key);
+    const state = `${open}/${inUse}/${touched}`;
+    if (groupPainted.get(key) === state) continue;
+    groupPainted.set(key, state);
+
+    node.classList.toggle('shut', !open);
+    button.setAttribute('aria-expanded', String(open));
+    // What the button says it will do, which is not the same sentence as the heading.
+    button.setAttribute('aria-label', `${open ? 'collapse' : 'expand'} ${group.label}`);
+    // The count only where it is the only thing that can say so. An open group has its
+    // rows on screen and a number over them would be a second, worse copy of them; a
+    // shut group that is genuinely at its defaults has nothing to announce. The one
+    // case with nothing to count is `detail` revealed by a reading, which shows the
+    // mark without a number rather than a misleading zero.
+    mark.hidden = open || !inUse;
+    mark.textContent = touched > 0 ? String(touched) : '';
+    mark.title = touched > 0
+      ? `${touched} of these are set to something` : 'this group is in use';
+  }
+  // Once at the end, and only where the map actually moved. `setItem` serialises the
+  // whole thing synchronously, so writing it on every pass would put a `JSON.stringify`
+  // and a storage write into the render path to store the bytes that were already
+  // there - which is the cost the painting rule above exists to keep out, arriving
+  // through the door beside it.
+  if (groupOverrideDirty) {
+    groupOverrideDirty = false;
+    storeGroupOverride();
+  }
+}
+
+/**
+ * A person disagreeing with the derivation, which is the only thing that is stored.
+ *
+ * It writes what was asked for and nothing else. Whether that survives is the prune's
+ * question and is asked in `refreshGroups` above, where the derivation is read - a
+ * toggle that dropped an agreeing entry on its own way past would be the same rule
+ * spelled a second time, and the second spelling would be the one covering for the
+ * first every time anything tried to measure either.
+ */
+function toggleGroup(key) {
+  const entry = panelGroupNodes.get(key);
+  if (!entry) return;
+  groupOverride.set(key, !groupIsOpen(entry.group));
+  groupOverrideDirty = true;
+  refreshGroups();
+}
+
+// The no-op declared beside `paramWritten` becomes the real thing here, where both of
+// the stores the predicate reads exist, and the panel is painted once for the state the
+// page booted into.
+groupRevealChanged = refreshGroups;
+refreshGroups();
 
 // Every track written through the one door, at one program position. This is the
 // evaluator the note on `evaluating` asked for: it runs inside
@@ -5896,6 +6343,13 @@ const ui = {
   presetExport: document.getElementById('tPresetExport'),
   presetImport: document.getElementById('tPresetImport'),
   presetFile: document.getElementById('tPresetFile'),
+  pickDialog: document.getElementById('presetPick'),
+  pickTitle: document.getElementById('ppTitle'),
+  pickName: document.getElementById('ppName'),
+  pickGroups: document.getElementById('ppGroups'),
+  pickCount: document.getElementById('ppCount'),
+  pickCancel: document.getElementById('ppCancel'),
+  pickGo: document.getElementById('ppGo'),
   project: document.getElementById('tProject'),
   projectOpen: document.getElementById('tProjectOpen'),
   projectSave: document.getElementById('tProjectSave'),
@@ -7858,6 +8312,14 @@ function paintLanes() {
 function lanesChanged() {
   rebuildLanes();
   paintLanes();
+  // The keyframe half of the panel's collapse rule, and this is the one announcement
+  // that carries it: a track appearing is not a registry write, so `params.set` never
+  // hears about it. Every path that changes the set of tracks arrives here - keying
+  // from a panel button, a tool writing a whole set at once, undo, and a project being
+  // opened, which reaches it through `timingChanged`. A group whose only evidence is a
+  // keyed parameter sitting on its default would otherwise stay shut until the next
+  // time anything wrote a value.
+  groupRevealChanged();
 }
 
 /**
@@ -8056,6 +8518,210 @@ function presetFromCurrentLook(names) {
 }
 
 /**
+ * Whether a document says what the whole look is, rather than adjusting part of one.
+ *
+ * The distinction did not exist while the only thing that could write a preset wrote
+ * the entire look tag, and it decides two separate things now - whether a file may
+ * stamp a clip with its provenance, and whether saving one moves the stamp - so it is
+ * one predicate both of them ask rather than the same `every` written twice.
+ */
+const wholeLookTag = (values) => params.names('look').every((n) => Object.hasOwn(values, n));
+
+// ------------------------------------------- which look values a preset carries
+
+/**
+ * The subset picker, built once at boot and shown by both doors a look leaves by.
+ *
+ * `presetFromCurrentLook` has taken a subset of names since it was written and both
+ * of its callers passed nothing, so every preset this program could author was the
+ * whole look tag - the capability sat one layer down with no way to reach it. What
+ * that cost was not expressiveness: "just my grain and bloom" had to be a hand-edited
+ * file, and a hand-edited file is the one door into this program that nothing
+ * upstream validates.
+ *
+ * **The groups come from `PANEL_GROUPS` and `PARAMS[n].group`, never from a list
+ * here.** A second statement of which parameter belongs under which heading is a
+ * statement that drifts, and it would drift silently, because a parameter missing
+ * from this dialog is not an error anywhere - it is a value you can no longer choose
+ * to leave out. Derived, a parameter added next year appears by existing, under the
+ * heading the panel already gives it.
+ *
+ * **Built at boot rather than on the first press**, which is the same call
+ * `library.js` makes for the gallery's menus and for the same reason: `editor-check`
+ * enumerates what the document contains and demands a driver for every control in it,
+ * so a dialog that populated itself on open would show the sweep an empty box and the
+ * user fifty-odd checkboxes. A control no sweep can see is a control nothing proves.
+ */
+const presetPickBoxes = new Map();
+const presetPickGroups = [];
+
+/**
+ * One box written, and the four that may have to move with it.
+ *
+ * The five reading weights tick and untick as a unit because a document naming two of
+ * them is not a look at all - `refusePresetBody` refuses exactly that file, and the
+ * reason is that the three left out do not arrive as anything. They stay at whatever
+ * the clip was already wearing, so half a blend renders as a mixture nobody authored.
+ * The rule belongs to the format; this is the control declining to assemble the file
+ * the format will refuse, which is better than meeting that refusal at the end of the
+ * gesture with the boxes already ticked.
+ */
+function presetPickSet(name, on) {
+  for (const n of (PARAMS[name].reading ? READINGS : [name])) presetPickBoxes.get(n).checked = on;
+}
+
+/**
+ * The group headings and the count, read back off the boxes rather than tracked
+ * beside them.
+ *
+ * A heading is a third state and not two: ticked when the whole group is in,
+ * indeterminate when part of it is, which is what makes one control both the
+ * check-all and the honest readout of what the group currently holds. Recomputed from
+ * the boxes after every write because the reading rule crosses two groups - unticking
+ * `depth` under Reading · source takes the three under Reading · treatment with it,
+ * and a heading that only heard about its own members would go on claiming they were
+ * in.
+ */
+function presetPickSync() {
+  for (const group of presetPickGroups) {
+    const on = group.members.filter((n) => presetPickBoxes.get(n).checked).length;
+    group.box.checked = on === group.members.length;
+    group.box.indeterminate = on > 0 && on < group.members.length;
+  }
+  const picked = presetPickNames();
+  ui.pickCount.textContent = `${picked.length} of ${presetPickBoxes.size} look values`;
+  // A preset carrying nothing is refused on the way back in, so the confirm is what
+  // refuses to write one: meeting that at the end of the gesture would be a dialog
+  // that lets you spend a minute assembling a document it already knows it cannot use.
+  ui.pickGo.disabled = picked.length === 0;
+}
+
+const presetPickNames = () => [...presetPickBoxes.keys()].filter((n) => presetPickBoxes.get(n).checked);
+
+for (const group of PANEL_GROUPS) {
+  const members = params.names('look').filter((n) => PARAMS[n].group === group.key);
+  // Skipped where the panel generator refuses, and the opposite call is right for the
+  // opposite reason: an empty panel group is a group key misspelled on one side, where
+  // an empty group here is the Viewer heading, which holds render scale and auto-orbit
+  // and both of them are `view`. View state is not in any preset, so a heading with
+  // nothing under it would be the panel's shape leaking into a question about the
+  // document.
+  if (!members.length) continue;
+  const groupNode = document.createElement('div');
+  groupNode.className = 'ppgroup';
+  const head = document.createElement('label');
+  head.className = 'check pphead';
+  const all = document.createElement('input');
+  all.type = 'checkbox';
+  all.id = `ppg-${group.key}`;
+  head.append(all, ` ${group.label}`);
+  groupNode.append(head);
+  all.addEventListener('change', () => {
+    for (const name of members) presetPickSet(name, all.checked);
+    presetPickSync();
+  });
+
+  for (const name of members) {
+    const row = document.createElement('label');
+    row.className = 'check';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    // Prefixed, because the panel's own control for this parameter is already `id`
+    // = the parameter's name. Two nodes under one id is a document where
+    // `getElementById` answers whichever came first, and `editor-check` builds the
+    // set it diffs against the registry out of exactly these ids - so a bare name
+    // here would let a panel that had dropped a row pass the row that exists to
+    // catch it, on the strength of a checkbox in a dialog.
+    input.id = `pp-${name}`;
+    input.checked = true;
+    row.append(input, ` ${PARAMS[name].label}`);
+    groupNode.append(row);
+    presetPickBoxes.set(name, input);
+    input.addEventListener('change', () => { presetPickSet(name, input.checked); presetPickSync(); });
+  }
+  ui.pickGroups.append(groupNode);
+  presetPickGroups.push({ box: all, members });
+}
+
+// Every reading needs a box, on the same reasoning as the uniform assertion beside
+// `READINGS` itself: `presetPickSet` reaches for all five whenever one of them is
+// ticked, so a reading the loop above did not build - one tagged something other than
+// `look`, which is the only way it could be skipped - would not be a missing checkbox.
+// It would be a dialog that throws on the first tick of any reading, which is a control
+// that appears to work until somebody uses it.
+for (const name of READINGS) {
+  if (!presetPickBoxes.has(name)) {
+    throw new Error(`the reading ${name} has no box in the preset subset dialog: ticking any of the five would throw`);
+  }
+}
+
+// Wired once rather than per opening: cancel means the same thing every time, and a
+// listener added on each open is a listener added again on the next one.
+ui.pickCancel.addEventListener('click', () => ui.pickDialog.close());
+
+/**
+ * Opens the picker and answers with a name and a subset, or with null.
+ *
+ * **Every box starts ticked**, so the gesture somebody already knows - press save,
+ * type a name, confirm - writes the whole look tag exactly as it did before, and a
+ * sparse preset is something you go out of your way to author. The state is rebuilt
+ * on each opening rather than remembered, because a selection carried over from the
+ * last save is a document shape decided by something off screen.
+ *
+ * **Cancelling writes nothing**, which is the whole of what `null` means here, and
+ * closing is one path rather than three: the confirm closes the dialog, so the
+ * `close` event is where the promise is settled whether it arrived from the button,
+ * from Escape, or from anything added later. Focus goes back to the control that
+ * opened the dialog on that same path, for the reason `library.js` states beside
+ * `closeMenus` - a surface dismissed while focus sat inside it leaves the caret
+ * nowhere, and the fix that is a rule survives the next caller where the fix that is
+ * a case does not.
+ */
+function pickPresetSubset({ title, verb, name }) {
+  return new Promise((resolve) => {
+    const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    for (const input of presetPickBoxes.values()) input.checked = true;
+    presetPickSync();
+    ui.pickTitle.textContent = title;
+    ui.pickGo.textContent = verb;
+    ui.pickName.value = name;
+
+    let picked = null;
+    const confirm = () => {
+      // A document is named before it is written, and an unnamed one is neither a
+      // library entry nor a filename. The refusal is the field taking the focus back
+      // rather than a sentence, because there is only one field to be wrong about.
+      const chosen = ui.pickName.value.trim();
+      if (!chosen) { ui.pickName.focus(); return; }
+      picked = { name: chosen, names: presetPickNames() };
+      ui.pickDialog.close();
+    };
+    // Enter in the name field confirms, because it did when this was a `prompt()` and
+    // a dialog that quietly stopped answering the return key would be the gesture
+    // getting longer for everybody who already knew it. Guarded on the confirm being
+    // live so the key cannot write a document the button is refusing to write.
+    const typed = (e) => {
+      if (e.key !== 'Enter' || ui.pickGo.disabled) return;
+      e.preventDefault();
+      confirm();
+    };
+    const settle = () => {
+      ui.pickGo.removeEventListener('click', confirm);
+      ui.pickName.removeEventListener('keydown', typed);
+      ui.pickDialog.removeEventListener('close', settle);
+      if (opener?.isConnected && !opener.disabled) opener.focus();
+      resolve(picked);
+    };
+    ui.pickGo.addEventListener('click', confirm);
+    ui.pickName.addEventListener('keydown', typed);
+    ui.pickDialog.addEventListener('close', settle);
+    ui.pickDialog.showModal();
+    ui.pickName.focus();
+    ui.pickName.select();
+  });
+}
+
+/**
  * Everything about a preset that can be refused without writing anything.
  *
  * Split out of `applyStoredPreset` so the import path can ask the question before it
@@ -8071,11 +8737,62 @@ function refusePresetBody(name, body) {
   if (body?.version !== PROJECT_VERSION) {
     throw new Error(versionRefusal(`preset ${name}`, body?.version));
   }
+  // **The envelope, checked with the same suspicion as what is inside it.** Every key
+  // in `values` is put to the registry below, and for a while nothing looked at the
+  // document's own keys at all - so `{"version": 4, "mode": 4, "values": {...}}` walked
+  // straight through. `mode` is the exact field version 4 dissolved into the five
+  // reading weights, it means something specific in a version 3 document, and a file
+  // carrying it is a file whose author believes this build reads it. Answering that
+  // file with silence is the failure the version check one line above exists to
+  // prevent, arriving through the one part of the document nobody was reading.
+  //
+  // Named rather than counted, because the point is to tell somebody editing by hand
+  // which word to delete. `Object.keys` on a parsed document reports `__proto__` as an
+  // own key, so a file smuggling one is refused here as well - earlier than the values
+  // walk that already refuses it, and for the more accurate reason.
+  //
+  // `presetFromCurrentLook` emits these two and the five shipped looks carry these two,
+  // so this is the shape the program authors rather than a shape asserted about it.
+  const PRESET_KEYS = ['version', 'values'];
+  const stray = Object.keys(body).filter((k) => !PRESET_KEYS.includes(k));
+  if (stray.length) {
+    throw new Error(
+      `preset ${name} carries ${stray.join(', ')}, which a version ${PROJECT_VERSION} preset has no `
+      + `place for: a preset is ${PRESET_KEYS.join(' and ')} and nothing else, so a key beside them is `
+      + 'either a field an older version had or a typo, and both would be read as neither',
+    );
+  }
   // A document with no values is not a look that happens to change nothing. `?? {}`
   // used to make it one: the apply wrote nothing, the stamp went on anyway, and what
   // came back was a clip claiming provenance from a file that had said nothing at all.
-  if (!body.values || typeof body.values !== 'object' || Array.isArray(body.values)) {
+  //
+  // **An empty `values` object is that same document spelled differently**, and it
+  // needed saying out loud only once the reading rule below became a rule about
+  // scope. While all five readings were demanded of every file, `{}` was refused for
+  // naming none of them; a file whose scope is "nothing" now walks through that gate
+  // truthfully, so the sentence the shape deserves has to be stated where it was
+  // always meant - here, about the values.
+  //
+  // Three shapes and three sentences, because they are three different mistakes and
+  // one sentence fitted one of them. The person reading it is editing the file by
+  // hand, and telling somebody who has just deleted the last entry out of `values`
+  // that their document "carries no values object" sends them looking for a key that
+  // is in front of them.
+  if (!body.values || typeof body.values !== 'object') {
     throw new Error(`preset ${name} carries no values object, so there is no look in it to apply`);
+  }
+  if (Array.isArray(body.values)) {
+    throw new Error(
+      `preset ${name} carries a list where its values should be: a look is an object of `
+      + 'parameter names against values, so a list has nothing in it this program can name',
+    );
+  }
+  if (Object.keys(body.values).length === 0) {
+    throw new Error(
+      `preset ${name} has a values object with nothing in it, so its scope is nothing: `
+      + 'applying it would write no value and move no pixel. Name the values this look is '
+      + 'made of, or delete the document rather than keep one that describes no look',
+    );
   }
 
   // The values, checked against the registry without reaching it. `params.apply` does
@@ -8106,34 +8823,94 @@ function refusePresetBody(name, body) {
     params.normalise(key, value);
   }
 
-  // **And all five readings have to be there**, which is the whole reason there is a
-  // version 4. `format.js` puts it plainly about a version 3 file: every value it names
-  // is still a parameter, so the apply writes all of them without complaint and only
-  // the reading is missing, leaving whatever the previous document happened to select.
-  // A version 4 file that simply omits the five keys reaches that identical state while
-  // passing the version gate - the same look rendering as somebody else's shading,
-  // silently, only now with a stamp on it saying which file it came from. Everything
-  // that writes a preset writes all five: the converter emits them, and an export is
-  // `params.values` over the whole look tag. So a file missing them is hand-made, and
-  // this is the sentence it should get.
+  // **And the readings are all or none**, which is the version 4 rule stated as a
+  // scope rather than as a census, because the file's own keys are what it claims to
+  // be about.
+  //
+  // The danger the rule exists for has not moved. `format.js` puts it plainly about a
+  // version 3 file: every value it names is still a parameter, so the apply writes all
+  // of them without complaint and only the reading is missing, leaving whatever the
+  // previous document happened to select. A file naming `readRgb` and `readDepth` and
+  // stopping reaches that identical state for the other three - a blend of the two it
+  // set against whatever the clip was already wearing, which is a mixture nobody
+  // authored and which nothing on screen says is a mixture. That file still gets the
+  // sentence below.
+  //
+  // What changed is the file that names **none** of them, which used to be caught by
+  // the same test and is a different document. It is not a look with a hole in it, it
+  // is a look that is not about the reading: `applyStoredPreset` writes the keys the
+  // document names and no others, so the blend on screen afterwards is the one the
+  // clip already had, chosen by whoever was grading rather than left over from a file.
+  // The half that made the old refusal necessary - a stamp on the clip claiming
+  // provenance from a document that had not said what the look is - is closed at the
+  // stamp instead, where it belongs, and a partial file cannot claim it at all.
   const missing = missingReadings(body.values);
-  if (missing.length) {
+  if (missing.length && missing.length !== READINGS.length) {
+    // **Both ways out, because the file in front of this person has two.** The old
+    // sentence said the look "carries all five reading weights", which stopped being
+    // true the moment naming none of them became legal, and it named the one exit that
+    // adds keys - so somebody who had deliberately cut the blend down to two was told
+    // to put three back rather than told that taking two out is the other answer and
+    // the one they probably meant. The reason for refusing the middle has not moved and
+    // is still the whole of it: a document naming some of the weights leaves the rest
+    // wherever the clip had them, which is a blend nobody authored.
+    //
+    // Off `missingReadings` for both halves rather than a second census of the same
+    // thing, since two spellings of one count is how one of them comes to be wrong.
+    const named = READINGS.filter((n) => !missing.includes(n));
     throw new Error(
-      `preset ${name} names no ${missing.join(', ')}: a version ${PROJECT_VERSION} look carries all `
-      + 'five reading weights, and one that leaves them out would render as whatever was on '
-      + 'screen before it',
+      `preset ${name} names ${named.join(', ')} but not ${missing.join(', ')}: the reading `
+      + 'weights are all or none, because a file naming some of them blends what it says with '
+      + `whatever the clip was already wearing. Name the other ${missing.length}, or take `
+      + `${named.length === 1 ? 'the one it has' : `all ${named.length} it has`} out and leave `
+      + 'the reading to whoever is grading',
     );
   }
 }
 
-/** Applies a saved preset and stamps where it came from. */
+/**
+ * Applies a saved preset, and stamps where it came from only if the document said
+ * what the whole look is.
+ *
+ * The stamp answers one question - what look is this clip wearing - and a document
+ * that set three of the fifty-four look values did not answer it. Naming it as the
+ * clip's origin is the same silent lie the reading rule above exists to stop, one
+ * level up: a gallery comparing revisions would show three clips agreeing on a look
+ * they only agree about in the three values that file happened to carry.
+ *
+ * So a partial apply leaves the stamp exactly where it was, which is the same thing
+ * moving a slider does, and is the honest answer for the same reason - the clip's
+ * provenance is the last document that described the whole of it. The two surfaces
+ * that report an apply read the result rather than the stamp, because a note that
+ * printed `appliedPreset.rev` after a partial apply would either name a revision the
+ * user did not just apply or, once the clip has no stamp at all, throw inside the
+ * handler and report a successful apply as a failure.
+ */
 function applyStoredPreset(doc) {
   refuseDuringEvaluation('a stored preset applied');
   refusePresetBody(doc.name, doc.body);
-  params.apply(doc.body.values ?? {});
-  appliedPreset = { name: doc.name, rev: doc.rev };
+  const values = doc.body.values ?? {};
+  const stamped = wholeLookTag(values);
+  params.apply(values);
+  if (stamped) appliedPreset = { name: doc.name, rev: doc.rev };
   requestRepaint();
   history.commit();
+  return { stamped, written: Object.keys(values).length, look: params.names('look').length };
+}
+
+/**
+ * What a surface says after an apply, in one place because there are two surfaces and
+ * they were already saying it twice.
+ *
+ * A partial apply has no revision to print - there is no stamp, and printing the one
+ * the clip is still carrying would attribute this gesture to a document that had
+ * nothing to do with it - so what it reports is what it did: how much of the look came
+ * out of the file, and that the clip's provenance was left alone.
+ */
+function presetAppliedNote(name, applied) {
+  return applied.stamped
+    ? `applied ${name} · ${appliedPreset.rev.slice(7, 15)}`
+    : `applied ${applied.written} of ${applied.look} values from ${name} · part of a look, so the clip keeps its provenance`;
 }
 
 /**
@@ -9599,88 +10376,216 @@ function paintPreviewRange(minDepth, maxDepth) {
   ui.recRange.textContent = `preview only · ${kept}`;
 }
 
-ui.recPresetApply.addEventListener('click', async () => {
+// Every control that starts a preset gesture, named once so a fifth is covered by being
+// added to this list rather than by being remembered.
+//
+// **The apply and the import are in it, and leaving them out is the hole this list was
+// drawn up to close arriving through the other side.** What the guard protects is
+// `appliedPreset`, and four doors write it: a save that describes the whole look, an
+// apply of one, an import, and the apply on the recorder. Scoping the flag to the two
+// controls that share the subset dialog left the other two live with a PUT in flight -
+// press save, confirm, and apply a whole-look preset while the write is unanswered, and
+// the apply's stamp lands first with the save's overwriting it, so the clip ends up
+// wearing the older revision. That is the same corruption the dialog introduced, through
+// a door the guard did not cover.
+//
+// It is one gate rather than a second rule sequencing writes to `appliedPreset`, because
+// two gates that agree cannot be tested apart and one of them would be doing all the
+// work - `docs/instruments.md` records the rename refusal costing exactly that. And it
+// sits on the handlers rather than inside `applyStoredPreset`, because that function and
+// `restoreProject` beside it are exposed raw for the proof tools to drive: a guard
+// pushed down there would start silently dropping calls that are not gestures at all.
+const PRESET_WRITERS = [ui.presetSave, ui.presetExport, ui.presetApply, ui.presetImport, ui.recPresetApply];
+
+// Whether one of those gestures is running. It is a flag on the program rather than a
+// state of a control, because what has to be true is that there is one gesture, not that
+// a particular button is unpressable - a second door added later would otherwise be a
+// second way in with no guard on it.
+let presetGesture = false;
+
+/**
+ * One preset gesture at a time, whichever control started it.
+ *
+ * **This is a regression the dialog introduced and the `prompt()` it replaced did not
+ * have.** A `prompt` blocks the whole page, so two saves could not overlap and nothing
+ * had to say so; a `<dialog>` closes before the PUT it authorised has been answered,
+ * and from that moment every preset control is live again with a write in flight behind
+ * them. Two gestures whose responses come back out of order then run the stale handler
+ * last, and `appliedPreset` ends up naming the older revision - which corrupts the one
+ * thing the stamp is for, quietly, in the direction that looks like it worked.
+ *
+ * **A refused gesture is answered rather than dropped**, and the surface is the caller's
+ * because the recorder has no timeline strip to write into. A second press of save is a
+ * repeat of the gesture already running and silence there reads as the press not having
+ * registered; an apply or an import is a *different* gesture, chosen from a picker or an
+ * operating system file dialog, and swallowing one without a word is a document answered
+ * with silence.
+ *
+ * The export half of this closes no race of its own: `exportPresetFile` builds a blob
+ * and clicks a link, with no request whose answer could arrive late. It is here because
+ * a gesture is a gesture, and because the controls share the dialog - a save left in
+ * flight underneath a fresh export sheet is a name field over a document that is still
+ * being written.
+ */
+async function withPresetGesture(note, run) {
+  if (presetGesture) {
+    note.textContent = 'a preset gesture is still running, so this one did not start';
+    return false;
+  }
+  presetGesture = true;
+  try {
+    await run();
+  } finally {
+    presetGesture = false;
+  }
+  return true;
+}
+
+/**
+ * The write itself: the controls held down for as long as a request is unanswered, and
+ * the caret given back to whichever of them was carrying it.
+ *
+ * The two spans differ on purpose. The **flag** covers the whole gesture including the
+ * dialog, because that is the honest statement of the rule. The **disabled** state
+ * covers only the write, because while the dialog is up it is modal and nothing outside
+ * it can be pressed anyway.
+ *
+ * **And the caret is put back, because disabling is what took it.** `pickPresetSubset`
+ * hands focus to the control that opened the dialog on the `close` event and resolves in
+ * the same breath, so the button is holding the caret exactly when this runs a microtask
+ * later - `el.disabled = true` on a focused element blurs it, the browser falls back to
+ * the body, and re-enabling does not undo that. The guard's own comment used to argue
+ * that the narrow span avoided this and the order made it false. `library.js` states the
+ * rule beside `closeMenus` and `library-check` carries two mutations for it, so a
+ * surface that strands the caret is a defect here rather than a detail. Only where the
+ * caret has fallen to the body, so a gesture the user has moved on from does not have
+ * focus dragged back out from under them.
+ */
+async function whileWriting(run) {
+  const held = document.activeElement;
+  for (const el of PRESET_WRITERS) el.disabled = true;
+  try {
+    return await run();
+  } finally {
+    for (const el of PRESET_WRITERS) el.disabled = false;
+    const stranded = document.activeElement === null || document.activeElement === document.body;
+    if (stranded && PRESET_WRITERS.includes(held) && held.isConnected) held.focus();
+  }
+}
+
+ui.recPresetApply.addEventListener('click', () => withPresetGesture(ui.recLookNote, () => whileWriting(async () => {
   const name = ui.recPreset.value;
   if (!name) return;
   try {
-    applyStoredPreset(await (await fetch(`/presets/${encodeURIComponent(name)}`)).json());
-    ui.recLookNote.textContent = `applied ${name} · ${appliedPreset.rev.slice(7, 15)}`;
+    const applied = applyStoredPreset(await (await fetch(`/presets/${encodeURIComponent(name)}`)).json());
+    ui.recLookNote.textContent = presetAppliedNote(name, applied);
   } catch (err) {
     // The recorder has no timeline bar, so `showTimelineError` would write into a
-    // strip nobody on this surface can see.
+    // strip nobody on this surface can see. Kept at the call site rather than folded
+    // into the guard for that reason: one shared `catch` would move this sentence to a
+    // surface the person pressing the button cannot see.
     ui.recLookNote.textContent = `could not apply ${name}: ${err.message}`;
     console.error(err);
   }
-});
+})));
 
-ui.presetApply.addEventListener('click', async () => {
+ui.presetApply.addEventListener('click', () => withPresetGesture(ui.note, () => whileWriting(async () => {
   const name = ui.preset.value;
   if (!name) return;
   try {
-    applyStoredPreset(await (await fetch(`/presets/${encodeURIComponent(name)}`)).json());
-    ui.note.textContent = `applied ${name} · ${appliedPreset.rev.slice(7, 15)}`;
+    const applied = applyStoredPreset(await (await fetch(`/presets/${encodeURIComponent(name)}`)).json());
+    ui.note.textContent = presetAppliedNote(name, applied);
   } catch (err) {
     showTimelineError(err);
   }
-});
+})));
 
-ui.presetSave.addEventListener('click', async () => {
-  // Named by the user, because a preset library whose entries are called
-  // "preset 3" is a library nobody uses twice.
-  const name = prompt('save this look as', appliedPreset?.name ?? 'look-1');
-  if (!name) return;
-  try {
-    const res = await fetch(`/presets/${encodeURIComponent(name)}`, {
+/** Pick a subset, then do one thing with it, inside the one gesture the program allows. */
+async function withPresetSubset(ask, run) {
+  await withPresetGesture(ui.note, async () => {
+    try {
+      const picked = await pickPresetSubset(ask);
+      if (!picked) return;
+      await whileWriting(() => run(picked));
+    } catch (err) {
+      showTimelineError(err);
+    }
+  });
+}
+
+// Named by the user, because a preset library whose entries are called "preset 3" is a
+// library nobody uses twice - and the name is asked for in the same gesture as the
+// subset, because they are two halves of one decision about the document being written
+// and asking them one after the other would put a `prompt` in front of a dialog.
+ui.presetSave.addEventListener('click', () => withPresetSubset(
+  { title: 'Save this look', verb: 'save', name: appliedPreset?.name ?? 'look-1' },
+  async (picked) => {
+    const body = presetFromCurrentLook(picked.names);
+    const res = await fetch(`/presets/${encodeURIComponent(picked.name)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(presetFromCurrentLook()),
+      body: JSON.stringify(body),
     });
     const saved = await res.json();
     if (saved.error) throw new Error(saved.error);
-    // Saving stamps the clip too. The look on screen genuinely is that revision of
-    // that preset, and leaving the stamp on whatever was applied before would have
-    // the provenance say a look this clip no longer has.
-    appliedPreset = { name: saved.name, rev: saved.rev };
+    // Saving stamps the clip too, on the same condition an apply does. The look on
+    // screen genuinely is that revision of that preset when the file describes the
+    // whole of it, and leaving the stamp on whatever was applied before would have the
+    // provenance say a look this clip no longer has. A saved *subset* is the other
+    // case, and the same sentence rules it out from the other end: the file does not
+    // say what this clip is wearing, so the clip's origin is still whatever last did.
+    if (wholeLookTag(body.values)) appliedPreset = { name: saved.name, rev: saved.rev };
     await refreshPresets();
-    ui.note.textContent = `saved ${saved.name} · ${saved.rev.slice(7, 15)}`;
+    ui.note.textContent = `saved ${saved.name} · ${saved.rev.slice(7, 15)}`
+      + (wholeLookTag(body.values) ? '' : ` · ${picked.names.length} of ${params.names('look').length} values`);
     history.commit();
-  } catch (err) {
-    showTimelineError(err);
-  }
-});
+  },
+));
 
 // The look on screen, not the document the picker happens to be pointing at. Those are
 // the same thing only until you move a slider, and exporting what you can see is the
-// answer that is right in both cases - the picker's name is used for the filename
-// because it is the best guess at what to call it, which is a different question.
-ui.presetExport.addEventListener('click', () => {
-  try {
-    const name = ui.preset.value || appliedPreset?.name || 'look';
-    exportPresetFile(name, presetFromCurrentLook());
-    ui.note.textContent = `exported ${name}.braindance-preset.json`;
-  } catch (err) {
-    showTimelineError(err);
-  }
-});
+// answer that is right in both cases - the picker's name is the filename it is offered
+// under, because it is the best guess at what to call it, which is a different question.
+//
+// Through the same dialog the save goes through, and that is the point rather than a
+// saving of code: a file is what a look leaves this program as, so a subset you could
+// put in a library and not in a file would be a document shape that exists on one side
+// of the export and not the other.
+ui.presetExport.addEventListener('click', () => withPresetSubset(
+  {
+    title: 'Export this look',
+    verb: 'export',
+    name: ui.preset.value || appliedPreset?.name || 'look',
+  },
+  async (picked) => {
+    exportPresetFile(picked.name, presetFromCurrentLook(picked.names));
+    ui.note.textContent = `exported ${picked.name}.braindance-preset.json`;
+  },
+));
 
 // The button and the input are two halves of one control: a file input cannot be
 // styled into the strip, and one that opens on its own is a control nobody can find.
 ui.presetImport.addEventListener('click', () => ui.presetFile.click());
-ui.presetFile.addEventListener('change', async () => {
+ui.presetFile.addEventListener('change', () => {
   const file = ui.presetFile.files?.[0];
   // Cleared before the await rather than after, so choosing the same file twice in a
   // row fires `change` the second time. An input that keeps its value is an import
   // button that works once per file per session.
   ui.presetFile.value = '';
   if (!file) return;
-  try {
-    const saved = await importPresetFile(file);
-    await refreshPresets();
-    ui.preset.value = saved.name;
-    ui.note.textContent = `imported ${saved.name} · ${saved.rev.slice(7, 15)}`;
-  } catch (err) {
-    showTimelineError(err);
-  }
+  // The input itself is never disabled and does not need to be: the button in front of
+  // it is, and this is the only thing that opens it. The gesture is what the guard is
+  // about anyway, so a file arriving here by any other route is still refused.
+  return withPresetGesture(ui.note, () => whileWriting(async () => {
+    try {
+      const saved = await importPresetFile(file);
+      await refreshPresets();
+      ui.preset.value = saved.name;
+      ui.note.textContent = `imported ${saved.name} · ${saved.rev.slice(7, 15)}`;
+    } catch (err) {
+      showTimelineError(err);
+    }
+  }));
 });
 
 ui.projectSave.addEventListener('click', async () => {
@@ -10242,6 +11147,13 @@ globalThis.__kinect = {
   params, applyPreset,
   readings: () => READINGS.slice(),
 
+  // How often the panel has re-derived which groups are open, since boot. Published
+  // because the claim it carries is about *how many times* a bulk write asks that
+  // question, and nothing outside the page can count that - a driver timing the gesture
+  // measures the driver, which is the rule `docs/measurement.md` states about the paused
+  // orbit. It is also the only way to see a gate whose whole effect is an absence.
+  groupRefreshes: () => groupRefreshes,
+
   /**
    * Keys, the curve and the undo stack. Every number a check reads comes from
    * here rather than from the DOM, because a lane is a view on a track the same
@@ -10468,6 +11380,22 @@ globalThis.__kinect = {
     setActiveDeliverable,
     activeDeliverable: () => activeDeliverable,
     appliedPreset: () => appliedPreset,
+    /**
+     * Whether a preset gesture is running, which is the guard's own state and is
+     * published because a driver cannot see it any other way.
+     *
+     * The `disabled` attribute is only half the span - it goes on after the dialog
+     * closes and comes off when the write is answered - and the flag covers the dialog
+     * too. So a tool pressing one of these controls has to know when the last gesture
+     * finished, and the observable it would otherwise reach for is wrong in a way that
+     * costs a whole run: `dialog.close()` clears `open` synchronously and fires its
+     * `close` event in a later task, so a driver that waited for `open === false` can
+     * press again while the promise is still unresolved and the flag still up. That
+     * press is correctly ignored, the dialog does not open, and the check dies on a
+     * ten-second timeout with no failed assertion - a crash wearing the shape of a
+     * finding. Measured exactly once, on `editor-check` at 238 of 274.
+     */
+    presetGestureRunning: () => presetGesture,
     marks: () => takeMarks.map((m) => ({ ...m })),
     markHere,
     takeId: () => openTakeId,


### PR DESCRIPTION
Two changes answering one complaint: every look parameter was always on screen, and every
preset had to describe all of them.

## A preset's keys are its scope

`presetFromCurrentLook` already took a subset of names and both call sites passed nothing, so
the capability sat one layer below anything that could reach it. Saving and exporting now go
through one dialog asking which values go in, every box ticked, so the gesture that existed
before writes what it always wrote. The boxes are generated from the registry under the panel's
own group headings, so a parameter added later appears by existing.

The five reading weights tick as a unit, and the format refuses the document that would
otherwise be assembled. A file naming any reading must name all five, because the ones it
leaves out do not arrive as anything — they stay at whatever the clip was already wearing, so
two fifths of a blend renders as a mixture nobody authored and nothing on screen says it is a
mixture. A file naming none of them is not a look with a hole in it; it is a look that is not
about the reading.

Also refused now: an empty `values` object, on its own terms rather than borrowed wording,
since "names nothing" became legal in the same change; and a key beside `version` and `values`,
by name, so a field an older version carried is answered rather than ignored.

**A preset describing part of a look does not stamp the clip.** The stamp answers "what look is
this clip wearing", and a document that set three of the fifty-four look values did not answer
it. Applying or saving a subset leaves the provenance where it was, which is what moving a
slider has always done.

## A panel group derives whether it is shown

A group is open when one of its parameters carries keyframes or holds a value off its own
default. The keyframe term is not decoration: during playback the evaluator writes every keyed
parameter through `params.set`, so a predicate reading only values would make panel visibility
a function of where the playhead is parked, and groups would breathe open and shut as a curve
crossed its default.

`Reading · detail` carries a rule of its own, because choosing a reading writes `source` and
`treatment` and never those seven — but it widens the default rule rather than replacing it, so
a group with anything touched inside it always derives open, and a shut group that is in use is
always one a person shut. That is what makes the mark on a collapsed header mean something.

A person disagreeing with the derivation is the only thing stored, in `localStorage` beside the
lane height rather than in the document, for the reason the Viewer group's note already gives.
The entry is pruned where the pair has *changed* into agreement rather than wherever it agrees,
because at boot the derivation is not a statement about the document but a statement about
there not being one yet — and a prune that could not tell those apart deleted a collapse before
the take it belonged to had loaded.

Rows hide with a class and are never removed, so the generator still emits one per declared
parameter and refuses to boot when the count comes out short.

## Measurements

On this machine at load 8.2, `--replay captures/sample.knct`, after merging main:

- `editor-check --no-render`: **314 assertions, 0 failed.**
- Nine new mutations, each caught for its stated reason. `reveal-ignores-tracks` reddens
  exactly one row — the group whose parameter carries a keyframe while sitting on its default
  at the parked frame — with the precondition row above it still passing, so the failure is for
  the claimed reason rather than a neighbour's.
- The panel re-derives **1.00 times per rendered frame** with the write gated, at both four and
  eight keyed parameters, against 4.00 and 8.00 with `panel-rederives-per-write` applied. The
  count is invariant in the number of keyed parameters rather than merely small.
- The panel column keeps **1232px of scroll travel** at 1512x900 with the four collapsible
  groups shut, against 1874px open, so the nav placement rows below it still measure something.
- `registry-check`, `keyframe-check` pass. `sensor-view-check` fires only the row needing a
  second capture's intrinsics.
- `syntax-check`: 282 anchors in 14 tables all matching once, 28 tools named, 39 files parsing.

## Review

Two adversarial rounds found seventeen defects, all fixed and each now carrying a row that
fails when the fix is reverted. Lenses: a cold reader with no design context, an external
non-Claude gate at xhigh, and a runtime pass feeding hand-authored malformed documents through
the real import path. Three findings were one recurring shape — a row driving the path that
already works — including one where a fix round diagnosed a regression correctly and then
reversed the failing test rather than fixing the code under it. `docs/instruments.md` gains
case files for those.

## Merge note

Main added `editor-check` sections 13 and 14 while this branch added its own 13, and both
renumbered the pinned-drive section after it. The panel-group section is now 15 and the pinned
drive 16, with the row labels, both `DRIVER_RULES` strings and the mutation docstrings moved to
match. The one remaining "section 13" is main's resize note and is correct.

## Not in scope

The five shipped presets still name the whole look tag; re-authoring them sparse needs the
sensor and a person judging the result, and is #65. Per-group bypass — what "remove this
effect" will eventually mean — is named in the comments and deliberately unbuilt.
