### PR TITLE
Cut the shaders into a spine and move every effect's GLSL into its package

### DIFF
--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -1437,6 +1437,20 @@ the move finds an anchor over none. `--mutate anchor-in-dead-fallback` repoints
 neighbouring package's chunk — a *different* file, since a duplicate inside its own is already
 refused one rule up — and is the control for the first.
 
+**The count had to grow a third control the moment there were two spines, and the reason is
+that both plants above sit inside one program.** Cutting the grade pass out of
+`web/post-chain.js` gave this build four assembled strings rather than two, and the tempting
+shape for the count is to ask each program about the anchors of the files that feed *it* —
+which reads as tidier, keeps every existing control catching, and stops testing the thing the
+rule now claims. A line living in two programs at once counts one in each, so a per-program
+count sees nothing. `--mutate anchor-duplicated-into-a-second-program` plants
+`streak-ignored`'s guard, which belongs to the grade, in the thermal package's tone chunk,
+which feeds the cloud's fragment program: its own file still matches once and the sum is two.
+Measured rather than argued — with the count rewritten as a maximum over the four strings
+instead of a sum, `anchor-duplicated-into-a-second-chunk` still comes back 1 failed and this
+one comes back 0, which is what makes it an arm rather than a fourth way of saying the same
+thing.
+
 **`web/shader-assembly.js` is inside the rule as well, and the count is not asked of it.** An
 anchor on a branch the emit never takes is the same dead control wearing JavaScript, so the move
 half covers it; its anchors are JavaScript and the two programs are GLSL, so the count half would

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -1155,6 +1155,16 @@ each with its own comment saying why; `level-check`, `vcam-check`, `monitor-chec
 refuse could not have known which trees it broke, which is the argument for the refusal being
 checked rather than for the lists being remembered.
 
+**All four lists name it now, and unblocking the last three cost one more finding.** `vcam-check`
+came back 41 assertions and `jobs-check` 56, both clean the first time either of them booted.
+`monitor-check` reached its rows and reddened one, and the row it reddened was a precondition
+that had not run since the packages arrived — the entry under "Things that bite in a browser"
+below carries it. That is the second half of the argument above stated as a measurement: a tool
+that cannot boot is not a tool that is passing, and what four commits of silence were holding was
+not nothing. The sweep behind the count is worth writing down too, because the number is smaller
+than it looks — six tools in `tools/` stage a tree and spawn a server out of it, and
+`sensor-view-check` and `boot-check` spawn from the checkout itself, so they were never exposed.
+
 ### And `fails=1` can be the same crash wearing the count
 
 Counting assertions is not enough on its own if the harness's own failure is one of the
@@ -2552,6 +2562,24 @@ avoided exactly this, and the ordering made it false. Measuring it needs the dri
 changed as well: a programmatic `element.click()` leaves the caret on the body, where a
 build that stranded it and a build that never had it read identically, so `openPicker`
 focuses before it clicks.
+
+**`waitUntil: 'load'` stopped meaning the page is up when the effect packages moved onto the
+wire.** Boot fetches them over HTTP now, so `globalThis.__kinect` publishes *after* the event
+`page.goto` waits for — measured at 366ms to `load` against 398ms to the handle, on loopback with
+a warm page cache. Every driver that reaches straight through that handle on the line after a
+`goto` is a race from that commit onward, and it does not arrive looking like one: a predicate
+raising `TypeError: Cannot read properties of undefined` inside `waitFor` is not caught by it, so
+the twenty seconds the wait was given are never spent. `monitor-check`'s colour precondition did
+exactly that — it reddened saying no colour ever bound, against a build whose colour binds 451ms
+after the same `goto`, and skipped the viewer row beneath it as unmeasurable. **A red that
+arrives instantly out of a wait that was given seconds is a throw rather than a timeout**, and
+the timestamp on the line is the cheapest thing that tells those apart; here the failed row and
+the section heading above it carry the same second. The repair is a guarded read that leaves the
+timeout reachable and reports "the page never published `__kinect`" apart from "colour never
+arrived", because those are different findings. What it is *not* is a fixed `wait()` after the
+`goto` — the two sections above it in the same tool survive on one, which is the silent-pass
+shape their own comments refuse, and a sleep tuned on this machine is a pass waiting for a
+slower one.
 
 **A contended machine fails a check in a way that reads as a finding.** Two worktrees running
 proof tools at once produced four failed runs, and the quiet one is the dangerous one: under

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -1365,6 +1365,35 @@ another module's text exports none of the names its importer asks for. With the 
 and `crush-ignored`, which still names `web/main.js`, fires 3 and reddens the drop-one sweep on
 `crush` — so neither path was traded for the other.
 
+**And the third file stopped being a module.** When the glyph field's and the rain's GLSL moved
+into their packages, sixteen anchors moved with it onto files no browser requests as a script:
+`effects-builtin/glyph/index.frag.glsl` and its neighbours are fetched out of
+`/effects/:id/file/:name` and spliced into the material by `assembleShaders`. Three tools grew the
+same branch — `servedAt` maps a package path to that route, and the fulfilment answers
+`text/plain` because that is what `server/index.js` answers, rather than inventing a second
+promise about one route. Two properties of the fix are worth having written down rather than
+rediscovered. **A mutation now edits more than one file, and two of them span two packages**:
+`rain-ignored` patches the rain's own colour lift and the glyph field's index block, because the
+rain key is read where the character is chosen — so `registry-check` stages per edit, honouring
+the third element of an edit pair the way `export-check` already did and `syntax-check` always
+read, and its delivery guard counts per file. A total would be satisfied by one of two chunks
+arriving, which is half a mutation measured under the whole one's name. And **`export-check`'s
+"is this a page mutation" filter was `file.startsWith('web/')`**, which silently sorted a chunk
+into the server-mutation bucket where nothing serves it and nothing counts it — the filter is a
+predicate now, and it is the same class as the `**/main.js` glob one level up.
+
+**The one that syntax-check cannot see, and the reason it is written here.** `v.pointSize` and
+`f.mark` are slots: the spine carries the text to use when nothing claims them, and the glyph
+package's chunk carries an `else` branch that is the same statement again. So
+`export-check`'s `pointsize-absolute`, whose anchor is `gl_PointSize = clamp(pointSize * k /
+max(0.15, -mv.z), 1.0, 64.0);` with no leading whitespace, went on matching **exactly once** in
+`web/cloud-shader.js` after the split — against the fallback, which is text nothing compiles while
+the glyph package is installed. The anchor row is green either way, because "matches once in the
+file it names" is true of a line nobody reaches. It was repointed at the chunk by reading the
+anchor map rather than by running the tool, and what would find the next one is the same reading:
+a slot's fallback is a second copy of the shipped text, and an anchor is only in the right one of
+the two if somebody decided which.
+
 ### A mutation can erase its own evidence
 
 `plant-open-take` originally appended its foreign bytes through a second file descriptor.

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -1137,6 +1137,24 @@ exit code. Seen twice on step 5, on two different mutations in two different sui
 **Count failed assertions, not exit codes**, and treat `fails=0` as a crash to investigate
 rather than a success to record.
 
+### And a tool that says `DID NOT RUN` on every run says it to nobody
+
+`level-check` reported `0 assertions, 0 failed` and exit 2 on every invocation for three commits,
+and the reason was one line: its staged tree copies `server`, `tools` and `web`, and the effect
+store refuses to *boot* without `effects-builtin` — deliberately, so that a broken install cannot
+read as nothing-installed. So from the commit that made the effects packages onward, the server it
+spawns could not start. The verdict was loud, correct and unread, because the tool is run when
+somebody is about to touch levelling and nobody was.
+
+Two things worth keeping. **The exit-2 convention did its job and it is not enough on its own** —
+`DID NOT RUN` distinguishes "the harness did not run" from "the harness found something" for a
+reader who is there, and a check nobody ran this week has no reader. **And one staging list was
+updated while four were not.** `library-check` and `guard-check` name `effects-builtin` in theirs,
+each with its own comment saying why; `level-check`, `vcam-check`, `monitor-check` and
+`jobs-check` do not, and nothing joins the five lists together. The commit that made the store
+refuse could not have known which trees it broke, which is the argument for the refusal being
+checked rather than for the lists being remembered.
+
 ### And `fails=1` can be the same crash wearing the count
 
 Counting assertions is not enough on its own if the harness's own failure is one of the
@@ -1382,7 +1400,7 @@ arriving, which is half a mutation measured under the whole one's name. And **`e
 into the server-mutation bucket where nothing serves it and nothing counts it — the filter is a
 predicate now, and it is the same class as the `**/main.js` glob one level up.
 
-**The one that syntax-check cannot see, and the reason it is written here.** `v.pointSize` and
+**The one that syntax-check could not see, and now can.** `v.pointSize` and
 `f.mark` are slots: the spine carries the text to use when nothing claims them, and the glyph
 package's chunk carries an `else` branch that is the same statement again. So
 `export-check`'s `pointsize-absolute`, whose anchor is `gl_PointSize = clamp(pointSize * k /
@@ -1390,9 +1408,37 @@ max(0.15, -mv.z), 1.0, 64.0);` with no leading whitespace, went on matching **ex
 `web/cloud-shader.js` after the split — against the fallback, which is text nothing compiles while
 the glyph package is installed. The anchor row is green either way, because "matches once in the
 file it names" is true of a line nobody reaches. It was repointed at the chunk by reading the
-anchor map rather than by running the tool, and what would find the next one is the same reading:
-a slot's fallback is a second copy of the shipped text, and an anchor is only in the right one of
-the two if somebody decided which.
+anchor map rather than by running the tool, and what would find the next one was the same
+reading: a slot's fallback is a second copy of the shipped text, and an anchor is only in the
+right one of the two if somebody decided which.
+
+**Closing it took two rules and not one, and the second is the one that works.** The obvious
+rule — every anchor into the spine or a chunk appears exactly once in the *assembled* pair, which
+`web/shader-assembly.js` will build under bare node because it imports nothing — is green on
+exactly this defect. The glyph chunk's `else` branch carries the old clamp statement verbatim, on
+purpose and with its own comment saying so, so the anchor appears once in the assembled text
+whichever copy it names and the count cannot tell them apart. What separates them is applying the
+edit: staged against the fallback the two programs come back byte-identical, because nothing
+emits it. So `syntax-check` asks both, and they catch different things — the count finds an anchor
+over two live sites, where a mutation reaches one and is recorded under the whole one's name, and
+the move finds an anchor over none. `--mutate anchor-in-dead-fallback` repoints
+`pointsize-absolute` back at `web/cloud-shader.js` and is the control for the second;
+`--mutate anchor-duplicated-into-a-second-chunk` copies `lattice-ignored`'s anchored line into a
+neighbouring package's chunk — a *different* file, since a duplicate inside its own is already
+refused one rule up — and is the control for the first.
+
+**`web/shader-assembly.js` is inside the rule as well, and the count is not asked of it.** An
+anchor on a branch the emit never takes is the same dead control wearing JavaScript, so the move
+half covers it; its anchors are JavaScript and the two programs are GLSL, so the count half would
+be asking a question with no answer. `registry-check`'s `ripple-outside-the-gate` is the first
+spec to land there, because the region's gate is generated from its consumers' `when` clauses and
+there is no longer a line of GLSL anybody wrote to anchor on.
+
+**And the seam this rule needed cost a round of its own.** The row above reads its targets off
+disk while these read through the mutation substitution, which looks like an inconsistency and is
+the opposite: reading a staged file in the anchor-existence row makes every control report *its
+own* anchor as stale, since a control's whole job is to replace the line it anchors on. Written
+that way it added one red row to four of `syntax-check`'s seven controls, none of them findings.
 
 ### A mutation can erase its own evidence
 
@@ -2864,6 +2910,27 @@ Four instruments written for the crop box in one session were each aimed somewhe
 correct build and the broken one would have agreed. All four were caught by running the
 mutation rather than by reading the code, which is the argument for the rule that a proof
 tool is mutation-tested rather than reasoned about.
+
+**A sort whose subject is already sorted.** The shader assembler places each stage's chunks by
+the `order` their manifests declare, and `test/shader-assembly.test.mjs` holds the assembled
+programs byte for byte against the monolith — so taking `stages.sort(byOrder)` out of the
+assembler entirely ought to redden it. It does not. The packages are read in directory order and
+every shipped stage's declared order *is* that order: glitch before lattice on `v.displace`,
+glyph before rain on both declaration stages and on `f.tone`, noise before push before ripple on
+`v.regionDisplace`. Six stages, six coincidences, and each arrived honestly, because a package is
+named after its effect and the effects were written roughly in the order they run. A build that
+lost the sort would draw today's picture exactly and a different one the first time somebody adds
+a package whose name sorts the wrong way, which is a defect that ships and then waits.
+
+This was found by running the mutation and then obeying the rule about a mutation that seems to
+have been missed: the count of caught defects was 13 of 14, and the fourteenth turned out to have
+changed no byte of either program. What holds it now is a fixture rather than the shipped set,
+because the property under test is that the *numbers* decide and the shipped numbers agree with
+the alphabet: two synthetic packages named against their orders — the one that goes first called
+`zeta`, the one that goes second `alpha` — with the same inversion put through a service's
+`gateOrder`. The gate's half is live on the shipped set as well, since the region's push consumes
+at 100 where its noise consumes at 200; the stage's half exists only in the fixture, and saying so
+is the point.
 
 **A counter that is zero in both builds.** The face drag had to be shown to arm a redraw
 rather than render out of its own handler, and the first counter reached for was

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -145,8 +145,9 @@ Two things follow, and the second is the one that costs somebody an afternoon. A
 meant to reject jitter cannot be stated in mm/s, because it would need re-tuning per link -
 and it cannot be stated in millimetres either, because then a slow surface registers over a
 slow link and vanishes over a fast one. `duotone.motion` carries no such threshold for exactly
-that reason, and the comment beside it in `web/cloud-shader.js` - where the fragment stage
-mixes it - has the numbers. And **the median
+that reason, and the comment beside it in `effects-builtin/duotone/tone.frag.glsl` - where the
+fragment stage mixes it, having travelled there with the block when the tone run left the
+spine - has the numbers. And **the median
 displacement being the same at both spacings is itself the discriminator between jitter and
 motion**: measure at two intervals, and whatever holds its millimetres rather than its
 millimetres per second is the sensor talking to itself.

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -535,6 +535,12 @@ node tools/syntax-check.mjs --mutate web-citation-outlives-its-module # ... and 
 node tools/syntax-check.mjs --mutate line-citation-past-the-end # ... and the line half of that, which rots without the path rotting
 node tools/syntax-check.mjs --mutate citation-outside-the-prose # ... and one written in the C++, which is the half of the tree the walk used to skip
 node tools/syntax-check.mjs --mutate manifest-does-not-parse # ... and a shipped effect package the store would throw on must be named, not counted
+node tools/syntax-check.mjs --mutate anchor-in-dead-fallback # ... and a shader anchor that matches its file exactly once
+                                                     #   while sitting in a slot's fallback, which is a second copy
+                                                     #   of the shipped text that nothing compiles
+node tools/syntax-check.mjs --mutate anchor-duplicated-into-a-second-chunk # ... and the other half of the same
+                                                     #   row: one anchor over two sites in the assembled pair,
+                                                     #   where the edit reaches one and the count reads whole
 node tools/release-gate-check.mjs                    # the .npmrc supply-chain gate is actually armed
 node tools/release-gate-check.mjs --mutate wrong-unit # ... and must FAIL (also: no-gate, absent)
 node tools/cpp-check.mjs                             # both C++ files parse and typecheck, in all four

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -539,8 +539,12 @@ node tools/syntax-check.mjs --mutate anchor-in-dead-fallback # ... and a shader 
                                                      #   while sitting in a slot's fallback, which is a second copy
                                                      #   of the shipped text that nothing compiles
 node tools/syntax-check.mjs --mutate anchor-duplicated-into-a-second-chunk # ... and the other half of the same
-                                                     #   row: one anchor over two sites in the assembled pair,
+                                                     #   row: one anchor over two sites in the assembled text,
                                                      #   where the edit reaches one and the count reads whole
+node tools/syntax-check.mjs --mutate anchor-duplicated-into-a-second-program # ... and the same duplicate placed
+                                                     #   in the *other* program, which is the arm that says the
+                                                     #   count sums over every assembled string rather than
+                                                     #   asking each one on its own
 node tools/release-gate-check.mjs                    # the .npmrc supply-chain gate is actually armed
 node tools/release-gate-check.mjs --mutate wrong-unit # ... and must FAIL (also: no-gate, absent)
 node tools/cpp-check.mjs                             # both C++ files parse and typecheck, in all four

--- a/effects-builtin/duotone/manifest.json
+++ b/effects-builtin/duotone/manifest.json
@@ -90,5 +90,12 @@
       },
       "under": "amount"
     }
-  }
+  },
+  "chunks": [
+    {
+      "stage": "f.tone",
+      "order": 300,
+      "file": "tone.frag.glsl"
+    }
+  ]
 }

--- a/effects-builtin/duotone/tone.frag.glsl
+++ b/effects-builtin/duotone/tone.frag.glsl
@@ -1,0 +1,106 @@
+  // The duotone, and it is the governing tonal transform rather than a tint over one:
+  // the near pole runs toward black and the far pole toward hot, so a single term
+  // produces both the depth-keyed palette and the near-black silhouette against a
+  // burning core. The note beside the uniforms has why those are one parameter.
+  //
+  // It sits here, after the blend, for the reason thermal and edges above it do - a term
+  // written into one reading is inert in every other, and is then exercised only by
+  // whichever sweep arm happens to select that reading. And it sits *before* the glitch
+  // flare below rather than after it, which is a decision rather than an ordering
+  // accident: a torn band is emitted light, so it belongs on top of the tonal transform
+  // and not underneath one that would crush it back toward black.
+  //
+  // Read off t, the point's position inside the near/far clip range, so the split is a
+  // place in the room the way the crop faces are and not a fraction of a frame. The split
+  // is where the two poles meet and moving it decides which half of the room the subject
+  // falls in.
+  //
+  // **How wide the ramp is either side of that is a distance rather than a share of the
+  // box**, which is what duotoneSpan buys and why the division below exists. t is already
+  // normalised by the clip range, so a ramp stated in t is a ramp whose metres change
+  // every time a crop face moves - the grade would follow the framing, and shutting the
+  // far plane to steepen the toning would be the only way to steepen it. Dividing the span
+  // by the range converts metres back into t's units at the width the look asked for, and
+  // the long note beside the uniform carries what that was measured to cost.
+  //
+  // Guarded, and the shape was measured rather than chosen. Both shapes are arithmetically
+  // clean here, which is not obvious and is worth writing down: a mix at zero is a plus
+  // zero times b minus a, which is exact whether or not the compiler contracts it, where
+  // the mix at one this file guards elsewhere is the one that is not. So the question was
+  // never the identity but what a branch does to the contractions either side of it, which
+  // the flare below records going the surprising way. Measured here, guarded, against the
+  // pinned pre-registry build: readRgb, readDepth, readContour and readBlackwall all came
+  // back bit-identical over six frames, and readGhost reproduced its own pre-existing
+  // failure unchanged - the same two frames, 2 and 3, and the same pair of hashes
+  // 55d01311394e against 36fb79d8fa45. That last part was the half that mattered, because
+  // a row already red is where a new perturbation would hide.
+  //
+  // **That standing failure has since been measured and it was never this file's.** The
+  // two frames differed by one byte of 1,024,000, by exactly 1 - one channel of one
+  // fragment landing the other side of a rounding boundary between two independently
+  // compiled builds, which is the same contraction effect the flare below records rather
+  // than a term. registry-check's section 1b compares pictures now, with the threshold
+  // derived from that noise at one end and from ghost-alpha-term-dropped at the other,
+  // no backticks in this comment on purpose - it sits inside the GLSL template literal,
+  // and one here ends the shader. That is the seventh time in this repo,
+  // which moves 187k bytes by 47. So the row is green at baseline and a re-measurement
+  // like this one no longer has to reason around a red row while doing it.
+  if (duotoneDepth > 0.0) {
+    vec3 cold = hueSpin(vec3(0.020, 0.030, 0.075), duotoneHue);
+    vec3 heat = hueSpin(vec3(1.000, 0.380, 0.120), duotoneHue);
+    float w = duotoneSpan / max(0.001, farClip - nearClip);
+    float k = smoothstep(duotoneSplit - w * 0.5, duotoneSplit + w * 0.5, t);
+    // The motion half of the same transform, and it is the same two poles rather than a
+    // second palette laid over them: depth decides where the room falls between cold and
+    // hot, and this pushes whatever is moving through the room toward the hot end of it.
+    // That is the reading the depth key on its own cannot draw - a subject and the wall
+    // behind it are graded by where they stand, so a person walking through a scene is
+    // exactly as cold as the air they walk through until something keys on the walking.
+    //
+    // Toward 1 rather than added to k, so a point at the hot end cannot be pushed past
+    // it and the term has its room where the picture is near-black, which is where a
+    // subject usually is. The far half of the room is already hot and has nothing to
+    // gain, which is right: motion is only news against the pole it is not at.
+    //
+    // **1200 mm/s is the speed at which a point reaches the pole**, and it is baked for
+    // the reason the two poles themselves are - a look parameterises how much of a ramp
+    // it wants, not the ramp. It is about the axial speed of somebody walking straight
+    // at the sensor at an ordinary pace, so the pole belongs to a person crossing the
+    // room rather than to a hand. Measured over the sample capture: the 99th percentile
+    // of a nearly-static stretch is 430 mm/s and the fastest sample in five pairs is
+    // about 1900, while a take with somebody moving through it runs a median of 286 and
+    // a 90th percentile of 1082.
+    //
+    // **The sensor's jitter is a displacement rather than a speed, so what it reads as
+    // here depends on how fast the frames arrive**, and that is worth knowing before
+    // trusting any threshold in these units. Measured on the same capture at two
+    // spacings: the median sample moves about 4mm whichever pair you take, which is 31
+    // mm/s across the 128ms pairs registry-check pins and about 140 mm/s across the
+    // capture's own 32ms ones. Real movement is a fixed speed and reads the same at both,
+    // so this estimator gets noisier as the link gets faster - which is a property of
+    // measuring a rate from two adjacent samples and not something a constant fixes.
+    //
+    // No floor under it, and that is measured rather than assumed. A smoothstep has zero
+    // derivative at the origin, which is most of the suppression on its own: on a wall
+    // planted flat at 1100mm with this amount at 1 and the depth at 1, driven through the
+    // editor at 1280 wide rather than through the check's own stage, mean red over the
+    // frame goes 7.83 still, 7.90 with 4mm of jitter across a 128ms pair, 8.76 with the
+    // same 4mm across a 32ms one, and 22.84 at a real 600 mm/s. So even at the frame rate
+    // where the jitter
+    // reads loudest it costs about one 8-bit step against fifteen for the signal. A floor
+    // would have to be stated in one unit or the other and neither is right at both
+    // spacings - in mm/s it would need re-tuning per link, which is what dividing by the
+    // span exists to stop, and in millimetres it would let a slow surface register over a
+    // slow link and vanish over a fast one.
+    //
+    // A duotoneMotion of 0 is exactly the picture this block drew before the term
+    // existed. mix at zero is x times one plus y times zero, or x plus zero times the
+    // difference, and both are exact whether or not the compiler contracts them - which
+    // is the same arithmetic the guard comment above this block records measuring, and
+    // it is measured again rather than inherited: the comparison is in registry-check's
+    // planted-motion section, where a frame with a fast point in it and a frame with a
+    // still one have to come back bit-identical while this sits at its default.
+    k = mix(k, 1.0, duotoneMotion * smoothstep(0.0, 1200.0, vSpeed));
+    col = mix(col, mix(cold, heat, k), duotoneDepth);
+  }
+

--- a/effects-builtin/edges/manifest.json
+++ b/effects-builtin/edges/manifest.json
@@ -21,5 +21,12 @@
       },
       "role": "master"
     }
-  }
+  },
+  "chunks": [
+    {
+      "stage": "f.tone",
+      "order": 200,
+      "file": "outline.frag.glsl"
+    }
+  ]
 }

--- a/effects-builtin/edges/outline.frag.glsl
+++ b/effects-builtin/edges/outline.frag.glsl
@@ -1,0 +1,8 @@
+  if (edges > 0.0) {
+    // vEdge is the neighbour spread the vertex stage already computed for the
+    // speckle test, so an edge-only reading costs a mix rather than a second pass.
+    float e = pow(vEdge, 0.6);
+    col = mix(col, mix(vec3(0.02, 0.03, 0.05), vec3(0.82, 0.94, 1.0), e), edges);
+    alpha *= mix(1.0, 0.05 + 0.95 * e, edges);
+  }
+

--- a/effects-builtin/glitch/flare.frag.glsl
+++ b/effects-builtin/glitch/flare.frag.glsl
@@ -1,0 +1,48 @@
+  // Torn bands flare cyan where the feed shears - and it sits here, after the blend,
+  // for the reason thermal and edges two blocks up sit here. This line used to live
+  // inside the Blackwall branch, which made it inert in the other four readings while
+  // the displacement that earns it kept firing in all five: the geometry tore under
+  // Colour and Depth and nothing lit up, so a slider that plainly worked in one reading
+  // looked broken in the rest. Worse than inert, it was coupled to something nobody
+  // asked it to be - the readings normalise by their weight sum, so a dissolve from
+  // Blackwall into Depth dimmed the corruption on the way past and the flare rode the
+  // colour crossfade.
+  //
+  // Moving it changes what the Blackwall preset draws, because inside the branch the
+  // flare was multiplied by that reading's 0.55 + 0.75 * lum shading before the
+  // normalisation reached it. glitchTint was given a default of 1.8 to absorb that,
+  // rather than carrying 3.0 over, on the grounds that a term reconstructing the old
+  // inside-the-branch arithmetic would be a second implementation of this line.
+  //
+  // **That default is worse than the literal it replaced, measured on the reading the
+  // shipped preset actually uses.** Against the pinned build on readBlackwall at the
+  // shipped glitch of 0.18: 1.8 lands 30 of 255 off at worst with a frame mean of 0.0391,
+  // where 3.0 lands 5 off with a mean of 0.0062, and 0 and 5.0 are worse than either. No
+  // constant can match exactly, because the multiplier it is standing in for varied per
+  // fragment - but the ordering is not close, and the number was chosen without this
+  // comparison being run. Colour only, no alpha term: that is what the
+  // old line did, and an additive splat shows a brighter colour without being asked to
+  // cover more.
+  //
+  // Unconditional, and the missing guard on vGlitch is a measurement rather than an
+  // oversight. Guarded, this line reddened three of registry-check's five reading rows
+  // against the pinned pre-readings build - readDepth and readContour at frame 4 and
+  // readBlackwall at frames 0 and 1 - at parameter defaults, where glitch is 0 and the
+  // guard means the add never runs at all. Nothing mathematical moved: adding zero is
+  // exact, and the branch was never taken. What moved was the code around it, because a
+  // branch dropped into the common path costs the compiler contractions it was making
+  // across the lines either side. Written straight through, all five rows are bit-identical
+  // again and only the pre-existing readGhost failure remains. So the cost of a fragment
+  // being able to skip a multiply-add it does not need is three false regressions in a
+  // check with no tolerance and no way to re-baseline, and the multiply-add is cheaper.
+  //
+  // **The readGhost failure named above was the same effect as the three, and it has since
+  // been measured rather than lived with**: one byte of 1,024,000 differing by exactly 1,
+  // which is one fragment rounding the other way between two independently compiled
+  // builds. Section 1b compares pictures now, so "a check with no tolerance" is no longer
+  // the situation - but the conclusion above stands unchanged, because a tolerance sized
+  // to admit one byte at one step admits nothing like the three regressions that
+  // paragraph is about, and writing the multiply-add straight through is still cheaper
+  // than reasoning about what a branch did to the contractions around it.
+  col += vec3(0.2, 0.9, 1.0) * vGlitch;
+

--- a/effects-builtin/glitch/manifest.json
+++ b/effects-builtin/glitch/manifest.json
@@ -134,5 +134,17 @@
       "after": "signal",
       "order": 100
     }
+  ],
+  "chunks": [
+    {
+      "stage": "v.displace",
+      "order": 100,
+      "file": "tear.vert.glsl"
+    },
+    {
+      "stage": "f.tone",
+      "order": 100,
+      "file": "flare.frag.glsl"
+    }
   ]
 }

--- a/effects-builtin/glitch/manifest.json
+++ b/effects-builtin/glitch/manifest.json
@@ -143,7 +143,7 @@
     },
     {
       "stage": "f.tone",
-      "order": 100,
+      "order": 400,
       "file": "flare.frag.glsl"
     }
   ]

--- a/effects-builtin/glitch/tear.vert.glsl
+++ b/effects-builtin/glitch/tear.vert.glsl
@@ -1,0 +1,47 @@
+  // Datastream corruption: horizontal bands tear sideways, the way a failing
+  // feed shears. Bands are picked stochastically so it stutters rather than pulses.
+  //
+  // The shove is sensor-frame X applied before the view matrix, and the bands are
+  // depth-image rows, so the tear belongs to the feed rather than to the display. That
+  // is the point rather than an oversight: orbit around a torn band and it shoves in
+  // depth, which is what says the volume is corrupt, and under a levelled room the
+  // bands run at the angle the bracket was actually at. Screen-locked tearing is a
+  // different effect and would belong at the grade stage beside the scanlines.
+  //
+  // The floor of time times the rate is written twice rather than hoisted into a local,
+  // and the shove's ceiling is parenthesised as twice glitchShove rather than folded
+  // into the chain. Both are here to hold the float arithmetic at the defaults exactly
+  // where the literals left it - this file has already measured that handing a value
+  // through a variable licenses a contraction the inline expression does not get, and
+  // doubling 0.45 is exact in float32 where a re-associated product need not be. At the
+  // defaults the *geometry* of this block is bit-identical to the one-slider version it
+  // replaces, and that is measured rather than reasoned: with the flare taken to zero, the
+  // colour, depth and contour readings come back byte for byte identical to the pinned
+  // build at the shipped glitch of 0.18, over six frames, and the shove is live on both
+  // sides so the equality is not vacuous.
+  //
+  // **The flare is the exception and the claim used to be stated without it.** glitchTint
+  // defaults to 1.8 where the line it replaced baked 3.0, so the picture does move - see
+  // the registry entry for the measurement. The blanket version of this sentence stood for
+  // as long as it did because nothing ever rendered these two builds with the glitch
+  // switched on: the cross-build section renders at parameter defaults, where glitch is 0
+  // and none of this executes.
+  vGlitch = 0.0;
+  if (glitch > 0.0) {
+    // The axis the bands are cut along, and the default path is the old expression itself
+    // rather than one that computes what the old expression computed. That distinction has
+    // already cost this file a measurement twice - the comment above says why, and the
+    // raster's guard in the grade shader in web/post-chain.js says it again - so the zero
+    // case reaches the old division textually, with no local in the way to license a
+    // contraction the inline form does not get.
+    float band = glitchAxis > 0.0
+      ? floor(mix(position.y, position.x, glitchAxis) / glitchBands)
+      : floor(position.y / glitchBands);
+    float roll = hash(band + floor(time * glitchRate) * 31.7);
+    if (roll > 1.0 - glitch * glitchDensity) {
+      float shove = (hash(band * 3.1 + floor(time * glitchRate)) - 0.5) * glitch * (2.0 * glitchShove);
+      pos.x += shove;
+      vGlitch = abs(shove) * glitchTint;
+    }
+  }
+

--- a/effects-builtin/glyph/cell.vert.glsl
+++ b/effects-builtin/glyph/cell.vert.glsl
@@ -1,0 +1,1 @@
+    vCellSeed = hash(dot(wc, vec3(127.1, 311.7, 74.7)));

--- a/effects-builtin/glyph/decl.frag.glsl
+++ b/effects-builtin/glyph/decl.frag.glsl
@@ -1,0 +1,5 @@
+// The glyph field's master and its three keys. The master is declared in both stages
+// because it does two things that belong at two stages - it grows the sprite up there and
+// it crossfades the mark here - and the three keys are here alone, because the character
+// index is decided beside the colour it reads.
+uniform float glyph, glyphTone, glyphHash, glyphRain;

--- a/effects-builtin/glyph/decl.vert.glsl
+++ b/effects-builtin/glyph/decl.vert.glsl
@@ -1,0 +1,5 @@
+// The glyph field's master, which this stage needs for one thing only - growing the
+// sprite into the cell the lattice already cut. Which character gets drawn is decided in
+// the fragment stage, because it keys on a luminance that does not exist until the colour
+// is built, so the other three weights are declared there and not here.
+uniform float glyph;

--- a/effects-builtin/glyph/helpers.frag.glsl
+++ b/effects-builtin/glyph/helpers.frag.glsl
@@ -1,0 +1,104 @@
+// The alphabet, as sixty-four 8x8 bitmasks held in the shader source.
+//
+// **There is no atlas, no texture and no fetch, and that is a decision about boot rather
+// than about memory.** This renderer loads no static image: every texture it binds is built
+// out of frame bytes in web/gpu-textures.js, so an atlas would be the first file the render
+// path ever went and got - a route on the server to serve it, a load order to get right, a
+// question about what the shader draws in the frames before it arrives, and the same
+// question again inside the headless browser tools/render-worker.mjs drives, where a missing
+// asset is a deliverable with no characters in it rather than a visible error. A table in
+// the source has none of those states, because it is there the moment the shader compiles.
+// The other thing it buys is that the alphabet is reviewable: a bitmask is a diff a person
+// can read, where an atlas is a binary nobody looks inside.
+//
+// 8x8 rather than the 5x6 the probe drew, and the size is the whole reason for it. 5x6
+// draws latin, digits and symbols and cannot draw kana, which would put the reference
+// look's own alphabet permanently out of reach. 8x8 is what the home computers of the
+// eighties drew kana at, so it is the smallest grid that keeps the option, and two
+// unsigned ints carry one character exactly.
+//
+// **Sorted by ink, sparsest first, which is what lets three keys share one table.** A
+// luminance ramp is ASCII art and only works if the index means ink, so that a bright cell
+// draws a dense character and a dark one draws a sparse one; a hash and a rain counter want
+// the index to mean nothing, because looking like noise is their whole job. Sorting by ink
+// dissolves that rather than resolving it - the tone key reads the table as tone and the
+// hash key reads the same table as noise, and both readings are true of it at once - so no
+// parameter has to choose between them, which matters because a chooser would be an enum
+// and this registry has refused those since the region's shape control, on the grounds that
+// an enum cannot keyframe and a slider can. What it costs is a latin tone ramp: a luminance
+// sweep now runs through kana, so the picture is ASCII art drawn in an alphabet that is not
+// ASCII.
+//
+// Packed with x holding rows 0 to 3 and y holding rows 4 to 7, row 0 at the top, and within
+// a word the bit at row * 8 + col with column 0 on the left. **Column 7 and row 7 are clear
+// in every one of the sixty-four**, and that is where the margin between neighbouring cells
+// comes from rather than from a parameter: an 8x8 character does not fill its own 8x8 box,
+// so cells tile while the marks inside them do not touch, which is how the reference frames
+// actually look - characters with dark between them rather than a solid wall of ink.
+const uvec2 GLYPHS[64] = uvec2[64](
+  uvec2(0x00080800u, 0x00000000u), // '  apostrophe  ink 2
+  uvec2(0x00000000u, 0x000c0c00u), // .  period  ink 4
+  uvec2(0x00141400u, 0x00000000u), // "  quote  ink 4
+  uvec2(0x04081000u, 0x00001008u), // <  less-than  ink 5
+  uvec2(0x10080400u, 0x00000408u), // >  greater-than  ink 5
+  uvec2(0x3e000000u, 0x00000000u), // -  hyphen  ink 5
+  uvec2(0x00000000u, 0x00060c0cu), // ,  comma  ink 6
+  uvec2(0x00000000u, 0x007f0000u), // _  underscore  ink 7
+  uvec2(0x08040201u, 0x00402010u), //   backslash  ink 7
+  uvec2(0x08080808u, 0x00080808u), // |  vertical bar  ink 7
+  uvec2(0x08102040u, 0x00010204u), // /  slash  ink 7
+  uvec2(0x10204300u, 0x00000408u), // ン  katakana N  ink 7
+  uvec2(0x000c0c00u, 0x00000c0cu), // :  colon  ink 8
+  uvec2(0x0c081020u, 0x0008080au), // イ  katakana I  ink 9
+  uvec2(0x10204442u, 0x00020408u), // ソ  katakana SO  ink 9
+  uvec2(0x3e080800u, 0x00000808u), // +  plus  ink 9
+  uvec2(0x000c0c00u, 0x00060c0cu), // ;  semicolon  ink 10
+  uvec2(0x003e0000u, 0x0000003eu), // =  equals  ink 10
+  uvec2(0x08080c08u, 0x001c0808u), // 1  digit one  ink 10
+  uvec2(0x10204a0au, 0x00020408u), // ツ  katakana TSU  ink 10
+  uvec2(0x14240404u, 0x0004040cu), // ト  katakana TO  ink 10
+  uvec2(0x23400300u, 0x00060810u), // シ  katakana SHI  ink 10
+  uvec2(0x003c0000u, 0x00007f00u), // ニ  katakana NI  ink 11
+  uvec2(0x02020202u, 0x003e0202u), // L  latin L  ink 11
+  uvec2(0x0808081cu, 0x001c0808u), // I  latin I  ink 11
+  uvec2(0x0808083eu, 0x00080808u), // T  latin T  ink 11
+  uvec2(0x0810203eu, 0x00040404u), // 7  digit seven  ink 11
+  uvec2(0x1c2a0800u, 0x0000082au), // *  asterisk  ink 11
+  uvec2(0x10107f00u, 0x00081010u), // ナ  katakana NA  ink 12
+  uvec2(0x1020223eu, 0x00020408u), // ク  katakana KU  ink 12
+  uvec2(0x2020407eu, 0x00040810u), // フ  katakana FU  ink 12
+  uvec2(0x22222222u, 0x000c1020u), // リ  katakana RI  ink 12
+  uvec2(0x22420202u, 0x00060a12u), // レ  katakana RE  ink 12
+  uvec2(0x44242800u, 0x00414242u), // ハ  katakana HA  ink 12
+  uvec2(0x0202221cu, 0x001c2202u), // C  latin C  ink 13
+  uvec2(0x2040427eu, 0x00040810u), // ワ  katakana WA  ink 13
+  uvec2(0x20427e08u, 0x00040810u), // ウ  katakana U  ink 13
+  uvec2(0x040c1424u, 0x007c0404u), // ヒ  katakana HI  ink 14
+  uvec2(0x0c08103eu, 0x00402112u), // ス  katakana SU  ink 14
+  uvec2(0x1020221cu, 0x003e0408u), // 2  digit two  ink 14
+  uvec2(0x1810201eu, 0x001c2220u), // 3  digit three  ink 14
+  uvec2(0x1e02023eu, 0x00020202u), // F  latin F  ink 14
+  uvec2(0x20203e00u, 0x003e2020u), // コ  katakana KO  ink 14
+  uvec2(0x24247e00u, 0x00020c10u), // ア  katakana A  ink 14
+  uvec2(0x2c20223eu, 0x00040810u), // タ  katakana TA  ink 14
+  uvec2(0x0810203eu, 0x003e0204u), // Z  latin Z  ink 15
+  uvec2(0x087f003cu, 0x00040808u), // テ  katakana TE  ink 15
+  uvec2(0x0e10207fu, 0x00101008u), // マ  katakana MA  ink 15
+  uvec2(0x107f1212u, 0x00081010u), // サ  katakana SA  ink 15
+  uvec2(0x22242424u, 0x00612122u), // ル  katakana RU  ink 15
+  uvec2(0x22242830u, 0x0020203eu), // 4  digit four  ink 15
+  uvec2(0x08083e00u, 0x007f0808u), // エ  katakana E  ink 16
+  uvec2(0x207f003cu, 0x00060810u), // ラ  katakana RA  ink 16
+  uvec2(0x2222221cu, 0x001c2222u), // 0  digit zero  ink 16
+  uvec2(0x201e023eu, 0x001c2220u), // 5  digit five  ink 17
+  uvec2(0x3c22221cu, 0x001c2220u), // 9  digit nine  ink 17
+  uvec2(0x4244447cu, 0x00011922u), // カ  katakana KA  ink 17
+  uvec2(0x18107f10u, 0x00191214u), // オ  katakana O  ink 18
+  uvec2(0x1e02023eu, 0x003e0202u), // E  latin E  ink 18
+  uvec2(0x2a2a3622u, 0x00222222u), // M  latin M  ink 18
+  uvec2(0x3c20203eu, 0x003e2020u), // ヨ  katakana YO  ink 18
+  uvec2(0x7f107f10u, 0x00040808u), // キ  katakana KI  ink 19
+  uvec2(0x1c087f08u, 0x00084936u), // ホ  katakana HO  ink 20
+  uvec2(0x2222223eu, 0x003e2222u)  // ロ  katakana RO  ink 20
+);
+

--- a/effects-builtin/glyph/index.frag.glsl
+++ b/effects-builtin/glyph/index.frag.glsl
@@ -1,0 +1,58 @@
+  // **Which character this cell draws.** Decided here rather than in the vertex stage
+  // because one of the three keys does not exist up there: the tone key is the luminance of
+  // the colour the cell is about to draw, which is the line above this one. Nothing is lost
+  // by the move - the cell seed and the rain coordinate are both constant across a sprite,
+  // so the character is too.
+  //
+  // **The three keys add and wrap rather than mixing the way the five readings do**, and
+  // the difference is forced rather than stylistic: character indices do not average.
+  // Character 3 blended half and half with character 9 is character 6, which is an
+  // unrelated symbol rather than anything between the two. A sum wrapped into the table is
+  // the only composition that leaves each weight meaning how far it moves the character,
+  // and it keeps the property the readings have, that a weight at zero contributes exactly
+  // nothing.
+  //
+  // **The tone key is scaled by 63/64 where the other two keep the pure wrap**, and that
+  // departs from the design document, which writes all three the same. Luminance is the one
+  // key with a direction: the table is sorted by ink, so a tone ramp is only a ramp if full
+  // luminance lands on the densest character. Unscaled it lands on fract(1.0), which is 0
+  // and therefore the sparsest, so the brightest point in the picture would draw an
+  // apostrophe and the top of the ramp would read as a hole in it. The hash and the rain
+  // are not scaled, because wrapping is exactly what makes them look like noise.
+  //
+  // The luminance is clamped for the same reason the scaling exists. col can leave the unit
+  // interval - the readings sum, the flare adds, and a duotone pole is hot - and an
+  // unclamped tone term would carry the top of the ramp round to the sparse end again.
+  //
+  // The rain key reads whole heads gone past rather than the continuous coordinate, because
+  // a character index that blends is a character nobody wrote. It is multiplied by the
+  // golden ratio rather than used raw, and that is not decoration: at a weight of 1 an
+  // integer counter contributes exactly nothing, since the fract of a whole number is zero,
+  // so the one setting where the key should be strongest is the one where it would be
+  // inert. An irrational step walks the table without repeating, which is what a scramble
+  // has to do.
+  if (glyphMix > 0.0) {
+    float lum = clamp(dot(col, vec3(0.299, 0.587, 0.114)), 0.0, 1.0);
+    float rainStep = floor(vRain) * 0.6180339887498949;
+    float f = fract(glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);
+    // Guarded rather than trusted. fract is below 1 by definition, but a value arriving at
+    // exactly 1.0 through a rounding would index one past the end of the table, and reading
+    // a constant array out of range in GLSL is undefined rather than an error - so the one
+    // way this could go wrong is also the way nothing would report it.
+    int idx = min(int(f * 64.0), 63);
+    uvec2 g = GLYPHS[idx];
+    // gl_PointCoord runs from the sprite's upper left, which is where row 0 and column 0 of
+    // the bitmask are, so the two grids line up without a flip anywhere. Sampled across the
+    // whole 8x8 box rather than across the ink: the clear eighth row and column are the
+    // margin, and cropping to the ink would be a parameter for something the font already
+    // says.
+    uint gc = uint(clamp(gl_PointCoord.x * 8.0, 0.0, 7.0));
+    uint gr = uint(clamp(gl_PointCoord.y * 8.0, 0.0, 7.0));
+    uint bits = gr < 4u ? g.x >> (gr * 8u + gc) : g.y >> ((gr - 4u) * 8u + gc);
+    // A hard cut rather than an antialiased one, and the crossfade above is why it can be.
+    // The mark is already blending back toward the round falloff wherever it is too small
+    // to resolve, so softening the bits as well would be a second legibility mechanism
+    // doing the first one's job - and the two would then have to be kept in step.
+    falloff = mix(falloff, (bits & 1u) == 1u ? 1.0 : 0.0, glyphMix);
+  }
+

--- a/effects-builtin/glyph/manifest.json
+++ b/effects-builtin/glyph/manifest.json
@@ -83,5 +83,53 @@
       "after": "points",
       "order": 100
     }
+  ],
+  "varyings": [
+    {
+      "name": "vCellSeed",
+      "type": "float",
+      "init": "0.0",
+      "order": 100
+    }
+  ],
+  "consumes": [
+    {
+      "service": "cell",
+      "when": "glyph > 0.0",
+      "gateOrder": 100
+    }
+  ],
+  "chunks": [
+    {
+      "stage": "v.decl",
+      "order": 100,
+      "file": "decl.vert.glsl"
+    },
+    {
+      "stage": "cell",
+      "file": "cell.vert.glsl"
+    },
+    {
+      "slot": "v.pointSize",
+      "file": "size.vert.glsl"
+    },
+    {
+      "stage": "f.decl",
+      "order": 100,
+      "file": "decl.frag.glsl"
+    },
+    {
+      "stage": "f.helpers",
+      "order": 100,
+      "file": "helpers.frag.glsl"
+    },
+    {
+      "slot": "f.mark",
+      "file": "mark.frag.glsl"
+    },
+    {
+      "slot": "f.glyph",
+      "file": "index.frag.glsl"
+    }
   ]
 }

--- a/effects-builtin/glyph/mark.frag.glsl
+++ b/effects-builtin/glyph/mark.frag.glsl
@@ -1,0 +1,46 @@
+  // How much of the mark is a character rather than a round splat, worked out here
+  // because the discard below has to know about it and finished a long way down, where the
+  // luminance the character index keys on finally exists.
+  //
+  // **The distance term multiplies into the master rather than clamping the sprite**, and
+  // that is what protects the recession. A cell four metres from the sensor projects to
+  // about six pixels, and an 8x8 bitmask sampled across six pixels is not a small
+  // character - it is a different random set of bits every time the camera moves, which
+  // bloom then amplifies. Clamping the sprite to a legible minimum would keep every cell
+  // readable at any range, but far cells would stop being cell-sized and start
+  // overlapping, which collapses the perspective recession at depth into exactly the flat
+  // screen grid this design was chosen over. So the mark stops trying to be legible and
+  // the geometry never stops being true, and it does it by reusing the blend the master
+  // already is rather than adding a mechanism that could go out of step with it.
+  //
+  // The two ends are the font's own sampling limits: at 8 the 8x8 grid gets one pixel per
+  // font cell, which is where the bits start aliasing into speckle, and at 16 it gets two
+  // and the character resolves. The design document says the fallback is somewhere below
+  // about ten pixels, which is inside this band rather than at either end of it.
+  //
+  // **What the two numbers are pixels *of* is the whole of what the vertex stage works out
+  // above**, and it is neither of this renderer's two existing references on its own. Below
+  // 1080 they are framebuffer pixels, because aliasing is a fact about the samples that
+  // exist and a mark cannot resolve on texels it does not have. At and above 1080 they are
+  // reference pixels, because the boundary between text and texture is a property of the
+  // look and a 4K export has to draw the same picture the grade was made on. The band is
+  // therefore stated once and read against whichever limit is nearer.
+  float glyphMix = glyph * smoothstep(8.0, 16.0, vLegiblePx);
+
+  // Additive mode shapes the sprite purely with alpha falloff. Skipping the
+  // discard keeps Apple's tile-based hidden-surface removal working.
+  //
+  // **The disc the hard-edged branch cuts would take the corners off a character**, so it
+  // is asked about the glyph first. At a glyphMix of exactly zero - which is every value of
+  // every look that does not draw characters, because the master multiplies - the condition
+  // collapses to the test that has always been here and the executed path is literally the
+  // old one, discard and then smoothstep. Above zero the sprite keeps its corners, and what
+  // shapes it is the bitmask rather than the disc.
+  float falloff;
+  if (softEdge == 1) {
+    falloff = exp(-r2 * 9.0);
+  } else {
+    if (glyphMix <= 0.0 && r2 > 0.25) discard;
+    falloff = smoothstep(0.25, 0.02, r2);
+  }
+

--- a/effects-builtin/glyph/size.vert.glsl
+++ b/effects-builtin/glyph/size.vert.glsl
@@ -1,0 +1,29 @@
+  // **The sprite grows into its cell as the master rises**, so one character stands for one
+  // cube of room, which is the whole reading the cube variant of this was chosen for. A
+  // 5.5cm cell a metre away is about 64 reference pixels where pointSize 9 is 9, so the
+  // two are nowhere near each other and something had to give; blending rather than
+  // switching is what keeps pointSize meaning something at every value in between.
+  //
+  // **The ceiling on the glyph branch is the hardware's and not the literal 64**, because a
+  // cell-sized sprite reaches 64 pixels at a metre and that is where a person stands. Past
+  // that the sprite would stop growing while the cell kept growing, so characters would
+  // stop filling their cells, the tiling would open up, and spriteWorld / cell would stop
+  // being 1 at full glyph - which is the property the energy compensation in the fragment
+  // stage rests on. The clamp is in framebuffer pixels, so that failure moves with output
+  // size: the same look that opens gaps at a metre on screen opens them at two metres in a
+  // 4K export, which is exactly the drift the 1080p reference unit exists to stop.
+  //
+  // **The old statement survives verbatim on the else branch, and that departs from the
+  // design document on purpose.** The document replaces the literal 64 outright. It is kept
+  // here because no shipped look reaches it - pointSize tops out at 9 across all nine, so
+  // 64 needs a subject 14cm from the sensor, nearer than a Kinect v2 will range - and
+  // because leaving the statement textually alone is what keeps the old path byte-identical
+  // across output sizes and keeps export-check's anchor alive. What the document is right
+  // about is the case it was written for, which is the grown sprite, and that case is the
+  // branch above.
+  if (glyph > 0.0) {
+    float base = clamp(pointSize * k / dist, 1.0, 64.0);
+    gl_PointSize = clamp(mix(base, cellPx * k, glyph), 1.0, pointCeiling);
+  } else {
+    gl_PointSize = clamp(pointSize * k / max(0.15, -mv.z), 1.0, 64.0);
+  }

--- a/effects-builtin/grain/grain.grade.glsl
+++ b/effects-builtin/grain/grain.grade.glsl
@@ -1,0 +1,16 @@
+      if (grain > 0.0) {
+        // Weighted by luminance so grain lives in the signal instead of lifting
+        // the empty background into a grey haze.
+        //
+        // Quantised onto the reference grid rather than sampled continuously, so
+        // one grain cell is one 1080p pixel wherever the frame is drawn. Sampling
+        // continuously would give four sub-pixels of a 2x render four unrelated
+        // hash values that average to a quarter of the variance, which is exactly
+        // the "grain grows finer as resolution rises" this reference exists to
+        // stop. At 1080p it is the same one-value-per-pixel noise it always was,
+        // off a different seed.
+        float lum = dot(col, vec3(0.299, 0.587, 0.114));
+        float n = hash(floor(vUv * ref) + fract(time) * 137.0);
+        col += (n - 0.5) * grain * 0.22 * (0.15 + lum);
+      }
+

--- a/effects-builtin/grain/manifest.json
+++ b/effects-builtin/grain/manifest.json
@@ -22,5 +22,12 @@
       },
       "role": "master"
     }
-  }
+  },
+  "chunks": [
+    {
+      "stage": "g.body",
+      "order": 300,
+      "file": "grain.grade.glsl"
+    }
+  ]
 }

--- a/effects-builtin/lattice/energy.vert.glsl
+++ b/effects-builtin/lattice/energy.vert.glsl
@@ -1,0 +1,34 @@
+  // **What the lattice does to additive brightness, cancelled here rather than in the
+  // fragment stage.** The normalisation down there divides a splat's alpha by its own area,
+  // on the assumption that sources are spread at the sprite's scale - and the lattice
+  // breaks that assumption by collapsing them onto cells. Pulling points a fraction L of
+  // the way to their cell centre leaves a cluster spanning cell * (1 - L), so brightness
+  // runs up as one over that squared until the cluster is smaller than the sprite, after
+  // which it saturates at the fully coincident case. voxel.json has been in exactly that
+  // state since it shipped: lattice 0.55, additive on, and a pointSize of 6.5 well under
+  // its 3.5cm cell.
+  //
+  // **It is computed here because two of the three things it needs do not exist in the
+  // fragment stage.** The view distance and the projection are vertex-stage quantities, so
+  // the design document's single fragment-stage expression cannot be written where it puts
+  // it; crossing the finished factor is one varying where crossing its inputs would be
+  // three, and it puts the arithmetic where its inputs are. vSize is the sprite that was
+  // actually rasterised - taken after both clamps - so wherever the ceiling bites,
+  // brightness stays correct and only the tiling degrades.
+  //
+  // **The min bounding the sprite term is a correction to the document and not a
+  // transcription of it.** As written there the factor is max((1-L)^2, (sprite/cell)^2),
+  // which at lattice 0 is 1 only while the sprite is no bigger than the cell - and
+  // pointSize reaches 64 against a cell that bottoms out at 5mm, so the region where it
+  // exceeds 1 is reachable through the sliders and the factor would then *brighten*, in
+  // contradiction of the document's own "exactly 1 at lattice 0". Bounded, it is exactly 1
+  // at lattice 0, exactly (sprite/cell)^2 at lattice 1, and exactly 1 again at full glyph
+  // where the sprite *is* the cell - which is the property that makes the compensation and
+  // the glyph field not interact at all at full strength.
+  //
+  // Straight through with no guard, following the flare's measurement in the fragment
+  // stage: multiplying by the computed 1.0 is exact in IEEE, where a branch dropped into a
+  // common path costs the compiler contractions across the lines either side of it.
+  float spriteCells = vSize / cellPx;
+  vCellNorm = max((1.0 - lattice) * (1.0 - lattice), min(1.0, spriteCells * spriteCells));
+

--- a/effects-builtin/lattice/manifest.json
+++ b/effects-builtin/lattice/manifest.json
@@ -21,5 +21,16 @@
       },
       "role": "master"
     }
-  }
+  },
+  "chunks": [
+    {
+      "stage": "v.displace",
+      "order": 200,
+      "file": "snap.vert.glsl"
+    },
+    {
+      "slot": "v.cellNorm",
+      "file": "energy.vert.glsl"
+    }
+  ]
 }

--- a/effects-builtin/lattice/snap.vert.glsl
+++ b/effects-builtin/lattice/snap.vert.glsl
@@ -1,0 +1,26 @@
+  // The volume rebuilt on a grid: every axis quantised to a cell, so surfaces break into
+  // steps and the cloud reads as something a machine is reconstructing rather than
+  // something that was measured. It sits last of the displacements, after the tear, so
+  // what gets snapped is the position the point actually ends at - a lattice applied
+  // before the turbulence would be smoothly pushed back off its own grid and buy nothing.
+  //
+  // **Snapped in the levelled frame and not the sensor's**, which is the whole of why this
+  // is more than a rounding. The grid has to belong to the room: with a canted mount the
+  // sensor frame is tilted, and a lattice cut along its axes would stand at whatever angle
+  // the bracket happened to be at, so the floor would step diagonally. Levelling first
+  // means the cells line up with the room, and a mount corrected afterwards does not
+  // re-cut the grid.
+  //
+  // **The rotation is the model matrix three already hands this shader, not a second copy
+  // of it.** The cloud carries the world tilt as its only transform, so mat3(modelMatrix)
+  // is exactly the sensor-to-levelled rotation and cannot drift from it the way a uniform
+  // derived beside it could. Getting back is the transpose rather than inverse(), which is
+  // both cheaper and exact - but that identity holds only while the matrix stays a pure
+  // rotation, so registry-check asserts the cloud carries no scale and no translation
+  // rather than leaving it as a thing this comment claims.
+  if (lattice > 0.0) {
+    mat3 level = mat3(modelMatrix);
+    vec3 cell = floor((level * pos) / latticeCell + 0.5) * latticeCell;
+    pos = mix(pos, transpose(level) * cell, lattice);
+  }
+

--- a/effects-builtin/mask/manifest.json
+++ b/effects-builtin/mask/manifest.json
@@ -21,5 +21,18 @@
       },
       "role": "master"
     }
-  }
+  },
+  "consumes": [
+    {
+      "service": "region",
+      "when": "regionMask != 0.0",
+      "gateOrder": 300
+    }
+  ],
+  "chunks": [
+    {
+      "slot": "v.mask",
+      "file": "soften.vert.glsl"
+    }
+  ]
 }

--- a/effects-builtin/mask/soften.vert.glsl
+++ b/effects-builtin/mask/soften.vert.glsl
@@ -1,0 +1,14 @@
+  // Positive hides what is inside the region, negative what is outside. Carried to the
+  // fragment stage rather than culled here, because the whole point of the falloff is
+  // that the edge is soft.
+  //
+  // The crop's own dimming rides here rather than on a varying of its own, and it is
+  // the same idea rather than a similar one: both are a boundary the vertex stage knows
+  // about attenuating a fragment it cannot discard. A second varying would be a second
+  // spelling of "how much is this point attenuated", and the two would then have to be
+  // multiplied together somewhere anyway.
+  vMask = (regionMask > 0.0
+    ? 1.0 - regionMask * rw
+    : 1.0 + regionMask * (1.0 - rw))
+    * (outsideCrop ? cropOutside : 1.0);
+

--- a/effects-builtin/noise/manifest.json
+++ b/effects-builtin/noise/manifest.json
@@ -71,5 +71,19 @@
         "uniform": "regionNoise"
       }
     }
-  }
+  },
+  "consumes": [
+    {
+      "service": "region",
+      "when": "regionNoise > 0.0",
+      "gateOrder": 200
+    }
+  ],
+  "chunks": [
+    {
+      "stage": "v.regionDisplace",
+      "order": 100,
+      "file": "turbulence.vert.glsl"
+    }
+  ]
 }

--- a/effects-builtin/noise/turbulence.vert.glsl
+++ b/effects-builtin/noise/turbulence.vert.glsl
@@ -1,0 +1,8 @@
+  // Gated because it is the most expensive thing in this shader: eight hashes of three
+  // sines each, against the six the old sine field cost. A look with no turbulence pays
+  // none of it, which is the same bargain the ghost half of the geometry makes.
+  float amp = noise + regionNoise * rw;
+  if (amp > 0.0) {
+    pos += amp * vnoise3(p0 * noiseScale + time * noiseSpeed * vec3(0.7, 1.13, 0.31));
+  }
+

--- a/effects-builtin/push/manifest.json
+++ b/effects-builtin/push/manifest.json
@@ -21,5 +21,19 @@
       },
       "role": "master"
     }
-  }
+  },
+  "consumes": [
+    {
+      "service": "region",
+      "when": "regionPush != 0.0",
+      "gateOrder": 100
+    }
+  ],
+  "chunks": [
+    {
+      "stage": "v.regionDisplace",
+      "order": 200,
+      "file": "swell.vert.glsl"
+    }
+  ]
 }

--- a/effects-builtin/push/swell.vert.glsl
+++ b/effects-builtin/push/swell.vert.glsl
@@ -1,0 +1,11 @@
+  // Radial rather than along the field's gradient. The gradient of a rounded box is
+  // degenerate at the centre - there is no outward direction there - and flattens
+  // against the faces, where a radial push is defined everywhere and reads as a blob
+  // swelling. The guard is for the point that lands exactly on the centre, where
+  // normalize would hand back NaN and take the whole vertex with it.
+  if (regionPush != 0.0 && rw > 0.0) {
+    vec3 away = p0 - regionCentre;
+    float d = length(away);
+    if (d > 1e-4) pos += (away / d) * regionPush * rw;
+  }
+

--- a/effects-builtin/rain/cell.vert.glsl
+++ b/effects-builtin/rain/cell.vert.glsl
@@ -1,0 +1,14 @@
+    // Counted in whole drops rather than wrapped into one, so that the fragment stage can
+    // read both halves of the same number off one varying: the fraction is how far above
+    // the last head this point sits, which is the brightness, and the integer is how many
+    // heads have already gone past it, which is the scramble. Wrapping here would throw
+    // the counter away and cost a second varying to get it back.
+    //
+    // Heads descend, so world height enters with the same sign program time does and a
+    // point standing still watches the coordinate climb. One head every rainSpan metres
+    // down each column rather than a single head wrapping over the whole room: a column
+    // always has two or three running, where one head spends half its cycle below the
+    // floor with the room dark behind it. The per-column offset is a hash of the cell's
+    // own x and z, so neighbouring columns are out of step and the room does not pulse as
+    // a single plane.
+    vRain = (rainPhase * rainSpeed + room.y) / rainSpan + hash(dot(wc.xz, vec2(269.5, 183.3)));

--- a/effects-builtin/rain/decl.frag.glsl
+++ b/effects-builtin/rain/decl.frag.glsl
@@ -1,0 +1,4 @@
+// The rain's brightness and the two lengths that shape it. The speed is not here: how fast
+// a head falls only enters through the scalar the vertex stage already computed, where the
+// world height it is a rate against lives.
+uniform float rain, rainSpan, rainTrail;

--- a/effects-builtin/rain/decl.vert.glsl
+++ b/effects-builtin/rain/decl.vert.glsl
@@ -1,0 +1,12 @@
+// The rain, which is a colour term rather than a property of the alphabet and so has its
+// own four parameters. Three of them are read here because the scalar the whole thing
+// rests on is a function of world height, which only this stage knows; rainTrail shapes
+// the brightness and is read in the fragment stage beside the colour it lifts.
+uniform float rain, rainSpeed, rainSpan;
+// Program time again, and it is a second cell holding the same number rather than a reuse
+// of time on purpose. The rain has to be a pure function of program time or a seek lands
+// where playback never would, and the control that holds that claim -
+// timeline-check --mutate rain-accumulates - has to be able to integrate exactly one
+// line. Mutating time itself would redden the ripple, the glitch and the raster along
+// with it, and a control that fails everything cannot say which claim is load-bearing.
+uniform float rainPhase;

--- a/effects-builtin/rain/lift.frag.glsl
+++ b/effects-builtin/rain/lift.frag.glsl
@@ -1,0 +1,28 @@
+  // **The rain, which is a colour term rather than a property of the alphabet.** It sits
+  // here for the reason thermal, the edges and the duotone above it do - a term written
+  // into one reading is inert in every other one - and it is a term of its own rather than
+  // a setting inside the glyph field because the brightness *is* the effect. What the
+  // reference clips show carrying the picture is a drop head descending a column with a
+  // trail of afterglow above it; scrambling on its own is invisible, since which character
+  // a cell draws is noise either way. Filed inside the glyph field, a wave descending
+  // through the room would have been unreachable for any look that was not drawing text -
+  // including voxel, which now gets it for nothing.
+  //
+  // It is below the flare rather than above it so that the line the flare's own comment
+  // measured keeps the neighbours it was measured beside, and because a torn band is
+  // emitted light: the rain lifts what the cell actually draws, flare included, and the
+  // tone key one block down reads the same colour the frame gets.
+  //
+  // vRain counts whole drops, so its fraction is how far above the last head this point
+  // stands as a share of the span, and the trail arrives in metres and is converted into
+  // that same share. **The trail sits above the head and not below it**, which is what
+  // makes the wave read as falling rather than as a band sliding through: the lift is 1 at
+  // the head and decays upward over rainTrail metres, and a point just under a head is a
+  // whole span below the next one and so is dark.
+  //
+  // Unconditional and written straight through, on the flare's own measurement above: at a
+  // rain of 0 the multiplier is exactly 1.0 whether or not the compiler contracts it, where
+  // a branch dropped into this path costs contractions across the lines either side of it.
+  float rainLift = 1.0 - smoothstep(0.0, rainTrail / rainSpan, fract(vRain));
+  col *= 1.0 + rain * rainLift;
+

--- a/effects-builtin/rain/manifest.json
+++ b/effects-builtin/rain/manifest.json
@@ -83,5 +83,41 @@
       "after": "style",
       "order": 100
     }
+  ],
+  "varyings": [
+    {
+      "name": "vRain",
+      "type": "float",
+      "init": "0.0",
+      "order": 200
+    }
+  ],
+  "consumes": [
+    {
+      "service": "cell",
+      "when": "rain > 0.0",
+      "gateOrder": 200
+    }
+  ],
+  "chunks": [
+    {
+      "stage": "v.decl",
+      "order": 200,
+      "file": "decl.vert.glsl"
+    },
+    {
+      "stage": "cell",
+      "file": "cell.vert.glsl"
+    },
+    {
+      "stage": "f.decl",
+      "order": 200,
+      "file": "decl.frag.glsl"
+    },
+    {
+      "stage": "f.tone",
+      "order": 500,
+      "file": "lift.frag.glsl"
+    }
   ]
 }

--- a/effects-builtin/raster/decl.grade.glsl
+++ b/effects-builtin/raster/decl.grade.glsl
@@ -1,0 +1,2 @@
+    uniform vec2 scanAxis;
+    uniform float scanPitch, scanHard;

--- a/effects-builtin/raster/lines.grade.glsl
+++ b/effects-builtin/raster/lines.grade.glsl
@@ -1,0 +1,42 @@
+      if (scanlines > 0.0) {
+        // **The default path is the old line itself, not an expression that computes what
+        // the old line computed**, and that distinction is a measurement rather than
+        // caution. The shipped Blackwall document names a scanlines of 0.35, so this block
+        // runs in the one shipped look that is a look, and a raster a hair off the one it
+        // replaces is that document quietly re-grading itself.
+        //
+        // Two things were tried before this and both failed, which is worth recording
+        // because each looked like the answer. Taking the sine and cosine of the angle in
+        // the shader leaked a whisker of x into a raster meant to run along y, since GLSL
+        // ES does not promise the sine of zero is zero - that is real and is why the axis
+        // is built on the CPU, but fixing it moved nothing here. What moves the frame is
+        // the substitution docs/measurement.md already records: handing the wave a
+        // coordinate through a local is not the same as handing it the expression, because
+        // the compiler contracts the whole of y times the reference times 1.3 plus the
+        // clock across one line and will not do so through a variable. Measured at the
+        // shipped 0.35, all six frames differed, 054b99215d9f against 44e1ccf8, with every
+        // parameter at its default.
+        //
+        // So the branch goes around the whole statement and the default path *is* the old
+        // one - the same shape, and for the same reason, as the depth reading's gamma in
+        // web/cloud-shader.js. It is not a legacy path beside a new one: the general form
+        // below is the implementation, and this is the one input for which the arithmetic
+        // has to be reached rather than reproduced.
+        float line;
+        if (scanAxis.x == 0.0 && scanAxis.y == 1.0 && scanPitch == 1.3 && scanHard == 0.0) {
+          line = sin(vUv.y * ref.y * 1.3 + time * 2.0) * 0.5 + 0.5;
+        } else {
+          // The raster's own axis, as a direction in reference pixels, built on the CPU
+          // for the reason beside the uniform.
+          float coord = dot(vUv * ref, scanAxis);
+          float wave = sin(coord * scanPitch + time * 2.0) * 0.5 + 0.5;
+          // Hardness is a duty cycle rather than a second term. It narrows a smoothstep
+          // about the middle of the wave until the sine becomes a grille of hard lines
+          // with dark gaps between them, which is what the reference frames actually
+          // carry and what no amount of rotating a sine will ever reach.
+          float w = mix(0.5, 0.004, scanHard);
+          line = mix(wave, smoothstep(0.5 - w, 0.5 + w, wave), scanHard);
+        }
+        col *= 1.0 - scanlines * 0.35 * line;
+      }
+

--- a/effects-builtin/raster/manifest.json
+++ b/effects-builtin/raster/manifest.json
@@ -85,5 +85,17 @@
       "after": "post",
       "order": 100
     }
+  ],
+  "chunks": [
+    {
+      "stage": "g.decl",
+      "order": 200,
+      "file": "decl.grade.glsl"
+    },
+    {
+      "stage": "g.body",
+      "order": 200,
+      "file": "lines.grade.glsl"
+    }
   ]
 }

--- a/effects-builtin/rgbsplit/manifest.json
+++ b/effects-builtin/rgbsplit/manifest.json
@@ -22,5 +22,11 @@
       },
       "role": "master"
     }
-  }
+  },
+  "chunks": [
+    {
+      "slot": "g.fetch",
+      "file": "split.grade.glsl"
+    }
+  ]
 }

--- a/effects-builtin/rgbsplit/split.grade.glsl
+++ b/effects-builtin/rgbsplit/split.grade.glsl
@@ -1,0 +1,11 @@
+      if (rgbSplit > 0.0) {
+        // Split grows toward the edges, so the centre stays legible.
+        vec2 dir = (vUv - 0.5);
+        vec2 off = dir * rgbSplit * texel * 8.0;
+        col.r = texture2D(tDiffuse, vUv + off).r;
+        col.g = texture2D(tDiffuse, vUv).g;
+        col.b = texture2D(tDiffuse, vUv - off).b;
+      } else {
+        col = texture2D(tDiffuse, vUv).rgb;
+      }
+

--- a/effects-builtin/ripple/manifest.json
+++ b/effects-builtin/ripple/manifest.json
@@ -55,5 +55,19 @@
       },
       "under": "amount"
     }
-  }
+  },
+  "consumes": [
+    {
+      "service": "region",
+      "when": "ripple > 0.0",
+      "gateOrder": 400
+    }
+  ],
+  "chunks": [
+    {
+      "stage": "v.regionDisplace",
+      "order": 300,
+      "file": "wave.vert.glsl"
+    }
+  ]
 }

--- a/effects-builtin/ripple/wave.vert.glsl
+++ b/effects-builtin/ripple/wave.vert.glsl
@@ -1,0 +1,24 @@
+  // The region read a fourth way: a wave travelling out along the radius, so the volume
+  // breathes where the push only swells it. It shares the push's radial direction and its
+  // centre guard for the same reasons - the gradient of a rounded box is degenerate at the
+  // centre, and normalize there would hand back NaN and take the vertex with it.
+  //
+  // **The clock is stepped rather than continuous, which is the whole character of it.**
+  // A sine of raw time is a thing breathing; this design wants a thing being rebuilt by a
+  // machine, so the phase advances in eighth-cycles and the surface arrives at each one
+  // rather than sliding between them. Eight steps and not a parameter: the count is what
+  // makes it read as machinery, and a slider that could set it to a thousand would just
+  // be a way to author the smooth version this is deliberately not.
+  //
+  // The step is on the clock alone and not on the radius, so the wave is quantised in
+  // time and smooth in space. Quantising both would put the region on a set of shells,
+  // which is the lattice's job two blocks down and would be a second way to do it.
+  if (ripple > 0.0 && rw > 0.0) {
+    vec3 out0 = p0 - regionCentre;
+    float dist = length(out0);
+    if (dist > 1e-4) {
+      float cycles = dist * rippleFreq - floor(time * rippleSpeed * 8.0) * 0.125;
+      pos += (out0 / dist) * (sin(cycles * 6.2831853) * ripple * rw);
+    }
+  }
+

--- a/effects-builtin/streak/decl.grade.glsl
+++ b/effects-builtin/streak/decl.grade.glsl
@@ -1,0 +1,2 @@
+    uniform float streak;
+    uniform vec2 streakAxis;

--- a/effects-builtin/streak/fall.grade.glsl
+++ b/effects-builtin/streak/fall.grade.glsl
@@ -1,0 +1,59 @@
+      // Light bleeds. Each pixel gathers back along the streak's own axis and keeps the
+      // brightest thing it finds, decayed by how far it had to look, so a highlight smears
+      // across the frame the way a sensor smears one down a column of wells. It sits here,
+      // below the raster and the vignette and above the tonemap, because it is a thing that
+      // happened to the light rather than a thing drawn over the picture: a streak applied
+      // after the vignette would glow in the corners the vignette had just put out.
+      //
+      // **A gather and not a feedback buffer**, which is a decision rather than a
+      // simplification. A buffer accumulating across frames smears along whatever the
+      // camera did last, so an orbit would drag every streak sideways, and - the half that
+      // settles it - a seek would arrive carrying the streak the scrub built rather than
+      // the one playback would have built. That is the property the whole transport rests
+      // on, broken by an effect nobody would think to test it against.
+      //
+      // Distances are in reference pixels through texel, for the reason stated at the top
+      // of this shader: a streak whose length grew with the window would be the nearly
+      // resolution-independent look that is worse than an honestly dependent one. The axis
+      // is a *direction* in those same reference pixels rather than in uv, which is the
+      // half that keeps the angle honest: the offset below is d reference pixels along the
+      // axis whatever shape the window is, where a step taken in uv and scaled afterwards
+      // would run at the aspect ratio's angle instead of the one the slider names, and
+      // would swing as somebody dragged the window.
+      //
+      // **The tap schedule is written down because the first one was wrong.** Eight taps at
+      // a geometric ratio of 2.1 put the far samples so far apart that they land as separate
+      // ghosts - a comb rather than a smear. Sixteen at 1.35 overlap enough to read as
+      // continuous and reach about 168 reference pixels.
+      //
+      // **The direction is the measurement and not the derivation, and the cost of getting
+      // that backwards is recorded here because it was paid twice.** When this gather ran
+      // one way only it was written with the plus, doubted against a busy frame that seemed
+      // to show the light climbing, flipped to a minus, and then restored - because a build
+      // cropped down to a single bright band with darkness above and below settles in one
+      // look what a full frame full of structure will support either reading of. Two
+      // separate readings of the *same* sign came out opposite. Nothing in the suite could
+      // have caught the flip: every uniform still landed and every image still changed, so
+      // the drop-one sweep stayed green through all of it.
+      //
+      // That sign is now a whole direction, and the lesson is the same one scaled up: the
+      // arm in the registry check calibrates *both* screen axes off the crop's own faces
+      // and asks where each angle's light actually lands, rather than deriving where it
+      // ought to from which way uv grows - which is the derivation that was wrong the first
+      // time. An angle of 0 keeps the fall this always had, and it keeps it exactly: at the
+      // default axis the offset below renders bit-identical to the plain vertical vec2 it
+      // replaces, measured at four looks and three drawing-buffer sizes, so there is no
+      // guard here of the kind the raster below needs. Multiplying by an axis that is
+      // exactly zero and exactly one introduces no rounding, where the raster's general
+      // form is a dot product against a sum the compiler contracts differently.
+      if (streak > 0.0) {
+        vec3 fall = col;
+        float d = 1.5;
+        for (int i = 0; i < 16; i++) {
+          vec3 tap = texture2D(tDiffuse, vUv + d * texel * streakAxis).rgb;
+          fall = max(fall, tap * exp2(-d * 0.02));
+          d *= 1.35;
+        }
+        col = mix(col, fall, streak);
+      }
+

--- a/effects-builtin/streak/manifest.json
+++ b/effects-builtin/streak/manifest.json
@@ -40,5 +40,17 @@
       },
       "under": "amount"
     }
-  }
+  },
+  "chunks": [
+    {
+      "stage": "g.decl",
+      "order": 100,
+      "file": "decl.grade.glsl"
+    },
+    {
+      "stage": "g.body",
+      "order": 100,
+      "file": "fall.grade.glsl"
+    }
+  ]
 }

--- a/effects-builtin/thermal/heat.frag.glsl
+++ b/effects-builtin/thermal/heat.frag.glsl
@@ -1,0 +1,10 @@
+  if (thermal > 0.0) {
+    // Luminance where there is a colour camera, depth where there is not. A thermal
+    // picture is a reading of a signal, and with the colour stream off the only signal
+    // left is range - falling back to a flat tint instead would be a slider that
+    // appears to work and is showing nothing.
+    float lum = dot(rgb, vec3(0.299, 0.587, 0.114));
+    float heat = hasColor == 1 ? lum : 1.0 - t;
+    col = mix(col, heatRamp(clamp(heat, 0.0, 1.0)), thermal);
+  }
+

--- a/effects-builtin/thermal/manifest.json
+++ b/effects-builtin/thermal/manifest.json
@@ -21,5 +21,12 @@
       },
       "role": "master"
     }
-  }
+  },
+  "chunks": [
+    {
+      "stage": "f.tone",
+      "order": 100,
+      "file": "heat.frag.glsl"
+    }
+  ]
 }

--- a/effects-builtin/vignette/corners.grade.glsl
+++ b/effects-builtin/vignette/corners.grade.glsl
@@ -1,0 +1,7 @@
+      // How far the frame closes down on the subject, which used to be the literal 0.55
+      // and therefore a hidden function of whether any of the three terms above was up.
+      // The extent is still fixed - a vignette this look wants is a corner falloff and
+      // not a shape to author - so the parameter is the depth alone.
+      float vig = smoothstep(1.05, 0.32, length(vUv - 0.5));
+      col *= mix(1.0, vig, vignette);
+

--- a/effects-builtin/vignette/manifest.json
+++ b/effects-builtin/vignette/manifest.json
@@ -22,5 +22,12 @@
       },
       "role": "master"
     }
-  }
+  },
+  "chunks": [
+    {
+      "stage": "g.body",
+      "order": 400,
+      "file": "corners.grade.glsl"
+    }
+  ]
 }

--- a/test/cloud-shader.test.mjs
+++ b/test/cloud-shader.test.mjs
@@ -1,27 +1,44 @@
-// Every uniform the cloud's two programs declare, against the object that feeds them.
+// Every uniform each assembled program declares, against the object that feeds it.
 //
 // **This is the obligation the split created, so it arrives with the split rather than
-// after it.** The GLSL lives in `web/cloud-shader.js` and, since the effects began
-// carrying their own, in the chunk files under `effects-builtin/`; the `uniforms` table
-// lives in `web/point-cloud.js`, and nothing pairs them at runtime: three.js writes the keys it is
-// given and ignores the rest, so a uniform declared in the shader with no key is read as
-// zero with nothing on the console, and a key with no declaration is a write per frame
-// that reaches no pixel. Both are silent, and both are exactly what a move of nine hundred
-// lines out of one file makes easy - and the table has since made the same journey, which
-// is the second half of why this row exists.
+// after it.** The GLSL lives in `web/cloud-shader.js` and `web/grade-shader.js` and, since
+// the effects began carrying their own, in the chunk files under `effects-builtin/`; the
+// tables live in `web/point-cloud.js` and `web/post-chain.js`, and nothing pairs them at
+// runtime: three.js writes the keys it is given and ignores the rest, so a uniform declared
+// in the shader with no key is read as zero with nothing on the console, and a key with no
+// declaration is a write per frame that reaches no pixel. Both are silent, and both are
+// exactly what a move of a thousand lines out of two files makes easy - and both tables have
+// since made the same journey, which is the second half of why this row exists.
 //
-// Read as text on both sides, which is the honest way and not a shortcut. The shader is
-// text by nature. The table could in principle be imported, but `web/point-cloud.js`
-// reaches the scene through `web/scene.js`, which builds a renderer as it evaluates, so it
-// cannot be loaded outside a browser at all - and a test that ran the module would be
-// asserting against what the registry has already overwritten rather than against what is
-// declared. So both sides are scanned, and the scan is made to fail loudly when it matches
-// nothing: an empty extraction passing an equality against another empty extraction is the
-// shape this repo keeps case files about.
+// **Two programs and two tables, paired separately and never pooled.** The cloud's uniforms
+// and the grade's are different populations feeding different passes, and a single set
+// unioned across both would go green on a grade term that had drifted into the point cloud's
+// table: the name would be declared somewhere and keyed somewhere, and neither somewhere
+// would be the same shader. The pairing is per program, so a term in the wrong table is a
+// red row on both sides at once.
+//
+// Read as text on the table side, which is the honest way and not a shortcut. The tables
+// could in principle be imported, but `web/point-cloud.js` reaches the scene through
+// `web/scene.js`, which builds a renderer as it evaluates, and `web/post-chain.js` reaches
+// the same renderer - so neither can be loaded outside a browser at all, and a test that ran
+// either module would be asserting against what the registry has already overwritten rather
+// than against what is declared. So the tables are scanned, and each scan is made to fail
+// loudly when it matches nothing: an empty extraction passing an equality against another
+// empty extraction is the shape this repo keeps case files about.
+//
+// **The shader side is assembled rather than scanned**, which is the half that changed when
+// the grade pass moved out. A file scan cannot say which program a chunk feeds without
+// reading its name, and it counts text a slot fallback carries that nothing ever compiles -
+// two more things to be right about, for a question the assembler answers exactly. What the
+// driver is handed is what gets scanned, so a declaration in the `v.mask` or `g.fetch`
+// fallback is correctly absent here, and a chunk that reaches no program contributes nothing
+// rather than demanding a key.
 //
 // What this does not claim is that a uniform is ever *written* with a value that means
 // anything - that is `registry-check`, which drives each parameter through the registry
-// and compares pixels. This one only says the two lists are the same list.
+// and compares pixels. This one only says the two lists are the same list. Nor does it claim
+// a chunk is spliced at all: that is `test/shader-assembly.test.mjs`, which flips a byte in
+// each chunk in turn and requires the program its name promises to move.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -29,38 +46,54 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
+import { cloudSpine } from '../web/cloud-shader.js';
+import { gradeSpine } from '../web/grade-shader.js';
+import { assembleShaders } from '../web/shader-assembly.js';
+
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const WEB = join(ROOT, 'web');
 const BUILTIN = join(ROOT, 'effects-builtin');
 
 /**
- * Every name declared by a `uniform` line in the shipped GLSL, wherever it lives.
+ * Where each program's uniform table lives, and what bounds it.
+ *
+ * The indents are the tables' positions in their files rather than a formatting preference.
+ * The cloud's cannot be built while its module evaluates - four of its cells come back from
+ * `buildTextures` and `stateTex` samples a target the surface memory has not made yet - so
+ * it lives one scope in; the grade's holds two constructed defaults and nothing else, so it
+ * sits at the top level. A scan anchored at the wrong column finds nothing at all, which is
+ * the case the floor row below exists to make loud.
+ */
+const TABLES = {
+  cloud: { file: 'point-cloud.js', open: '\n  uniforms = {\n', close: '\n  };\n', key: /^ {4}([A-Za-z_]\w*):/gm, floor: 60 },
+  grade: { file: 'post-chain.js', open: '\nconst GRADE_UNIFORMS = {\n', close: '\n};\n', key: /^ {2}([A-Za-z_]\w*):/gm, floor: 8 },
+};
+
+const shippedPackages = () => readdirSync(BUILTIN, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name)
+  .sort()
+  .map((id) => {
+    const manifest = JSON.parse(readFileSync(join(BUILTIN, id, 'manifest.json'), 'utf8'));
+    const chunks = {};
+    for (const c of manifest.chunks ?? []) chunks[c.file] = readFileSync(join(BUILTIN, id, c.file), 'utf8');
+    return { id, manifest, chunks };
+  });
+
+const PROGRAMS = assembleShaders({ cloud: cloudSpine, grade: gradeSpine }, shippedPackages());
+
+/**
+ * Every name declared by a `uniform` line in one assembled program.
  *
  * One declaration carries several names - `uniform vec2 focal, center, resolution;` is
- * three - which is why this splits on the comma rather than taking one name per line.
- *
- * **The spine and the chunk files together, because a uniform in a package is a uniform.**
- * Nine of the eighty-six moved out of `web/cloud-shader.js` and into the glyph and rain
- * packages when their GLSL did, and a scan left pointing at the spine alone would have
- * reported those nine keys as writes reaching nothing - a red row about a build with
- * nothing wrong with it, and worse, a row that would go green again by deleting nine
- * working parameters. The walk is over the directory rather than over a list of packages,
- * so a chunk added next year is asked by existing.
- *
- * What this cannot say is that a declaration is ever *spliced* - a chunk no joint claims
- * would be scanned here and reach no program. That is the claim
- * `test/shader-assembly.test.mjs` holds, by flipping a byte in each chunk in turn and
- * requiring the assembled program to move.
+ * three - which is why this splits on the comma rather than taking one name per line. Both
+ * shaders of the program together, because a term declared in the vertex stage and read in
+ * the fragment stage is one uniform with one key: the glyph field's master is declared in
+ * both, since it grows the sprite up there and crossfades the mark down here.
  */
-const declaredInGlsl = () => {
-  const sources = [readFileSync(join(WEB, 'cloud-shader.js'), 'utf8')];
-  for (const pkg of readdirSync(BUILTIN, { withFileTypes: true }).filter((e) => e.isDirectory())) {
-    for (const file of readdirSync(join(BUILTIN, pkg.name)).filter((f) => f.endsWith('.glsl'))) {
-      sources.push(readFileSync(join(BUILTIN, pkg.name, file), 'utf8'));
-    }
-  }
+const declaredInGlsl = (program) => {
   const names = new Set();
-  for (const source of sources) {
+  for (const source of [PROGRAMS[program].vertexShader, PROGRAMS[program].fragmentShader]) {
     for (const line of source.matchAll(/^\s*uniform\s+\w+\s+([^;]+);/gm)) {
       for (const name of line[1].split(',')) names.add(name.trim());
     }
@@ -69,50 +102,47 @@ const declaredInGlsl = () => {
 };
 
 /**
- * Every key of the `uniforms` table in `point-cloud.js`.
+ * Every key of one program's uniform table.
  *
  * Bounded by the literal's own braces rather than scanned over the whole file, so a
  * `key: { value }` pair in some unrelated object cannot join the list, and keys are taken
  * at exactly one level in from the literal for the same reason: the nested `{ value: ... }`
- * is one deeper, and so is every property of the material built underneath it.
- *
- * The two indents this reads are the table's position inside `buildPointCloud` rather than
- * a formatting preference. The table cannot be built while the module evaluates - four of
- * its cells come back from `buildTextures` and `stateTex` samples a target the surface
- * memory has not made yet - so it lives one scope in, and a scan anchored at column zero
- * would find nothing at all. Which is the case the row below exists to make loud.
+ * is one deeper, and so is every property of whatever is built underneath it.
  */
-const keysInTable = () => {
-  const source = readFileSync(join(WEB, 'point-cloud.js'), 'utf8');
-  const start = source.indexOf('\n  uniforms = {\n');
-  assert.notEqual(start, -1, 'point-cloud.js no longer assigns `uniforms = {` inside its build');
-  const end = source.indexOf('\n  };\n', start);
-  assert.notEqual(end, -1, 'the uniforms literal has no terminator at the build function\'s indent');
+const keysInTable = (program) => {
+  const { file, open, close, key } = TABLES[program];
+  const source = readFileSync(join(WEB, file), 'utf8');
+  const start = source.indexOf(open);
+  assert.notEqual(start, -1, `web/${file} no longer declares ${JSON.stringify(open.trim())}, so this scan reads nothing`);
+  const end = source.indexOf(close, start);
+  assert.notEqual(end, -1, `web/${file}'s ${program} uniform literal has no terminator at its own indent`);
   const names = new Set();
-  for (const line of source.slice(start, end).matchAll(/^ {4}([A-Za-z_]\w*):/gm)) names.add(line[1]);
+  for (const line of source.slice(start, end).matchAll(key)) names.add(line[1]);
   return names;
 };
 
-test('the scan finds both lists, so an equality below cannot pass on two empty sets', () => {
-  // The falsification control for this file. Both sides are read by pattern, and a pattern
-  // that stopped matching would leave two empty sets that are trivially equal - a green row
-  // saying nothing at all. Sixty is well under the eighty-six there are and well over
-  // anything a broken scan would return. It is deliberately not raised to catch a scan
-  // that lost the chunk files and kept the spine: seventy-seven would still clear any
-  // floor worth having, and the row that names that failure is the third one below, which
-  // lists the nine keys as writes reaching nothing rather than printing a count.
-  assert.ok(declaredInGlsl().size > 60, `only ${declaredInGlsl().size} uniforms found in the GLSL`);
-  assert.ok(keysInTable().size > 60, `only ${keysInTable().size} keys found in the uniforms literal`);
-});
+for (const program of Object.keys(TABLES)) {
+  test(`the ${program} scan finds both lists, so an equality below cannot pass on two empty sets`, () => {
+    // The falsification control for this file. Both sides are read by pattern, and a pattern
+    // that stopped matching would leave two empty sets that are trivially equal - a green row
+    // saying nothing at all. Each floor is well under what its program holds and well over
+    // anything a broken scan would return. Neither is raised to catch a scan that lost the
+    // packages and kept the spine: the row that names that failure is the third one below,
+    // which lists the keys as writes reaching nothing rather than printing a count.
+    const { floor } = TABLES[program];
+    assert.ok(declaredInGlsl(program).size > floor, `only ${declaredInGlsl(program).size} uniforms found in the ${program} GLSL`);
+    assert.ok(keysInTable(program).size > floor, `only ${keysInTable(program).size} keys found in the ${program} uniforms literal`);
+  });
 
-test('every uniform the shaders declare has a key, so none of them reads a silent zero', () => {
-  const keys = keysInTable();
-  const missing = [...declaredInGlsl()].filter((name) => !keys.has(name));
-  assert.deepEqual(missing, [], `declared in the GLSL with no key in point-cloud.js: ${missing.join(', ')}`);
-});
+  test(`every uniform the ${program} program declares has a key, so none of them reads a silent zero`, () => {
+    const keys = keysInTable(program);
+    const missing = [...declaredInGlsl(program)].filter((name) => !keys.has(name));
+    assert.deepEqual(missing, [], `declared in the ${program} GLSL with no key in web/${TABLES[program].file}: ${missing.join(', ')}`);
+  });
 
-test('and every key is declared, so none of them is written to nothing', () => {
-  const declared = declaredInGlsl();
-  const orphan = [...keysInTable()].filter((name) => !declared.has(name));
-  assert.deepEqual(orphan, [], `keys in point-cloud.js the GLSL never declares: ${orphan.join(', ')}`);
-});
+  test(`and every ${program} key is declared, so none of them is written to nothing`, () => {
+    const declared = declaredInGlsl(program);
+    const orphan = [...keysInTable(program)].filter((name) => !declared.has(name));
+    assert.deepEqual(orphan, [], `keys in web/${TABLES[program].file} the ${program} GLSL never declares: ${orphan.join(', ')}`);
+  });
+}

--- a/test/cloud-shader.test.mjs
+++ b/test/cloud-shader.test.mjs
@@ -1,8 +1,9 @@
 // Every uniform the cloud's two programs declare, against the object that feeds them.
 //
 // **This is the obligation the split created, so it arrives with the split rather than
-// after it.** The GLSL lives in `web/cloud-shader.js` and the `uniforms` table lives in
-// `web/point-cloud.js`, and nothing pairs them at runtime: three.js writes the keys it is
+// after it.** The GLSL lives in `web/cloud-shader.js` and, since the effects began
+// carrying their own, in the chunk files under `effects-builtin/`; the `uniforms` table
+// lives in `web/point-cloud.js`, and nothing pairs them at runtime: three.js writes the keys it is
 // given and ignores the rest, so a uniform declared in the shader with no key is read as
 // zero with nothing on the console, and a key with no declaration is a write per frame
 // that reaches no pixel. Both are silent, and both are exactly what a move of nine hundred
@@ -24,23 +25,45 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-const WEB = join(dirname(fileURLToPath(import.meta.url)), '..', 'web');
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WEB = join(ROOT, 'web');
+const BUILTIN = join(ROOT, 'effects-builtin');
 
 /**
- * Every name declared by a `uniform` line in the two programs.
+ * Every name declared by a `uniform` line in the shipped GLSL, wherever it lives.
  *
  * One declaration carries several names - `uniform vec2 focal, center, resolution;` is
  * three - which is why this splits on the comma rather than taking one name per line.
+ *
+ * **The spine and the chunk files together, because a uniform in a package is a uniform.**
+ * Nine of the eighty-six moved out of `web/cloud-shader.js` and into the glyph and rain
+ * packages when their GLSL did, and a scan left pointing at the spine alone would have
+ * reported those nine keys as writes reaching nothing - a red row about a build with
+ * nothing wrong with it, and worse, a row that would go green again by deleting nine
+ * working parameters. The walk is over the directory rather than over a list of packages,
+ * so a chunk added next year is asked by existing.
+ *
+ * What this cannot say is that a declaration is ever *spliced* - a chunk no joint claims
+ * would be scanned here and reach no program. That is the claim
+ * `test/shader-assembly.test.mjs` holds, by flipping a byte in each chunk in turn and
+ * requiring the assembled program to move.
  */
 const declaredInGlsl = () => {
-  const source = readFileSync(join(WEB, 'cloud-shader.js'), 'utf8');
+  const sources = [readFileSync(join(WEB, 'cloud-shader.js'), 'utf8')];
+  for (const pkg of readdirSync(BUILTIN, { withFileTypes: true }).filter((e) => e.isDirectory())) {
+    for (const file of readdirSync(join(BUILTIN, pkg.name)).filter((f) => f.endsWith('.glsl'))) {
+      sources.push(readFileSync(join(BUILTIN, pkg.name, file), 'utf8'));
+    }
+  }
   const names = new Set();
-  for (const line of source.matchAll(/^\s*uniform\s+\w+\s+([^;]+);/gm)) {
-    for (const name of line[1].split(',')) names.add(name.trim());
+  for (const source of sources) {
+    for (const line of source.matchAll(/^\s*uniform\s+\w+\s+([^;]+);/gm)) {
+      for (const name of line[1].split(',')) names.add(name.trim());
+    }
   }
   return names;
 };
@@ -73,8 +96,11 @@ const keysInTable = () => {
 test('the scan finds both lists, so an equality below cannot pass on two empty sets', () => {
   // The falsification control for this file. Both sides are read by pattern, and a pattern
   // that stopped matching would leave two empty sets that are trivially equal - a green row
-  // saying nothing at all. Sixty is well under the seventy-six there are and well over
-  // anything a broken scan would return.
+  // saying nothing at all. Sixty is well under the eighty-six there are and well over
+  // anything a broken scan would return. It is deliberately not raised to catch a scan
+  // that lost the chunk files and kept the spine: seventy-seven would still clear any
+  // floor worth having, and the row that names that failure is the third one below, which
+  // lists the nine keys as writes reaching nothing rather than printing a count.
   assert.ok(declaredInGlsl().size > 60, `only ${declaredInGlsl().size} uniforms found in the GLSL`);
   assert.ok(keysInTable().size > 60, `only ${keysInTable().size} keys found in the uniforms literal`);
 });

--- a/test/shader-assembly.test.mjs
+++ b/test/shader-assembly.test.mjs
@@ -1,8 +1,8 @@
-// The cloud's two programs, assembled out of the spine and the shipped packages, against
-// the two literals the file used to hold.
+// Every program this page compiles, assembled out of the spines and the shipped packages,
+// against the literals the two files used to hold.
 //
 // **This is the gate the whole extraction rests on, and it is an equality rather than a
-// resemblance.** Moving GLSL out of one file and into fifteen is a refactor exactly as long
+// resemblance.** Moving GLSL out of two files and into twenty is a refactor exactly as long
 // as the text that reaches the driver does not move, and the ways it can move quietly are
 // not exotic: a chunk boundary off by one line, a blank line the spine keeps and the chunk
 // also carries, an indent normalised on the way through, a generated declaration written
@@ -18,10 +18,21 @@
 // show` exits non-zero with nothing asserted, which reads exactly like a check that ran and
 // failed. So the marker is a string only the monolithic file contains, `git log -S` names
 // the commits where its count changed, and the newest revision still holding it is the one
-// this compares against. Before the split lands that is `HEAD` itself, whose blob still
+// this compares against. Before a split lands that is `HEAD` itself, whose blob still
 // carries the literals while the working tree no longer does; after it lands it is the
 // commit before the removal. Both are the same question - the last revision holding the
-// monolith - asked without ever writing a hash down.
+// monolith - asked without ever writing a hash down. The two programs are pinned
+// separately, because they were cut in different commits and each names its own marker.
+//
+// **The two monoliths are read differently, and the difference is forced rather than
+// chosen.** `web/cloud-shader.js` imports nothing at any revision, so its literals are
+// evaluated whole through a `data:` module - which is exact by construction, escape
+// sequences included. `web/post-chain.js` imports three.js and three of its addons, and a
+// `data:` module cannot resolve a bare specifier at all, so that one is read by cutting the
+// template literal out of the source and evaluating the cut on its own. What makes that
+// safe is asserted rather than assumed: the file carries no backslash anywhere, so no
+// literal in it can hold an escaped backtick, and the first backtick after the property name
+// therefore opens the literal and the next one closes it.
 //
 // What this does not claim is that the assembled shader is *correct*. It says the split
 // changed nothing, which is the only claim a refactor gets to make, and `registry-check`
@@ -35,20 +46,44 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { cloudSpine } from '../web/cloud-shader.js';
+import { gradeSpine } from '../web/grade-shader.js';
 import { assembleShaders } from '../web/shader-assembly.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const BUILTIN = join(ROOT, 'effects-builtin');
 
-// A string the monolithic file contains and the spine does not. The export declaration
-// itself rather than a piece of GLSL, because GLSL is exactly what moved into the chunk
-// files and a marker that moved with it would resolve to the wrong side of the split.
-const MARKER = 'export const vertexShader';
+const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+
+// What a chunk's name says about where its text ends up, and it is a claim rather than a
+// convention: the control below flips a byte in every chunk and requires the program its
+// name promises to move while every other program stands still, so a file misnamed is a red
+// row rather than a chunk quietly compiled into the wrong shader.
+const NAMES = {
+  '.vert.glsl': ['cloud', 'vertexShader'],
+  '.frag.glsl': ['cloud', 'fragmentShader'],
+  '.grade.glsl': ['grade', 'fragmentShader'],
+};
+
+// Each monolith by the string only it contains, and by the file that used to hold it.
+//
+// The cloud's marker is the export declaration itself rather than a piece of GLSL, because
+// GLSL is exactly what moved into the chunk files and a marker that moved with it would
+// resolve to the wrong side of the split. The grade has no export to name - its literal sat
+// inside an object - so its marker is the one line of that shader which is neither a term
+// nor a comment: the hash function, which moved to the spine entire and so is absent from
+// `web/post-chain.js` at every revision after the cut and present at every one before it.
+const MONOLITHS = {
+  cloud: { file: 'web/cloud-shader.js', marker: 'export const vertexShader' },
+  grade: {
+    file: 'web/post-chain.js',
+    marker: 'float hash(vec2 p) { return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453); }',
+  },
+};
 
 const git = (...args) => execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', maxBuffer: 1 << 28 });
 
 /**
- * The newest revision whose `web/cloud-shader.js` still holds the marker.
+ * The newest revision whose file still holds the marker.
  *
  * `git log -S` lists the commits where the marker's count changed, newest first - the one
  * that introduced it and, once the split is committed, the one that removed it. Asking
@@ -57,29 +92,57 @@ const git = (...args) => execFileSync('git', args, { cwd: ROOT, encoding: 'utf8'
  * its own would answer with the commit that *introduced* the literals, months of shader
  * work ago.
  */
-const revBeforeSplit = () => {
-  if (git('show', `HEAD:web/cloud-shader.js`).includes(MARKER)) return 'HEAD';
-  const touched = git('log', '-S', MARKER, '--format=%H', '--', 'web/cloud-shader.js')
+const revBeforeSplit = (program) => {
+  const { file, marker } = MONOLITHS[program];
+  if (git('show', `HEAD:${file}`).includes(marker)) return 'HEAD';
+  const touched = git('log', '-S', marker, '--format=%H', '--', file)
     .split('\n').map((s) => s.trim()).filter(Boolean);
-  assert.ok(touched.length, `no commit in this history changes the count of ${JSON.stringify(MARKER)} in web/cloud-shader.js`);
+  assert.ok(touched.length, `no commit in this history changes the count of ${JSON.stringify(marker)} in ${file}`);
   return `${touched[0]}^`;
 };
 
 /**
- * The two literals as that revision holds them, evaluated rather than parsed.
+ * One program as that revision holds it, evaluated rather than parsed.
  *
- * Through a `data:` URL because the file imports nothing at all - which is asserted rather
- * than assumed, since a relative specifier inside a `data:` module has no base to resolve
- * against and would throw a message about the URL rather than about the file.
+ * The cloud's file imports nothing at all - which is asserted rather than assumed, since a
+ * relative specifier inside a `data:` module has no base to resolve against and would throw
+ * a message about the URL rather than about the file - so the whole module evaluates and its
+ * two exports are read straight off.
+ *
+ * The grade's cannot: it imports three.js, and stubbing that out to get at a string would be
+ * a second three.js living in a test. So each of its two literals is cut from the source
+ * between the backtick that follows its property name and the next backtick, and the cut is
+ * evaluated on its own. **The cut is only the whole literal if no backtick in the file is
+ * escaped**, so the absence of any backslash at all is asserted first - and the evaluation
+ * is kept rather than trusting the cut to be its own value, because that is the half that
+ * would go wrong silently if one ever arrived.
  */
-const literalsAt = async (rev) => {
-  const source = git('show', `${rev}:web/cloud-shader.js`);
-  assert.ok(source.includes(MARKER), `${rev} does not hold ${JSON.stringify(MARKER)}, so the marker resolved to the wrong revision`);
-  assert.equal(source.match(/^\s*import\s/m), null, `${rev}'s web/cloud-shader.js imports something, so it cannot be evaluated as a data: module`);
-  const url = `data:text/javascript;base64,${Buffer.from(source, 'utf8').toString('base64')}`;
-  const { vertexShader, fragmentShader } = await import(url);
-  return { vertexShader, fragmentShader };
+const monolithAt = async (program, rev) => {
+  const { file, marker } = MONOLITHS[program];
+  const source = git('show', `${rev}:${file}`);
+  assert.ok(source.includes(marker), `${rev} does not hold ${JSON.stringify(marker)}, so the marker resolved to the wrong revision`);
+  if (program === 'cloud') {
+    assert.equal(source.match(/^\s*import\s/m), null, `${rev}'s ${file} imports something, so it cannot be evaluated as a data: module`);
+    const { vertexShader, fragmentShader } = await evaluate(source);
+    return { vertexShader, fragmentShader };
+  }
+  assert.equal(source.includes('\\'), false,
+    `${rev}'s ${file} carries a backslash, so a backtick in it could be escaped and this cut could end in the middle of a literal`);
+  const cut = async (label) => {
+    const at = source.indexOf(`${label}: /* glsl */ \``);
+    assert.ok(at >= 0, `${rev}'s ${file} declares no ${label} literal, so the marker resolved to the wrong revision`);
+    const from = source.indexOf('`', at) + 1;
+    const to = source.indexOf('`', from);
+    assert.ok(to > from, `${rev}'s ${file} has an unterminated ${label} literal`);
+    const text = source.slice(from, to);
+    assert.ok(text.length > 0, `${rev}'s ${label} literal is empty, so this comparison would run on nothing`);
+    const { value } = await evaluate(`export const value = \`${text}\`;`);
+    return value;
+  };
+  return { vertexShader: await cut('vertexShader'), fragmentShader: await cut('fragmentShader') };
 };
+
+const evaluate = (source) => import(`data:text/javascript;base64,${Buffer.from(source, 'utf8').toString('base64')}`);
 
 /**
  * Every shipped package, in the shape `/effects/:id` answers with: the manifest, and the
@@ -102,14 +165,16 @@ const shippedPackages = () => readdirSync(BUILTIN, { withFileTypes: true })
     return { id, manifest, chunks };
   });
 
-test('the spine and the shipped packages assemble to the two programs the monolith held', async () => {
-  const rev = revBeforeSplit();
-  const before = await literalsAt(rev);
-  const after = assembleShaders(cloudSpine, shippedPackages());
-  assert.equal(after.vertexShader, before.vertexShader,
-    `the assembled vertex program is not the one ${rev} holds`);
-  assert.equal(after.fragmentShader, before.fragmentShader,
-    `the assembled fragment program is not the one ${rev} holds`);
+test('the spines and the shipped packages assemble to the programs the monoliths held', async () => {
+  const after = assembleShaders(SPINES, shippedPackages());
+  for (const program of Object.keys(MONOLITHS)) {
+    const rev = revBeforeSplit(program);
+    const before = await monolithAt(program, rev);
+    assert.equal(after[program].vertexShader, before.vertexShader,
+      `the assembled ${program} vertex program is not the one ${rev} holds`);
+    assert.equal(after[program].fragmentShader, before.fragmentShader,
+      `the assembled ${program} fragment program is not the one ${rev} holds`);
+  }
 });
 
 test('one byte moved in any chunk moves the program it belongs to, and only that one', async () => {
@@ -118,13 +183,21 @@ test('one byte moved in any chunk moves the program it belongs to, and only that
   // contributing nothing, and one arm aimed at one file cannot see the rest. The arms are
   // enumerated from the manifests rather than listed here, so a package that declares a
   // chunk is asked about it by existing - which is what kept this control whole when the
-  // glitch and the lattice moved out after the glyph field and the rain. The
-  // direction is asserted as well as the difference, because a chunk spliced into the
-  // wrong program is a thing this assembler could do and the equality alone would only say
-  // that something moved.
-  const rev = revBeforeSplit();
-  const before = await literalsAt(rev);
+  // glitch and the lattice moved out after the glyph field and the rain, and again when the
+  // region family, the tone run and the grade pass followed them. The direction is asserted
+  // as well as the difference, because a chunk spliced into the wrong program is a thing
+  // this assembler could do and the equality alone would only say that something moved.
+  //
+  // **Every other program has to stand still, not just the sibling shader.** While there was
+  // one spine, "the other one" was a pair and the assertion could name it; there are four
+  // assembled strings now, so the arm walks them all and requires the one the file's name
+  // promises to be the only one that moved. A chunk landing in a second program is what that
+  // catches, and it is the same defect `syntax-check`'s count rule watches for from the
+  // other end.
   const packages = shippedPackages();
+  const strings = (built) => Object.entries(built)
+    .flatMap(([program, p]) => [[`${program}.vertexShader`, p.vertexShader], [`${program}.fragmentShader`, p.fragmentShader]]);
+  const before = strings(assembleShaders(SPINES, packages));
   let flipped = 0;
   for (const pkg of packages) {
     for (const [file, text] of Object.entries(pkg.chunks)) {
@@ -133,17 +206,16 @@ test('one byte moved in any chunk moves the program it belongs to, and only that
       const mutated = `${text.slice(0, at)}${text[at] === 'x' ? 'y' : 'x'}${text.slice(at + 1)}`;
       // Rule 2: confirm the mutation did something before believing what it caught.
       assert.notEqual(mutated, text, `${pkg.id}/${file} did not change under the flip`);
+      const named = Object.entries(NAMES).filter(([suffix]) => file.endsWith(suffix));
+      assert.equal(named.length, 1,
+        `${pkg.id}/${file} names ${named.length} of the known programs, so which one it belongs to is a guess`);
+      const [wantProgram, wantShader] = named[0][1];
       const staged = packages.map((p) => (p === pkg ? { ...p, chunks: { ...p.chunks, [file]: mutated } } : p));
-      const after = assembleShaders(cloudSpine, staged);
-      const vert = /\.vert\./.test(file);
-      const frag = /\.frag\./.test(file);
-      assert.ok(vert !== frag, `${pkg.id}/${file} says neither .vert. nor .frag., so which program it belongs to is a guess`);
-      assert.notEqual(vert ? after.vertexShader : after.fragmentShader,
-        vert ? before.vertexShader : before.fragmentShader,
-        `${pkg.id}/${file} was flipped and the ${vert ? 'vertex' : 'fragment'} program did not move - it reaches no program at all`);
-      assert.equal(vert ? after.fragmentShader : after.vertexShader,
-        vert ? before.fragmentShader : before.vertexShader,
-        `${pkg.id}/${file} was flipped and the ${vert ? 'fragment' : 'vertex'} program moved, so it is spliced into the program its name denies`);
+      const after = strings(assembleShaders(SPINES, staged));
+      const moved = after.filter(([, text], i) => text !== before[i][1]).map(([which]) => which);
+      assert.deepEqual(moved, [`${wantProgram}.${wantShader}`],
+        `${pkg.id}/${file} was flipped and ${moved.length === 0 ? 'no program moved - it reaches none of them'
+          : `the programs that moved are ${moved.join(', ')} rather than the ${wantProgram}.${wantShader} its name promises`}`);
       flipped++;
     }
   }
@@ -152,36 +224,47 @@ test('one byte moved in any chunk moves the program it belongs to, and only that
   // the commit that wrote it stops being a floor the moment the next package arrives - a
   // manifest that silently lost its `chunks` section would take four arms away and still
   // clear eleven. Eleven with the glyph field and the rain, fifteen with the glitch and the
-  // lattice, nineteen with the region family's four.
-  assert.ok(flipped >= 19, `only ${flipped} chunk files were flipped, so this control ran on almost nothing`);
+  // lattice, nineteen with the region family's four, and twenty-nine with the tone run's
+  // three and the grade pass's seven.
+  assert.ok(flipped >= 29, `only ${flipped} chunk files were flipped, so this control ran on almost nothing`);
 });
 
 test('the numbers place the text, and the order the packages arrive in does not', () => {
-  // **The two arms above cannot see the sort, and that was measured rather than assumed.**
-  // Taking `stages.sort(byOrder)` out of the assembler entirely leaves both of them green:
-  // the packages are read in directory order, and every shipped stage's declared order
-  // happens to be that same order - glitch before lattice on `v.displace`, glyph before rain
-  // on the two declaration stages and on `f.tone`, noise before push before ripple on
-  // `v.regionDisplace`. Six stages, six coincidences, and each one arrived honestly, because
-  // a package is named after the effect and the effects were written in roughly the order
-  // they run. So a build that lost the sort would draw the identical picture today and a
-  // different one the first time somebody adds a package whose name sorts the wrong way -
-  // which is a defect that ships and then waits.
+  // **The two arms above could not see the sort until the tone run moved out, and that was
+  // measured rather than assumed.** Taking `stages.sort(byOrder)` out of the assembler
+  // entirely used to leave both of them green: the packages are read in directory order, and
+  // every shipped stage's declared order happened to be that same order - glitch before
+  // lattice on `v.displace`, glyph before rain on the two declaration stages and on
+  // `f.tone`, noise before push before ripple on `v.regionDisplace`. Six stages, six
+  // coincidences, and each one arrived honestly, because a package is named after the effect
+  // and the effects were written in roughly the order they run. So a build that lost the sort
+  // would draw the identical picture and a different one the first time somebody added a
+  // package whose name sorted the wrong way - a defect that ships and then waits.
   //
-  // A fixture rather than a shipped set is the only thing that can hold it, for the reason
-  // above: what has to be asserted is that the *numbers* decide, and the shipped numbers
-  // agree with the alphabet. So the two packages here are named against their orders - the
-  // one that goes first is called `zeta` and the one that goes second `alpha` - and the same
-  // inversion is put through the gate, where `gateOrder` and the id disagree the same way.
-  // The gate's half is live on the shipped set as well, since the region's push consumes at
-  // 100 where its noise consumes at 200; the stage's half exists only here.
-  const spine = {
-    vertex: [
-      { text: 'head\n' },
-      { stage: 'run' },
-      { service: 'gate', open: 'if (', body: ') {\n', close: '}\n' },
-    ],
-    fragment: [{ text: 'frag\n' }],
+  // Two of the shipped stages disagree with the alphabet now. `f.tone` runs thermal, edges,
+  // duotone, glitch, rain against a directory handing them over as duotone, edges, glitch,
+  // rain, thermal, and `g.body` runs streak, raster, grain, vignette against grain, raster,
+  // streak, vignette - so the arms above would redden on a build that lost the sort. This
+  // one stays anyway, and not out of caution: what it asserts is that the *numbers* decide,
+  // where those two stages assert only that the current numbers and the current alphabet
+  // disagree, which is a fact about the sixteen packages installed today and would go away
+  // the moment somebody renamed one.
+  //
+  // A fixture rather than a shipped set is the only thing that can hold the general claim.
+  // So the two packages here are named against their orders - the one that goes first is
+  // called `zeta` and the one that goes second `alpha` - and the same inversion is put
+  // through the gate, where `gateOrder` and the id disagree the same way. The gate's half is
+  // live on the shipped set as well, since the region's push consumes at 100 where its noise
+  // consumes at 200.
+  const spines = {
+    only: {
+      vertex: [
+        { text: 'head\n' },
+        { stage: 'run' },
+        { service: 'gate', open: 'if (', body: ') {\n', close: '}\n' },
+      ],
+      fragment: [{ text: 'frag\n' }],
+    },
   };
   const pkg = (id, order, gateOrder) => ({
     id,
@@ -196,8 +279,21 @@ test('the numbers place the text, and the order the packages arrive in does not'
   });
   // Handed in alphabetically, which is the order the directory and `/effects` both give.
   const packages = [pkg('alpha', 200, 200), pkg('zeta', 100, 100)];
-  const { vertexShader } = assembleShaders(spine, packages);
-  assert.equal(vertexShader,
+  const { only } = assembleShaders(spines, packages);
+  assert.equal(only.vertexShader,
     'head\nzeta-run\nalpha-run\nif (zetaOn || alphaOn) {\n  zeta-gate\n  alpha-gate\n}\n',
     'the assembler placed the chunks by the order the packages arrived in rather than by the numbers they declare');
+});
+
+test('a joint name means one place across every spine, so a second spine cannot shadow one', () => {
+  // The refusal the one-call shape exists for, asserted rather than described. Two spines
+  // offering the same joint name is not a conflict either of them can see on its own - each
+  // is a well-formed spine - and the chunk that names it would be spliced into both, which
+  // compiles and draws twice. Assembling every spine together is what makes the collision
+  // visible at all, so the collision is what proves the collecting is happening.
+  const spine = (text) => ({ vertex: [{ text }, { stage: 'shared' }], fragment: [{ text }] });
+  assert.throws(
+    () => assembleShaders({ first: spine('a\n'), second: spine('b\n') }, []),
+    /declare "shared" twice/,
+    'two spines declaring one joint name assembled without complaint, so the joints are being collected per spine');
 });

--- a/test/shader-assembly.test.mjs
+++ b/test/shader-assembly.test.mjs
@@ -151,6 +151,53 @@ test('one byte moved in any chunk moves the program it belongs to, and only that
   // is raised whenever a package moves its GLSL out, because a floor left at the count of
   // the commit that wrote it stops being a floor the moment the next package arrives - a
   // manifest that silently lost its `chunks` section would take four arms away and still
-  // clear eleven.
-  assert.ok(flipped >= 15, `only ${flipped} chunk files were flipped, so this control ran on almost nothing`);
+  // clear eleven. Eleven with the glyph field and the rain, fifteen with the glitch and the
+  // lattice, nineteen with the region family's four.
+  assert.ok(flipped >= 19, `only ${flipped} chunk files were flipped, so this control ran on almost nothing`);
+});
+
+test('the numbers place the text, and the order the packages arrive in does not', () => {
+  // **The two arms above cannot see the sort, and that was measured rather than assumed.**
+  // Taking `stages.sort(byOrder)` out of the assembler entirely leaves both of them green:
+  // the packages are read in directory order, and every shipped stage's declared order
+  // happens to be that same order - glitch before lattice on `v.displace`, glyph before rain
+  // on the two declaration stages and on `f.tone`, noise before push before ripple on
+  // `v.regionDisplace`. Six stages, six coincidences, and each one arrived honestly, because
+  // a package is named after the effect and the effects were written in roughly the order
+  // they run. So a build that lost the sort would draw the identical picture today and a
+  // different one the first time somebody adds a package whose name sorts the wrong way -
+  // which is a defect that ships and then waits.
+  //
+  // A fixture rather than a shipped set is the only thing that can hold it, for the reason
+  // above: what has to be asserted is that the *numbers* decide, and the shipped numbers
+  // agree with the alphabet. So the two packages here are named against their orders - the
+  // one that goes first is called `zeta` and the one that goes second `alpha` - and the same
+  // inversion is put through the gate, where `gateOrder` and the id disagree the same way.
+  // The gate's half is live on the shipped set as well, since the region's push consumes at
+  // 100 where its noise consumes at 200; the stage's half exists only here.
+  const spine = {
+    vertex: [
+      { text: 'head\n' },
+      { stage: 'run' },
+      { service: 'gate', open: 'if (', body: ') {\n', close: '}\n' },
+    ],
+    fragment: [{ text: 'frag\n' }],
+  };
+  const pkg = (id, order, gateOrder) => ({
+    id,
+    manifest: {
+      consumes: [{ service: 'gate', when: `${id}On`, gateOrder }],
+      chunks: [
+        { stage: 'run', order, file: 'run.vert.glsl' },
+        { stage: 'gate', file: 'gate.vert.glsl' },
+      ],
+    },
+    chunks: { 'run.vert.glsl': `${id}-run\n`, 'gate.vert.glsl': `  ${id}-gate\n` },
+  });
+  // Handed in alphabetically, which is the order the directory and `/effects` both give.
+  const packages = [pkg('alpha', 200, 200), pkg('zeta', 100, 100)];
+  const { vertexShader } = assembleShaders(spine, packages);
+  assert.equal(vertexShader,
+    'head\nzeta-run\nalpha-run\nif (zetaOn || alphaOn) {\n  zeta-gate\n  alpha-gate\n}\n',
+    'the assembler placed the chunks by the order the packages arrived in rather than by the numbers they declare');
 });

--- a/test/shader-assembly.test.mjs
+++ b/test/shader-assembly.test.mjs
@@ -2,15 +2,15 @@
 // the two literals the file used to hold.
 //
 // **This is the gate the whole extraction rests on, and it is an equality rather than a
-// resemblance.** Moving GLSL out of one file and into eleven is a refactor exactly as long
+// resemblance.** Moving GLSL out of one file and into fifteen is a refactor exactly as long
 // as the text that reaches the driver does not move, and the ways it can move quietly are
 // not exotic: a chunk boundary off by one line, a blank line the spine keeps and the chunk
 // also carries, an indent normalised on the way through, a generated declaration written
 // `out float x;` where the file said something else. None of those breaks a compile and
 // none of them shows up in a picture anybody would look twice at - the shader still runs,
 // it just is not the shader that was graded. So the assembled strings are held byte for
-// byte against `git show`, and the falsification control below flips one byte in each of
-// the eleven chunk files in turn to prove the equality is reading them at all.
+// byte against `git show`, and the falsification control below flips one byte in each
+// chunk file in turn to prove the equality is reading them at all.
 //
 // **The revision is resolved by content and never by hash.** Preparing this repository for
 // release rewrote its history once already, which moved every hash after the first
@@ -115,7 +115,10 @@ test('the spine and the shipped packages assemble to the two programs the monoli
 test('one byte moved in any chunk moves the program it belongs to, and only that one', async () => {
   // The falsification control, and it flips a byte in **every** chunk rather than in one:
   // a chunk that never reached the output would leave the equality above green while
-  // contributing nothing, and one arm aimed at one file cannot see the other ten. The
+  // contributing nothing, and one arm aimed at one file cannot see the rest. The arms are
+  // enumerated from the manifests rather than listed here, so a package that declares a
+  // chunk is asked about it by existing - which is what kept this control whole when the
+  // glitch and the lattice moved out after the glyph field and the rain. The
   // direction is asserted as well as the difference, because a chunk spliced into the
   // wrong program is a thing this assembler could do and the equality alone would only say
   // that something moved.
@@ -144,6 +147,10 @@ test('one byte moved in any chunk moves the program it belongs to, and only that
       flipped++;
     }
   }
-  // The floor under the loop: a scan that found no chunks would run zero arms and pass.
-  assert.ok(flipped >= 11, `only ${flipped} chunk files were flipped, so this control ran on almost nothing`);
+  // The floor under the loop: a scan that found no chunks would run zero arms and pass. It
+  // is raised whenever a package moves its GLSL out, because a floor left at the count of
+  // the commit that wrote it stops being a floor the moment the next package arrives - a
+  // manifest that silently lost its `chunks` section would take four arms away and still
+  // clear eleven.
+  assert.ok(flipped >= 15, `only ${flipped} chunk files were flipped, so this control ran on almost nothing`);
 });

--- a/test/shader-assembly.test.mjs
+++ b/test/shader-assembly.test.mjs
@@ -1,0 +1,149 @@
+// The cloud's two programs, assembled out of the spine and the shipped packages, against
+// the two literals the file used to hold.
+//
+// **This is the gate the whole extraction rests on, and it is an equality rather than a
+// resemblance.** Moving GLSL out of one file and into eleven is a refactor exactly as long
+// as the text that reaches the driver does not move, and the ways it can move quietly are
+// not exotic: a chunk boundary off by one line, a blank line the spine keeps and the chunk
+// also carries, an indent normalised on the way through, a generated declaration written
+// `out float x;` where the file said something else. None of those breaks a compile and
+// none of them shows up in a picture anybody would look twice at - the shader still runs,
+// it just is not the shader that was graded. So the assembled strings are held byte for
+// byte against `git show`, and the falsification control below flips one byte in each of
+// the eleven chunk files in turn to prove the equality is reading them at all.
+//
+// **The revision is resolved by content and never by hash.** Preparing this repository for
+// release rewrote its history once already, which moved every hash after the first
+// rewritten commit and left a pinned sha naming nothing - a tool that dies inside `git
+// show` exits non-zero with nothing asserted, which reads exactly like a check that ran and
+// failed. So the marker is a string only the monolithic file contains, `git log -S` names
+// the commits where its count changed, and the newest revision still holding it is the one
+// this compares against. Before the split lands that is `HEAD` itself, whose blob still
+// carries the literals while the working tree no longer does; after it lands it is the
+// commit before the removal. Both are the same question - the last revision holding the
+// monolith - asked without ever writing a hash down.
+//
+// What this does not claim is that the assembled shader is *correct*. It says the split
+// changed nothing, which is the only claim a refactor gets to make, and `registry-check`
+// is what says the terms reach pixels.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { cloudSpine } from '../web/cloud-shader.js';
+import { assembleShaders } from '../web/shader-assembly.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILTIN = join(ROOT, 'effects-builtin');
+
+// A string the monolithic file contains and the spine does not. The export declaration
+// itself rather than a piece of GLSL, because GLSL is exactly what moved into the chunk
+// files and a marker that moved with it would resolve to the wrong side of the split.
+const MARKER = 'export const vertexShader';
+
+const git = (...args) => execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', maxBuffer: 1 << 28 });
+
+/**
+ * The newest revision whose `web/cloud-shader.js` still holds the marker.
+ *
+ * `git log -S` lists the commits where the marker's count changed, newest first - the one
+ * that introduced it and, once the split is committed, the one that removed it. Asking
+ * `HEAD` first is what makes this exact before the split lands: the working tree has
+ * already dropped the marker while `HEAD`'s blob still carries it, and the `-S` walk on
+ * its own would answer with the commit that *introduced* the literals, months of shader
+ * work ago.
+ */
+const revBeforeSplit = () => {
+  if (git('show', `HEAD:web/cloud-shader.js`).includes(MARKER)) return 'HEAD';
+  const touched = git('log', '-S', MARKER, '--format=%H', '--', 'web/cloud-shader.js')
+    .split('\n').map((s) => s.trim()).filter(Boolean);
+  assert.ok(touched.length, `no commit in this history changes the count of ${JSON.stringify(MARKER)} in web/cloud-shader.js`);
+  return `${touched[0]}^`;
+};
+
+/**
+ * The two literals as that revision holds them, evaluated rather than parsed.
+ *
+ * Through a `data:` URL because the file imports nothing at all - which is asserted rather
+ * than assumed, since a relative specifier inside a `data:` module has no base to resolve
+ * against and would throw a message about the URL rather than about the file.
+ */
+const literalsAt = async (rev) => {
+  const source = git('show', `${rev}:web/cloud-shader.js`);
+  assert.ok(source.includes(MARKER), `${rev} does not hold ${JSON.stringify(MARKER)}, so the marker resolved to the wrong revision`);
+  assert.equal(source.match(/^\s*import\s/m), null, `${rev}'s web/cloud-shader.js imports something, so it cannot be evaluated as a data: module`);
+  const url = `data:text/javascript;base64,${Buffer.from(source, 'utf8').toString('base64')}`;
+  const { vertexShader, fragmentShader } = await import(url);
+  return { vertexShader, fragmentShader };
+};
+
+/**
+ * Every shipped package, in the shape `/effects/:id` answers with: the manifest, and the
+ * text of every chunk it names.
+ *
+ * Read off the directory rather than fetched, which is the whole reason `assembleShaders`
+ * takes its packages as an argument and imports nothing - the page gets them over HTTP and
+ * this gets them off disk, and where they came from is exactly what must not matter.
+ */
+const shippedPackages = () => readdirSync(BUILTIN, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name)
+  .sort()
+  .map((id) => {
+    const manifest = JSON.parse(readFileSync(join(BUILTIN, id, 'manifest.json'), 'utf8'));
+    const chunks = {};
+    for (const c of manifest.chunks ?? []) {
+      chunks[c.file] = readFileSync(join(BUILTIN, id, c.file), 'utf8');
+    }
+    return { id, manifest, chunks };
+  });
+
+test('the spine and the shipped packages assemble to the two programs the monolith held', async () => {
+  const rev = revBeforeSplit();
+  const before = await literalsAt(rev);
+  const after = assembleShaders(cloudSpine, shippedPackages());
+  assert.equal(after.vertexShader, before.vertexShader,
+    `the assembled vertex program is not the one ${rev} holds`);
+  assert.equal(after.fragmentShader, before.fragmentShader,
+    `the assembled fragment program is not the one ${rev} holds`);
+});
+
+test('one byte moved in any chunk moves the program it belongs to, and only that one', async () => {
+  // The falsification control, and it flips a byte in **every** chunk rather than in one:
+  // a chunk that never reached the output would leave the equality above green while
+  // contributing nothing, and one arm aimed at one file cannot see the other ten. The
+  // direction is asserted as well as the difference, because a chunk spliced into the
+  // wrong program is a thing this assembler could do and the equality alone would only say
+  // that something moved.
+  const rev = revBeforeSplit();
+  const before = await literalsAt(rev);
+  const packages = shippedPackages();
+  let flipped = 0;
+  for (const pkg of packages) {
+    for (const [file, text] of Object.entries(pkg.chunks)) {
+      const at = text.search(/\S/);
+      assert.ok(at >= 0, `${pkg.id}/${file} is whitespace, so a flip in it could not be seen`);
+      const mutated = `${text.slice(0, at)}${text[at] === 'x' ? 'y' : 'x'}${text.slice(at + 1)}`;
+      // Rule 2: confirm the mutation did something before believing what it caught.
+      assert.notEqual(mutated, text, `${pkg.id}/${file} did not change under the flip`);
+      const staged = packages.map((p) => (p === pkg ? { ...p, chunks: { ...p.chunks, [file]: mutated } } : p));
+      const after = assembleShaders(cloudSpine, staged);
+      const vert = /\.vert\./.test(file);
+      const frag = /\.frag\./.test(file);
+      assert.ok(vert !== frag, `${pkg.id}/${file} says neither .vert. nor .frag., so which program it belongs to is a guess`);
+      assert.notEqual(vert ? after.vertexShader : after.fragmentShader,
+        vert ? before.vertexShader : before.fragmentShader,
+        `${pkg.id}/${file} was flipped and the ${vert ? 'vertex' : 'fragment'} program did not move - it reaches no program at all`);
+      assert.equal(vert ? after.fragmentShader : after.vertexShader,
+        vert ? before.fragmentShader : before.vertexShader,
+        `${pkg.id}/${file} was flipped and the ${vert ? 'fragment' : 'vertex'} program moved, so it is spliced into the program its name denies`);
+      flipped++;
+    }
+  }
+  // The floor under the loop: a scan that found no chunks would run zero arms and pass.
+  assert.ok(flipped >= 11, `only ${flipped} chunk files were flipped, so this control ran on almost nothing`);
+});

--- a/tools/export-check.mjs
+++ b/tools/export-check.mjs
@@ -326,7 +326,7 @@ const MUTATIONS = {
     'vSize = gl_PointSize;',
   ]] },
   // Grain and scanlines go back to being sized in framebuffer pixels.
-  'grade-absolute': { file: 'web/post-chain.js', edits: [[
+  'grade-absolute': { file: 'web/grade-shader.js', edits: [[
     `      float k = resolution.y / 1080.0;
       vec2 ref = resolution / k;`,
     `      float k = 1.0;
@@ -386,7 +386,7 @@ const MUTATIONS = {
   // is the reading that says these rows have one guard rather than two.
   //
   // Only the split reverts, so the claim cannot be carried by the other two.
-  'rgbsplit-absolute': { file: 'web/post-chain.js', edits: [[
+  'rgbsplit-absolute': { file: 'effects-builtin/rgbsplit/split.grade.glsl', edits: [[
     'vec2 off = dir * rgbSplit * texel * 8.0;',
     'vec2 off = dir * rgbSplit * (1.0 / resolution) * 8.0;',
   ]] },
@@ -451,7 +451,7 @@ const MUTATIONS = {
       + '    }',
     ],
   ] },
-  'grain-continuous': { file: 'web/post-chain.js', edits: [[
+  'grain-continuous': { file: 'effects-builtin/grain/grain.grade.glsl', edits: [[
     'float n = hash(floor(vUv * ref) + fract(time) * 137.0);',
     'float n = hash(vUv * ref + fract(time) * 137.0);',
   ]] },
@@ -536,7 +536,7 @@ const MUTATIONS = {
     [
       '      float k = resolution.y / 1080.0;',
       '      float k = resolution.x / 1728.0;',
-      'web/post-chain.js',
+      'web/grade-shader.js',
     ],
   ] },
   // The failure path reaches back to the output it did not write. This is the
@@ -618,9 +618,10 @@ function mutatedSource(name) {
 function servedAt(file) {
   if (file.startsWith('effects-builtin/')) {
     // The effects' own GLSL, which the page fetches out of `/effects/:id/file/:name` and
-    // `assembleShaders` splices into the cloud's material - so a mutation that edits a
-    // chunk is delivered at the fetch rather than at a module, which from Playwright's
-    // side is the same interception.
+    // `assembleShaders` splices into the cloud's material or the grade pass's shader - so a
+    // mutation that edits a chunk is delivered at the fetch rather than at a module, which
+    // from Playwright's side is the same interception. The route is the same for both
+    // programs, because a chunk names the joint it joins rather than the program it feeds.
     const parts = file.split('/');
     if (parts.length !== 3) {
       throw new Error(`${file} is not an effect package file - a chunk is <id>/<name> under effects-builtin/`);

--- a/tools/export-check.mjs
+++ b/tools/export-check.mjs
@@ -313,7 +313,7 @@ const MUTATIONS = {
     "    ext: 'pngseq',\n    frameExt: null,",
   ]] },
   // The dominant screen-space term goes back to framebuffer pixels.
-  'pointsize-absolute': { file: 'web/cloud-shader.js', edits: [[
+  'pointsize-absolute': { file: 'effects-builtin/glyph/size.vert.glsl', edits: [[
     'gl_PointSize = clamp(pointSize * k / max(0.15, -mv.z), 1.0, 64.0);',
     'gl_PointSize = clamp(pointSize * (1.0 / max(0.15, -mv.z)), 1.0, 64.0);',
   ]] },
@@ -616,10 +616,30 @@ function mutatedSource(name) {
  * against a page.
  */
 function servedAt(file) {
+  if (file.startsWith('effects-builtin/')) {
+    // The effects' own GLSL, which the page fetches out of `/effects/:id/file/:name` and
+    // `assembleShaders` splices into the cloud's material - so a mutation that edits a
+    // chunk is delivered at the fetch rather than at a module, which from Playwright's
+    // side is the same interception.
+    const parts = file.split('/');
+    if (parts.length !== 3) {
+      throw new Error(`${file} is not an effect package file - a chunk is <id>/<name> under effects-builtin/`);
+    }
+    return `/effects/${parts[1]}/file/${parts[2]}`;
+  }
   if (!file.startsWith('web/')) {
     throw new Error(`${file} is not served to a browser, so a page mutation cannot reach it`);
   }
   return `/${file.slice('web/'.length)}`;
+}
+
+/**
+ * What the server answers a file with, restated here because the interception has to
+ * answer the same way: a chunk is `text/plain` in `server/index.js`, on the argument that
+ * what the tools anchor and the client compiles is the file's own bytes.
+ */
+function contentTypeFor(file) {
+  return file.endsWith('.glsl') ? 'text/plain; charset=utf-8' : 'text/javascript; charset=utf-8';
 }
 
 // ------------------------------------------------------------------- playwright
@@ -1048,7 +1068,13 @@ const mutation = MUTATE ? mutatedSource(MUTATE) : null;
 // parameter for: a cross-build arm passes its own older `main.js` and must not be handed
 // this run's mutated one, while every other staged module is a file that arm's build never
 // imports, so it can be routed on every page unconditionally.
-const pageMutants = (mutation ?? []).filter((m) => m.file.startsWith('web/'));
+// **Reachable in a browser is no longer `web/` alone.** An effect package's chunk is
+// fetched out of `/effects/:id/file/:name` and assembled into the cloud's material, so a
+// mutation editing one is a page mutation in every sense that matters here - and a filter
+// that still read `web/` would drop it silently into the server-mutation bucket, where
+// nothing serves it and nothing counts it.
+const inBrowser = (file) => file.startsWith('web/') || file.startsWith('effects-builtin/');
+const pageMutants = (mutation ?? []).filter((m) => inBrowser(m.file));
 const mutatedBody = pageMutants.find((m) => m.file === 'web/main.js')?.body ?? null;
 const otherMutants = pageMutants.filter((m) => m.file !== 'web/main.js');
 // The path this mutation would arrive at if a browser asked for it, read off the
@@ -1141,7 +1167,7 @@ async function openPage(viewport, source = mutatedBody, html = null) {
     await page.route((url) => url.pathname === path, (route) => {
       mutantServed++;
       mutantServedBy.set(mutant.file, mutantServedBy.get(mutant.file) + 1);
-      route.fulfill({ contentType: 'text/javascript; charset=utf-8', body: mutant.body });
+      route.fulfill({ contentType: contentTypeFor(mutant.file), body: mutant.body });
     });
   }
   if (source) {

--- a/tools/jobs-check.mjs
+++ b/tools/jobs-check.mjs
@@ -200,6 +200,14 @@ const root = join(WORK, 'root');
 mkdirSync(root, { recursive: true });
 cpSync(join(REPO, 'server'), join(root, 'server'), { recursive: true });
 cpSync(join(REPO, 'web'), join(root, 'web'), { recursive: true });
+// **`effects-builtin` is staged because without it the server refuses to boot at all.**
+// The effect store declines the absence of its shipped root deliberately, so a broken
+// install cannot read as nothing-installed - which makes a staged tree missing it a
+// server this check can never start, and every run then reports `DID NOT RUN` with no
+// assertions rather than reddening a row. Copied rather than symlinked, like the two
+// trees above it, so a mutation naming a chunk under it could not rewrite the repo's own
+// source.
+cpSync(join(REPO, 'effects-builtin'), join(root, 'effects-builtin'), { recursive: true });
 // **The worker is staged too, and the render row spawns the staged copy.** It used to
 // be copied nowhere and spawned from the repo path, so a mutation naming
 // `tools/render-worker.mjs` would have edited a file nothing runs and reported a miss

--- a/tools/level-check.mjs
+++ b/tools/level-check.mjs
@@ -229,7 +229,14 @@ if (MUTATE && !MUTATIONS[MUTATE]) {
 // here would rewrite the repo's own source.
 rmSync(WORK, { recursive: true, force: true });
 mkdirSync(WORK, { recursive: true });
-for (const dir of ['server', 'tools', 'web']) cpSync(join(REPO, dir), join(WORK, dir), { recursive: true });
+// `effects-builtin` joined this list when the shaders did, and the three commits it took to
+// notice are the whole argument for the row below refusing loudly. The effect store declines
+// to BOOT without its shipped root - deliberately, so a broken install cannot read as
+// nothing-installed - so from the moment the packages arrived, the staged tree here was a
+// server that could not start, and this tool had reported `DID NOT RUN` on every run since.
+// `guard-check` carries the same note over the same list; nothing joins the two, which is why
+// both say it.
+for (const dir of ['server', 'tools', 'web', 'effects-builtin']) cpSync(join(REPO, dir), join(WORK, dir), { recursive: true });
 // **`native/` is deliberately not among these, and that is load-bearing rather than an
 // omission.** Every frame this tool grades is one it planted, and a live socket wipes a
 // plant in well under a second - measured on a page with the sensor attached, a sentinel

--- a/tools/module-check.mjs
+++ b/tools/module-check.mjs
@@ -1378,7 +1378,7 @@ const EXEMPTIONS = [
   {
     module: 'web/post-chain.js',
     binding: 'grade',
-    why: 'The one combined grade pass. Eight look parameters write their term into `uniforms` and four of them gate `enabled` on whether any term is up, which is the reason the pass is one rather than four.',
+    why: 'The one combined grade pass. Ten look parameters write their term into `uniforms` and five of them gate `enabled` on whether any term is up - which five read off the packages\' `gates` bindings rather than listed - and that is the reason the pass is one rather than four.',
   },
   // The one entry in this table that is not a three.js object with a published interface,
   // and the only one that needed arguing rather than citing. A uniform is a cell the GPU

--- a/tools/monitor-check.mjs
+++ b/tools/monitor-check.mjs
@@ -236,6 +236,13 @@ cpSync(join(REPO, 'tools'), join(WORK, 'tools'), { recursive: true });
 // one state a proof tool must never produce - and it would do it silently, since the
 // staged tree is deleted at the end of every run.
 cpSync(join(REPO, 'web'), join(WORK, 'web'), { recursive: true });
+// `effects-builtin` is staged for a different reason than the three above: the effect
+// store refuses to BOOT without its shipped root - deliberately, so a broken install
+// cannot read as nothing-installed - so a staged tree missing it is a server that never
+// comes up, and this tool then says `DID NOT RUN` rather than failing a row, which is a
+// silence nobody reads. Copied rather than linked on the same argument `web/` is, so a
+// mutation naming a chunk under it could never rewrite the repo's own source.
+cpSync(join(REPO, 'effects-builtin'), join(WORK, 'effects-builtin'), { recursive: true });
 for (const name of ['node_modules', 'vendor', 'captures']) {
   const from = join(REPO, name);
   if (existsSync(from)) symlinkSync(from, join(WORK, name));
@@ -1073,14 +1080,35 @@ try {
       // that ever sets it - so if it never arrives, everything below is measuring nothing
       // and has to say so. A fixed wait here would turn "no colour ever decoded" into a
       // silent pass on the row that matters most.
-      const hasColor = () => page.evaluate('globalThis.__kinect.uniforms.hasColor.value');
+      //
+      // **It reads through a published `__kinect` rather than off one, and that is the
+      // difference between a wait and a throw.** `load` stopped meaning the page is up
+      // when the effect packages moved onto the wire: boot now fetches them over HTTP, so
+      // `__kinect` publishes tens of milliseconds *after* the event `goto` waits for -
+      // measured at 366ms to `load` against 398ms to the handle. Reaching straight through
+      // the handle raises a TypeError inside the predicate, `waitFor` does not catch one,
+      // and the twenty seconds are never spent: the row reddened in the same second it was
+      // printed, saying no colour ever bound about a build whose colour binds in 451ms.
+      // The two sections above survive on a fixed `wait()` after their own `goto`, which is
+      // the silent-pass shape this comment already refuses, so the guard belongs here rather
+      // than a third sleep. `-1` for an unpublished handle keeps the timeout reachable, and
+      // the two states are reported apart below because "the page never booted" and "colour
+      // never arrived" are different findings.
+      const hasColor = () => page.evaluate('globalThis.__kinect ? globalThis.__kinect.uniforms.hasColor.value : -1');
       let bound = false;
       try {
         await waitFor(async () => (await hasColor()) === 1, 20000, 'a colour frame to decode and bind');
         bound = true;
       } catch { /* the row below is the report, and the rows after it are skipped */ }
+      // Short-circuited and caught, because this read runs on the path where the wait has
+      // already failed: a page that died during those twenty seconds would throw here and
+      // turn a red row into a crash with the count still short, which is the shape that
+      // reads as a catch to anything checking exit codes.
+      const booted = bound || (await hasColor().catch(() => -1)) !== -1;
       ok('a colour-on grabber paints the cloud with a real decoded JPEG, which is what the toggle is measured against',
-        bound, bound ? '' : 'hasColor never reached 1, so no colour ever bound and nothing below would have measured the toggle');
+        bound, bound ? '' : (booted
+          ? 'hasColor never reached 1, so no colour ever bound and nothing below would have measured the toggle'
+          : 'the page never published __kinect, so this is a viewer that did not boot rather than a colour that did not arrive'));
 
       // Counted before the press, because the restart can be under way by the time the
       // click resolves and a hello read after the fact could be the one already on file.

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -404,7 +404,7 @@ const MUTATIONS = {
   },
   // The ripple switched off the same way.
   'ripple-ignored': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/ripple/wave.vert.glsl',
     edits: [[
       '  if (ripple > 0.0 && rw > 0.0) {',
       '  if (false) {',
@@ -415,11 +415,21 @@ const MUTATIONS = {
   // only computed when one of the older three effects asks for it. **The drop-one sweep
   // cannot see this**: the scrambled set raises all four at once, so the weight is there
   // anyway and the ripple goes on working. Only the arm that raises it alone reddens.
+  //
+  // **It edits the assembler because the gate is no longer a line anybody wrote.** The
+  // region's condition is generated from the `when` of every package consuming the service,
+  // in `gateOrder`, so the state this control reproduces is the ripple's manifest declaring
+  // no `consumes` at all - which is now the way a term goes missing. The manifest itself
+  // cannot be the anchor: a package's declaration reaches the page inside the JSON
+  // `/effects/:id` builds, and staging that would mean this tool rebuilding a route's answer
+  // rather than serving a file's bytes. Dropping the same consumer out of the join is the
+  // same three-term condition, delivered at `/shader-assembly.js`, which the page imports.
+  // Held against the monolith mutated the old way: byte-identical vertex and fragment.
   'ripple-outside-the-gate': {
-    file: 'web/cloud-shader.js',
+    file: 'web/shader-assembly.js',
     edits: [[
-      '  float rw = (regionPush != 0.0 || regionNoise > 0.0 || regionMask != 0.0 || ripple > 0.0)',
-      '  float rw = (regionPush != 0.0 || regionNoise > 0.0 || regionMask != 0.0)',
+      "        out += consumers.map((c) => c.when).join(' || ');",
+      "        out += consumers.filter((c) => c.id !== 'ripple').map((c) => c.when).join(' || ');",
     ]],
     fails: 'the ripple-alone row, and nothing else - the drop-one sweep stays green',
   },
@@ -428,7 +438,7 @@ const MUTATIONS = {
   // off the eighths it steps in, so the smooth phase lands somewhere the stepped one never
   // does rather than agreeing with it by luck at one instant.
   'ripple-clock-continuous': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/ripple/wave.vert.glsl',
     edits: [[
       '      float cycles = dist * rippleFreq - floor(time * rippleSpeed * 8.0) * 0.125;',
       '      float cycles = dist * rippleFreq - time * rippleSpeed;',

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -176,7 +176,7 @@ const MUTATIONS = {
   // right answer and a fifth would mean some other parameter had quietly become reachable
   // only through the duotone.
   'duotone-ignored': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/duotone/tone.frag.glsl',
     edits: [[
       '  if (duotoneDepth > 0.0) {',
       '  if (false) {',
@@ -191,7 +191,7 @@ const MUTATIONS = {
   // cannot draw the silhouette this parameter exists for, which is exactly the shape of
   // failure that ships looking like a control that works.
   'duotone-ignores-depth': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/duotone/tone.frag.glsl',
     edits: [[
       '    float k = smoothstep(duotoneSplit - w * 0.5, duotoneSplit + w * 0.5, t);',
       '    float k = 0.5;',
@@ -205,7 +205,7 @@ const MUTATIONS = {
   // lands in a uniform nothing reads. The plain shape, and the drop-one sweep is what sees
   // it: a parameter whose picture never changes when you take it away.
   'duotone-span-ignored': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/duotone/tone.frag.glsl',
     edits: [[
       '    float w = duotoneSpan / max(0.001, farClip - nearClip);',
       '    float w = 1.0;',
@@ -224,7 +224,7 @@ const MUTATIONS = {
   // parameter was added to remove, reinstated in a form nothing that renders one range can
   // detect.
   'duotone-span-against-a-frozen-range': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/duotone/tone.frag.glsl',
     edits: [[
       '    float w = duotoneSpan / max(0.001, farClip - nearClip);',
       '    float w = duotoneSpan / 5.95;',
@@ -299,7 +299,7 @@ const MUTATIONS = {
   // in this file can fail on a default that leaks, because every other comparison here either
   // has the term raised on both sides or has the block switched off entirely.
   'motion-leaks-at-zero': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/duotone/tone.frag.glsl',
     edits: [[
       '    k = mix(k, 1.0, duotoneMotion * smoothstep(0.0, 1200.0, vSpeed));',
       '    k = mix(k, 1.0, (duotoneMotion + 0.02) * smoothstep(0.0, 1200.0, vSpeed));',
@@ -347,7 +347,7 @@ const MUTATIONS = {
   // the only row that can see it is the drop-one sweep, where reverting a parameter that
   // reaches nothing changes no pixel.
   'crush-ignored': {
-    file: 'web/post-chain.js',
+    file: 'web/grade-shader.js',
     edits: [[
       '      col = max(col - crush, 0.0) * 1.12;',
       '      col = max(col - 0.018, 0.0) * 1.12;',
@@ -365,7 +365,7 @@ const MUTATIONS = {
   // bearing, green means it does not and the branch should come out, because a fast path
   // that is bit-identical to the slow one is the second implementation this repo refuses.
   'raster-recomputes-the-default': {
-    file: 'web/post-chain.js',
+    file: 'effects-builtin/raster/lines.grade.glsl',
     edits: [[
       '        if (scanAxis.x == 0.0 && scanAxis.y == 1.0 && scanPitch == 1.3 && scanHard == 0.0) {',
       '        if (false) {',
@@ -464,7 +464,7 @@ const MUTATIONS = {
   // change. The drop-one sweep is where that shows, because reverting a parameter nothing
   // reads leaves the image where it was.
   'streak-ignored': {
-    file: 'web/post-chain.js',
+    file: 'effects-builtin/streak/fall.grade.glsl',
     edits: [[
       '      if (streak > 0.0) {',
       '      if (false) {',
@@ -497,7 +497,7 @@ const MUTATIONS = {
   // is the sharper half of `duotone-ignored`: that one asks whether the term is wired up at
   // all, this one asks whether it does the thing it is named for.
   'streak-ignores-angle': {
-    file: 'web/post-chain.js',
+    file: 'effects-builtin/streak/fall.grade.glsl',
     edits: [[
       '          vec3 tap = texture2D(tDiffuse, vUv + d * texel * streakAxis).rgb;',
       '          vec3 tap = texture2D(tDiffuse, vUv + vec2(0.0, d * texel.y)).rgb;',
@@ -569,7 +569,7 @@ const MUTATIONS = {
   // is reverted. This is the vertical column grille the whole of D1 is for, so a build
   // that quietly lost it would be drawing television scanlines under a green run.
   'raster-ignores-angle': {
-    file: 'web/post-chain.js',
+    file: 'effects-builtin/raster/lines.grade.glsl',
     edits: [[
       '          float coord = dot(vUv * ref, scanAxis);',
       '          float coord = vUv.y * ref.y;',
@@ -580,7 +580,7 @@ const MUTATIONS = {
   // nothing about the shipped picture moves - which is the point, and which leaves the
   // drop-one sweep as the only thing that can tell the two builds apart.
   'raster-pitch-fixed': {
-    file: 'web/post-chain.js',
+    file: 'effects-builtin/raster/lines.grade.glsl',
     edits: [[
       '          float wave = sin(coord * scanPitch + time * 2.0) * 0.5 + 0.5;',
       '          float wave = sin(coord * 1.3 + time * 2.0) * 0.5 + 0.5;',
@@ -592,7 +592,7 @@ const MUTATIONS = {
   // and a build without it draws rotated softness at every setting - which looks like a
   // raster right up until you compare it against a reference frame.
   'raster-hard-ignored': {
-    file: 'web/post-chain.js',
+    file: 'effects-builtin/raster/lines.grade.glsl',
     edits: [[
       '          line = mix(wave, smoothstep(0.5 - w, 0.5 + w, wave), scanHard);',
       '          line = wave;',
@@ -617,11 +617,18 @@ const MUTATIONS = {
   // by 1, which is two compilers rounding a fragment differently, and 1b compares pictures
   // now. All five of its rows are green at baseline, so all five reddening here is five
   // clean signals rather than four and a widening.
+  // **The anchor moved when the gate stopped being a list**, and it plants the same defect
+  // it always did: `crush` joining the terms that switch the pass on. The five names used to
+  // be five hand-written lines here and are read off the packages' `gates` bindings now, so
+  // there is no `rgbSplit` line left to add a disjunct to - and `crush` has no package to
+  // carry a binding, which is the whole reason it is the term this control is about. So the
+  // edit puts it in front of the derived test, which is exactly what a build that gated it
+  // would compute.
   'crush-gates-the-grade': {
     file: 'web/main.js',
     edits: [[
-      '  return grade.uniforms.rgbSplit.value > 0',
-      '  return grade.uniforms.crush.value > 0 || grade.uniforms.rgbSplit.value > 0',
+      '  return GRADE_GATES.some(',
+      '  return grade.uniforms.crush.value > 0 || GRADE_GATES.some(',
     ]],
     fails: 'the pass-gate row for crush, all five rows of 1b (each at 6 of 6 frames and '
       + 'about three quarters of every frame), and the boot comparison naming all four '
@@ -1254,7 +1261,9 @@ const mutatedSource = (() => {
  * **The second branch is the effects' own GLSL, which the page fetches rather than
  * imports.** A chunk under `effects-builtin/<id>/<name>` has no URL of its own under
  * `web/`; it is answered by `/effects/:id/file/:name`, which is the route the boot in
- * `web/main.js` reads it out of before `assembleShaders` splices it into the material. So
+ * `web/main.js` reads it out of before `assembleShaders` splices it into the point cloud's
+ * material or the grade pass's shader - one route for both, since a chunk names the joint it
+ * joins rather than the program it feeds. So
  * a mutation that edits a chunk is delivered at the fetch rather than at the module - and
  * from Playwright's side those are the same interception, because `page.route` sees a
  * `fetch` exactly as it sees a script tag. Everything else is a refusal: a spec naming a

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -629,10 +629,10 @@ const MUTATIONS = {
   // only observable through the block this closes, so which character a cell would have
   // drawn cannot reach a pixel once no character is drawn at all.
   'glyph-ignored': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/glyph/size.vert.glsl',
     edits: [
       ['  if (glyph > 0.0) {', '  if (false) {'],
-      ['  if (glyphMix > 0.0) {', '  if (false) {'],
+      ['  if (glyphMix > 0.0) {', '  if (false) {', 'effects-builtin/glyph/index.frag.glsl'],
     ],
     fails: 'twenty-two rows on top of the six section 1b carries on the clean tree, counted out '
       + 'because a list that undercounts sends the next reader hunting a defect that is not '
@@ -680,7 +680,7 @@ const MUTATIONS = {
   // asymmetry to prove a value is per point, this one plants a redundancy to prove one is
   // per cell.
   'glyph-hash-per-point': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/glyph/cell.vert.glsl',
     edits: [[
       '    vCellSeed = hash(dot(wc, vec3(127.1, 311.7, 74.7)));',
       '    vCellSeed = hash(dot(vec3(position.xy, 0.0), vec3(127.1, 311.7, 74.7)));',
@@ -757,7 +757,7 @@ const MUTATIONS = {
   // ratio has no scale, so a mix renders the identical image when every weight is doubled
   // where a sum does not. This is the one property the two compositions cannot share.
   'glyph-index-averages': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/glyph/index.frag.glsl',
     edits: [[
       '    float f = fract(glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
       '    float f = (glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep) '
@@ -774,7 +774,7 @@ const MUTATIONS = {
   // about - a build drawing characters from a shuffled table is a build whose tone key
   // draws noise, which is what the hash key is already for.
   'glyph-tone-ignored': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/glyph/index.frag.glsl',
     edits: [[
       '    float f = fract(glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
       '    float f = fract(0.0 * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
@@ -795,11 +795,12 @@ const MUTATIONS = {
   // `glyph.rain` goes into the no-effect bucket with the four, on the `duotone-ignored`
   // terms: a key that reads the rain cannot be observed with the rain gone.
   'rain-ignored': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/rain/lift.frag.glsl',
     edits: [
       ['  float rainLift = 1.0 - smoothstep(0.0, rainTrail / rainSpan, fract(vRain));',
         '  float rainLift = 0.0;'],
-      ['    float rainStep = floor(vRain) * 0.6180339887498949;', '    float rainStep = 0.0;'],
+      ['    float rainStep = floor(vRain) * 0.6180339887498949;', '    float rainStep = 0.0;',
+        'effects-builtin/glyph/index.frag.glsl'],
     ],
     fails: 'nine rows. The claim: glyph.rain, rain.amount, rain.speed, rain.span and rain.trail '
       + 'unexplained in the drop-one sweep, with the count at 81 of 89. The rest is the '
@@ -821,7 +822,7 @@ const MUTATIONS = {
   // No row that asks whether the rain changed the picture can see it, because every sign
   // changes the picture. It takes a fixture that can say which way.
   'rain-trail-below-the-head': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/rain/lift.frag.glsl',
     edits: [[
       '  float rainLift = 1.0 - smoothstep(0.0, rainTrail / rainSpan, fract(vRain));',
       '  float rainLift = 1.0 - smoothstep(0.0, rainTrail / rainSpan, 1.0 - fract(vRain));',
@@ -838,7 +839,7 @@ const MUTATIONS = {
   // over a degraded link. The fixture this repo ships was shot at about 9.3fps, which is
   // the condition nobody grades in and the one this row stands in.
   'rain-span-in-frames': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/rain/cell.vert.glsl',
     edits: [[
       '    vRain = (rainPhase * rainSpeed + room.y) / rainSpan + hash(dot(wc.xz, vec2(269.5, 183.3)));',
       '    vRain = (rainPhase * rainSpeed + room.y) / (rainSpan * spanSec * 30.0) '
@@ -861,7 +862,7 @@ const MUTATIONS = {
   // reference ones, so the far cloud draws one arbitrary bit of a character each instead of
   // a dot.
   'crossfade-reads-the-reference': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/glyph/mark.frag.glsl',
     edits: [[
       '  float glyphMix = glyph * smoothstep(8.0, 16.0, vLegiblePx);',
       '  float glyphMix = glyph * smoothstep(8.0, 16.0, vSize);',
@@ -929,7 +930,7 @@ const MUTATIONS = {
   // is the one term in this expression whose absence is invisible at every weight except
   // the one the slider tops out at.
   'rain-key-counts-whole-drops': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/glyph/index.frag.glsl',
     edits: [[
       '    float rainStep = floor(vRain) * 0.6180339887498949;',
       '    float rainStep = floor(vRain);',
@@ -950,7 +951,7 @@ const MUTATIONS = {
   // pixel, and no row that reads one frame however carefully, can see it: a still of rain
   // rising and a still of rain falling are the same kind of picture. It takes two phases.
   'rain-climbs': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/rain/cell.vert.glsl',
     edits: [[
       '    vRain = (rainPhase * rainSpeed + room.y) / rainSpan + hash(dot(wc.xz, vec2(269.5, 183.3)));',
       '    vRain = (-rainPhase * rainSpeed + room.y) / rainSpan + hash(dot(wc.xz, vec2(269.5, 183.3)));',
@@ -1068,7 +1069,7 @@ const MUTATIONS = {
   // renders at defaults and would move on both arms, and every other comparison here either
   // has the master raised on both sides or is not looking at a character.
   'glyph-leaks-at-zero': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/glyph/mark.frag.glsl',
     edits: [[
       '  float glyphMix = glyph * smoothstep(8.0, 16.0, vLegiblePx);',
       '  float glyphMix = glyph * smoothstep(8.0, 16.0, vLegiblePx) + 0.02;',
@@ -1088,7 +1089,7 @@ const MUTATIONS = {
   // multiplier being exactly one. A term that leaked here would move all nine shipped
   // documents at once.
   'rain-leaks-at-zero': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/rain/lift.frag.glsl',
     edits: [[
       '  col *= 1.0 + rain * rainLift;',
       '  col *= 1.0 + (rain + 0.02) * rainLift;',
@@ -1179,40 +1180,59 @@ const mutatedSource = (() => {
   const spec = MUTATIONS[MUTATE];
   if (!spec) throw new Error(`unknown mutation ${MUTATE} - have ${Object.keys(MUTATIONS).join(', ')}`);
   const staged = new Map();
+  const touched = [];
   const read = (rel) => {
     if (!staged.has(rel)) staged.set(rel, readFileSync(join(REPO, rel), 'utf8'));
     return staged.get(rel);
   };
-  for (const [from, to] of spec.edits) {
-    const body = read(spec.file);
+  // **An edit may name its own file, and two edits of one mutation may name two.** The
+  // third element of an edit pair is that file, defaulting to the spec's, which is the
+  // shape `syntax-check`'s anchor row has always read and the shape `export-check` has
+  // always staged - this file ignored it, which was true by coincidence right up until the
+  // effects began carrying their own GLSL. `glyph-ignored` now switches the master off in
+  // the glyph package's vertex chunk and again in its fragment chunk, and `rain-ignored`
+  // spans two packages: the rain's own lift and the glyph field's index block, which is
+  // where the rain key is read. A staging loop that read one file would have applied the
+  // second edit to the first file, matched nothing, and refused - which is the loud
+  // direction, but it would have refused a control that is perfectly well defined.
+  for (const [from, to, where] of spec.edits) {
+    const file = where ?? spec.file;
+    const body = read(file);
     const hits = body.split(from).length - 1;
     if (hits !== 1) {
-      throw new Error(`mutation ${MUTATE} matched its anchor ${hits} times in ${spec.file}, not once: `
+      throw new Error(`mutation ${MUTATE} matched its anchor ${hits} times in ${file}, not once: `
         + `${JSON.stringify(from)}`);
     }
-    staged.set(spec.file, body.replace(from, to));
+    staged.set(file, body.replace(from, to));
+    if (!touched.includes(file)) touched.push(file);
   }
   // The panel and the module, which this tool has always served as a pair because a
   // build's `PARAMS` throws at boot on a parameter with no control in the markup - and
-  // beside them whatever file the spec actually edited. For a spec naming `main.js` that
-  // third member is the same string as `js`; for one naming a module `main.js` imports it
-  // is that module's own bytes, requested by the browser under its own path.
+  // beside them every file the spec actually edited, each at the URL a browser reaches it
+  // by. For a spec naming `main.js` that third member is the same string as `js`; for one
+  // naming a module `main.js` imports it is that module's own bytes; for one naming an
+  // effect's chunk it is the text the page fetches out of `/effects/:id/file/:name` and
+  // assembles its shader from.
   //
   // **This used to be the pair alone, and a spec naming a third file was refused outright**
   // with a note saying the pairing would be fixed when something needed it. Eighteen of the
   // entries below need it: the cloud's two GLSL programs are `web/cloud-shader.js` now, and
   // a refusal there is eighteen falsification controls that cannot run. What the refusal
   // was protecting against is real and is closed differently here - the staged edit used to
-  // be discarded at this line while `mutantPath` still resolved to the module's own path,
+  // be discarded at this line while the mutant's path still resolved to the module's own,
   // so the interception fired on a request for that module and answered it with `main.js`'s
   // unmutated bytes, which reads as a delivered mutation and asserts about code nobody
   // wrote. Serving each file at its own path is what makes that impossible rather than
   // refused.
-  return { js: read('web/main.js'), html: read('web/index.html'), mutated: read(spec.file) };
+  return {
+    js: read('web/main.js'),
+    html: read('web/index.html'),
+    mutants: touched.map((file) => ({ file, path: servedAt(file), body: read(file), type: contentTypeFor(file) })),
+  };
 })();
 
 /**
- * Where a file under `web/` is reached from a browser.
+ * Where a file this repo ships is reached from a browser.
  *
  * Matched on the whole pathname rather than with a `**​/name.js` glob, because a glob
  * on the basename is a claim about a filename where the server's rule is about a path -
@@ -1220,12 +1240,42 @@ const mutatedSource = (() => {
  * anything failing. `timeline-check` carries the same function for the same reason;
  * this file keeps its own copy rather than importing one, the way every tool here
  * resolves its own `REPO` rather than sharing it.
+ *
+ * **The second branch is the effects' own GLSL, which the page fetches rather than
+ * imports.** A chunk under `effects-builtin/<id>/<name>` has no URL of its own under
+ * `web/`; it is answered by `/effects/:id/file/:name`, which is the route the boot in
+ * `web/main.js` reads it out of before `assembleShaders` splices it into the material. So
+ * a mutation that edits a chunk is delivered at the fetch rather than at the module - and
+ * from Playwright's side those are the same interception, because `page.route` sees a
+ * `fetch` exactly as it sees a script tag. Everything else is a refusal: a spec naming a
+ * file no browser asks for would install a route that never fires, which is the shape the
+ * guard at the foot of this file is about.
  */
 function servedAt(file) {
+  if (file.startsWith('effects-builtin/')) {
+    const parts = file.split('/');
+    if (parts.length !== 3) {
+      throw new Error(`${file} is not an effect package file - a chunk is <id>/<name> under effects-builtin/`);
+    }
+    return `/effects/${parts[1]}/file/${parts[2]}`;
+  }
   if (!file.startsWith('web/')) {
     throw new Error(`${file} is not served to a browser, so a page mutation cannot reach it`);
   }
   return `/${file.slice('web/'.length)}`;
+}
+
+/**
+ * What the server answers a file with, restated here because the interception has to
+ * answer the same way.
+ *
+ * A chunk is served `text/plain` by `server/index.js` on the argument that what the tools
+ * anchor and the client compiles is the file's own bytes; answering it as JavaScript here
+ * would be this tool inventing a second promise about the same route, which is exactly
+ * the kind of difference between a mutated arm and a clean one that gets read as a finding.
+ */
+function contentTypeFor(file) {
+  return file.endsWith('.glsl') ? 'text/plain; charset=utf-8' : 'text/javascript; charset=utf-8';
 }
 
 // The route below used to be a bare `'**/main.js'` glob, true of every mutation this
@@ -1240,15 +1290,20 @@ function servedAt(file) {
 // call site wants the same answer under `--mutate`: which file, if any, is the
 // mutated one.
 const MAIN_PATH = servedAt('web/main.js');
-const mutantPath = MUTATE ? servedAt(MUTATIONS[MUTATE].file) : MAIN_PATH;
-// Counted rather than assumed. A route that matches nothing fulfils nothing and
-// throws no error - the page simply loads the tree's own source - so the only way to
-// tell a mutation that was delivered from one that was never asked for is to watch
-// the interception fire, and it has to be watched across every page this file opens
-// under `--mutate`, not just the first: the after-arm, the pin arm and the panel arm
-// all default to the current tree's source, and any one of them failing to ask for
-// the mutated module would leave the others carrying a run that never happened.
-let mutantServed = 0;
+// Counted rather than assumed, and counted per file. A route that matches nothing
+// fulfils nothing and throws no error - the page simply loads the tree's own source -
+// so the only way to tell a mutation that was delivered from one that was never asked
+// for is to watch the interception fire, and it has to be watched across every page
+// this file opens under `--mutate`, not just the first: the after-arm, the pin arm and
+// the panel arm all default to the current tree's source, and any one of them failing
+// to ask for the mutated module would leave the others carrying a run that never
+// happened.
+//
+// **Per file rather than in total, because a mutation now edits more than one.** A sum
+// is satisfied by one of two chunks arriving, which is a half-delivered mutation
+// reported as delivered - and the half that goes missing is the one whose route was
+// wrong, so the total would be loudest exactly where it is least true.
+const mutantServed = new Map((mutatedSource?.mutants ?? []).map((m) => [m.path, 0]));
 
 const HEADED = argv.includes('--headed');
 const SOURCE_FRAMES = Number(flag('--frames', '6'));
@@ -2115,10 +2170,12 @@ async function openPage({
   // answer `/main.js` with a property of null. The mutation has to exist for there to be
   // one to serve.
   if (mutatedSource && source === mutatedSource) {
-    await page.route((url) => url.pathname === mutantPath, (route) => {
-      mutantServed++;
-      return route.fulfill({ contentType: 'text/javascript; charset=utf-8', body: source.mutated });
-    });
+    for (const mutant of mutatedSource.mutants) {
+      await page.route((url) => url.pathname === mutant.path, (route) => {
+        mutantServed.set(mutant.path, mutantServed.get(mutant.path) + 1);
+        return route.fulfill({ contentType: mutant.type, body: mutant.body });
+      });
+    }
   }
   if (pin) {
     await page.route('**/__pinned.bin', (route) => route.fulfill({
@@ -2292,10 +2349,13 @@ const afterArm = await bootState({});
 // ordinary catch is inverted (0 caught, 1 not caught): a run that tested nothing is
 // neither of those, and reusing either code would make it unrecoverably ambiguous
 // with a real verdict.
-if (MUTATE && mutantServed === 0) {
-  console.log(`\n[registry] DID NOT RUN - ${MUTATE} was staged for ${mutantPath} and the page never `
-    + 'requested it, so this run would have measured the unmutated build');
-  process.exit(2);
+if (MUTATE) {
+  const unserved = [...mutantServed].filter(([, n]) => n === 0).map(([path]) => path);
+  if (unserved.length) {
+    console.log(`\n[registry] DID NOT RUN - ${MUTATE} was staged for ${unserved.join(', ')} and the page never `
+      + 'requested it, so this run would have measured a build the mutation did not fully reach');
+    process.exit(2);
+  }
 }
 const measuredBar = await afterArm.page.evaluate(
   "Math.round(document.getElementById('appBar').getBoundingClientRect().height)");

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -390,7 +390,7 @@ const MUTATIONS = {
   // the lattice - so if the glyph field is ever removed this control loses its subject and
   // will come back caught on the streak fixture alone.
   'lattice-ignored': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/lattice/snap.vert.glsl',
     edits: [[
       '  if (lattice > 0.0) {',
       '  if (false) {',
@@ -442,7 +442,7 @@ const MUTATIONS = {
   // reverted. A build that quietly lost it tears horizontally under a green run, which is
   // the whole of what this control was added to stop being the only option.
   'glitch-axis-ignored': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/glitch/tear.vert.glsl',
     edits: [[
       '      ? floor(mix(position.y, position.x, glitchAxis) / glitchBands)',
       '      ? floor(position.y / glitchBands)',
@@ -1120,7 +1120,7 @@ const MUTATIONS = {
   // `cell` can reach a pixel with the lattice at zero, which is the plainest
   // statement of "those eight documents render the frames they always did".
   'compensation-leaks-at-lattice-zero': {
-    file: 'web/cloud-shader.js',
+    file: 'effects-builtin/lattice/energy.vert.glsl',
     edits: [[
       '  vCellNorm = max((1.0 - lattice) * (1.0 - lattice), min(1.0, spriteCells * spriteCells));',
       '  vCellNorm = max((1.0 - lattice) * (1.0 - lattice), spriteCells * spriteCells);',

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -116,6 +116,38 @@ const MUTATIONS = {
     edits: [['{\n  "format": 1,', '{{\n  "format": 1,']],
   },
 
+  // The assembled-program row's first control, and it plants the defect that row was
+  // written for rather than an invented one: `export-check`'s `pointsize-absolute` pointed
+  // at `web/cloud-shader.js` for a whole commit after the glyph field moved out, matching
+  // the `v.pointSize` fallback exactly once while the text the driver compiles came from
+  // the package's own chunk. Repointing it there again reproduces that state exactly.
+  //
+  // **It is the count rule's blind spot as well as the move rule's subject**, which is why
+  // this is the control and not a line invented for the purpose. The glyph chunk's `else`
+  // branch carries the old clamp statement verbatim - the chunk's own comment says it is
+  // kept byte-identical on purpose - so the anchor still appears exactly once in the
+  // assembled pair, and only applying the edit and finding the programs unmoved can see it.
+  'anchor-in-dead-fallback': {
+    file: 'tools/export-check.mjs',
+    edits: [[
+      "  'pointsize-absolute': { file: 'effects-builtin/glyph/size.vert.glsl', edits: [[",
+      "  'pointsize-absolute': { file: 'web/cloud-shader.js', edits: [[",
+    ]],
+  },
+
+  // The second control, for the other half of the same row, and it has to plant its
+  // duplicate in a *different* file from the one the anchor names. A line copied inside its
+  // own chunk is already refused by the row above - two matches in one file - so a control
+  // built that way would prove nothing about the assembled text. Copied into a neighbouring
+  // package's chunk, `lattice-ignored`'s anchor still matches its own file exactly once,
+  // the edit still moves the vertex program, and the only thing that can see the second
+  // copy is counting the anchor against what the two programs actually hold: the mutation
+  // would then reach one of the two sites and be recorded under the whole one's name.
+  'anchor-duplicated-into-a-second-chunk': {
+    file: 'effects-builtin/glitch/tear.vert.glsl',
+    edits: [['  vGlitch = 0.0;', '  vGlitch = 0.0;\n  if (lattice > 0.0) {']],
+  },
+
   // The third half of the same row, and the one that says the walk reaches outside the
   // prose. Both mutations above plant their failure in a file the old citing set already
   // read - a root markdown page and a `docs/` page - so both stayed caught while the walk
@@ -901,14 +933,14 @@ const withoutStringBodies = (src) => {
     // declare `{ file, edits }` like everything else, so a nested-array first element
     // is no longer a shape this row recognises and would fail below naming the tool.
     if (Array.isArray(spec)) {
-      return typeof spec[0] === 'string' ? { anchors: [{ file: REGISTRATION, from: spec[0] }] } : null;
+      return typeof spec[0] === 'string' ? { anchors: [{ file: REGISTRATION, from: spec[0], to: spec[1] }] } : null;
     }
     if (typeof spec === 'function') return { anchorless: 'functions that redirect the oracle' };
     if (spec === null || typeof spec === 'string') return { anchorless: 'whole replacement file bodies' };
     if (typeof spec === 'object') {
       if (typeof spec.file === 'string' && Array.isArray(spec.edits)) {
         return {
-          anchors: spec.edits.map(([from, , where]) => ({ file: where ?? spec.file, from })),
+          anchors: spec.edits.map(([from, to, where]) => ({ file: where ?? spec.file, from, to })),
         };
       }
       // `registry-check`'s old `{ from, to }` shape used to be read here and resolved to
@@ -922,6 +954,15 @@ const withoutStringBodies = (src) => {
     return null;
   };
 
+  // **Off disk and deliberately not through the mutation substitution**, which is a
+  // distinction this row had for free until the assembled-program rule below arrived with
+  // controls that stage source text. The question here is whether the tree still holds an
+  // anchor's text; the question below is what that text assembles into. Reading a staged
+  // file here answers the first question about a file nobody has, and it does it in the
+  // shape that is hardest to read: `spec-drifts` replaces the very line it anchors on, so
+  // this row would report the running control's own anchor as stale on every run of it -
+  // one extra red row per control, none of them findings, on four of the seven controls
+  // this tool carries.
   const targets = new Map();
   const targetSource = (path) => {
     if (!targets.has(path)) {
@@ -931,10 +972,102 @@ const withoutStringBodies = (src) => {
     return targets.get(path);
   };
 
+  // ---- and the same anchor asked of the text the driver is handed
+  //
+  // **A file is not a program any more, and the row above cannot tell the difference.**
+  // Since the cloud's two shaders became a spine plus the installed packages' chunks, a
+  // slot carries the text to use when nothing claims it - so `web/cloud-shader.js` holds
+  // two copies of the shipped point-size statement and the shipped mark, one of them live
+  // and one of them a fallback nothing compiles while the glyph package is installed. An
+  // anchor in the dead copy matches its file **exactly once**, which is all the row above
+  // asks, and the control it belongs to then edits a line no driver ever sees. That is not
+  // hypothetical: `export-check`'s `pointsize-absolute` sat in that fallback for a commit,
+  // green the whole time, and it was found by reading rather than by any check.
+  //
+  // So every anchor into one of the three files the two programs are built out of is asked
+  // two more questions, and they catch different things. **It appears exactly once in the
+  // assembled pair**, which finds a line that reaches no program and a line that reaches two
+  // sites where the edit would reach one - a half-delivered mutation recorded under the
+  // whole one's name. And **applying the edit moves one of the two programs**, which is the
+  // one that sees the dead fallback, because the fallback's twin is the live chunk's own
+  // text: the count is 1 either way and only the edit can tell which copy it landed in.
+  //
+  // The third file is `web/shader-assembly.js`. It is here because the emit is text as much
+  // as the spine is - an anchor on a branch the assembler never takes is the same dead
+  // control wearing JavaScript - and it can be here because it imports nothing, so its bytes
+  // evaluate under a `data:` module the way the spine's do. The count question is not asked
+  // of it: its anchors are JavaScript and the programs are GLSL.
+  //
+  // Nothing here needs a server, a browser or a package. `assembleShaders` is concatenation
+  // over data handed in, and the manifests and chunks are files - which is the whole reason
+  // the assembler was written import-free and pure.
+  const SPINE = 'web/cloud-shader.js';
+  const ASSEMBLER = 'web/shader-assembly.js';
+  const isChunk = (file) => /^effects-builtin\/[^/]+\/[^/]+\.glsl$/.test(file);
+  const buildsTheProgram = (file) => file === SPINE || file === ASSEMBLER || isChunk(file);
+
+  const moduleOf = (source) => import(`data:text/javascript;base64,${Buffer.from(source, 'utf8').toString('base64')}`);
+  // A string replacement rather than a pattern one: `String.replace` reads `$&` and its
+  // relatives out of a replacement *string*, and a mutation's `to` is source text that owes
+  // this row nothing about dollar signs.
+  const swap = (body, from, to) => body.replace(from, () => to);
+
+  // **These three read through the substitution where the row above reads off disk**, and
+  // the seam is the point rather than an inconsistency: what assembles is the question here,
+  // so a control that stages one of the three files has to reach this and must not reach the
+  // anchor-existence row, where it would report its own anchor as stale.
+  let clean = null, spineSource = null, assemblerSource = null, basePackages = null;
+  try {
+    spineSource = sourceWithMutation(SPINE);
+    assemblerSource = sourceWithMutation(ASSEMBLER);
+    const builtin = join(ROOT, 'effects-builtin');
+    // The manifests are read off disk even so: `manifest-does-not-parse` is the
+    // package-parse gate's control and owns that question one block up, and routing it
+    // through here as well would give one control two red rows in two rules asking the
+    // same thing.
+    basePackages = readdirSync(builtin, { withFileTypes: true })
+      .filter((e) => e.isDirectory()).map((e) => e.name).sort()
+      .map((id) => {
+        const manifest = JSON.parse(readFileSync(join(builtin, id, 'manifest.json'), 'utf8'));
+        const chunks = {};
+        for (const c of manifest.chunks ?? []) chunks[c.file] = sourceWithMutation(`effects-builtin/${id}/${c.file}`);
+        return { id, manifest, chunks };
+      });
+  } catch (err) {
+    // A `fail` rather than a throw, following the rule the whole suite is written under: a
+    // run that dies here exits non-zero with nothing asserted, which reads exactly like a
+    // check that ran and found something.
+    fail(`the shipped packages could not be read for the assembled-program rule - ${String(err.message).split('\n')[0]}`);
+  }
+
+  const assembleStaged = async (staged = {}) => {
+    const { cloudSpine } = await moduleOf(staged.spine ?? spineSource);
+    const { assembleShaders } = await moduleOf(staged.assembler ?? assemblerSource);
+    const packages = basePackages.map((p) => ({ ...p, chunks: { ...p.chunks } }));
+    if (staged.chunk) {
+      const [, id, name] = staged.chunk.file.split('/');
+      const pkg = packages.find((p) => p.id === id);
+      if (!pkg) throw new Error(`${staged.chunk.file} names an effect package this build does not ship`);
+      pkg.chunks[name] = staged.chunk.text;
+    }
+    return assembleShaders(cloudSpine, packages);
+  };
+
+  if (basePackages) {
+    try {
+      clean = await assembleStaged();
+    } catch (err) {
+      fail(`the spine and the shipped packages do not assemble at all, so no anchor could be checked against the programs - ${String(err.message).split('\n')[0]}`);
+    }
+  }
+
+  let programChecked = 0, dead = 0, miscounted = 0;
   let tablesDeclared = 0, tablesWithAnchors = 0, anchorsChecked = 0, stale = 0, unreadable = 0;
   const anchorless = [];
   for (const name of readdirSync(join(ROOT, 'tools')).filter((f) => PARSES.test(f)).sort()) {
-    const source = readFileSync(join(ROOT, 'tools', name), 'utf8');
+    // Through the substitution for the reason `targetSource` above is: the two controls for
+    // the assembled-program rule below move a *spec*, and a spec is source text in a tool.
+    const source = sourceWithMutation(`tools/${name}`);
     const declared = DECLARATION.exec(source);
     if (!declared) continue;
     tablesDeclared++;
@@ -984,7 +1117,7 @@ const withoutStringBodies = (src) => {
         if (!anchorless.some((a) => a.name === name)) anchorless.push({ name, why: shape.anchorless });
         continue;
       }
-      for (const { file, from } of shape.anchors) {
+      for (const { file, from, to } of shape.anchors) {
         const body = targetSource(file);
         if (body === null) {
           fail(`${name}/${mutation} anchors into ${file}, which does not exist`);
@@ -997,6 +1130,43 @@ const withoutStringBodies = (src) => {
           stale++;
           fail(`${name}/${mutation} matches ${hits} times in ${file}, expected exactly 1`
             + ` - ${hits === 0 ? 'the text it anchors on has moved, so this control cannot run' : 'the text it anchors on appears more than once, so the tool refuses it'}`);
+          continue;
+        }
+        if (!clean || !buildsTheProgram(file) || typeof to !== 'string') continue;
+        programChecked++;
+        if (file !== ASSEMBLER) {
+          const inProgram = (clean.vertexShader.split(from).length - 1)
+            + (clean.fragmentShader.split(from).length - 1);
+          if (inProgram !== 1) {
+            miscounted++;
+            fail(`${name}/${mutation} anchors on text appearing ${inProgram} times in the assembled vertex and fragment programs, not once`
+              + ` - ${inProgram === 0 ? 'it matches its file and reaches no program, so the edit lands in text nothing compiles'
+                : 'the edit reaches one of those sites and the control would be recorded under the whole mutation\'s name'}`);
+          }
+        }
+        // Staged against what assembles rather than against what `targetSource` read, so a
+        // running control that moved one of the three files is not silently reverted here
+        // by an edit applied to the tree's own copy of it.
+        const chunkOf = (rel) => {
+          const [, id, chunk] = rel.split('/');
+          return basePackages.find((p) => p.id === id)?.chunks[chunk] ?? '';
+        };
+        let after = null;
+        try {
+          after = await assembleStaged(
+            file === SPINE ? { spine: swap(spineSource, from, to) }
+              : file === ASSEMBLER ? { assembler: swap(assemblerSource, from, to) }
+                : { chunk: { file, text: swap(chunkOf(file), from, to) } },
+          );
+        } catch (err) {
+          dead++;
+          fail(`${name}/${mutation} staged against ${file} and the programs would not assemble - ${String(err.message).split('\n')[0]}`);
+        }
+        if (after && after.vertexShader === clean.vertexShader && after.fragmentShader === clean.fragmentShader) {
+          dead++;
+          fail(`${name}/${mutation} edits ${file} and neither assembled program moves`
+            + ' - a slot carries a second copy of the shipped text, so an anchor can match its file exactly once'
+            + ' and still sit in the copy nothing compiles');
         }
       }
     }
@@ -1025,6 +1195,23 @@ const withoutStringBodies = (src) => {
     console.log(`  anchors/ ${anchorsChecked} checked in ${tablesWithAnchors} tables of ${tablesDeclared} declared, ${parts.join(', ')}`);
   } else {
     console.log(`  anchors/ all ${anchorsChecked} in ${tablesWithAnchors} tables match once, of ${tablesDeclared} declared`);
+  }
+
+  // The assembled-program half gets its own line rather than being folded into the one
+  // above, because it counts a different population - the anchors into the three files the
+  // shaders are built out of, which is a fraction of the whole - and a total covering both
+  // would read as though every anchor had been asked the harder question.
+  if (clean === null) {
+    // Nothing further to say: the two failures above already name why, and a clean line
+    // here would be this row reporting on a comparison that never ran.
+  } else if (programChecked === 0) {
+    fail('no anchor was checked against the assembled shader programs, so that rule passed on nothing'
+      + ' - either the mutations stopped naming the spine and the chunks, or this scan is looking in the wrong place');
+  } else if (dead || miscounted) {
+    console.log(`  program/ ${programChecked} shader anchors checked against the assembled pair, `
+      + [dead && `${dead} reaching no program`, miscounted && `${miscounted} not appearing exactly once`].filter(Boolean).join(', '));
+  } else {
+    console.log(`  program/ all ${programChecked} shader anchors appear once in the assembled pair and move it when applied`);
   }
 }
 
@@ -1134,10 +1321,13 @@ const withoutStringBodies = (src) => {
 
 console.log(`\n${total} JavaScript files, ${failed} failed`);
 // Said out loud because `npm test` runs this, and a green `npm test` that meant "the
-// suite passed" would be the most expensive wrong impression in the repo. **One thing here
-// executes rather than parses**, and it is named rather than buried: the specification row
+// suite passed" would be the most expensive wrong impression in the repo. **Two things here
+// execute rather than parse**, and they are named rather than buried. The specification row
 // imports a copy of `server/protocol.js`, which is a module of constants with no imports of
-// its own, and reads its exported values. Nothing is called and no behaviour is exercised.
-// Everything else is `node --check` and nothing runs.
+// its own, and reads its exported values; nothing is called and no behaviour is exercised.
+// The anchor row imports `web/cloud-shader.js` and `web/shader-assembly.js` the same way and
+// does call one function - `assembleShaders`, which concatenates the strings it is handed
+// and touches nothing outside them. Both files import nothing, which is what lets their
+// bytes evaluate here at all. Everything else is `node --check` and nothing runs.
 console.log('syntax only - no proof tool ran here; see CLAUDE.md "Proof tools" for the suite and what each of them needs');
 process.exit(failed ? 1 : 0);

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -126,7 +126,7 @@ const MUTATIONS = {
   // this is the control and not a line invented for the purpose. The glyph chunk's `else`
   // branch carries the old clamp statement verbatim - the chunk's own comment says it is
   // kept byte-identical on purpose - so the anchor still appears exactly once in the
-  // assembled pair, and only applying the edit and finding the programs unmoved can see it.
+  // assembled programs, and only applying the edit and finding them unmoved can see it.
   'anchor-in-dead-fallback': {
     file: 'tools/export-check.mjs',
     edits: [[
@@ -146,6 +146,25 @@ const MUTATIONS = {
   'anchor-duplicated-into-a-second-chunk': {
     file: 'effects-builtin/glitch/tear.vert.glsl',
     edits: [['  vGlitch = 0.0;', '  vGlitch = 0.0;\n  if (lattice > 0.0) {']],
+  },
+
+  // The same rule's third control, and the one the grade pass made necessary. Both plants
+  // above put their duplicate in the same *program* as the anchor, so a count that
+  // partitioned by program - asking each of the four assembled strings on its own rather
+  // than summing them - would go on catching both while claiming something it no longer
+  // tested. That partition is the tempting shape, because a file belongs to a program and it
+  // reads as tidier to ask its own; what it misses is a line living in two programs at once,
+  // which is exactly what a shared idea copied between the point shader and the grade would
+  // be.
+  //
+  // So `streak-ignored`'s guard is planted in the thermal package's tone chunk, which feeds
+  // the cloud's fragment program. Its own file still matches once, the anchor row above stays
+  // green, and each program taken alone still counts one - only the sum over all of them
+  // sees two, and only then would the edit reach one of the two sites and be recorded under
+  // the whole mutation's name.
+  'anchor-duplicated-into-a-second-program': {
+    file: 'effects-builtin/thermal/heat.frag.glsl',
+    edits: [['  if (thermal > 0.0) {', '  if (thermal > 0.0) {\n      if (streak > 0.0) {']],
   },
 
   // The third half of the same row, and the one that says the walk reaches outside the
@@ -208,15 +227,21 @@ if (mutateAt !== -1 && !MUTATIONS[mutation]) {
 // the split began and 4 after `scene.js`, `curve.js` and `record-poll.js`; it was 9 with
 // `world-tilt.js`, `export-sizes.js` and `plan-geometry.js` beside them, 11 with
 // `view-window.js` and `clip-range.js`, 13 with `cloud-shader.js` and `bloom-pass.js`,
-// 15 with `gpu-textures.js` and `surface-memory.js`, 16 with `post-chain.js`, and it is
-// 17 with `point-cloud.js`. `test` moves with it for the same reason - most of those
+// 15 with `gpu-textures.js` and `surface-memory.js`, 16 with `post-chain.js`, and 17 with
+// `point-cloud.js`. It is 18 with `grade-shader.js`, which is the first of these to be cut
+// out of a module other than `main.js` - the grade pass's GLSL had to leave `post-chain.js`
+// because a spine has to evaluate under bare node and that file imports three.js. Two
+// modules arrived between those without the floor following them, `shader-assembly.js` and
+// `effect-manifests.js`, so the number is under the tree by more than one; that is the slack
+// this file's own header asks for, a tripwire rather than a manifest.
+// `test` moves with it for the same reason - most of those
 // modules arrived with a test file, which is most of why they are modules - but it has
 // stopped moving, and the last three phases are why. `surface-memory.js` asks the live
 // context whether it can render to float, `post-chain.js` hands a composer a renderer and
 // `point-cloud.js` imports both of them, so none of the three can be imported under bare
 // node at all, and a floor that counted a test nobody can write would be a floor that has
 // to be lowered later.
-const FLOORS = { server: 5, test: 10, tools: 12, web: 17 };
+const FLOORS = { server: 5, test: 10, tools: 12, web: 18 };
 
 // **Two different questions, so two different sets, and the difference is the point.**
 // `PARSES` is what `node --check` can be handed and have its answer mean anything - a
@@ -984,27 +1009,45 @@ const withoutStringBodies = (src) => {
   // hypothetical: `export-check`'s `pointsize-absolute` sat in that fallback for a commit,
   // green the whole time, and it was found by reading rather than by any check.
   //
-  // So every anchor into one of the three files the two programs are built out of is asked
-  // two more questions, and they catch different things. **It appears exactly once in the
-  // assembled pair**, which finds a line that reaches no program and a line that reaches two
-  // sites where the edit would reach one - a half-delivered mutation recorded under the
-  // whole one's name. And **applying the edit moves one of the two programs**, which is the
-  // one that sees the dead fallback, because the fallback's twin is the live chunk's own
-  // text: the count is 1 either way and only the edit can tell which copy it landed in.
+  // So every anchor into one of the files the programs are built out of is asked two more
+  // questions, and they catch different things. **It appears exactly once across every
+  // assembled program**, which finds a line that reaches no program and a line that reaches
+  // two sites where the edit would reach one - a half-delivered mutation recorded under the
+  // whole one's name. And **applying the edit moves one of them**, which is the one that
+  // sees the dead fallback, because the fallback's twin is the live chunk's own text: the
+  // count is 1 either way and only the edit can tell which copy it landed in.
   //
-  // The third file is `web/shader-assembly.js`. It is here because the emit is text as much
-  // as the spine is - an anchor on a branch the assembler never takes is the same dead
-  // control wearing JavaScript - and it can be here because it imports nothing, so its bytes
-  // evaluate under a `data:` module the way the spine's do. The count question is not asked
-  // of it: its anchors are JavaScript and the programs are GLSL.
+  // **Across every program and not within the one the file belongs to**, which is what the
+  // grade pass made a real question rather than a wording. There are two spines now and four
+  // assembled strings, and a line copied from the point shader into the grade's would count
+  // once in each if the question were asked per program - so the sum is taken over all of
+  // them, exactly as `assembleShaders` collects the joints of every spine before reading a
+  // package. A count that partitioned by file would have been a rule that got weaker every
+  // time this repo grew a program.
+  //
+  // The assembler is in the list too. It is here because the emit is text as much as a spine
+  // is - an anchor on a branch the assembler never takes is the same dead control wearing
+  // JavaScript - and it can be here because it imports nothing, so its bytes evaluate under
+  // a `data:` module the way the spines' do. The count question is not asked of it: its
+  // anchors are JavaScript and the programs are GLSL.
+  //
+  // **`web/post-chain.js` is deliberately not in this list, and the exclusion has a
+  // mechanism behind it rather than a promise.** It holds the grade pass's uniform table and
+  // not a byte of its GLSL, and it imports three.js, so it could not be evaluated here even
+  // if it did. The thing that keeps that honest is that it has nothing left to anchor a
+  // shader mutation on: every GLSL anchor that used to name it names `web/grade-shader.js`
+  // or a chunk now, and one that drifted back would be an anchor into a file with no shader
+  // in it.
   //
   // Nothing here needs a server, a browser or a package. `assembleShaders` is concatenation
   // over data handed in, and the manifests and chunks are files - which is the whole reason
   // the assembler was written import-free and pure.
-  const SPINE = 'web/cloud-shader.js';
+  const SPINES = { cloud: 'web/cloud-shader.js', grade: 'web/grade-shader.js' };
+  const SPINE_EXPORT = { cloud: 'cloudSpine', grade: 'gradeSpine' };
   const ASSEMBLER = 'web/shader-assembly.js';
+  const isSpine = (file) => Object.values(SPINES).includes(file);
   const isChunk = (file) => /^effects-builtin\/[^/]+\/[^/]+\.glsl$/.test(file);
-  const buildsTheProgram = (file) => file === SPINE || file === ASSEMBLER || isChunk(file);
+  const buildsTheProgram = (file) => isSpine(file) || file === ASSEMBLER || isChunk(file);
 
   const moduleOf = (source) => import(`data:text/javascript;base64,${Buffer.from(source, 'utf8').toString('base64')}`);
   // A string replacement rather than a pattern one: `String.replace` reads `$&` and its
@@ -1014,11 +1057,12 @@ const withoutStringBodies = (src) => {
 
   // **These three read through the substitution where the row above reads off disk**, and
   // the seam is the point rather than an inconsistency: what assembles is the question here,
-  // so a control that stages one of the three files has to reach this and must not reach the
+  // so a control that stages one of the four files has to reach this and must not reach the
   // anchor-existence row, where it would report its own anchor as stale.
-  let clean = null, spineSource = null, assemblerSource = null, basePackages = null;
+  let clean = null, spineSources = null, assemblerSource = null, basePackages = null;
   try {
-    spineSource = sourceWithMutation(SPINE);
+    spineSources = Object.fromEntries(Object.entries(SPINES)
+      .map(([name, file]) => [name, sourceWithMutation(file)]));
     assemblerSource = sourceWithMutation(ASSEMBLER);
     const builtin = join(ROOT, 'effects-builtin');
     // The manifests are read off disk even so: `manifest-does-not-parse` is the
@@ -1041,7 +1085,10 @@ const withoutStringBodies = (src) => {
   }
 
   const assembleStaged = async (staged = {}) => {
-    const { cloudSpine } = await moduleOf(staged.spine ?? spineSource);
+    const spines = {};
+    for (const [name, source] of Object.entries(spineSources)) {
+      spines[name] = (await moduleOf(staged.spines?.[name] ?? source))[SPINE_EXPORT[name]];
+    }
     const { assembleShaders } = await moduleOf(staged.assembler ?? assemblerSource);
     const packages = basePackages.map((p) => ({ ...p, chunks: { ...p.chunks } }));
     if (staged.chunk) {
@@ -1050,7 +1097,16 @@ const withoutStringBodies = (src) => {
       if (!pkg) throw new Error(`${staged.chunk.file} names an effect package this build does not ship`);
       pkg.chunks[name] = staged.chunk.text;
     }
-    return assembleShaders(cloudSpine, packages);
+    return assembleShaders(spines, packages);
+  };
+
+  // Every assembled string, flattened, so the count below is over the whole build rather
+  // than over whichever pair a file happens to belong to.
+  const everyProgram = (built) => Object.values(built)
+    .flatMap((p) => [p.vertexShader, p.fragmentShader]);
+  const sameProgram = (a, b) => {
+    const x = everyProgram(a), y = everyProgram(b);
+    return x.length === y.length && x.every((s, i) => s === y[i]);
   };
 
   if (basePackages) {
@@ -1135,26 +1191,27 @@ const withoutStringBodies = (src) => {
         if (!clean || !buildsTheProgram(file) || typeof to !== 'string') continue;
         programChecked++;
         if (file !== ASSEMBLER) {
-          const inProgram = (clean.vertexShader.split(from).length - 1)
-            + (clean.fragmentShader.split(from).length - 1);
+          const inProgram = everyProgram(clean)
+            .reduce((n, text) => n + text.split(from).length - 1, 0);
           if (inProgram !== 1) {
             miscounted++;
-            fail(`${name}/${mutation} anchors on text appearing ${inProgram} times in the assembled vertex and fragment programs, not once`
+            fail(`${name}/${mutation} anchors on text appearing ${inProgram} times in the assembled programs, not once`
               + ` - ${inProgram === 0 ? 'it matches its file and reaches no program, so the edit lands in text nothing compiles'
                 : 'the edit reaches one of those sites and the control would be recorded under the whole mutation\'s name'}`);
           }
         }
         // Staged against what assembles rather than against what `targetSource` read, so a
-        // running control that moved one of the three files is not silently reverted here
+        // running control that moved one of the four files is not silently reverted here
         // by an edit applied to the tree's own copy of it.
         const chunkOf = (rel) => {
           const [, id, chunk] = rel.split('/');
           return basePackages.find((p) => p.id === id)?.chunks[chunk] ?? '';
         };
+        const spineNamed = Object.entries(SPINES).find(([, path]) => path === file)?.[0];
         let after = null;
         try {
           after = await assembleStaged(
-            file === SPINE ? { spine: swap(spineSource, from, to) }
+            spineNamed ? { spines: { [spineNamed]: swap(spineSources[spineNamed], from, to) } }
               : file === ASSEMBLER ? { assembler: swap(assemblerSource, from, to) }
                 : { chunk: { file, text: swap(chunkOf(file), from, to) } },
           );
@@ -1162,9 +1219,9 @@ const withoutStringBodies = (src) => {
           dead++;
           fail(`${name}/${mutation} staged against ${file} and the programs would not assemble - ${String(err.message).split('\n')[0]}`);
         }
-        if (after && after.vertexShader === clean.vertexShader && after.fragmentShader === clean.fragmentShader) {
+        if (after && sameProgram(after, clean)) {
           dead++;
-          fail(`${name}/${mutation} edits ${file} and neither assembled program moves`
+          fail(`${name}/${mutation} edits ${file} and no assembled program moves`
             + ' - a slot carries a second copy of the shipped text, so an anchor can match its file exactly once'
             + ' and still sit in the copy nothing compiles');
         }
@@ -1198,7 +1255,7 @@ const withoutStringBodies = (src) => {
   }
 
   // The assembled-program half gets its own line rather than being folded into the one
-  // above, because it counts a different population - the anchors into the three files the
+  // above, because it counts a different population - the anchors into the four files the
   // shaders are built out of, which is a fraction of the whole - and a total covering both
   // would read as though every anchor had been asked the harder question.
   if (clean === null) {
@@ -1208,10 +1265,10 @@ const withoutStringBodies = (src) => {
     fail('no anchor was checked against the assembled shader programs, so that rule passed on nothing'
       + ' - either the mutations stopped naming the spine and the chunks, or this scan is looking in the wrong place');
   } else if (dead || miscounted) {
-    console.log(`  program/ ${programChecked} shader anchors checked against the assembled pair, `
+    console.log(`  program/ ${programChecked} shader anchors checked against the assembled programs, `
       + [dead && `${dead} reaching no program`, miscounted && `${miscounted} not appearing exactly once`].filter(Boolean).join(', '));
   } else {
-    console.log(`  program/ all ${programChecked} shader anchors appear once in the assembled pair and move it when applied`);
+    console.log(`  program/ all ${programChecked} shader anchors appear once across the assembled programs and move one when applied`);
   }
 }
 
@@ -1325,7 +1382,7 @@ console.log(`\n${total} JavaScript files, ${failed} failed`);
 // execute rather than parse**, and they are named rather than buried. The specification row
 // imports a copy of `server/protocol.js`, which is a module of constants with no imports of
 // its own, and reads its exported values; nothing is called and no behaviour is exercised.
-// The anchor row imports `web/cloud-shader.js` and `web/shader-assembly.js` the same way and
+// The anchor row imports the two spines and `web/shader-assembly.js` the same way and
 // does call one function - `assembleShaders`, which concatenates the strings it is handed
 // and touches nothing outside them. Both files import nothing, which is what lets their
 // bytes evaluate here at all. Everything else is `node --check` and nothing runs.

--- a/tools/timeline-check.mjs
+++ b/tools/timeline-check.mjs
@@ -270,7 +270,7 @@ const MUTATIONS = {
   // the accumulators hold over `cascade` is the wave moving through them, so a wave that
   // does not move leaves a pre-roll with nothing to warm. That is the same reading the note
   // above `CASCADE_LOOK` arrives at from the other side.
-  'rain-phase-unread': { file: 'web/cloud-shader.js', edits: [[
+  'rain-phase-unread': { file: 'effects-builtin/rain/cell.vert.glsl', edits: [[
     '    vRain = (rainPhase * rainSpeed + room.y) / rainSpan + hash(dot(wc.xz, vec2(269.5, 183.3)));',
     '    vRain = (0.0 * rainSpeed + room.y) / rainSpan + hash(dot(wc.xz, vec2(269.5, 183.3)));',
   ]] },
@@ -311,10 +311,30 @@ function mutatedSource() {
  * anything failing.
  */
 function servedAt(file) {
+  if (file.startsWith('effects-builtin/')) {
+    // The effects' own GLSL, which the page fetches out of `/effects/:id/file/:name` and
+    // `assembleShaders` splices into the cloud's material - so a mutation that edits a
+    // chunk is delivered at the fetch rather than at a module, which from Playwright's
+    // side is the same interception.
+    const parts = file.split('/');
+    if (parts.length !== 3) {
+      throw new Error(`${file} is not an effect package file - a chunk is <id>/<name> under effects-builtin/`);
+    }
+    return `/effects/${parts[1]}/file/${parts[2]}`;
+  }
   if (!file.startsWith('web/')) {
     throw new Error(`${file} is not served to a browser, so a page mutation cannot reach it`);
   }
   return `/${file.slice('web/'.length)}`;
+}
+
+/**
+ * What the server answers a file with, restated here because the interception has to
+ * answer the same way: a chunk is `text/plain` in `server/index.js`, on the argument that
+ * what the tools anchor and the client compiles is the file's own bytes.
+ */
+function contentTypeFor(file) {
+  return file.endsWith('.glsl') ? 'text/plain; charset=utf-8' : 'text/javascript; charset=utf-8';
 }
 
 // ------------------------------------------------------------------- playwright
@@ -547,7 +567,7 @@ if (MUTATE) {
   mutantPath = servedAt(file);
   await page.route((url) => url.pathname === mutantPath, (route) => {
     mutantServed++;
-    route.fulfill({ contentType: 'text/javascript; charset=utf-8', body });
+    route.fulfill({ contentType: contentTypeFor(file), body });
   });
   console.log(`[timeline] MUTATED BUILD: ${MUTATE} in ${file} at ${mutantPath} - this run is expected to FAIL`);
 }

--- a/tools/vcam-check.mjs
+++ b/tools/vcam-check.mjs
@@ -285,7 +285,13 @@ if (!existsSync(SOURCE)) {
 // behind any crash, which is the one state a proof tool must never produce.
 rmSync(WORK, { recursive: true, force: true });
 mkdirSync(WORK, { recursive: true });
-for (const dir of ['server', 'tools', 'web']) {
+// `effects-builtin` is in this list because the effect store refuses to BOOT without its
+// shipped root - deliberately, so a broken install cannot read as nothing-installed. A
+// staged tree without it is a server this tool can never start, and the run then reports
+// `DID NOT RUN` with no assertions at all rather than reddening a row, which is the shape
+// nobody reads. It is copied rather than symlinked like the trees beside it, so a mutation
+// naming a chunk under it could not reach the repo's own source.
+for (const dir of ['server', 'tools', 'web', 'effects-builtin']) {
   cpSync(join(REPO, dir), join(WORK, dir), { recursive: true });
 }
 for (const name of ['node_modules', 'vendor', 'captures']) {

--- a/web/cloud-shader.js
+++ b/web/cloud-shader.js
@@ -1,25 +1,53 @@
-// The two programs a depth sample is drawn by, as source text and nothing else.
+// The core of the two programs a depth sample is drawn by, and the joints the installed
+// effects are spliced into.
 //
-// There is no arithmetic here, nothing is constructed and nothing is imported: this file
-// is what the point cloud's material is compiled from, lifted whole out of `main.js` so
-// that nine hundred lines of GLSL stop sitting between the uniforms that feed them and
-// the hundred places that write those uniforms. Neither program interpolates anything -
-// there is no `${}` in either literal - so the text below is exactly what the driver is
-// handed, and it stays that way: a shader that needs a value from JavaScript takes it as
-// a uniform, which is the boundary the uniform block is for and the reason this could
-// move at all.
+// There is no arithmetic here, nothing is constructed and nothing is imported: what this
+// file exports is source text, in ordered segments, and `web/shader-assembly.js` joins
+// those segments to whatever the effect packages bring to produce the two strings three.js
+// is handed. Neither program interpolates anything - there is no `${}` in any segment -
+// so the text below is exactly what the driver is handed, and it stays that way: a shader
+// that needs a value from JavaScript takes it as a uniform, which is the boundary the
+// uniform block is for and the reason any of this could move at all.
 //
-// **What the move costs is the pairing, and it is worth naming here rather than being
-// discovered.** Every `uniform` declared below has to have a key in the `uniforms` object
-// in `main.js`, and nothing enforces that in either direction. A uniform with no key is
-// silent: three.js simply never writes it, the shader reads zero, and the look is subtly
-// wrong with nothing on the console. A key with no uniform is dead weight that costs a
-// slider's write on every frame it is animated. Measured across the split: 86 declared
-// here, 86 keys there, and the two sets are equal both ways. That equality is a fact
-// about today rather than something this file can hold, so a term added to one side
-// belongs in the same commit as the other.
+// **The text did not change when the joints arrived, and that is measured rather than
+// intended.** `test/shader-assembly.test.mjs` assembles this spine against the shipped
+// packages read off disk and asserts the two strings equal the two literals this file used
+// to hold, taken out of the last revision carrying them - so an edit here that moves a byte
+// is a red row naming which program moved, and a chunk file edited by one byte is the
+// control beside it. Until an effect actually differs from what the monolith drew, "the
+// look is unchanged" is a thing a check says rather than a thing a commit message claims.
+//
+// **A joint is one of four kinds, and `web/shader-assembly.js` carries what each is for.**
+// A `stage` takes any number of chunks in declared order, a `slot` takes one and carries
+// the text to use when nothing claims it, a `service` is a gate this file opens and the
+// consumers fill, and a `varyings` entry is generated from the packages' own declarations.
+// The comments below say why each joint is where it is, because a cut through a shader is
+// a claim about what belongs to an effect and what belongs to every point in the frame -
+// and the second class is the one that goes wrong quietly.
+//
+// **What the split costs is the pairing, and it is worth naming here rather than being
+// discovered.** Every `uniform` in the assembled programs has to have a key in the
+// `uniforms` object in `web/point-cloud.js`, and nothing enforces that in either
+// direction. A uniform with no key is silent: three.js simply never writes it, the shader
+// reads zero, and the look is subtly wrong with nothing on the console. A key with no
+// uniform is dead weight that costs a slider's write on every frame it is animated.
+// Measured across the split: 86 distinct uniforms in the assembled pair, 86 keys there,
+// and the two sets are equal both ways - 77 of them declared in the segments below and 9
+// in the glyph and rain packages' own declaration chunks. That equality is a fact about
+// today rather than something this file can hold, so a term added to one side belongs in
+// the same commit as the other, and `test/cloud-shader.test.mjs` asks it of the assembled
+// text rather than of this file, which is what keeps a uniform arriving in a package
+// inside the question.
 
-export const vertexShader = /* glsl */ `
+// Each entry frozen as well as the list, because the spine is read by two callers that
+// share one object - the page's material and the gate - and a segment somebody trimmed in
+// place would move the look of one and the verdict of the other in the same breath.
+const frozen = (entries) => Object.freeze(entries.map((e) => Object.freeze(e)));
+
+export const cloudSpine = Object.freeze({
+  vertex: frozen([
+    { text: /* glsl */ `\
+
 precision highp float;
 precision highp usampler2D;
 
@@ -41,23 +69,13 @@ uniform float pointSize, nearClip, farClip, time, edgeTol;
 uniform float cropL, cropR, cropB, cropT, cropOn, cropOutside;
 uniform float noise, noiseScale, noiseSpeed;
 uniform float lattice, latticeCell;
-// The glyph field's master, which this stage needs for one thing only - growing the
-// sprite into the cell the lattice already cut. Which character gets drawn is decided in
-// the fragment stage, because it keys on a luminance that does not exist until the colour
-// is built, so the other three weights are declared there and not here.
-uniform float glyph;
-// The rain, which is a colour term rather than a property of the alphabet and so has its
-// own four parameters. Three of them are read here because the scalar the whole thing
-// rests on is a function of world height, which only this stage knows; rainTrail shapes
-// the brightness and is read in the fragment stage beside the colour it lifts.
-uniform float rain, rainSpeed, rainSpan;
-// Program time again, and it is a second cell holding the same number rather than a reuse
-// of time on purpose. The rain has to be a pure function of program time or a seek lands
-// where playback never would, and the control that holds that claim -
-// timeline-check --mutate rain-accumulates - has to be able to integrate exactly one
-// line. Mutating time itself would redden the ripple, the glitch and the raster along
-// with it, and a control that fails everything cannot say which claim is load-bearing.
-uniform float rainPhase;
+` },
+    // The uniforms an effect declares for this stage, above the region's block because
+    // that is where the two that use it were written. A package adds its own `uniform`
+    // lines here and nothing else: a term that needs a value from the registry needs a
+    // cell to read it out of, and this is where the cell is named.
+    { stage: 'v.decl' },
+    { text: /* glsl */ `\
 uniform vec3 regionCentre, regionHalf;
 uniform float regionRound, regionSoft, regionPush, regionNoise, regionMask;
 uniform float ripple, rippleFreq, rippleSpeed;
@@ -78,8 +96,14 @@ out float vGhost;
 out float vFade;
 out float vMask;
 out float vSpeed;
-out float vCellSeed;
-out float vRain;
+` },
+    // The channels an effect carries to the fragment stage, declared from the packages'
+    // `varyings` rather than written out, so this `out` and the `in` far below cannot
+    // come apart. `vCellNorm` is deliberately not one of them: it is the energy
+    // compensation the lattice needs, it is written unconditionally below, and it belongs
+    // to every point in the frame rather than to any effect.
+    { varyings: 'out' },
+    { text: /* glsl */ `\
 out float vCellNorm;
 
 float depthAt(usampler2D tex, ivec2 p) {
@@ -210,8 +234,15 @@ void main() {
   // normalisation at one is a multiply that changes no alpha. That third one is written
   // unconditionally further down rather than under a gate, so what its initialisation
   // covers is the early returns alone.
-  vCellSeed = 0.0;
-  vRain = 0.0;
+` },
+    // The same declarations again as the value that makes each consumer inert, and this
+    // is the half that has to sit here rather than where the varyings are computed. There
+    // are three early returns above this line and a whole branch - the ghost - that never
+    // reaches the block below, so a varying only written on the live path is undefined
+    // everywhere else, and undefined in a shader is whatever the last invocation left in
+    // the register.
+    { varyings: 'init' },
+    { text: /* glsl */ `\
   vCellNorm = 1.0;
 
   if (aSlot > 0.5) {
@@ -397,25 +428,23 @@ void main() {
   // is exactly the sensor-to-levelled rotation and cannot come apart from the one the snap
   // uses. Gated on the two masters together because neither consumer exists below them and
   // the block is a mat3 multiply and two hashes on every point in the frame.
-  if (glyph > 0.0 || rain > 0.0) {
+` },
+    // Which cell of the room this point fell in, computed once for everything that keys
+    // on the lattice's own grid. The gate is generated from the `when` of every consumer
+    // rather than written out, which is the property that makes it right by construction:
+    // a build with neither consumer installed does not pay a mat3 multiply and two hashes
+    // on every point in the frame, and a build with one pays for one. The body is the
+    // room-space position and the cell index, because those are what "which cell" means
+    // and every consumer needs both.
+    {
+      service: 'cell',
+      indent: '  ',
+      body: /* glsl */ `\
     vec3 room = mat3(modelMatrix) * p0;
     vec3 wc = floor(room / latticeCell + 0.5);
-    vCellSeed = hash(dot(wc, vec3(127.1, 311.7, 74.7)));
-    // Counted in whole drops rather than wrapped into one, so that the fragment stage can
-    // read both halves of the same number off one varying: the fraction is how far above
-    // the last head this point sits, which is the brightness, and the integer is how many
-    // heads have already gone past it, which is the scramble. Wrapping here would throw
-    // the counter away and cost a second varying to get it back.
-    //
-    // Heads descend, so world height enters with the same sign program time does and a
-    // point standing still watches the coordinate climb. One head every rainSpan metres
-    // down each column rather than a single head wrapping over the whole room: a column
-    // always has two or three running, where one head spends half its cycle below the
-    // floor with the room dark behind it. The per-column offset is a hash of the cell's
-    // own x and z, so neighbouring columns are out of step and the room does not pulse as
-    // a single plane.
-    vRain = (rainPhase * rainSpeed + room.y) / rainSpan + hash(dot(wc.xz, vec2(269.5, 183.3)));
-  }
+`,
+    },
+    { text: /* glsl */ `\
 
   // Gated because it is the most expensive thing in this shader: eight hashes of three
   // sines each, against the six the old sine field cost. A look with no turbulence pays
@@ -583,35 +612,20 @@ void main() {
   // control off rather than move it.
   float dist = max(0.15, -mv.z);
   float cellPx = latticeCell * projectionMatrix[1][1] * 540.0 / dist;
-  // **The sprite grows into its cell as the master rises**, so one character stands for one
-  // cube of room, which is the whole reading the cube variant of this was chosen for. A
-  // 5.5cm cell a metre away is about 64 reference pixels where pointSize 9 is 9, so the
-  // two are nowhere near each other and something had to give; blending rather than
-  // switching is what keeps pointSize meaning something at every value in between.
-  //
-  // **The ceiling on the glyph branch is the hardware's and not the literal 64**, because a
-  // cell-sized sprite reaches 64 pixels at a metre and that is where a person stands. Past
-  // that the sprite would stop growing while the cell kept growing, so characters would
-  // stop filling their cells, the tiling would open up, and spriteWorld / cell would stop
-  // being 1 at full glyph - which is the property the energy compensation in the fragment
-  // stage rests on. The clamp is in framebuffer pixels, so that failure moves with output
-  // size: the same look that opens gaps at a metre on screen opens them at two metres in a
-  // 4K export, which is exactly the drift the 1080p reference unit exists to stop.
-  //
-  // **The old statement survives verbatim on the else branch, and that departs from the
-  // design document on purpose.** The document replaces the literal 64 outright. It is kept
-  // here because no shipped look reaches it - pointSize tops out at 9 across all nine, so
-  // 64 needs a subject 14cm from the sensor, nearer than a Kinect v2 will range - and
-  // because leaving the statement textually alone is what keeps the old path byte-identical
-  // across output sizes and keeps export-check's anchor alive. What the document is right
-  // about is the case it was written for, which is the grown sprite, and that case is the
-  // branch above.
-  if (glyph > 0.0) {
-    float base = clamp(pointSize * k / dist, 1.0, 64.0);
-    gl_PointSize = clamp(mix(base, cellPx * k, glyph), 1.0, pointCeiling);
-  } else {
-    gl_PointSize = clamp(pointSize * k / max(0.15, -mv.z), 1.0, 64.0);
-  }
+` },
+    // How big the sprite is drawn, and the one joint here that is a replacement rather
+    // than an addition: an effect that grows the sprite into something other than a point
+    // has to stand where the clamp stood, not beside it. The fallback is that clamp,
+    // exactly as it was written before anything claimed this - pixels at 1080p over the
+    // view distance, floored at one framebuffer pixel and ceilinged at the literal 64 -
+    // and the long argument for both bounds is in the comment above `dist`.
+    {
+      slot: 'v.pointSize',
+      fallback: /* glsl */ `\
+  gl_PointSize = clamp(pointSize * k / max(0.15, -mv.z), 1.0, 64.0);
+`,
+    },
+    { text: /* glsl */ `\
   // Carried in reference pixels rather than framebuffer ones, because the fragment
   // shader normalises a splat's additive energy against its area. For the same
   // image at twice the size each point covers four times the pixels, so it has to
@@ -699,9 +713,11 @@ void main() {
   // because brightness has to be invariant to output size where legibility cannot be.
   vLegiblePx = gl_PointSize / max(k, 1.0);
 }
-`;
+` },
+  ]),
+  fragment: frozen([
+    { text: /* glsl */ `\
 
-export const fragmentShader = /* glsl */ `
 precision highp float;
 
 uniform sampler2D colorPrev, colorCurr;
@@ -711,15 +727,13 @@ uniform float duotoneDepth, duotoneHue, duotoneSplit, duotoneSpan, duotoneMotion
 uniform float readRgb, readDepth, readGhost, readContour, readBlackwall;
 uniform float rgbSaturation, depthGamma, ghostRim, ghostFill;
 uniform float contourBands, contourLo, contourHi, blackwallSweep;
-// The glyph field's master and its three keys. The master is declared in both stages
-// because it does two things that belong at two stages - it grows the sprite up there and
-// it crossfades the mark here - and the three keys are here alone, because the character
-// index is decided beside the colour it reads.
-uniform float glyph, glyphTone, glyphHash, glyphRain;
-// The rain's brightness and the two lengths that shape it. The speed is not here: how fast
-// a head falls only enters through the scalar the vertex stage already computed, where the
-// world height it is a rate against lives.
-uniform float rain, rainSpan, rainTrail;
+` },
+    // The uniforms an effect declares for this stage. A term is declared in the stage
+    // that reads it and in both when both read it, which is why the glyph field's master
+    // appears here as well as in the vertex stage: it grows the sprite up there and
+    // crossfades the mark down here.
+    { stage: 'f.decl' },
+    { text: /* glsl */ `\
 uniform int hasColor, softEdge;
 
 in vec2 vUv;
@@ -732,116 +746,21 @@ in float vGhost;
 in float vFade;
 in float vMask;
 in float vSpeed;
-in float vCellSeed;
-in float vRain;
+` },
+    // The far end of the channels the vertex stage declared, from the same `varyings`
+    // entries, in the same order.
+    { varyings: 'in' },
+    { text: /* glsl */ `\
 in float vCellNorm;
 
 out vec4 fragColor;
 
-// The alphabet, as sixty-four 8x8 bitmasks held in the shader source.
-//
-// **There is no atlas, no texture and no fetch, and that is a decision about boot rather
-// than about memory.** This renderer loads no static image: every texture it binds is built
-// out of frame bytes in web/gpu-textures.js, so an atlas would be the first file the render
-// path ever went and got - a route on the server to serve it, a load order to get right, a
-// question about what the shader draws in the frames before it arrives, and the same
-// question again inside the headless browser tools/render-worker.mjs drives, where a missing
-// asset is a deliverable with no characters in it rather than a visible error. A table in
-// the source has none of those states, because it is there the moment the shader compiles.
-// The other thing it buys is that the alphabet is reviewable: a bitmask is a diff a person
-// can read, where an atlas is a binary nobody looks inside.
-//
-// 8x8 rather than the 5x6 the probe drew, and the size is the whole reason for it. 5x6
-// draws latin, digits and symbols and cannot draw kana, which would put the reference
-// look's own alphabet permanently out of reach. 8x8 is what the home computers of the
-// eighties drew kana at, so it is the smallest grid that keeps the option, and two
-// unsigned ints carry one character exactly.
-//
-// **Sorted by ink, sparsest first, which is what lets three keys share one table.** A
-// luminance ramp is ASCII art and only works if the index means ink, so that a bright cell
-// draws a dense character and a dark one draws a sparse one; a hash and a rain counter want
-// the index to mean nothing, because looking like noise is their whole job. Sorting by ink
-// dissolves that rather than resolving it - the tone key reads the table as tone and the
-// hash key reads the same table as noise, and both readings are true of it at once - so no
-// parameter has to choose between them, which matters because a chooser would be an enum
-// and this registry has refused those since the region's shape control, on the grounds that
-// an enum cannot keyframe and a slider can. What it costs is a latin tone ramp: a luminance
-// sweep now runs through kana, so the picture is ASCII art drawn in an alphabet that is not
-// ASCII.
-//
-// Packed with x holding rows 0 to 3 and y holding rows 4 to 7, row 0 at the top, and within
-// a word the bit at row * 8 + col with column 0 on the left. **Column 7 and row 7 are clear
-// in every one of the sixty-four**, and that is where the margin between neighbouring cells
-// comes from rather than from a parameter: an 8x8 character does not fill its own 8x8 box,
-// so cells tile while the marks inside them do not touch, which is how the reference frames
-// actually look - characters with dark between them rather than a solid wall of ink.
-const uvec2 GLYPHS[64] = uvec2[64](
-  uvec2(0x00080800u, 0x00000000u), // '  apostrophe  ink 2
-  uvec2(0x00000000u, 0x000c0c00u), // .  period  ink 4
-  uvec2(0x00141400u, 0x00000000u), // "  quote  ink 4
-  uvec2(0x04081000u, 0x00001008u), // <  less-than  ink 5
-  uvec2(0x10080400u, 0x00000408u), // >  greater-than  ink 5
-  uvec2(0x3e000000u, 0x00000000u), // -  hyphen  ink 5
-  uvec2(0x00000000u, 0x00060c0cu), // ,  comma  ink 6
-  uvec2(0x00000000u, 0x007f0000u), // _  underscore  ink 7
-  uvec2(0x08040201u, 0x00402010u), // \  backslash  ink 7
-  uvec2(0x08080808u, 0x00080808u), // |  vertical bar  ink 7
-  uvec2(0x08102040u, 0x00010204u), // /  slash  ink 7
-  uvec2(0x10204300u, 0x00000408u), // ン  katakana N  ink 7
-  uvec2(0x000c0c00u, 0x00000c0cu), // :  colon  ink 8
-  uvec2(0x0c081020u, 0x0008080au), // イ  katakana I  ink 9
-  uvec2(0x10204442u, 0x00020408u), // ソ  katakana SO  ink 9
-  uvec2(0x3e080800u, 0x00000808u), // +  plus  ink 9
-  uvec2(0x000c0c00u, 0x00060c0cu), // ;  semicolon  ink 10
-  uvec2(0x003e0000u, 0x0000003eu), // =  equals  ink 10
-  uvec2(0x08080c08u, 0x001c0808u), // 1  digit one  ink 10
-  uvec2(0x10204a0au, 0x00020408u), // ツ  katakana TSU  ink 10
-  uvec2(0x14240404u, 0x0004040cu), // ト  katakana TO  ink 10
-  uvec2(0x23400300u, 0x00060810u), // シ  katakana SHI  ink 10
-  uvec2(0x003c0000u, 0x00007f00u), // ニ  katakana NI  ink 11
-  uvec2(0x02020202u, 0x003e0202u), // L  latin L  ink 11
-  uvec2(0x0808081cu, 0x001c0808u), // I  latin I  ink 11
-  uvec2(0x0808083eu, 0x00080808u), // T  latin T  ink 11
-  uvec2(0x0810203eu, 0x00040404u), // 7  digit seven  ink 11
-  uvec2(0x1c2a0800u, 0x0000082au), // *  asterisk  ink 11
-  uvec2(0x10107f00u, 0x00081010u), // ナ  katakana NA  ink 12
-  uvec2(0x1020223eu, 0x00020408u), // ク  katakana KU  ink 12
-  uvec2(0x2020407eu, 0x00040810u), // フ  katakana FU  ink 12
-  uvec2(0x22222222u, 0x000c1020u), // リ  katakana RI  ink 12
-  uvec2(0x22420202u, 0x00060a12u), // レ  katakana RE  ink 12
-  uvec2(0x44242800u, 0x00414242u), // ハ  katakana HA  ink 12
-  uvec2(0x0202221cu, 0x001c2202u), // C  latin C  ink 13
-  uvec2(0x2040427eu, 0x00040810u), // ワ  katakana WA  ink 13
-  uvec2(0x20427e08u, 0x00040810u), // ウ  katakana U  ink 13
-  uvec2(0x040c1424u, 0x007c0404u), // ヒ  katakana HI  ink 14
-  uvec2(0x0c08103eu, 0x00402112u), // ス  katakana SU  ink 14
-  uvec2(0x1020221cu, 0x003e0408u), // 2  digit two  ink 14
-  uvec2(0x1810201eu, 0x001c2220u), // 3  digit three  ink 14
-  uvec2(0x1e02023eu, 0x00020202u), // F  latin F  ink 14
-  uvec2(0x20203e00u, 0x003e2020u), // コ  katakana KO  ink 14
-  uvec2(0x24247e00u, 0x00020c10u), // ア  katakana A  ink 14
-  uvec2(0x2c20223eu, 0x00040810u), // タ  katakana TA  ink 14
-  uvec2(0x0810203eu, 0x003e0204u), // Z  latin Z  ink 15
-  uvec2(0x087f003cu, 0x00040808u), // テ  katakana TE  ink 15
-  uvec2(0x0e10207fu, 0x00101008u), // マ  katakana MA  ink 15
-  uvec2(0x107f1212u, 0x00081010u), // サ  katakana SA  ink 15
-  uvec2(0x22242424u, 0x00612122u), // ル  katakana RU  ink 15
-  uvec2(0x22242830u, 0x0020203eu), // 4  digit four  ink 15
-  uvec2(0x08083e00u, 0x007f0808u), // エ  katakana E  ink 16
-  uvec2(0x207f003cu, 0x00060810u), // ラ  katakana RA  ink 16
-  uvec2(0x2222221cu, 0x001c2222u), // 0  digit zero  ink 16
-  uvec2(0x201e023eu, 0x001c2220u), // 5  digit five  ink 17
-  uvec2(0x3c22221cu, 0x001c2220u), // 9  digit nine  ink 17
-  uvec2(0x4244447cu, 0x00011922u), // カ  katakana KA  ink 17
-  uvec2(0x18107f10u, 0x00191214u), // オ  katakana O  ink 18
-  uvec2(0x1e02023eu, 0x003e0202u), // E  latin E  ink 18
-  uvec2(0x2a2a3622u, 0x00222222u), // M  latin M  ink 18
-  uvec2(0x3c20203eu, 0x003e2020u), // ヨ  katakana YO  ink 18
-  uvec2(0x7f107f10u, 0x00040808u), // キ  katakana KI  ink 19
-  uvec2(0x1c087f08u, 0x00084936u), // ホ  katakana HO  ink 20
-  uvec2(0x2222223eu, 0x003e2222u)  // ロ  katakana RO  ink 20
-);
-
+` },
+    // Whatever an effect needs at file scope: a table, a helper, a constant array. Above
+    // the ramps rather than below them because a helper has to be declared before the
+    // function that calls it in GLSL, and `main` is at the bottom.
+    { stage: 'f.helpers' },
+    { text: /* glsl */ `\
 // Black through red and orange to white, the palette a thermal camera writes rather
 // than the cool-to-warm one depthRamp uses - the two are deliberately different, so
 // that thermal on top of Depth mode is a second reading and not the same one twice.
@@ -893,52 +812,29 @@ void main() {
   vec2 d = gl_PointCoord - 0.5;
   float r2 = dot(d, d);
 
-  // How much of the mark is a character rather than a round splat, worked out here
-  // because the discard below has to know about it and finished a long way down, where the
-  // luminance the character index keys on finally exists.
-  //
-  // **The distance term multiplies into the master rather than clamping the sprite**, and
-  // that is what protects the recession. A cell four metres from the sensor projects to
-  // about six pixels, and an 8x8 bitmask sampled across six pixels is not a small
-  // character - it is a different random set of bits every time the camera moves, which
-  // bloom then amplifies. Clamping the sprite to a legible minimum would keep every cell
-  // readable at any range, but far cells would stop being cell-sized and start
-  // overlapping, which collapses the perspective recession at depth into exactly the flat
-  // screen grid this design was chosen over. So the mark stops trying to be legible and
-  // the geometry never stops being true, and it does it by reusing the blend the master
-  // already is rather than adding a mechanism that could go out of step with it.
-  //
-  // The two ends are the font's own sampling limits: at 8 the 8x8 grid gets one pixel per
-  // font cell, which is where the bits start aliasing into speckle, and at 16 it gets two
-  // and the character resolves. The design document says the fallback is somewhere below
-  // about ten pixels, which is inside this band rather than at either end of it.
-  //
-  // **What the two numbers are pixels *of* is the whole of what the vertex stage works out
-  // above**, and it is neither of this renderer's two existing references on its own. Below
-  // 1080 they are framebuffer pixels, because aliasing is a fact about the samples that
-  // exist and a mark cannot resolve on texels it does not have. At and above 1080 they are
-  // reference pixels, because the boundary between text and texture is a property of the
-  // look and a 4K export has to draw the same picture the grade was made on. The band is
-  // therefore stated once and read against whichever limit is nearer.
-  float glyphMix = glyph * smoothstep(8.0, 16.0, vLegiblePx);
-
+` },
+    // What shape the mark is, which is a replacement for the same reason the point size
+    // is: an effect drawing something other than a round splat needs the disc test to
+    // stop cutting its corners, and a second test beside the first would be two answers
+    // to one question. The fallback is the pair that stood here before anything claimed
+    // it - the discard on the hard-edged branch, then the falloff - and it is the text
+    // that shipped rather than a reconstruction of it.
+    {
+      slot: 'f.mark',
+      fallback: /* glsl */ `\
   // Additive mode shapes the sprite purely with alpha falloff. Skipping the
   // discard keeps Apple's tile-based hidden-surface removal working.
-  //
-  // **The disc the hard-edged branch cuts would take the corners off a character**, so it
-  // is asked about the glyph first. At a glyphMix of exactly zero - which is every value of
-  // every look that does not draw characters, because the master multiplies - the condition
-  // collapses to the test that has always been here and the executed path is literally the
-  // old one, discard and then smoothstep. Above zero the sprite keeps its corners, and what
-  // shapes it is the bitmask rather than the disc.
   float falloff;
   if (softEdge == 1) {
     falloff = exp(-r2 * 9.0);
   } else {
-    if (glyphMix <= 0.0 && r2 > 0.25) discard;
+    if (r2 > 0.25) discard;
     falloff = smoothstep(0.25, 0.02, r2);
   }
 
+`,
+    },
+    { text: /* glsl */ `\
   float t = clamp((vDepth - nearClip) / max(0.001, farClip - nearClip), 0.0, 1.0);
   vec3 rgb = hasColor == 1
     ? mix(texture(colorPrev, vUv).rgb, texture(colorCurr, vUv).rgb, mixT)
@@ -1274,92 +1170,19 @@ void main() {
   // than reasoning about what a branch did to the contractions around it.
   col += vec3(0.2, 0.9, 1.0) * vGlitch;
 
-  // **The rain, which is a colour term rather than a property of the alphabet.** It sits
-  // here for the reason thermal, the edges and the duotone above it do - a term written
-  // into one reading is inert in every other one - and it is a term of its own rather than
-  // a setting inside the glyph field because the brightness *is* the effect. What the
-  // reference clips show carrying the picture is a drop head descending a column with a
-  // trail of afterglow above it; scrambling on its own is invisible, since which character
-  // a cell draws is noise either way. Filed inside the glyph field, a wave descending
-  // through the room would have been unreachable for any look that was not drawing text -
-  // including voxel, which now gets it for nothing.
-  //
-  // It is below the flare rather than above it so that the line the flare's own comment
-  // measured keeps the neighbours it was measured beside, and because a torn band is
-  // emitted light: the rain lifts what the cell actually draws, flare included, and the
-  // tone key one block down reads the same colour the frame gets.
-  //
-  // vRain counts whole drops, so its fraction is how far above the last head this point
-  // stands as a share of the span, and the trail arrives in metres and is converted into
-  // that same share. **The trail sits above the head and not below it**, which is what
-  // makes the wave read as falling rather than as a band sliding through: the lift is 1 at
-  // the head and decays upward over rainTrail metres, and a point just under a head is a
-  // whole span below the next one and so is dark.
-  //
-  // Unconditional and written straight through, on the flare's own measurement above: at a
-  // rain of 0 the multiplier is exactly 1.0 whether or not the compiler contracts it, where
-  // a branch dropped into this path costs contractions across the lines either side of it.
-  float rainLift = 1.0 - smoothstep(0.0, rainTrail / rainSpan, fract(vRain));
-  col *= 1.0 + rain * rainLift;
-
-  // **Which character this cell draws.** Decided here rather than in the vertex stage
-  // because one of the three keys does not exist up there: the tone key is the luminance of
-  // the colour the cell is about to draw, which is the line above this one. Nothing is lost
-  // by the move - the cell seed and the rain coordinate are both constant across a sprite,
-  // so the character is too.
-  //
-  // **The three keys add and wrap rather than mixing the way the five readings do**, and
-  // the difference is forced rather than stylistic: character indices do not average.
-  // Character 3 blended half and half with character 9 is character 6, which is an
-  // unrelated symbol rather than anything between the two. A sum wrapped into the table is
-  // the only composition that leaves each weight meaning how far it moves the character,
-  // and it keeps the property the readings have, that a weight at zero contributes exactly
-  // nothing.
-  //
-  // **The tone key is scaled by 63/64 where the other two keep the pure wrap**, and that
-  // departs from the design document, which writes all three the same. Luminance is the one
-  // key with a direction: the table is sorted by ink, so a tone ramp is only a ramp if full
-  // luminance lands on the densest character. Unscaled it lands on fract(1.0), which is 0
-  // and therefore the sparsest, so the brightest point in the picture would draw an
-  // apostrophe and the top of the ramp would read as a hole in it. The hash and the rain
-  // are not scaled, because wrapping is exactly what makes them look like noise.
-  //
-  // The luminance is clamped for the same reason the scaling exists. col can leave the unit
-  // interval - the readings sum, the flare adds, and a duotone pole is hot - and an
-  // unclamped tone term would carry the top of the ramp round to the sparse end again.
-  //
-  // The rain key reads whole heads gone past rather than the continuous coordinate, because
-  // a character index that blends is a character nobody wrote. It is multiplied by the
-  // golden ratio rather than used raw, and that is not decoration: at a weight of 1 an
-  // integer counter contributes exactly nothing, since the fract of a whole number is zero,
-  // so the one setting where the key should be strongest is the one where it would be
-  // inert. An irrational step walks the table without repeating, which is what a scramble
-  // has to do.
-  if (glyphMix > 0.0) {
-    float lum = clamp(dot(col, vec3(0.299, 0.587, 0.114)), 0.0, 1.0);
-    float rainStep = floor(vRain) * 0.6180339887498949;
-    float f = fract(glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);
-    // Guarded rather than trusted. fract is below 1 by definition, but a value arriving at
-    // exactly 1.0 through a rounding would index one past the end of the table, and reading
-    // a constant array out of range in GLSL is undefined rather than an error - so the one
-    // way this could go wrong is also the way nothing would report it.
-    int idx = min(int(f * 64.0), 63);
-    uvec2 g = GLYPHS[idx];
-    // gl_PointCoord runs from the sprite's upper left, which is where row 0 and column 0 of
-    // the bitmask are, so the two grids line up without a flip anywhere. Sampled across the
-    // whole 8x8 box rather than across the ink: the clear eighth row and column are the
-    // margin, and cropping to the ink would be a parameter for something the font already
-    // says.
-    uint gc = uint(clamp(gl_PointCoord.x * 8.0, 0.0, 7.0));
-    uint gr = uint(clamp(gl_PointCoord.y * 8.0, 0.0, 7.0));
-    uint bits = gr < 4u ? g.x >> (gr * 8u + gc) : g.y >> ((gr - 4u) * 8u + gc);
-    // A hard cut rather than an antialiased one, and the crossfade above is why it can be.
-    // The mark is already blending back toward the round falloff wherever it is too small
-    // to resolve, so softening the bits as well would be a second legibility mechanism
-    // doing the first one's job - and the two would then have to be kept in step.
-    falloff = mix(falloff, (bits & 1u) == 1u ? 1.0 : 0.0, glyphMix);
-  }
-
+` },
+    // A term over the colour the readings produced, after the blend and after the flare.
+    // It is a stage rather than a slot because these compose: a term written into one
+    // reading is inert in every other one, which is the argument the thermal, the edges
+    // and the duotone above it are all arranged by, and two effects lifting the same
+    // colour is two multiplies rather than a conflict.
+    { stage: 'f.tone' },
+    // What the mark actually draws, if it draws something other than the falloff. It
+    // reads the colour above it, which is why it is here and not at either end: the one
+    // key that cannot be decided in the vertex stage is the luminance of the colour this
+    // cell is about to draw, and that does not exist until the line above.
+    { slot: 'f.glyph', fallback: '' },
+    { text: /* glsl */ `\
   // Cross-fade. A dying point thins out where it stood instead of blinking off,
   // and its replacement comes up over the same window.
   alpha *= vFade;
@@ -1452,4 +1275,6 @@ void main() {
   if (softEdge == 0 && alpha * falloff <= 0.0) discard;
   fragColor = vec4(col * exposure, alpha * falloff);
 }
-`;
+` },
+  ]),
+});

--- a/web/cloud-shader.js
+++ b/web/cloud-shader.js
@@ -19,8 +19,9 @@
 //
 // **A joint is one of four kinds, and `web/shader-assembly.js` carries what each is for.**
 // A `stage` takes any number of chunks in declared order, a `slot` takes one and carries
-// the text to use when nothing claims it, a `service` is a gate this file opens and the
-// consumers fill, and a `varyings` entry is generated from the packages' own declarations.
+// the text to use when nothing claims it, a `service` is a value this file computes under a
+// gate its consumers generate - filling it is `cell`'s arrangement and not `region`'s - and a
+// `varyings` entry is generated from the packages' own declarations.
 // The comments below say why each joint is where it is, because a cut through a shader is
 // a claim about what belongs to an effect and what belongs to every point in the frame -
 // and the second class is the one that goes wrong quietly.
@@ -405,9 +406,32 @@ void main() {
   // The operators are not uniform on purpose: regionNoise and ripple cannot go negative
   // and are tested against zero, where regionPush and regionMask run from -1 and would be
   // switched off across half their travel by the same test.
-  float rw = (regionPush != 0.0 || regionNoise > 0.0 || regionMask != 0.0 || ripple > 0.0)
+` },
+    // The region weight, computed once for everything that reads it, under a gate that is
+    // the four consumers' own `when` clauses rather than a list kept here. The comment
+    // above is the one the monolith carried and it is left exactly as it was, because the
+    // property it insists on - that a term reading this weight without joining the gate is
+    // inert rather than broken - is now true by construction instead of by attention: a
+    // package that consumes this service gets its term, and one that forgets to consume it
+    // has no chunk in the program either.
+    //
+    // **This one closes nothing, which is the whole difference from `cell` below.** `rw` is
+    // a value at the surrounding scope and the four displacements that read it sit in the
+    // stage and the slot underneath, so there is no block for a consumer's chunk to go
+    // inside - the gate is a conditional expression and its consumers are placed by name.
+    // The operators are the consumers' own and are deliberately not uniform, for the reason
+    // the comment above gives: two of the four run from -1.
+    {
+      service: 'region',
+      open: '  float rw = (',
+      body: /* glsl */ `\
+)
     ? regionWeight(p0)
     : 0.0;
+`,
+      close: '',
+    },
+    { text: /* glsl */ `\
 
   // Which cell of the room this point belongs to, and where it stands in the falling
   // pattern. Both are read at the *undisplaced* position for the reason the region above
@@ -440,87 +464,63 @@ void main() {
     // and every consumer needs both.
     {
       service: 'cell',
-      indent: '  ',
+      open: '  if (',
       body: /* glsl */ `\
+) {
     vec3 room = mat3(modelMatrix) * p0;
     vec3 wc = floor(room / latticeCell + 0.5);
 `,
+      close: '  }\n',
     },
-    { text: /* glsl */ `\
+    // The blank line between the cell's block and the displacement run belongs to neither,
+    // which is why it is a segment of its own rather than the tail of one joint or the head
+    // of the next. Written into the cell's `close` it would vanish with the glyph field;
+    // written into the turbulence chunk it would arrive a second time behind the push.
+    { text: '\n' },
+    // The displacements the region weight drives, in the order the file held them:
+    // turbulence, then the push, then the ripple. **Two displacement stages and not one,
+    // and the split is forced by the text rather than chosen.** The soft mask writes a
+    // varying in the middle of this run - it is a slot, because a build without the mask
+    // package still has to carry the crop's own dimming - and a joint standing between two
+    // chunks of one stage would have to be spliced into the middle of it, which is exactly
+    // what a stage cannot do. So the run above the mask and the run below it are two
+    // joints, and each one's chunks are ordered inside it.
+    { stage: 'v.regionDisplace' },
+    // How much of this point the region hides, which is a replacement rather than an
+    // addition: the mask and the crop's dimming are one multiply on one varying, so a
+    // package adding to it beside the core would be a second spelling of "how much is this
+    // point attenuated" and the two would have to be multiplied together somewhere anyway.
+    //
+    // **The only fallback in this file carrying text no build has ever drawn**, and it is
+    // worth saying out loud rather than leaving to be discovered. The other two that carry
+    // text at all - `v.pointSize` and `f.mark` - are the shipped statements exactly as they
+    // stood before anything claimed them, so an anchor into either is at worst in the wrong
+    // one of two live copies. This one has no original: the crop's dimming has shared its
+    // statement with the region mask since both existed, so the mask-less form is written
+    // here for the first time. What settles it is that vMask is written on every live path
+    // and read unconditionally down in the fragment stage, so an uninstalled mask has to
+    // leave a write here and the crop's half is the part belonging to every point in the
+    // frame - asserted by assembling the shipped set with the mask dropped, where `rw` has
+    // no reader left and this is the one write vMask gets.
+    {
+      slot: 'v.mask',
+      fallback: /* glsl */ `\
+  vMask = outsideCrop ? cropOutside : 1.0;
 
-  // Gated because it is the most expensive thing in this shader: eight hashes of three
-  // sines each, against the six the old sine field cost. A look with no turbulence pays
-  // none of it, which is the same bargain the ghost half of the geometry makes.
-  float amp = noise + regionNoise * rw;
-  if (amp > 0.0) {
-    pos += amp * vnoise3(p0 * noiseScale + time * noiseSpeed * vec3(0.7, 1.13, 0.31));
-  }
-
-  // Radial rather than along the field's gradient. The gradient of a rounded box is
-  // degenerate at the centre - there is no outward direction there - and flattens
-  // against the faces, where a radial push is defined everywhere and reads as a blob
-  // swelling. The guard is for the point that lands exactly on the centre, where
-  // normalize would hand back NaN and take the whole vertex with it.
-  if (regionPush != 0.0 && rw > 0.0) {
-    vec3 away = p0 - regionCentre;
-    float d = length(away);
-    if (d > 1e-4) pos += (away / d) * regionPush * rw;
-  }
-
-  // The region read a fourth way: a wave travelling out along the radius, so the volume
-  // breathes where the push only swells it. It shares the push's radial direction and its
-  // centre guard for the same reasons - the gradient of a rounded box is degenerate at the
-  // centre, and normalize there would hand back NaN and take the vertex with it.
-  //
-  // **The clock is stepped rather than continuous, which is the whole character of it.**
-  // A sine of raw time is a thing breathing; this design wants a thing being rebuilt by a
-  // machine, so the phase advances in eighth-cycles and the surface arrives at each one
-  // rather than sliding between them. Eight steps and not a parameter: the count is what
-  // makes it read as machinery, and a slider that could set it to a thousand would just
-  // be a way to author the smooth version this is deliberately not.
-  //
-  // The step is on the clock alone and not on the radius, so the wave is quantised in
-  // time and smooth in space. Quantising both would put the region on a set of shells,
-  // which is the lattice's job two blocks down and would be a second way to do it.
-  if (ripple > 0.0 && rw > 0.0) {
-    vec3 out0 = p0 - regionCentre;
-    float dist = length(out0);
-    if (dist > 1e-4) {
-      float cycles = dist * rippleFreq - floor(time * rippleSpeed * 8.0) * 0.125;
-      pos += (out0 / dist) * (sin(cycles * 6.2831853) * ripple * rw);
-    }
-  }
-
-  // Positive hides what is inside the region, negative what is outside. Carried to the
-  // fragment stage rather than culled here, because the whole point of the falloff is
-  // that the edge is soft.
-  //
-  // The crop's own dimming rides here rather than on a varying of its own, and it is
-  // the same idea rather than a similar one: both are a boundary the vertex stage knows
-  // about attenuating a fragment it cannot discard. A second varying would be a second
-  // spelling of "how much is this point attenuated", and the two would then have to be
-  // multiplied together somewhere anyway.
-  vMask = (regionMask > 0.0
-    ? 1.0 - regionMask * rw
-    : 1.0 + regionMask * (1.0 - rw))
-    * (outsideCrop ? cropOutside : 1.0);
-
-` },
-    // The displacements an effect adds to the running position, after the turbulence, the
-    // push and the ripple that the region's own uniforms drive. A stage rather than a slot
-    // because these compose and their order is the whole of what they mean: the tear shoves
-    // a band of the feed sideways and the lattice quantises wherever the point ends up, so
-    // running them the other way round would snap a position the tear then walks off the
-    // grid. The order is declared in each package rather than left to whichever the server
-    // lists first, which is what makes "the order the file held them in" a fact rather than
-    // an accident of a directory listing.
+`,
+    },
+    // The displacements an effect adds after the mask has read the region weight. A stage
+    // rather than a slot because these compose and their order is the whole of what they
+    // mean: the tear shoves a band of the feed sideways and the lattice quantises wherever
+    // the point ends up, so running them the other way round would snap a position the tear
+    // then walks off the grid. The order is declared in each package rather than left to
+    // whichever the server lists first, which is what makes "the order the file held them
+    // in" a fact rather than an accident of a directory listing.
     //
     // **A stage appends its chunks after whatever core text is left above it, so only the
-    // tail of a run can move.** The turbulence, the push and the ripple are all still core
-    // and still above this line, along with the soft mask that shares their region weight;
-    // when they move out, this joint moves up with them and their orders sit below the two
-    // here. That is a property of the joint rather than a plan - a chunk cannot be spliced
-    // into the middle of a segment, so a cut through a run is always a cut at its end.
+    // tail of a run can move.** That is what kept the turbulence, the push and the ripple
+    // core while the tear and the snap moved out, and it is why they needed a joint of
+    // their own to leave through rather than orders below these two.
     { stage: 'v.displace' },
     { text: /* glsl */ `\
   vUv = (position.xy + 0.5) / resolution;

--- a/web/cloud-shader.js
+++ b/web/cloud-shader.js
@@ -922,139 +922,28 @@ void main() {
   // and would otherwise be recorded as a parameter that cannot touch a pixel. That
   // argument is what the readings above have now been rebuilt around, so the rule it
   // states applies to the readings themselves: registry-check sweeps each of them.
-  if (thermal > 0.0) {
-    // Luminance where there is a colour camera, depth where there is not. A thermal
-    // picture is a reading of a signal, and with the colour stream off the only signal
-    // left is range - falling back to a flat tint instead would be a slider that
-    // appears to work and is showing nothing.
-    float lum = dot(rgb, vec3(0.299, 0.587, 0.114));
-    float heat = hasColor == 1 ? lum : 1.0 - t;
-    col = mix(col, heatRamp(clamp(heat, 0.0, 1.0)), thermal);
-  }
-
-  if (edges > 0.0) {
-    // vEdge is the neighbour spread the vertex stage already computed for the
-    // speckle test, so an edge-only reading costs a mix rather than a second pass.
-    float e = pow(vEdge, 0.6);
-    col = mix(col, mix(vec3(0.02, 0.03, 0.05), vec3(0.82, 0.94, 1.0), e), edges);
-    alpha *= mix(1.0, 0.05 + 0.95 * e, edges);
-  }
-
-  // The duotone, and it is the governing tonal transform rather than a tint over one:
-  // the near pole runs toward black and the far pole toward hot, so a single term
-  // produces both the depth-keyed palette and the near-black silhouette against a
-  // burning core. The note beside the uniforms has why those are one parameter.
-  //
-  // It sits here, after the blend, for the reason thermal and edges above it do - a term
-  // written into one reading is inert in every other, and is then exercised only by
-  // whichever sweep arm happens to select that reading. And it sits *before* the glitch
-  // flare below rather than after it, which is a decision rather than an ordering
-  // accident: a torn band is emitted light, so it belongs on top of the tonal transform
-  // and not underneath one that would crush it back toward black.
-  //
-  // Read off t, the point's position inside the near/far clip range, so the split is a
-  // place in the room the way the crop faces are and not a fraction of a frame. The split
-  // is where the two poles meet and moving it decides which half of the room the subject
-  // falls in.
-  //
-  // **How wide the ramp is either side of that is a distance rather than a share of the
-  // box**, which is what duotoneSpan buys and why the division below exists. t is already
-  // normalised by the clip range, so a ramp stated in t is a ramp whose metres change
-  // every time a crop face moves - the grade would follow the framing, and shutting the
-  // far plane to steepen the toning would be the only way to steepen it. Dividing the span
-  // by the range converts metres back into t's units at the width the look asked for, and
-  // the long note beside the uniform carries what that was measured to cost.
-  //
-  // Guarded, and the shape was measured rather than chosen. Both shapes are arithmetically
-  // clean here, which is not obvious and is worth writing down: a mix at zero is a plus
-  // zero times b minus a, which is exact whether or not the compiler contracts it, where
-  // the mix at one this file guards elsewhere is the one that is not. So the question was
-  // never the identity but what a branch does to the contractions either side of it, which
-  // the flare below records going the surprising way. Measured here, guarded, against the
-  // pinned pre-registry build: readRgb, readDepth, readContour and readBlackwall all came
-  // back bit-identical over six frames, and readGhost reproduced its own pre-existing
-  // failure unchanged - the same two frames, 2 and 3, and the same pair of hashes
-  // 55d01311394e against 36fb79d8fa45. That last part was the half that mattered, because
-  // a row already red is where a new perturbation would hide.
-  //
-  // **That standing failure has since been measured and it was never this file's.** The
-  // two frames differed by one byte of 1,024,000, by exactly 1 - one channel of one
-  // fragment landing the other side of a rounding boundary between two independently
-  // compiled builds, which is the same contraction effect the flare below records rather
-  // than a term. registry-check's section 1b compares pictures now, with the threshold
-  // derived from that noise at one end and from ghost-alpha-term-dropped at the other,
-  // no backticks in this comment on purpose - it sits inside the GLSL template literal,
-  // and one here ends the shader. That is the seventh time in this repo,
-  // which moves 187k bytes by 47. So the row is green at baseline and a re-measurement
-  // like this one no longer has to reason around a red row while doing it.
-  if (duotoneDepth > 0.0) {
-    vec3 cold = hueSpin(vec3(0.020, 0.030, 0.075), duotoneHue);
-    vec3 heat = hueSpin(vec3(1.000, 0.380, 0.120), duotoneHue);
-    float w = duotoneSpan / max(0.001, farClip - nearClip);
-    float k = smoothstep(duotoneSplit - w * 0.5, duotoneSplit + w * 0.5, t);
-    // The motion half of the same transform, and it is the same two poles rather than a
-    // second palette laid over them: depth decides where the room falls between cold and
-    // hot, and this pushes whatever is moving through the room toward the hot end of it.
-    // That is the reading the depth key on its own cannot draw - a subject and the wall
-    // behind it are graded by where they stand, so a person walking through a scene is
-    // exactly as cold as the air they walk through until something keys on the walking.
-    //
-    // Toward 1 rather than added to k, so a point at the hot end cannot be pushed past
-    // it and the term has its room where the picture is near-black, which is where a
-    // subject usually is. The far half of the room is already hot and has nothing to
-    // gain, which is right: motion is only news against the pole it is not at.
-    //
-    // **1200 mm/s is the speed at which a point reaches the pole**, and it is baked for
-    // the reason the two poles themselves are - a look parameterises how much of a ramp
-    // it wants, not the ramp. It is about the axial speed of somebody walking straight
-    // at the sensor at an ordinary pace, so the pole belongs to a person crossing the
-    // room rather than to a hand. Measured over the sample capture: the 99th percentile
-    // of a nearly-static stretch is 430 mm/s and the fastest sample in five pairs is
-    // about 1900, while a take with somebody moving through it runs a median of 286 and
-    // a 90th percentile of 1082.
-    //
-    // **The sensor's jitter is a displacement rather than a speed, so what it reads as
-    // here depends on how fast the frames arrive**, and that is worth knowing before
-    // trusting any threshold in these units. Measured on the same capture at two
-    // spacings: the median sample moves about 4mm whichever pair you take, which is 31
-    // mm/s across the 128ms pairs registry-check pins and about 140 mm/s across the
-    // capture's own 32ms ones. Real movement is a fixed speed and reads the same at both,
-    // so this estimator gets noisier as the link gets faster - which is a property of
-    // measuring a rate from two adjacent samples and not something a constant fixes.
-    //
-    // No floor under it, and that is measured rather than assumed. A smoothstep has zero
-    // derivative at the origin, which is most of the suppression on its own: on a wall
-    // planted flat at 1100mm with this amount at 1 and the depth at 1, driven through the
-    // editor at 1280 wide rather than through the check's own stage, mean red over the
-    // frame goes 7.83 still, 7.90 with 4mm of jitter across a 128ms pair, 8.76 with the
-    // same 4mm across a 32ms one, and 22.84 at a real 600 mm/s. So even at the frame rate
-    // where the jitter
-    // reads loudest it costs about one 8-bit step against fifteen for the signal. A floor
-    // would have to be stated in one unit or the other and neither is right at both
-    // spacings - in mm/s it would need re-tuning per link, which is what dividing by the
-    // span exists to stop, and in millimetres it would let a slow surface register over a
-    // slow link and vanish over a fast one.
-    //
-    // A duotoneMotion of 0 is exactly the picture this block drew before the term
-    // existed. mix at zero is x times one plus y times zero, or x plus zero times the
-    // difference, and both are exact whether or not the compiler contracts them - which
-    // is the same arithmetic the guard comment above this block records measuring, and
-    // it is measured again rather than inherited: the comparison is in registry-check's
-    // planted-motion section, where a frame with a fast point in it and a frame with a
-    // still one have to come back bit-identical while this sits at its default.
-    k = mix(k, 1.0, duotoneMotion * smoothstep(0.0, 1200.0, vSpeed));
-    col = mix(col, mix(cold, heat, k), duotoneDepth);
-  }
-
 ` },
     // A term over the colour the readings produced, after the blend. It is a stage rather
     // than a slot because these compose: a term written into one reading is inert in every
-    // other one, which is the argument the thermal, the edges and the duotone above it are
-    // all arranged by, and two effects lifting the same colour is two multiplies rather than
-    // a conflict. The glitch's flare is the first of them and the rain's lift is the second,
-    // in the order the file held them - the rain's own chunk carries why it sits below the
-    // flare, and it is so that the line the flare's measurement was taken beside keeps the
-    // neighbours it was measured with.
+    // other one, which is the argument every term here is arranged by, and two effects
+    // lifting the same colour is two multiplies rather than a conflict. The GLSL comment
+    // immediately above states that argument for the reader of the assembled shader, and it
+    // stays in the spine rather than travelling with the first chunk because it is the
+    // stage's own reason: a build with no tone effect installed still has the run, and the
+    // sentence explaining why terms belong here would otherwise vanish with the last
+    // package that happened to carry it.
+    //
+    // **The whole run is generated now.** Five packages fill it, in the order the file held
+    // them and numbered with room between: the thermal at 100, the edges at 200, the duotone
+    // at 300, the glitch's flare at 400 and the rain's lift at 500. Each chunk carries why
+    // it sits where it does - the rain's says why it is below the flare, so that the line
+    // the flare's measurement was taken beside keeps the neighbours it was measured with.
+    //
+    // Those five are also the first stage in this build whose declared order disagrees with
+    // the order the packages arrive in, which `test/shader-assembly.test.mjs` records: the
+    // directory hands them over as duotone, edges, glitch, rain, thermal, so a build that
+    // lost the sort would draw a visibly different frame here rather than the identical one
+    // every other stage would still draw.
     { stage: 'f.tone' },
     // What the mark actually draws, if it draws something other than the falloff. It
     // reads the colour above it, which is why it is here and not at either end: the one

--- a/web/cloud-shader.js
+++ b/web/cloud-shader.js
@@ -99,9 +99,11 @@ out float vSpeed;
 ` },
     // The channels an effect carries to the fragment stage, declared from the packages'
     // `varyings` rather than written out, so this `out` and the `in` far below cannot
-    // come apart. `vCellNorm` is deliberately not one of them: it is the energy
-    // compensation the lattice needs, it is written unconditionally below, and it belongs
-    // to every point in the frame rather than to any effect.
+    // come apart. `vCellNorm` is deliberately not one of them: the fragment stage multiplies
+    // every additive splat's alpha by it whatever is installed, so the declaration and the
+    // inert 1.0 belong to every point in the frame. Only the write is an effect's, and it
+    // arrives through the `v.cellNorm` slot below rather than through a varying of its own -
+    // a package declaring it here would emit a second `out` beside the one this line covers.
     { varyings: 'out' },
     { text: /* glsl */ `\
 out float vCellNorm;
@@ -503,79 +505,24 @@ void main() {
     : 1.0 + regionMask * (1.0 - rw))
     * (outsideCrop ? cropOutside : 1.0);
 
-  // Datastream corruption: horizontal bands tear sideways, the way a failing
-  // feed shears. Bands are picked stochastically so it stutters rather than pulses.
-  //
-  // The shove is sensor-frame X applied before the view matrix, and the bands are
-  // depth-image rows, so the tear belongs to the feed rather than to the display. That
-  // is the point rather than an oversight: orbit around a torn band and it shoves in
-  // depth, which is what says the volume is corrupt, and under a levelled room the
-  // bands run at the angle the bracket was actually at. Screen-locked tearing is a
-  // different effect and would belong at the grade stage beside the scanlines.
-  //
-  // The floor of time times the rate is written twice rather than hoisted into a local,
-  // and the shove's ceiling is parenthesised as twice glitchShove rather than folded
-  // into the chain. Both are here to hold the float arithmetic at the defaults exactly
-  // where the literals left it - this file has already measured that handing a value
-  // through a variable licenses a contraction the inline expression does not get, and
-  // doubling 0.45 is exact in float32 where a re-associated product need not be. At the
-  // defaults the *geometry* of this block is bit-identical to the one-slider version it
-  // replaces, and that is measured rather than reasoned: with the flare taken to zero, the
-  // colour, depth and contour readings come back byte for byte identical to the pinned
-  // build at the shipped glitch of 0.18, over six frames, and the shove is live on both
-  // sides so the equality is not vacuous.
-  //
-  // **The flare is the exception and the claim used to be stated without it.** glitchTint
-  // defaults to 1.8 where the line it replaced baked 3.0, so the picture does move - see
-  // the registry entry for the measurement. The blanket version of this sentence stood for
-  // as long as it did because nothing ever rendered these two builds with the glitch
-  // switched on: the cross-build section renders at parameter defaults, where glitch is 0
-  // and none of this executes.
-  vGlitch = 0.0;
-  if (glitch > 0.0) {
-    // The axis the bands are cut along, and the default path is the old expression itself
-    // rather than one that computes what the old expression computed. That distinction has
-    // already cost this file a measurement twice - the comment above says why, and the
-    // raster's guard in the grade shader in web/post-chain.js says it again - so the zero
-    // case reaches the old division textually, with no local in the way to license a
-    // contraction the inline form does not get.
-    float band = glitchAxis > 0.0
-      ? floor(mix(position.y, position.x, glitchAxis) / glitchBands)
-      : floor(position.y / glitchBands);
-    float roll = hash(band + floor(time * glitchRate) * 31.7);
-    if (roll > 1.0 - glitch * glitchDensity) {
-      float shove = (hash(band * 3.1 + floor(time * glitchRate)) - 0.5) * glitch * (2.0 * glitchShove);
-      pos.x += shove;
-      vGlitch = abs(shove) * glitchTint;
-    }
-  }
-
-  // The volume rebuilt on a grid: every axis quantised to a cell, so surfaces break into
-  // steps and the cloud reads as something a machine is reconstructing rather than
-  // something that was measured. It sits last of the displacements, after the tear, so
-  // what gets snapped is the position the point actually ends at - a lattice applied
-  // before the turbulence would be smoothly pushed back off its own grid and buy nothing.
-  //
-  // **Snapped in the levelled frame and not the sensor's**, which is the whole of why this
-  // is more than a rounding. The grid has to belong to the room: with a canted mount the
-  // sensor frame is tilted, and a lattice cut along its axes would stand at whatever angle
-  // the bracket happened to be at, so the floor would step diagonally. Levelling first
-  // means the cells line up with the room, and a mount corrected afterwards does not
-  // re-cut the grid.
-  //
-  // **The rotation is the model matrix three already hands this shader, not a second copy
-  // of it.** The cloud carries the world tilt as its only transform, so mat3(modelMatrix)
-  // is exactly the sensor-to-levelled rotation and cannot drift from it the way a uniform
-  // derived beside it could. Getting back is the transpose rather than inverse(), which is
-  // both cheaper and exact - but that identity holds only while the matrix stays a pure
-  // rotation, so registry-check asserts the cloud carries no scale and no translation
-  // rather than leaving it as a thing this comment claims.
-  if (lattice > 0.0) {
-    mat3 level = mat3(modelMatrix);
-    vec3 cell = floor((level * pos) / latticeCell + 0.5) * latticeCell;
-    pos = mix(pos, transpose(level) * cell, lattice);
-  }
-
+` },
+    // The displacements an effect adds to the running position, after the turbulence, the
+    // push and the ripple that the region's own uniforms drive. A stage rather than a slot
+    // because these compose and their order is the whole of what they mean: the tear shoves
+    // a band of the feed sideways and the lattice quantises wherever the point ends up, so
+    // running them the other way round would snap a position the tear then walks off the
+    // grid. The order is declared in each package rather than left to whichever the server
+    // lists first, which is what makes "the order the file held them in" a fact rather than
+    // an accident of a directory listing.
+    //
+    // **A stage appends its chunks after whatever core text is left above it, so only the
+    // tail of a run can move.** The turbulence, the push and the ripple are all still core
+    // and still above this line, along with the soft mask that shares their region weight;
+    // when they move out, this joint moves up with them and their orders sit below the two
+    // here. That is a property of the joint rather than a plan - a chunk cannot be spliced
+    // into the middle of a segment, so a cut through a run is always a cut at its end.
+    { stage: 'v.displace' },
+    { text: /* glsl */ `\
   vUv = (position.xy + 0.5) / resolution;
   vDepth = z;
 
@@ -633,40 +580,17 @@ void main() {
   // the identical look sum four times too bright at twice the resolution.
   vSize = gl_PointSize / k;
 
-  // **What the lattice does to additive brightness, cancelled here rather than in the
-  // fragment stage.** The normalisation down there divides a splat's alpha by its own area,
-  // on the assumption that sources are spread at the sprite's scale - and the lattice
-  // breaks that assumption by collapsing them onto cells. Pulling points a fraction L of
-  // the way to their cell centre leaves a cluster spanning cell * (1 - L), so brightness
-  // runs up as one over that squared until the cluster is smaller than the sprite, after
-  // which it saturates at the fully coincident case. voxel.json has been in exactly that
-  // state since it shipped: lattice 0.55, additive on, and a pointSize of 6.5 well under
-  // its 3.5cm cell.
-  //
-  // **It is computed here because two of the three things it needs do not exist in the
-  // fragment stage.** The view distance and the projection are vertex-stage quantities, so
-  // the design document's single fragment-stage expression cannot be written where it puts
-  // it; crossing the finished factor is one varying where crossing its inputs would be
-  // three, and it puts the arithmetic where its inputs are. vSize is the sprite that was
-  // actually rasterised - taken after both clamps - so wherever the ceiling bites,
-  // brightness stays correct and only the tiling degrades.
-  //
-  // **The min bounding the sprite term is a correction to the document and not a
-  // transcription of it.** As written there the factor is max((1-L)^2, (sprite/cell)^2),
-  // which at lattice 0 is 1 only while the sprite is no bigger than the cell - and
-  // pointSize reaches 64 against a cell that bottoms out at 5mm, so the region where it
-  // exceeds 1 is reachable through the sliders and the factor would then *brighten*, in
-  // contradiction of the document's own "exactly 1 at lattice 0". Bounded, it is exactly 1
-  // at lattice 0, exactly (sprite/cell)^2 at lattice 1, and exactly 1 again at full glyph
-  // where the sprite *is* the cell - which is the property that makes the compensation and
-  // the glyph field not interact at all at full strength.
-  //
-  // Straight through with no guard, following the flare's measurement in the fragment
-  // stage: multiplying by the computed 1.0 is exact in IEEE, where a branch dropped into a
-  // common path costs the compiler contractions across the lines either side of it.
-  float spriteCells = vSize / cellPx;
-  vCellNorm = max((1.0 - lattice) * (1.0 - lattice), min(1.0, spriteCells * spriteCells));
-
+` },
+    // What a displacement does to a splat's additive energy, cancelled in the stage that
+    // knows the view distance and the projection. A slot rather than a stage, and the only
+    // one here whose fallback is empty: `vCellNorm` is one factor on one multiply down in
+    // the fragment stage, so two effects writing it would be two answers to one question,
+    // and with nothing claiming it the 1.0 written above the early returns is what stands -
+    // which is exactly the value that makes that multiply inert. The declaration and that
+    // initialisation stay core for the same reason the `in` far below does: every additive
+    // fragment reads it whatever is installed.
+    { slot: 'v.cellNorm', fallback: '' },
+    { text: /* glsl */ `\
   // Cut-away points draw at half the size, and **this has to come after vSize or it
   // undoes the dimming it is meant to help.** The fragment stage normalises a splat's
   // additive energy against vSize squared, so a point reported at half size gets four
@@ -1122,60 +1046,15 @@ void main() {
     col = mix(col, mix(cold, heat, k), duotoneDepth);
   }
 
-  // Torn bands flare cyan where the feed shears - and it sits here, after the blend,
-  // for the reason thermal and edges two blocks up sit here. This line used to live
-  // inside the Blackwall branch, which made it inert in the other four readings while
-  // the displacement that earns it kept firing in all five: the geometry tore under
-  // Colour and Depth and nothing lit up, so a slider that plainly worked in one reading
-  // looked broken in the rest. Worse than inert, it was coupled to something nobody
-  // asked it to be - the readings normalise by their weight sum, so a dissolve from
-  // Blackwall into Depth dimmed the corruption on the way past and the flare rode the
-  // colour crossfade.
-  //
-  // Moving it changes what the Blackwall preset draws, because inside the branch the
-  // flare was multiplied by that reading's 0.55 + 0.75 * lum shading before the
-  // normalisation reached it. glitchTint was given a default of 1.8 to absorb that,
-  // rather than carrying 3.0 over, on the grounds that a term reconstructing the old
-  // inside-the-branch arithmetic would be a second implementation of this line.
-  //
-  // **That default is worse than the literal it replaced, measured on the reading the
-  // shipped preset actually uses.** Against the pinned build on readBlackwall at the
-  // shipped glitch of 0.18: 1.8 lands 30 of 255 off at worst with a frame mean of 0.0391,
-  // where 3.0 lands 5 off with a mean of 0.0062, and 0 and 5.0 are worse than either. No
-  // constant can match exactly, because the multiplier it is standing in for varied per
-  // fragment - but the ordering is not close, and the number was chosen without this
-  // comparison being run. Colour only, no alpha term: that is what the
-  // old line did, and an additive splat shows a brighter colour without being asked to
-  // cover more.
-  //
-  // Unconditional, and the missing guard on vGlitch is a measurement rather than an
-  // oversight. Guarded, this line reddened three of registry-check's five reading rows
-  // against the pinned pre-readings build - readDepth and readContour at frame 4 and
-  // readBlackwall at frames 0 and 1 - at parameter defaults, where glitch is 0 and the
-  // guard means the add never runs at all. Nothing mathematical moved: adding zero is
-  // exact, and the branch was never taken. What moved was the code around it, because a
-  // branch dropped into the common path costs the compiler contractions it was making
-  // across the lines either side. Written straight through, all five rows are bit-identical
-  // again and only the pre-existing readGhost failure remains. So the cost of a fragment
-  // being able to skip a multiply-add it does not need is three false regressions in a
-  // check with no tolerance and no way to re-baseline, and the multiply-add is cheaper.
-  //
-  // **The readGhost failure named above was the same effect as the three, and it has since
-  // been measured rather than lived with**: one byte of 1,024,000 differing by exactly 1,
-  // which is one fragment rounding the other way between two independently compiled
-  // builds. Section 1b compares pictures now, so "a check with no tolerance" is no longer
-  // the situation - but the conclusion above stands unchanged, because a tolerance sized
-  // to admit one byte at one step admits nothing like the three regressions that
-  // paragraph is about, and writing the multiply-add straight through is still cheaper
-  // than reasoning about what a branch did to the contractions around it.
-  col += vec3(0.2, 0.9, 1.0) * vGlitch;
-
 ` },
-    // A term over the colour the readings produced, after the blend and after the flare.
-    // It is a stage rather than a slot because these compose: a term written into one
-    // reading is inert in every other one, which is the argument the thermal, the edges
-    // and the duotone above it are all arranged by, and two effects lifting the same
-    // colour is two multiplies rather than a conflict.
+    // A term over the colour the readings produced, after the blend. It is a stage rather
+    // than a slot because these compose: a term written into one reading is inert in every
+    // other one, which is the argument the thermal, the edges and the duotone above it are
+    // all arranged by, and two effects lifting the same colour is two multiplies rather than
+    // a conflict. The glitch's flare is the first of them and the rain's lift is the second,
+    // in the order the file held them - the rain's own chunk carries why it sits below the
+    // flare, and it is so that the line the flare's measurement was taken beside keeps the
+    // neighbours it was measured with.
     { stage: 'f.tone' },
     // What the mark actually draws, if it draws something other than the falloff. It
     // reads the colour above it, which is why it is here and not at either end: the one

--- a/web/grade-shader.js
+++ b/web/grade-shader.js
@@ -1,0 +1,141 @@
+// The core of the grade pass, and the joints the installed effects are spliced into.
+//
+// The same shape as `web/cloud-shader.js` one file over, and for the same three reasons.
+// There is no arithmetic here, nothing is constructed and **nothing is imported**: what this
+// file exports is source text in ordered segments, which `web/shader-assembly.js` joins with
+// whatever the packages bring. Neither program interpolates anything - there is no `${}` in
+// any segment - so the text below is exactly what the driver is handed.
+//
+// **It is a file of its own rather than a block inside `web/post-chain.js`, and the reason
+// is the gate rather than tidiness.** `test/shader-assembly.test.mjs` holds the assembled
+// text against the literal git history carries, and it does that by evaluating the spine
+// under bare node - no page, no server, no GPU. `post-chain.js` imports three.js and three
+// of its addons, so its bytes cannot be evaluated that way at all, and a spine living there
+// would be a spine the gate could only read by parsing. The uniforms stay behind with the
+// pass, because a `THREE.Vector2` default is a constructed object and this file constructs
+// nothing.
+//
+// **What the split costs is the pairing**, the same obligation `web/cloud-shader.js` names:
+// every `uniform` in the assembled program has to have a key in `GRADE_UNIFORMS` in
+// `web/post-chain.js`, and nothing enforces that in either direction at runtime - three.js
+// writes the keys it is given and reads zero for the rest. Measured across the split: 13
+// distinct uniforms in the assembled program, 13 keys there, and the two sets are equal both
+// ways - 8 declared in the segments below and 5 in the raster and streak packages' own
+// declaration chunks. `test/cloud-shader.test.mjs` asks it of both programs separately, so a
+// term arriving in a package is inside the question and a grade term that drifted into the
+// point cloud's table is outside both.
+//
+// **Three joints, and the run they sit in is the pass's order.** The order of the terms
+// below is the whole of this shader's opinion and is the same kind of decision the four
+// `addPass` calls in `web/post-chain.js` are: the streak is a thing that happened to the
+// light and sits above the tonemap, the raster and the grain are drawn over the picture, and
+// the vignette closes the corners down before any of it is rolled off. Each chunk carries
+// its own argument for where it sits.
+
+// Each entry frozen as well as the list, for the reason the cloud's spine gives: the spine
+// is read by the page's pass and by the gate, and a segment trimmed in place would move the
+// look of one and the verdict of the other in the same breath.
+const frozen = (entries) => Object.freeze(entries.map((e) => Object.freeze(e)));
+
+export const gradeSpine = Object.freeze({
+  // No joints at all, and that is a statement rather than an omission. A full-screen pass
+  // draws one quad and every term this shader has is a function of where that quad's
+  // fragments land, so there is nothing an effect could want to say up here - and a joint
+  // offered to nobody is a name the assembler would have to keep meaning something.
+  vertex: frozen([
+    { text: /* glsl */ `
+    varying vec2 vUv;
+    void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+  ` },
+  ]),
+  fragment: frozen([
+    { text: /* glsl */ `
+    uniform sampler2D tDiffuse;
+    uniform float rgbSplit, scanlines, grain, vignette, crush, time;
+` },
+    // The terms an effect declares for this pass.
+    //
+    // **The line immediately above is a stay-behind and it is the awkward one.** Six terms
+    // share one declaration - four of them a package's (`rgbSplit`, `scanlines`, `grain`,
+    // `vignette`) and two of them core (`crush`, which is a sub-control inside the grade
+    // rather than a term beside it, and `time`) - and splitting a comma-separated
+    // declaration moves bytes, which is the one thing this whole split may not do. So four
+    // packages have their master declared in the spine, and the two that carry further terms
+    // - the raster's axis, pitch and hardness, and the streak's amount and axis - declare
+    // those here. That reads as an inconsistency and is a measurement: the alternative is a
+    // second declaration stage wrapped around a fragment of one line, bought for four names
+    // that cost nothing to leave where they are. The streak's own amount is here rather than
+    // above only because that is where the monolith put it.
+    { stage: 'g.decl' },
+    { text: /* glsl */ `\
+    uniform vec2 resolution;
+    varying vec2 vUv;
+
+    float hash(vec2 p) { return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453); }
+
+    void main() {
+      // The same 1080p reference the point pass in web/cloud-shader.js uses. Every term
+      // here is sized in reference pixels rather than framebuffer ones, so the grade a
+      // look was built at holds at any output size: without it the split narrows, the
+      // scanlines crowd and the grain thins as resolution rises - a look that is
+      // *nearly* resolution-independent, which is the kind you trust and then have
+      // to debug. Bloom needs none of this and gets none, and by a different mechanism
+      // rather than by no mechanism: its chain is frozen at a fixed reference height by
+      // bloomChainSize in web/bloom-pass.js, because that pass bakes its tap count into
+      // its shaders at construction and so has no term to express in these units.
+      float k = resolution.y / 1080.0;
+      vec2 ref = resolution / k;
+      vec2 texel = 1.0 / ref;
+      vec3 col;
+
+` },
+    // How the frame is read out of the buffer behind it, which is a replacement rather than
+    // a stage: there is one `col` and one place it comes from, so a second chunk here would
+    // be two reads of the same texture disagreeing about which one wins.
+    //
+    // **This is the one fallback in either spine that is not the shipped bytes**, and the
+    // reason is where the monolith put the statement. It reads the buffer inside an `else`,
+    // so the text it holds is indented for a block that exists only while the split is
+    // installed - and an eight-space copy of it spliced at the top level would compile and
+    // would be the only line in either program indented against its neighbours. So the
+    // statement is the monolith's and the indent is this joint's.
+    //
+    // Nothing in the shipped build ever compiles it, exactly as `v.mask`'s fallback in the
+    // cloud is never compiled, so it is proved by assembling rather than by being read.
+    // Measured over four removal configurations: without rgbsplit the fetch is this line at
+    // the surrounding indent, without any of the four body packages the run collapses to the
+    // split and the tonemap, and with no grade package at all the whole shader is this line,
+    // the Reinhard curve and the toe.
+    {
+      slot: 'g.fetch',
+      fallback: /* glsl */ `\
+      col = texture2D(tDiffuse, vUv).rgb;
+
+`,
+    },
+    // Everything drawn over the picture or done to the light, in the order the pass runs
+    // them: the streak at 100, the raster at 200, the grain at 300 and the vignette at 400.
+    // A stage rather than four slots because these compose - each one takes the colour the
+    // one above it produced and hands it on - and because a build with none of them
+    // installed should be the tonemap alone rather than four branches on four zeros.
+    { stage: 'g.body' },
+    { text: /* glsl */ `\
+      // Roll highlights off per channel instead of letting additive accumulation
+      // clip to flat white - hot areas keep their hue this way.
+      col = col / (1.0 + col);
+      // Then crush the toe back down: Reinhard lifts blacks, and this look needs
+      // the empty space to stay genuinely black rather than dark red.
+      //
+      // The gain stays a literal while the toe becomes a parameter, and that asymmetry is
+      // measured rather than lazy. The obvious reading - that 1.12 normalises the toe back
+      // out and so should follow it - is wrong: a toe of 0.018 would normalise at 1.018,
+      // so 1.12 is an independent graded lift that happens to sit near it. Tying the two
+      // together would re-grade every look ever authored the moment anybody moved the toe,
+      // which is a whole preset library drifting to buy a tidier-looking line.
+      col = max(col - crush, 0.0) * 1.12;
+
+      gl_FragColor = vec4(col, 1.0);
+    }
+  ` },
+  ]),
+});

--- a/web/main.js
+++ b/web/main.js
@@ -101,6 +101,12 @@ import {
   geometry, uniforms, material, cloud, buildPointCloud, setAdditive,
   CLIP_NEAR_DEFAULT, CLIP_FAR_DEFAULT, CROP_LIMIT, cropReach, croppedOut,
 } from './point-cloud.js';
+// The text those two builders compile, and the concatenator that makes it. Source text and
+// a pure function over it - nothing here touches a GPU, which is why the same three imports
+// serve the gate under bare node.
+import { cloudSpine } from './cloud-shader.js';
+import { gradeSpine } from './grade-shader.js';
+import { assembleShaders } from './shader-assembly.js';
 
 // ------------------------------------------------ the installed effects, fetched
 //
@@ -149,6 +155,21 @@ const effectPackages = await (async () => {
     return pkg;
   }));
 })();
+
+// Every program this page compiles, in one call, before either builder runs.
+//
+// **One call and not one per spine**, which is the property the refusals rest on. A chunk
+// names the joint it joins and never the program it belongs to, so `assembleShaders` has to
+// see every spine at once to know that a name it does not recognise is nobody's - and a
+// build that assembled the cloud on its own would meet the grade pass's chunks with only two
+// answers available, throwing on text that is perfectly well placed elsewhere or skipping
+// it. The second is what a program-name tag on each chunk would have bought: a tag nobody
+// spelled right lands its text in no program at all, the page boots, the shader compiles,
+// and the effect is simply gone.
+//
+// It sits beside the fetch that feeds it rather than inside either builder, because the two
+// builders run seven hundred lines apart and the packages are one answer to one question.
+const shaderPrograms = assembleShaders({ cloud: cloudSpine, grade: gradeSpine }, effectPackages);
 
 // Which of the two surfaces this page is, decided by the path. One document still
 // serves both, because there is one renderer and one image pipeline and splitting
@@ -249,11 +270,14 @@ buildSurfaceMemory();
 // handed over rather than reached for, so the one place the two are wired together is this
 // line.
 //
-// The packages go the same way and for the same reason. The material is assembled out of
-// the spine and whatever effects are installed, so the cloud needs them - and handing them
-// over here rather than having `point-cloud.js` fetch them keeps the module free of the
-// network, which is what lets the same assembler run under bare node in the gate.
-buildPointCloud(sourceCells, effectPackages);
+// The assembled program goes the same way and for the same reason. The material is compiled
+// out of the spine and whatever effects are installed, so the cloud needs the text - and
+// assembling it above rather than having `point-cloud.js` fetch its own packages keeps the
+// module free of the network, which is what lets the same assembler run under bare node in
+// the gate. It also leaves one assembly site for the two programs, which is what the grade
+// pass's spine needed: a chunk is placed by the joint it names, and only a call that sees
+// every spine can tell a joint nobody holds from one another spine does.
+buildPointCloud(sourceCells, shaderPrograms.cloud);
 
 // And the one cell in that table the hardware fills rather than the registry or the
 // transport. `ALIASED_POINT_SIZE_RANGE` is what this GPU will actually rasterise a point
@@ -344,12 +368,14 @@ function applyWorldTilt() {
 // ---------------------------------------------------------------- post chain
 //
 // Moved to `post-chain.js`. The composer, the trails, the bloom instance and the grade
-// shader are there, and so is the order the image is put through them in, which is that
-// file's whole opinion. What is here is the moment the chain is built, which is a decision
-// about this program's boot rather than about the passes: the render pass is handed the
-// scene it draws, so it is built after the cloud above, and it is built by a call rather
-// than by an import, so the moment reads in the order it happens in.
-buildPostChain();
+// pass's uniform table are there, and so is the order the image is put through them in,
+// which is that file's whole opinion; the grade's own GLSL is in `grade-shader.js` beside
+// the cloud's, because a spine has to evaluate under bare node and `post-chain.js` imports
+// three.js. What is here is the moment the chain is built, which is a decision about this
+// program's boot rather than about the passes: the render pass is handed the scene it draws,
+// so it is built after the cloud above, and it is built by a call rather than by an import,
+// so the moment reads in the order it happens in.
+buildPostChain(shaderPrograms.grade);
 
 let renderScale = 1;
 
@@ -895,12 +921,31 @@ function updateDrawRange() {
   geometry.setDrawRange(0, shedding ? POINTS * 2 : POINTS);
 }
 
+/**
+ * The grade terms whose being up is what makes the pass worth running, read off the
+ * packages rather than listed here.
+ *
+ * A binding declares `gates` when a non-zero value has to switch the pass on, and five of
+ * the shipped effects do. That used to be five lines of `grade.uniforms.X.value > 0` in the
+ * function below, which was true of the shipped set and true by transcription: a package
+ * installed next year would have written its term into the pass and left the pass shut, so
+ * its slider would have moved a uniform nothing ran and the effect would have been silently
+ * absent - the shape this repo keeps case files about. Derived, a package is counted by
+ * existing.
+ *
+ * **What is not derived is `crush`.** It shares the pass and deliberately does not gate it,
+ * because it defaults to 0.018 rather than to 0 and so is up in every document there has
+ * ever been - gating it would run a full-screen read and write for the four shipped presets
+ * that ask for no grade at all. It is a core parameter with no package, so it is outside
+ * this list by construction rather than by being left out of it, and `registry-check`'s gate
+ * matrix asserts that negative rather than leaving it as an omission.
+ */
+const GRADE_GATES = effectPackages.flatMap((pkg) => Object.values(pkg.manifest.params ?? {})
+  .filter((p) => p.bind?.on === 'grade' && p.bind.gates)
+  .map((p) => p.bind.uniform));
+
 function gradeNeeded() {
-  return grade.uniforms.rgbSplit.value > 0
-    || grade.uniforms.scanlines.value > 0
-    || grade.uniforms.grain.value > 0
-    || grade.uniforms.vignette.value > 0
-    || grade.uniforms.streak.value > 0;
+  return GRADE_GATES.some((name) => grade.uniforms[name].value > 0);
 }
 
 // ------------------------------------------------- fitting the box to the footage

--- a/web/main.js
+++ b/web/main.js
@@ -50,9 +50,10 @@ import { tableFromPackages, withEffectGroups } from './effect-manifests.js';
 // One number out of the halo, and nothing else. `bloom-pass.js` holds the pass and
 // `post-chain.js` is what constructs it; what this file still needs is the reference the
 // chain is frozen at, because `resize` sizes that chain and `resize` lives here. The two
-// GLSL programs went the same way - `point-cloud.js` imports them from `cloud-shader.js`
-// directly, and both modules stay reachable through the ones that use them rather than
-// through a name carried here.
+// GLSL programs went the same way - `point-cloud.js` reaches the spine in
+// `cloud-shader.js` and the assembler in `shader-assembly.js` directly, and all three
+// modules stay reachable through the ones that use them rather than through a name
+// carried here.
 //
 // **A name imported and not used is worse than no import**, which is why this line is one
 // binding rather than the three it was. It reads as a dependency to anyone tracing the
@@ -100,6 +101,54 @@ import {
   geometry, uniforms, material, cloud, buildPointCloud, setAdditive,
   CLIP_NEAR_DEFAULT, CLIP_FAR_DEFAULT, CROP_LIMIT, cropReach, croppedOut,
 } from './point-cloud.js';
+
+// ------------------------------------------------ the installed effects, fetched
+//
+// The registry assembles from the effect packages the server holds, and so do the cloud's
+// two shader programs, so the packages come first and the module waits for them: a
+// top-level await, because everything below - the material the point cloud is compiled
+// into, the panel spine, the parameter table, the boot-time reset - is built from what
+// arrives here, and a page that raced its own registry would be the panel and the
+// parameters disagreeing about what exists. A fetch rather than an import, deliberately:
+// `module-check` walks the static graph and data crossing it as modules would join that
+// graph as code, when what crosses here is JSON a server answered. A package that cannot
+// be fetched fails the boot loudly - `__kinect` never publishes and every tool reports
+// DID NOT RUN - which is the honest shape until the missing-effect surface exists to say
+// something better.
+//
+// **It sits at the top of the module rather than beside the registry it feeds, and what
+// moved it up here is the shaders.** `buildPointCloud` compiles the material at its banner
+// below, which is seven hundred lines above where this block used to be - so the fetch had
+// to come up rather than the cloud go down: the cloud is built after the textures and the
+// surface memory because it composes cells those two own, and that order is a property of
+// the GPU rather than of the packages. Everything after this line stays synchronous, which
+// is the half worth keeping - one await site, at the top of the module, and no second one
+// anybody has to reason about.
+//
+// The chunk files arrive with their manifest rather than in a second pass, because
+// `assembleShaders` refuses a package whose text is missing: fetching the two apart would
+// open a window in which a package exists and cannot be assembled, and the boot this await
+// exists to close is the one place that window could be entered.
+const effectPackages = await (async () => {
+  const listed = await fetch('/effects');
+  if (!listed.ok) throw new Error(`GET /effects answered ${listed.status} - the registry cannot assemble without its packages`);
+  const { effects } = await listed.json();
+  return Promise.all(effects.map(async ({ id }) => {
+    const res = await fetch(`/effects/${encodeURIComponent(id)}`);
+    if (!res.ok) throw new Error(`GET /effects/${id} answered ${res.status} - the registry cannot assemble without its packages`);
+    const pkg = await res.json();
+    // Named once and fetched once. A manifest may point two joints at one file, and a
+    // second request for the same bytes would be a second answer to a question with one.
+    const names = [...new Set((pkg.manifest.chunks ?? []).map((c) => c.file))];
+    const texts = await Promise.all(names.map(async (name) => {
+      const chunk = await fetch(`/effects/${encodeURIComponent(id)}/file/${encodeURIComponent(name)}`);
+      if (!chunk.ok) throw new Error(`GET /effects/${id}/file/${name} answered ${chunk.status} - the cloud's shaders cannot be assembled without it`);
+      return chunk.text();
+    }));
+    pkg.chunks = Object.fromEntries(names.map((name, i) => [name, texts[i]]));
+    return pkg;
+  }));
+})();
 
 // Which of the two surfaces this page is, decided by the path. One document still
 // serves both, because there is one renderer and one image pipeline and splitting
@@ -199,7 +248,12 @@ buildSurfaceMemory();
 // program's boot rather than about the cloud - and the cells from the textures above,
 // handed over rather than reached for, so the one place the two are wired together is this
 // line.
-buildPointCloud(sourceCells);
+//
+// The packages go the same way and for the same reason. The material is assembled out of
+// the spine and whatever effects are installed, so the cloud needs them - and handing them
+// over here rather than having `point-cloud.js` fetch them keeps the module free of the
+// network, which is what lets the same assembler run under bare node in the gate.
+buildPointCloud(sourceCells, effectPackages);
 
 // And the one cell in that table the hardware fills rather than the registry or the
 // transport. `ALIASED_POINT_SIZE_RANGE` is what this GPU will actually rasterise a point
@@ -939,29 +993,6 @@ async function fitCropToTake(id, near, far) {
 // clicks, and Playwright's click waits for visibility - so a collapsible `framing` would
 // turn that row into a thirty-second timeout, which is a crash carrying no failed
 // assertion rather than a finding.
-//
-// ------------------------------------------------ the installed effects, fetched
-//
-// The registry assembles from the effect packages the server holds, so the packages
-// come first and the module waits for them: a top-level await, because everything
-// below - the panel spine, the parameter table, the boot-time reset - is built from
-// what arrives here, and a page that raced its own registry would be the panel and
-// the parameters disagreeing about what exists. A fetch rather than an import,
-// deliberately: `module-check` walks the static graph and data crossing it as
-// modules would join that graph as code, when what crosses here is JSON a server
-// answered. A package that cannot be fetched fails the boot loudly - `__kinect`
-// never publishes and every tool reports DID NOT RUN - which is the honest shape
-// until the missing-effect surface exists to say something better.
-const effectPackages = await (async () => {
-  const listed = await fetch('/effects');
-  if (!listed.ok) throw new Error(`GET /effects answered ${listed.status} - the registry cannot assemble without its packages`);
-  const { effects } = await listed.json();
-  return Promise.all(effects.map(async ({ id }) => {
-    const res = await fetch(`/effects/${encodeURIComponent(id)}`);
-    if (!res.ok) throw new Error(`GET /effects/${id} answered ${res.status} - the registry cannot assemble without its packages`);
-    return res.json();
-  }));
-})();
 
 // Where each effect parameter lands in the registry's declaration order. This is
 // the client's layout fact, not the packages': the order is load-bearing (the

--- a/web/point-cloud.js
+++ b/web/point-cloud.js
@@ -27,7 +27,8 @@
 import * as THREE from 'three';
 import { DEPTH_H, DEPTH_W, POINTS } from './format.js';
 import { scene } from './scene.js';
-import { vertexShader, fragmentShader } from './cloud-shader.js';
+import { cloudSpine } from './cloud-shader.js';
+import { assembleShaders } from './shader-assembly.js';
 import { statePrev } from './surface-memory.js';
 
 // The depth pair's defaults, named once because three separate things have to agree
@@ -74,8 +75,14 @@ export let cloud = null;
  * Called after the surface memory as well as after the textures, because `stateTex` is
  * seeded with the ghost target that exists by then - and that seed is not dead, it is what
  * the first frame samples before the first step of the memory has run.
+ *
+ * `packages` is the installed effects, each with its manifest and the text of the chunks
+ * it declares, and it is passed in for the same reason the cells are: the fetch that
+ * produced them is `web/main.js`'s, so this module compiles a shader without ever knowing
+ * there is a server - which is what lets the gate run the same assembler under bare node
+ * with the packages read off disk instead.
  */
-export function buildPointCloud(sourceCells) {
+export function buildPointCloud(sourceCells, packages) {
   // Two vertices per depth pixel: one for the live point, one for the ghost it
   // leaves behind. Shedding needs both on screen at once. The ghost half is left
   // out of the draw range entirely when nothing can be shed, so it costs nothing.
@@ -366,15 +373,23 @@ export function buildPointCloud(sourceCells) {
     sinceFrameSec: { value: 0 },
   };
 
-  // The two programs those uniforms feed are in `web/cloud-shader.js`, imported at the top
-  // of this file. Nine hundred lines of GLSL sitting between the table above and the
-  // hundred places in `web/main.js` that write it put the two ends of one parameter out of
-  // sight of each other, which is the whole of why they moved. What did not move is the
-  // obligation between them: every uniform declared there needs a key here, nothing checks
-  // it in either direction, and a uniform with no key is a silent zero rather than an
-  // error. Five of those keys hold cells `web/gpu-textures.js` owns rather than cells this
-  // table made, which leaves the obligation exactly where it was and moves who may write
-  // them.
+  // The two programs those uniforms feed, assembled here rather than imported whole. The
+  // spine in `web/cloud-shader.js` carries the text every point in the frame is drawn by
+  // and the joints the installed effects splice into; `assembleShaders` concatenates the
+  // two. Nine hundred lines of GLSL sitting between the table above and the hundred places
+  // in `web/main.js` that write it put the two ends of one parameter out of sight of each
+  // other, which is why the text moved out at all, and an effect's own GLSL travelling with
+  // its parameters is the same argument one file further.
+  //
+  // What did not move is the obligation between the two: every uniform the assembled pair
+  // declares needs a key here, nothing checks it in either direction, and a uniform with no
+  // key is a silent zero rather than an error. Nine of those declarations are in the glyph
+  // and rain packages now rather than in the spine, which widens where the obligation is
+  // written down without changing what it is - `test/cloud-shader.test.mjs` asks it of the
+  // shipped GLSL wherever the shipped GLSL lives. Five of the keys hold cells
+  // `web/gpu-textures.js` owns rather than cells this table made, which leaves the
+  // obligation exactly where it was and moves only who may write them.
+  const { vertexShader, fragmentShader } = assembleShaders(cloudSpine, packages);
   material = new THREE.ShaderMaterial({
     glslVersion: THREE.GLSL3,
     uniforms,

--- a/web/point-cloud.js
+++ b/web/point-cloud.js
@@ -27,8 +27,6 @@
 import * as THREE from 'three';
 import { DEPTH_H, DEPTH_W, POINTS } from './format.js';
 import { scene } from './scene.js';
-import { cloudSpine } from './cloud-shader.js';
-import { assembleShaders } from './shader-assembly.js';
 import { statePrev } from './surface-memory.js';
 
 // The depth pair's defaults, named once because three separate things have to agree
@@ -76,13 +74,19 @@ export let cloud = null;
  * seeded with the ghost target that exists by then - and that seed is not dead, it is what
  * the first frame samples before the first step of the memory has run.
  *
- * `packages` is the installed effects, each with its manifest and the text of the chunks
- * it declares, and it is passed in for the same reason the cells are: the fetch that
- * produced them is `web/main.js`'s, so this module compiles a shader without ever knowing
- * there is a server - which is what lets the gate run the same assembler under bare node
- * with the packages read off disk instead.
+ * `program` is the assembled `{ vertexShader, fragmentShader }` pair, and it is passed in
+ * for the same reason the cells are: the packages it was assembled from were fetched by
+ * `web/main.js`, so this module compiles a shader without ever knowing there is a server -
+ * which is what lets the gate run the same assembler under bare node with the packages read
+ * off disk instead.
+ *
+ * **The assembly itself moved up to that boot rather than happening here**, and the reason
+ * is the second spine. `web/shader-assembly.js` takes every spine in one call so that a
+ * joint name means one place across the whole build and a chunk naming a joint nothing holds
+ * is refused by name; assembling the cloud on its own would have had to answer for the grade
+ * pass's chunks somehow, and both available answers are wrong.
  */
-export function buildPointCloud(sourceCells, packages) {
+export function buildPointCloud(sourceCells, program) {
   // Two vertices per depth pixel: one for the live point, one for the ghost it
   // leaves behind. Shedding needs both on screen at once. The ghost half is left
   // out of the draw range entirely when nothing can be shed, so it costs nothing.
@@ -373,23 +377,24 @@ export function buildPointCloud(sourceCells, packages) {
     sinceFrameSec: { value: 0 },
   };
 
-  // The two programs those uniforms feed, assembled here rather than imported whole. The
-  // spine in `web/cloud-shader.js` carries the text every point in the frame is drawn by
-  // and the joints the installed effects splice into; `assembleShaders` concatenates the
-  // two. Nine hundred lines of GLSL sitting between the table above and the hundred places
-  // in `web/main.js` that write it put the two ends of one parameter out of sight of each
-  // other, which is why the text moved out at all, and an effect's own GLSL travelling with
-  // its parameters is the same argument one file further.
+  // The two programs those uniforms feed, assembled at the boot in `web/main.js` rather
+  // than imported whole. The spine in `web/cloud-shader.js` carries the text every point in
+  // the frame is drawn by and the joints the installed effects splice into. Nine hundred
+  // lines of GLSL sitting between the table above and the hundred places in `web/main.js`
+  // that write it put the two ends of one parameter out of sight of each other, which is
+  // why the text moved out at all, and an effect's own GLSL travelling with its parameters
+  // is the same argument one file further.
   //
   // What did not move is the obligation between the two: every uniform the assembled pair
   // declares needs a key here, nothing checks it in either direction, and a uniform with no
   // key is a silent zero rather than an error. Nine of those declarations are in the glyph
-  // and rain packages now rather than in the spine, which widens where the obligation is
-  // written down without changing what it is - `test/cloud-shader.test.mjs` asks it of the
-  // shipped GLSL wherever the shipped GLSL lives. Five of the keys hold cells
-  // `web/gpu-textures.js` owns rather than cells this table made, which leaves the
-  // obligation exactly where it was and moves only who may write them.
-  const { vertexShader, fragmentShader } = assembleShaders(cloudSpine, packages);
+  // and rain packages rather than in the spine, which widens where the obligation is written
+  // down without changing what it is - `test/cloud-shader.test.mjs` asks it of the assembled
+  // program rather than of any file, so a term arriving in a package is inside the question
+  // and one sitting in a slot's fallback, which nothing compiles, is correctly outside it.
+  // Five of the keys hold cells `web/gpu-textures.js` owns rather than cells this table
+  // made, which leaves the obligation exactly where it was and moves only who may write them.
+  const { vertexShader, fragmentShader } = program;
   material = new THREE.ShaderMaterial({
     glslVersion: THREE.GLSL3,
     uniforms,

--- a/web/post-chain.js
+++ b/web/post-chain.js
@@ -10,9 +10,19 @@
 // not spread across the callers that switch each pass on.
 //
 // What is *not* here is any opinion about the passes themselves. The halo's shape and the
-// reference height it is built at belong to `web/bloom-pass.js`, and the grade below owns
-// only its own shader - so this file changes when the pipeline gains or loses a stage, and
-// for nothing else.
+// reference height it is built at belong to `web/bloom-pass.js`, and the grade's own text
+// belongs to `web/grade-shader.js` and to the packages that splice into it - so this file
+// changes when the pipeline gains or loses a stage, and for nothing else.
+//
+// **The grade's GLSL left and its uniforms stayed**, which is the seam the split put here
+// rather than an accident of how far the move got. A uniform's default is a constructed
+// object - two of them are a `THREE.Vector2` - and the spine constructs nothing, because the
+// gate that holds the assembled text against the literal git history carries has to evaluate
+// that spine under bare node, with no three.js anywhere. So the text went to a file that
+// imports nothing and the table stayed beside the pass it feeds. What pairs the two is
+// `test/cloud-shader.test.mjs`, which reads every `uniform` line of both assembled programs
+// against the tables that feed them: a uniform with no key here reads a silent zero, and a
+// key with no uniform is a write per frame that reaches no pixel.
 //
 // **Nothing is allocated and no GL is touched while this module evaluates.** The composer,
 // the four passes and the render targets under them are built by `buildPostChain`, which
@@ -45,275 +55,92 @@ export let afterimage = null;
 export let bloom = null;
 export let grade = null;
 
-const GradeShader = {
-  uniforms: {
-    tDiffuse: { value: null },
-    rgbSplit: { value: 0 },
-    scanlines: { value: 0 },
-    // The three that turn one scanline term into a raster, and they are settings of
-    // `scanlines` rather than terms beside it. A raster is one idea and a sine is its
-    // softest duty cycle, so two terms that both darken the frame in stripes would be the
-    // drifting twin this file keeps refusing - and the hardness is what makes the other
-    // two reach anything, because adding an angle to a sine only ever gets you rotated
-    // softness where the reference frames are hard line grilles with dark gaps.
-    //
-    // The angle arrives as its own axis rather than as an angle, and that is a rounding
-    // measurement rather than a preference - the same shape `contourLo`/`contourHi` in
-    // `web/cloud-shader.js` are two uniforms for. Taking `sin` and `cos` in the shader
-    // looked obviously right and was measured wrong: GLSL ES permits a couple of
-    // thousandths of absolute error on a trigonometric function, so `sin(0.0)` is not
-    // promised to be exactly zero, and a whisker of x leaking into a raster that is
-    // supposed to run along y moved all six frames of the comparison against the build
-    // this replaces. Done here, `Math.sin(0)` is exactly 0 and `Math.cos(0)` exactly 1 in
-    // double, they survive the cast, and the dot below collapses to the frame's own y the
-    // way the old line's expression did.
-    //
-    // Degrees on the slider, and at zero the raster runs along y - the scanline this has
-    // always drawn. At a right angle it is the dense vertical column grille the reference
-    // frames slice their picture into, and because it keyframes a raster can *rotate*
-    // under the playhead, which is a capability rather than parity with a still frame.
-    //
-    // `scanPitch` was the literal 1.3 baked into the wave, and it defaults to it.
-    scanAxis: { value: new THREE.Vector2(0, 1) },
-    scanPitch: { value: 1.3 },
-    scanHard: { value: 0 },
-    grain: { value: 0 },
-    // The corner falloff, which was the literal 0.55 and applied whenever this pass ran
-    // at all. That made it a hidden function of the three terms above: a look with all
-    // of them at zero switched the pass off and lost its vignette, so the comment below
-    // claiming the frame "always closes down on the subject" was false in exactly the
-    // state the four shipped presets other than Blackwall are in.
-    //
-    // It defaults to 0 rather than to the 0.55 it was, and that is the one place in this
-    // file where a promoted literal does not keep its value. It cannot: the behaviour it
-    // replaces is not a constant but a conditional - 0.55 when something else was on, 0
-    // when nothing was - and no single default reproduces both branches. Zero is the
-    // branch that keeps the parameter defaults drawing what they drew, which is what
-    // registry-check hashes against a build from before any of this existed.
-    // `blackwall.json` names 0.55 explicitly so the one shipped look that had a vignette
-    // keeps it. A project saved before this that raised any grade term is the case that
-    // does change: it loses its corner falloff until it names one.
-    vignette: { value: 0 },
-    // The toe under the Reinhard curve, promoted from the literal 0.018 - and unlike
-    // `vignette` above it this one keeps the value it replaced, because the behaviour it
-    // replaces is a constant rather than a conditional. That difference decides the whole
-    // of how it is wired: a non-zero default cannot gate the pass, so `crush` is a
-    // sub-control inside the grade rather than a fifth term beside the four that gate it.
-    // See its entry in the registry in `web/main.js` for what gating it would have cost.
-    //
-    // **It is not the silhouette crush, whatever the name suggests**, and the comment is
-    // here to stop the next reader concluding that it is. This darkens near and far alike,
-    // so it cannot separate a subject from the space behind it; the term that does that is
-    // the duotone in the point shader, in `web/cloud-shader.js`. What this is for is the
-    // thing it always did - keep the empty background genuinely black after Reinhard lifts
-    // it.
-    streak: { value: 0 },
-    // Which way the light runs, as its own axis rather than as an angle, for exactly the
-    // reason `scanAxis` forty lines up carries in full: GLSL ES permits a couple of
-    // thousandths of absolute error on a trigonometric function, so `sin(0.0)` is not
-    // promised to be exactly zero, and a whisker of the wrong axis leaking into a fall
-    // that is meant to run straight down the frame is a defect no picture shows the shape
-    // of. Done here, `Math.sin(0)` is exactly 0 and `Math.cos(0)` exactly 1 in double,
-    // they survive the cast, and the offset in the gather below collapses to the frame's
-    // own y at the default the way the one-direction version's expression did.
-    //
-    // Degrees on the slider, and unlike the glitch's `glitchAxis` in `web/cloud-shader.js`
-    // that is the honest spelling rather than the lazy one. The tear's bands are quantised
-    // in the sensor's frame, where 512 columns meet 424 rows and a band is a run of
-    // scanlines rather than a distance, so there is no square in which an angle would mean
-    // what an angle means. This runs in the grade pass, in screen space, against a square
-    // reference pixel - so an angle here means what an angle means, and turning it 90
-    // degrees turns the streak 90 degrees on the glass.
-    streakAxis: { value: new THREE.Vector2(0, 1) },
-    crush: { value: 0.018 },
-    time: { value: 0 },
-    resolution: { value: new THREE.Vector2(1, 1) },
-  },
-  vertexShader: /* glsl */ `
-    varying vec2 vUv;
-    void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
-  `,
-  // One combined pass: chaining separate RGBShift/Film/Vignette passes would cost
-  // a full-screen read and write each.
-  fragmentShader: /* glsl */ `
-    uniform sampler2D tDiffuse;
-    uniform float rgbSplit, scanlines, grain, vignette, crush, time;
-    uniform float streak;
-    uniform vec2 streakAxis;
-    uniform vec2 scanAxis;
-    uniform float scanPitch, scanHard;
-    uniform vec2 resolution;
-    varying vec2 vUv;
-
-    float hash(vec2 p) { return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453); }
-
-    void main() {
-      // The same 1080p reference the point pass in web/cloud-shader.js uses. Every term
-      // here is sized in reference pixels rather than framebuffer ones, so the grade a
-      // look was built at holds at any output size: without it the split narrows, the
-      // scanlines crowd and the grain thins as resolution rises - a look that is
-      // *nearly* resolution-independent, which is the kind you trust and then have
-      // to debug. Bloom needs none of this and gets none, and by a different mechanism
-      // rather than by no mechanism: its chain is frozen at a fixed reference height by
-      // bloomChainSize in web/bloom-pass.js, because that pass bakes its tap count into
-      // its shaders at construction and so has no term to express in these units.
-      float k = resolution.y / 1080.0;
-      vec2 ref = resolution / k;
-      vec2 texel = 1.0 / ref;
-      vec3 col;
-
-      if (rgbSplit > 0.0) {
-        // Split grows toward the edges, so the centre stays legible.
-        vec2 dir = (vUv - 0.5);
-        vec2 off = dir * rgbSplit * texel * 8.0;
-        col.r = texture2D(tDiffuse, vUv + off).r;
-        col.g = texture2D(tDiffuse, vUv).g;
-        col.b = texture2D(tDiffuse, vUv - off).b;
-      } else {
-        col = texture2D(tDiffuse, vUv).rgb;
-      }
-
-      // Light bleeds. Each pixel gathers back along the streak's own axis and keeps the
-      // brightest thing it finds, decayed by how far it had to look, so a highlight smears
-      // across the frame the way a sensor smears one down a column of wells. It sits here,
-      // below the raster and the vignette and above the tonemap, because it is a thing that
-      // happened to the light rather than a thing drawn over the picture: a streak applied
-      // after the vignette would glow in the corners the vignette had just put out.
-      //
-      // **A gather and not a feedback buffer**, which is a decision rather than a
-      // simplification. A buffer accumulating across frames smears along whatever the
-      // camera did last, so an orbit would drag every streak sideways, and - the half that
-      // settles it - a seek would arrive carrying the streak the scrub built rather than
-      // the one playback would have built. That is the property the whole transport rests
-      // on, broken by an effect nobody would think to test it against.
-      //
-      // Distances are in reference pixels through texel, for the reason stated at the top
-      // of this shader: a streak whose length grew with the window would be the nearly
-      // resolution-independent look that is worse than an honestly dependent one. The axis
-      // is a *direction* in those same reference pixels rather than in uv, which is the
-      // half that keeps the angle honest: the offset below is d reference pixels along the
-      // axis whatever shape the window is, where a step taken in uv and scaled afterwards
-      // would run at the aspect ratio's angle instead of the one the slider names, and
-      // would swing as somebody dragged the window.
-      //
-      // **The tap schedule is written down because the first one was wrong.** Eight taps at
-      // a geometric ratio of 2.1 put the far samples so far apart that they land as separate
-      // ghosts - a comb rather than a smear. Sixteen at 1.35 overlap enough to read as
-      // continuous and reach about 168 reference pixels.
-      //
-      // **The direction is the measurement and not the derivation, and the cost of getting
-      // that backwards is recorded here because it was paid twice.** When this gather ran
-      // one way only it was written with the plus, doubted against a busy frame that seemed
-      // to show the light climbing, flipped to a minus, and then restored - because a build
-      // cropped down to a single bright band with darkness above and below settles in one
-      // look what a full frame full of structure will support either reading of. Two
-      // separate readings of the *same* sign came out opposite. Nothing in the suite could
-      // have caught the flip: every uniform still landed and every image still changed, so
-      // the drop-one sweep stayed green through all of it.
-      //
-      // That sign is now a whole direction, and the lesson is the same one scaled up: the
-      // arm in the registry check calibrates *both* screen axes off the crop's own faces
-      // and asks where each angle's light actually lands, rather than deriving where it
-      // ought to from which way uv grows - which is the derivation that was wrong the first
-      // time. An angle of 0 keeps the fall this always had, and it keeps it exactly: at the
-      // default axis the offset below renders bit-identical to the plain vertical vec2 it
-      // replaces, measured at four looks and three drawing-buffer sizes, so there is no
-      // guard here of the kind the raster below needs. Multiplying by an axis that is
-      // exactly zero and exactly one introduces no rounding, where the raster's general
-      // form is a dot product against a sum the compiler contracts differently.
-      if (streak > 0.0) {
-        vec3 fall = col;
-        float d = 1.5;
-        for (int i = 0; i < 16; i++) {
-          vec3 tap = texture2D(tDiffuse, vUv + d * texel * streakAxis).rgb;
-          fall = max(fall, tap * exp2(-d * 0.02));
-          d *= 1.35;
-        }
-        col = mix(col, fall, streak);
-      }
-
-      if (scanlines > 0.0) {
-        // **The default path is the old line itself, not an expression that computes what
-        // the old line computed**, and that distinction is a measurement rather than
-        // caution. The shipped Blackwall document names a scanlines of 0.35, so this block
-        // runs in the one shipped look that is a look, and a raster a hair off the one it
-        // replaces is that document quietly re-grading itself.
-        //
-        // Two things were tried before this and both failed, which is worth recording
-        // because each looked like the answer. Taking the sine and cosine of the angle in
-        // the shader leaked a whisker of x into a raster meant to run along y, since GLSL
-        // ES does not promise the sine of zero is zero - that is real and is why the axis
-        // is built on the CPU, but fixing it moved nothing here. What moves the frame is
-        // the substitution docs/measurement.md already records: handing the wave a
-        // coordinate through a local is not the same as handing it the expression, because
-        // the compiler contracts the whole of y times the reference times 1.3 plus the
-        // clock across one line and will not do so through a variable. Measured at the
-        // shipped 0.35, all six frames differed, 054b99215d9f against 44e1ccf8, with every
-        // parameter at its default.
-        //
-        // So the branch goes around the whole statement and the default path *is* the old
-        // one - the same shape, and for the same reason, as the depth reading's gamma in
-        // web/cloud-shader.js. It is not a legacy path beside a new one: the general form
-        // below is the implementation, and this is the one input for which the arithmetic
-        // has to be reached rather than reproduced.
-        float line;
-        if (scanAxis.x == 0.0 && scanAxis.y == 1.0 && scanPitch == 1.3 && scanHard == 0.0) {
-          line = sin(vUv.y * ref.y * 1.3 + time * 2.0) * 0.5 + 0.5;
-        } else {
-          // The raster's own axis, as a direction in reference pixels, built on the CPU
-          // for the reason beside the uniform.
-          float coord = dot(vUv * ref, scanAxis);
-          float wave = sin(coord * scanPitch + time * 2.0) * 0.5 + 0.5;
-          // Hardness is a duty cycle rather than a second term. It narrows a smoothstep
-          // about the middle of the wave until the sine becomes a grille of hard lines
-          // with dark gaps between them, which is what the reference frames actually
-          // carry and what no amount of rotating a sine will ever reach.
-          float w = mix(0.5, 0.004, scanHard);
-          line = mix(wave, smoothstep(0.5 - w, 0.5 + w, wave), scanHard);
-        }
-        col *= 1.0 - scanlines * 0.35 * line;
-      }
-
-      if (grain > 0.0) {
-        // Weighted by luminance so grain lives in the signal instead of lifting
-        // the empty background into a grey haze.
-        //
-        // Quantised onto the reference grid rather than sampled continuously, so
-        // one grain cell is one 1080p pixel wherever the frame is drawn. Sampling
-        // continuously would give four sub-pixels of a 2x render four unrelated
-        // hash values that average to a quarter of the variance, which is exactly
-        // the "grain grows finer as resolution rises" this reference exists to
-        // stop. At 1080p it is the same one-value-per-pixel noise it always was,
-        // off a different seed.
-        float lum = dot(col, vec3(0.299, 0.587, 0.114));
-        float n = hash(floor(vUv * ref) + fract(time) * 137.0);
-        col += (n - 0.5) * grain * 0.22 * (0.15 + lum);
-      }
-
-      // How far the frame closes down on the subject, which used to be the literal 0.55
-      // and therefore a hidden function of whether any of the three terms above was up.
-      // The extent is still fixed - a vignette this look wants is a corner falloff and
-      // not a shape to author - so the parameter is the depth alone.
-      float vig = smoothstep(1.05, 0.32, length(vUv - 0.5));
-      col *= mix(1.0, vig, vignette);
-
-      // Roll highlights off per channel instead of letting additive accumulation
-      // clip to flat white - hot areas keep their hue this way.
-      col = col / (1.0 + col);
-      // Then crush the toe back down: Reinhard lifts blacks, and this look needs
-      // the empty space to stay genuinely black rather than dark red.
-      //
-      // The gain stays a literal while the toe becomes a parameter, and that asymmetry is
-      // measured rather than lazy. The obvious reading - that 1.12 normalises the toe back
-      // out and so should follow it - is wrong: a toe of 0.018 would normalise at 1.018,
-      // so 1.12 is an independent graded lift that happens to sit near it. Tying the two
-      // together would re-grade every look ever authored the moment anybody moved the toe,
-      // which is a whole preset library drifting to buy a tidier-looking line.
-      col = max(col - crush, 0.0) * 1.12;
-
-      gl_FragColor = vec4(col, 1.0);
-    }
-  `,
+// Every cell the grade's shader reads, with the value it holds before a look lands. The
+// text that reads them is assembled from `web/grade-shader.js` and the installed packages
+// and arrives at `buildPostChain` below, so this is the whole of what stayed: a default a
+// package cannot carry, because two of them are constructed objects.
+const GRADE_UNIFORMS = {
+  tDiffuse: { value: null },
+  rgbSplit: { value: 0 },
+  scanlines: { value: 0 },
+  // The three that turn one scanline term into a raster, and they are settings of
+  // `scanlines` rather than terms beside it. A raster is one idea and a sine is its
+  // softest duty cycle, so two terms that both darken the frame in stripes would be the
+  // drifting twin this file keeps refusing - and the hardness is what makes the other
+  // two reach anything, because adding an angle to a sine only ever gets you rotated
+  // softness where the reference frames are hard line grilles with dark gaps.
+  //
+  // The angle arrives as its own axis rather than as an angle, and that is a rounding
+  // measurement rather than a preference - the same shape `contourLo`/`contourHi` in
+  // `web/cloud-shader.js` are two uniforms for. Taking `sin` and `cos` in the shader
+  // looked obviously right and was measured wrong: GLSL ES permits a couple of
+  // thousandths of absolute error on a trigonometric function, so `sin(0.0)` is not
+  // promised to be exactly zero, and a whisker of x leaking into a raster that is
+  // supposed to run along y moved all six frames of the comparison against the build
+  // this replaces. Done here, `Math.sin(0)` is exactly 0 and `Math.cos(0)` exactly 1 in
+  // double, they survive the cast, and the dot below collapses to the frame's own y the
+  // way the old line's expression did.
+  //
+  // Degrees on the slider, and at zero the raster runs along y - the scanline this has
+  // always drawn. At a right angle it is the dense vertical column grille the reference
+  // frames slice their picture into, and because it keyframes a raster can *rotate*
+  // under the playhead, which is a capability rather than parity with a still frame.
+  //
+  // `scanPitch` was the literal 1.3 baked into the wave, and it defaults to it.
+  scanAxis: { value: new THREE.Vector2(0, 1) },
+  scanPitch: { value: 1.3 },
+  scanHard: { value: 0 },
+  grain: { value: 0 },
+  // The corner falloff, which was the literal 0.55 and applied whenever this pass ran
+  // at all. That made it a hidden function of the three terms above: a look with all
+  // of them at zero switched the pass off and lost its vignette, so the comment below
+  // claiming the frame "always closes down on the subject" was false in exactly the
+  // state the four shipped presets other than Blackwall are in.
+  //
+  // It defaults to 0 rather than to the 0.55 it was, and that is the one place in this
+  // file where a promoted literal does not keep its value. It cannot: the behaviour it
+  // replaces is not a constant but a conditional - 0.55 when something else was on, 0
+  // when nothing was - and no single default reproduces both branches. Zero is the
+  // branch that keeps the parameter defaults drawing what they drew, which is what
+  // registry-check hashes against a build from before any of this existed.
+  // `blackwall.json` names 0.55 explicitly so the one shipped look that had a vignette
+  // keeps it. A project saved before this that raised any grade term is the case that
+  // does change: it loses its corner falloff until it names one.
+  vignette: { value: 0 },
+  // The toe under the Reinhard curve, promoted from the literal 0.018 - and unlike
+  // `vignette` above it this one keeps the value it replaced, because the behaviour it
+  // replaces is a constant rather than a conditional. That difference decides the whole
+  // of how it is wired: a non-zero default cannot gate the pass, so `crush` is a
+  // sub-control inside the grade rather than a fifth term beside the four that gate it.
+  // See its entry in the registry in `web/main.js` for what gating it would have cost.
+  //
+  // **It is not the silhouette crush, whatever the name suggests**, and the comment is
+  // here to stop the next reader concluding that it is. This darkens near and far alike,
+  // so it cannot separate a subject from the space behind it; the term that does that is
+  // the duotone in the point shader, in `web/cloud-shader.js`. What this is for is the
+  // thing it always did - keep the empty background genuinely black after Reinhard lifts
+  // it.
+  streak: { value: 0 },
+  // Which way the light runs, as its own axis rather than as an angle, for exactly the
+  // reason `scanAxis` forty lines up carries in full: GLSL ES permits a couple of
+  // thousandths of absolute error on a trigonometric function, so `sin(0.0)` is not
+  // promised to be exactly zero, and a whisker of the wrong axis leaking into a fall
+  // that is meant to run straight down the frame is a defect no picture shows the shape
+  // of. Done here, `Math.sin(0)` is exactly 0 and `Math.cos(0)` exactly 1 in double,
+  // they survive the cast, and the offset in the gather below collapses to the frame's
+  // own y at the default the way the one-direction version's expression did.
+  //
+  // Degrees on the slider, and unlike the glitch's `glitchAxis` in `web/cloud-shader.js`
+  // that is the honest spelling rather than the lazy one. The tear's bands are quantised
+  // in the sensor's frame, where 512 columns meet 424 rows and a band is a run of
+  // scanlines rather than a distance, so there is no square in which an angle would mean
+  // what an angle means. This runs in the grade pass, in screen space, against a square
+  // reference pixel - so an angle here means what an angle means, and turning it 90
+  // degrees turns the streak 90 degrees on the glass.
+  streakAxis: { value: new THREE.Vector2(0, 1) },
+  crush: { value: 0.018 },
+  time: { value: 0 },
+  resolution: { value: new THREE.Vector2(1, 1) },
 };
 
 /**
@@ -330,8 +157,14 @@ const GradeShader = {
  * enables the pass on a non-zero value, so a chain that came up enabled would pay a
  * full-screen read and write per pass for the fraction of a second before the first look
  * lands, on every surface including the ones that never grade anything.
+ *
+ * `gradeProgram` is the assembled `{ vertexShader, fragmentShader }` pair, handed in for
+ * the same reason `buildPointCloud` is handed its own: the packages the text comes from
+ * were fetched by `web/main.js`, so this module builds a pass without ever knowing there is
+ * a server - which is what lets the gate run the same assembler under bare node with the
+ * packages read off disk instead.
  */
-export function buildPostChain() {
+export function buildPostChain(gradeProgram) {
   composer = new EffectComposer(renderer);
   renderPass = new RenderPass(scene, viewCamera);
   composer.addPass(renderPass);
@@ -344,7 +177,13 @@ export function buildPostChain() {
   bloom.enabled = false;
   composer.addPass(bloom);
 
-  grade = new ShaderPass(GradeShader);
+  // One combined pass: chaining separate RGBShift/Film/Vignette passes would cost
+  // a full-screen read and write each.
+  grade = new ShaderPass({
+    uniforms: GRADE_UNIFORMS,
+    vertexShader: gradeProgram.vertexShader,
+    fragmentShader: gradeProgram.fragmentShader,
+  });
   grade.enabled = false;
   composer.addPass(grade);
 

--- a/web/shader-assembly.js
+++ b/web/shader-assembly.js
@@ -27,12 +27,23 @@
 //     it. A slot is a *replacement* - the glyph field's point-size branch stands where
 //     the old clamp line stood - so two claimants is a refusal rather than a
 //     concatenation nobody could read.
-//   - a **service** is a gate the spine opens and the packages fill: the condition is
-//     generated from the `when` of every package consuming it, joined with `||` in
-//     `gateOrder`, and the body is the spine's own prologue followed by each consumer's
-//     chunk in the same order. With no consumers the whole block disappears, which is
-//     the point - a build with neither glyph nor rain installed must not pay a mat3
-//     multiply and two hashes per point for a cell nothing reads.
+//   - a **service** is a value the spine computes under a gate generated from whoever
+//     needs it: the condition is the `when` of every package consuming it, joined with
+//     `||` in `gateOrder`, and the spine's own `open`, `body` and `close` are the text
+//     around it. With no consumers the whole thing disappears, which is the point - a
+//     build with neither glyph nor rain installed must not pay a mat3 multiply and two
+//     hashes per point for a cell nothing reads.
+//
+//     **A service that closes something it opened is a scope, and that changes what its
+//     consumers owe it.** `cell` opens a block, so `room` and `wc` are locals of that
+//     block and a consumer's chunk has to go *inside* it - which is why a chunk naming a
+//     service as its stage takes its place from `gateOrder` rather than from an `order`
+//     of its own: the term in the gate and the block it opens are one placement. `region`
+//     closes nothing: it computes `rw` at the surrounding scope, its consumers read that
+//     value from wherever they happen to sit, and their chunks are placed by the stage or
+//     slot they name. So the two services ask their consumers for different things, and
+//     the refusals below are written per shape rather than as one rule that would have to
+//     be wrong about one of them.
 //   - a **varying declaration** is generated from the packages' `varyings` entries, in
 //     three places out of one declaration: the vertex `out`, the fragment `in`, and the
 //     line in the prologue that gives it its inert value above the early returns. One
@@ -59,19 +70,22 @@ const byOrder = (a, b) => (a.order - b.order) || (a.id < b.id ? -1 : a.id > b.id
 const jointsOf = (spine) => {
   const stages = new Set();
   const slots = new Map();
-  const services = new Set();
+  const services = new Map();
   const claim = (name, where) => {
     if (stages.has(name) || slots.has(name) || services.has(name)) {
       throw new Error(`the shader spine declares ${JSON.stringify(name)} twice, so a chunk naming it would be spliced in two places`);
     }
     if (where === 'stage') stages.add(name);
-    if (where === 'service') services.add(name);
   };
   for (const program of [spine.vertex, spine.fragment]) {
     for (const entry of program) {
       if (entry.stage !== undefined) claim(entry.stage, 'stage');
-      else if (entry.service !== undefined) claim(entry.service, 'service');
-      else if (entry.slot !== undefined) {
+      // The entry rather than the name alone, because whether a service opens a scope
+      // decides what its consumers owe it, and that is a property of the spine's text.
+      else if (entry.service !== undefined) {
+        claim(entry.service, 'service');
+        services.set(entry.service, entry);
+      } else if (entry.slot !== undefined) {
         claim(entry.slot, 'slot');
         slots.set(entry.slot, entry);
       }
@@ -101,14 +115,18 @@ const chunkText = (pkg, file) => {
  *
  * `packages` are the objects `/effects/:id` answers with, each carrying its `manifest`
  * and a `chunks` map of file name to text. A package with no `chunks` section in its
- * manifest contributes nothing and is not an error: most of the sixteen shipped effects
- * are parameters over code the spine already holds.
+ * manifest contributes nothing and is not an error: half of the sixteen shipped effects
+ * are parameters over code the spine already holds. That number was "most" while the glyph
+ * field, the rain, the glitch and the lattice were the only packages carrying GLSL, and it
+ * is eight against eight now that the region family has moved out - a sentence worth
+ * keeping current rather than approximately true, since it is the one a reader checks
+ * before wondering why their package assembled to nothing.
  */
 export function assembleShaders(spine, packages) {
   const joints = jointsOf(spine);
   const stages = new Map([...joints.stages].map((name) => [name, []]));
   const slots = new Map();
-  const services = new Map([...joints.services].map((name) => [name, []]));
+  const services = new Map([...joints.services.keys()].map((name) => [name, []]));
   const varyings = [];
   const declared = new Set();
 
@@ -139,7 +157,7 @@ export function assembleShaders(spine, packages) {
       varyings.push({ ...v, id: pkg.id });
     }
 
-    const filled = new Set();
+    const filled = new Map();
     for (const c of manifest.chunks ?? []) {
       const text = chunkText(pkg, c.file);
       if (c.slot !== undefined) {
@@ -170,8 +188,7 @@ export function assembleShaders(spine, packages) {
         if (filled.has(c.stage)) {
           throw new Error(`effect ${pkg.id} fills the ${c.stage} service twice, and one consumer gets one block`);
         }
-        filled.add(c.stage);
-        services.get(c.stage).push({ id: pkg.id, order: consumed.gateOrder, when: consumed.when, text });
+        filled.set(c.stage, text);
         continue;
       }
       if (!joints.stages.has(c.stage)) {
@@ -183,10 +200,33 @@ export function assembleShaders(spine, packages) {
       stages.get(c.stage).push({ id: pkg.id, order: c.order, text });
     }
 
-    for (const service of consumes.keys()) {
-      if (!filled.has(service)) {
-        throw new Error(`effect ${pkg.id} consumes ${service} and brings no chunk for it, so it would widen the gate and put nothing inside it`);
+    // **A consumer widens a gate, so a consumer that contributes nothing is a build paying
+    // for a value nobody reads** - and what counts as contributing depends on whether the
+    // service opens a scope. A consumer of `cell` has to fill it: its chunk reads locals
+    // that exist only inside that block, so a chunk anywhere else would not compile and a
+    // consumer with no chunk at all is a mat3 multiply and two hashes bought for nothing.
+    // A consumer of `region` reads `rw` at the surrounding scope and puts its own text in
+    // whatever stage or slot it names, so what it owes is a chunk somewhere - the failure
+    // being refused is the same one either way, a term in the condition with nothing behind
+    // it, and only the place the something has to be differs.
+    //
+    // **The gate term comes from `consumes` and never from the chunk**, which is the half
+    // this loop had backwards while `cell` was the only service: the consumer list used to
+    // be built where a chunk filled the service, so a package consuming one and putting its
+    // text somewhere else declared a `when` nothing ever read, and the gate came out one
+    // term short with no error anywhere. Every consumer joins the condition here; the text
+    // it puts inside is whatever it filled the service with, or nothing.
+    for (const [service, consumed] of consumes) {
+      if (joints.services.get(service).close.length > 0) {
+        if (!filled.has(service)) {
+          throw new Error(`effect ${pkg.id} consumes the ${service} scope and brings no chunk for it, so it would widen the gate and put nothing inside it`);
+        }
+      } else if ((manifest.chunks ?? []).length === 0) {
+        throw new Error(`effect ${pkg.id} consumes ${service} and brings no chunk at all, so it would widen the gate and nothing would read the value behind it`);
       }
+      services.get(service).push({
+        id: pkg.id, order: consumed.gateOrder, when: consumed.when, text: filled.get(service) ?? '',
+      });
     }
   }
 
@@ -206,10 +246,16 @@ export function assembleShaders(spine, packages) {
       else if (entry.service !== undefined) {
         const consumers = services.get(entry.service);
         if (consumers.length === 0) continue;
-        out += `${entry.indent}if (${consumers.map((c) => c.when).join(' || ')}) {\n`;
+        // Four pieces and none of them assumed: the spine carries the text either side of
+        // the condition and after the chunks, so an `if` block and a conditional expression
+        // are the same joint with different text rather than two kinds. The alternative was
+        // baking `if (` and `) {` in here, which is a fact about one shader living inside a
+        // concatenator that is supposed to know nothing about GLSL at all.
+        out += entry.open;
+        out += consumers.map((c) => c.when).join(' || ');
         out += entry.body;
         out += consumers.map((c) => c.text).join('');
-        out += `${entry.indent}}\n`;
+        out += entry.close;
       } else {
         throw new Error(`the shader spine holds an entry of no kind this assembler knows: ${JSON.stringify(Object.keys(entry))}`);
       }

--- a/web/shader-assembly.js
+++ b/web/shader-assembly.js
@@ -1,12 +1,25 @@
-// The two programs the point cloud compiles, assembled out of a core spine and whatever
-// effect packages are installed.
+// The programs this page compiles, assembled out of a core spine each and whatever effect
+// packages are installed.
+//
+// **Every spine is assembled in one call, and that is a refusal rather than a convenience.**
+// There are two of them now - the point cloud's pair in `web/cloud-shader.js` and the grade
+// pass's in `web/grade-shader.js` - and a chunk names the joint it joins, never the program
+// it belongs to. So the joints of every spine are collected together before a package is
+// read, one name means one place across all of them, and a chunk naming a joint nothing
+// holds is refused by name. Assembling one spine at a time would have made that refusal
+// impossible: the grade's assembly would meet the glyph field's `v.decl` chunk, and the only
+// two answers available would be to throw on a chunk that is perfectly well placed
+// elsewhere, or to skip it - which is the same silent absence as a typo, wearing the clothes
+// of a design. The alternative considered and rejected was tagging every chunk with its
+// program's name, which reintroduces exactly that: a tag nobody spelled right lands the
+// chunk in no program at all, the page boots, and the effect is simply gone.
 //
 // **Assembly is concatenation and nothing else.** A chunk's text is spliced between two
 // verbatim segments exactly as it arrived - not re-indented, not substituted into, not
 // wrapped - because the property this whole split rests on is that the shipped set
-// assembles to the two literals the file used to hold, byte for byte, and every
+// assembles to the four literals the two files used to hold, byte for byte, and every
 // transformation on the way is a byte that can move. `test/shader-assembly.test.mjs`
-// holds that equality against the last revision carrying the monolith and refuses a
+// holds that equality against the last revision carrying each monolith and refuses a
 // single flipped byte in any chunk, which is what makes "verbatim" a measurement rather
 // than an intention.
 //
@@ -60,34 +73,40 @@
 const byOrder = (a, b) => (a.order - b.order) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
 
 /**
- * Every joint the spine holds, by kind.
+ * Every joint every spine holds, by kind.
  *
- * Collected before any package is read so a chunk can be refused against the spine
+ * Collected before any package is read so a chunk can be refused against the spines
  * rather than against whatever happens to be in the map by the time it is reached, and
  * a name declared twice is refused here: two joints sharing a name would take one
- * package's chunk to two places in the program, which compiles and draws twice.
+ * package's chunk to two places, which compiles and draws twice. **Across the spines and
+ * not within one**, which is what makes one name mean one place in the whole build - two
+ * spines both offering a `decl` would otherwise be a chunk that lands in a program its
+ * author never named, and no arm anywhere would report it as anything but a look that
+ * changed.
  */
-const jointsOf = (spine) => {
+const jointsOf = (spines) => {
   const stages = new Set();
   const slots = new Map();
   const services = new Map();
   const claim = (name, where) => {
     if (stages.has(name) || slots.has(name) || services.has(name)) {
-      throw new Error(`the shader spine declares ${JSON.stringify(name)} twice, so a chunk naming it would be spliced in two places`);
+      throw new Error(`the shader spines declare ${JSON.stringify(name)} twice, so a chunk naming it would be spliced in two places`);
     }
     if (where === 'stage') stages.add(name);
   };
-  for (const program of [spine.vertex, spine.fragment]) {
-    for (const entry of program) {
-      if (entry.stage !== undefined) claim(entry.stage, 'stage');
-      // The entry rather than the name alone, because whether a service opens a scope
-      // decides what its consumers owe it, and that is a property of the spine's text.
-      else if (entry.service !== undefined) {
-        claim(entry.service, 'service');
-        services.set(entry.service, entry);
-      } else if (entry.slot !== undefined) {
-        claim(entry.slot, 'slot');
-        slots.set(entry.slot, entry);
+  for (const spine of Object.values(spines)) {
+    for (const program of [spine.vertex, spine.fragment]) {
+      for (const entry of program) {
+        if (entry.stage !== undefined) claim(entry.stage, 'stage');
+        // The entry rather than the name alone, because whether a service opens a scope
+        // decides what its consumers owe it, and that is a property of the spine's text.
+        else if (entry.service !== undefined) {
+          claim(entry.service, 'service');
+          services.set(entry.service, entry);
+        } else if (entry.slot !== undefined) {
+          claim(entry.slot, 'slot');
+          slots.set(entry.slot, entry);
+        }
       }
     }
   }
@@ -111,19 +130,24 @@ const chunkText = (pkg, file) => {
 };
 
 /**
- * The two programs, as source text, from a spine and the installed packages.
+ * Every program, as source text, from the spines and the installed packages.
+ *
+ * `spines` is a map of program name to spine, and the answer is a map of the same names to
+ * a `{ vertexShader, fragmentShader }` pair each - so the caller asks for a program by the
+ * name it handed in rather than by position, and adding a third spine is one more key at
+ * both ends.
  *
  * `packages` are the objects `/effects/:id` answers with, each carrying its `manifest`
  * and a `chunks` map of file name to text. A package with no `chunks` section in its
- * manifest contributes nothing and is not an error: half of the sixteen shipped effects
- * are parameters over code the spine already holds. That number was "most" while the glyph
- * field, the rain, the glitch and the lattice were the only packages carrying GLSL, and it
- * is eight against eight now that the region family has moved out - a sentence worth
- * keeping current rather than approximately true, since it is the one a reader checks
- * before wondering why their package assembled to nothing.
+ * manifest contributes nothing and is not an error: some of the sixteen shipped effects
+ * are parameters over code a spine already holds. That number was "most" while the glyph
+ * field, the rain, the glitch and the lattice were the only packages carrying GLSL, it was
+ * eight against eight once the region family moved out, and the tone run and the grade
+ * leave three - a sentence worth keeping current rather than approximately true, since it
+ * is the one a reader checks before wondering why their package assembled to nothing.
  */
-export function assembleShaders(spine, packages) {
-  const joints = jointsOf(spine);
+export function assembleShaders(spines, packages) {
+  const joints = jointsOf(spines);
   const stages = new Map([...joints.stages].map((name) => [name, []]));
   const slots = new Map();
   const services = new Map([...joints.services.keys()].map((name) => [name, []]));
@@ -263,5 +287,7 @@ export function assembleShaders(spine, packages) {
     return out;
   };
 
-  return { vertexShader: emit(spine.vertex), fragmentShader: emit(spine.fragment) };
+  return Object.fromEntries(Object.entries(spines).map(([name, spine]) => [
+    name, { vertexShader: emit(spine.vertex), fragmentShader: emit(spine.fragment) },
+  ]));
 }

--- a/web/shader-assembly.js
+++ b/web/shader-assembly.js
@@ -1,0 +1,221 @@
+// The two programs the point cloud compiles, assembled out of a core spine and whatever
+// effect packages are installed.
+//
+// **Assembly is concatenation and nothing else.** A chunk's text is spliced between two
+// verbatim segments exactly as it arrived - not re-indented, not substituted into, not
+// wrapped - because the property this whole split rests on is that the shipped set
+// assembles to the two literals the file used to hold, byte for byte, and every
+// transformation on the way is a byte that can move. `test/shader-assembly.test.mjs`
+// holds that equality against the last revision carrying the monolith and refuses a
+// single flipped byte in any chunk, which is what makes "verbatim" a measurement rather
+// than an intention.
+//
+// **Nothing is imported here and nothing may be.** The spine is data handed in and the
+// packages are data handed in, so this module is a pure function of its two arguments -
+// which is what lets the gate evaluate it under bare node beside a `git show` of the old
+// file, with no page and no server standing around it. The same argument
+// `web/effect-manifests.js` makes about the registry's conversion: one statement of it,
+// used by the live page and by the test, because a test with its own copy of the
+// assembler would be a second assembler agreeing with itself.
+//
+// The four kinds of joint a spine can hold, and each is a different question:
+//
+//   - a **stage** takes any number of chunks, concatenated in the order they declare.
+//     Declaration blocks and helper tables are stages: two packages both adding uniforms
+//     is the ordinary case, not a conflict.
+//   - a **slot** takes at most one chunk and carries the text to use when nothing claims
+//     it. A slot is a *replacement* - the glyph field's point-size branch stands where
+//     the old clamp line stood - so two claimants is a refusal rather than a
+//     concatenation nobody could read.
+//   - a **service** is a gate the spine opens and the packages fill: the condition is
+//     generated from the `when` of every package consuming it, joined with `||` in
+//     `gateOrder`, and the body is the spine's own prologue followed by each consumer's
+//     chunk in the same order. With no consumers the whole block disappears, which is
+//     the point - a build with neither glyph nor rain installed must not pay a mat3
+//     multiply and two hashes per point for a cell nothing reads.
+//   - a **varying declaration** is generated from the packages' `varyings` entries, in
+//     three places out of one declaration: the vertex `out`, the fragment `in`, and the
+//     line in the prologue that gives it its inert value above the early returns. One
+//     statement rather than three, because an `out` with no `in` is a link error and an
+//     `in` with no prologue write is undefined-register roulette on every shed point -
+//     and a package declaring the three separately could get any pair of them out of
+//     step.
+//
+// Every refusal below names the silent failure it is standing in front of. A chunk
+// naming a joint that is not there would otherwise assemble into nothing at all: the
+// page boots, the shader compiles, and the effect is simply absent with no error
+// anywhere - which is the exact shape this repo keeps case files about.
+
+const byOrder = (a, b) => (a.order - b.order) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+
+/**
+ * Every joint the spine holds, by kind.
+ *
+ * Collected before any package is read so a chunk can be refused against the spine
+ * rather than against whatever happens to be in the map by the time it is reached, and
+ * a name declared twice is refused here: two joints sharing a name would take one
+ * package's chunk to two places in the program, which compiles and draws twice.
+ */
+const jointsOf = (spine) => {
+  const stages = new Set();
+  const slots = new Map();
+  const services = new Set();
+  const claim = (name, where) => {
+    if (stages.has(name) || slots.has(name) || services.has(name)) {
+      throw new Error(`the shader spine declares ${JSON.stringify(name)} twice, so a chunk naming it would be spliced in two places`);
+    }
+    if (where === 'stage') stages.add(name);
+    if (where === 'service') services.add(name);
+  };
+  for (const program of [spine.vertex, spine.fragment]) {
+    for (const entry of program) {
+      if (entry.stage !== undefined) claim(entry.stage, 'stage');
+      else if (entry.service !== undefined) claim(entry.service, 'service');
+      else if (entry.slot !== undefined) {
+        claim(entry.slot, 'slot');
+        slots.set(entry.slot, entry);
+      }
+    }
+  }
+  return { stages, slots, services };
+};
+
+/**
+ * One package's chunk text, or a refusal naming what was not fetched.
+ *
+ * The manifest lists the files and the caller fetches them, so a chunk the manifest
+ * names and the caller did not bring is a package half-loaded - and half-loaded
+ * assembles to a program missing one block, which compiles as often as not.
+ */
+const chunkText = (pkg, file) => {
+  const text = pkg.chunks?.[file];
+  if (typeof text !== 'string') {
+    throw new Error(`effect ${pkg.id} declares the chunk ${JSON.stringify(file)} and its text was not loaded - `
+      + 'a package assembled without one of its chunks is a program with a block missing');
+  }
+  return text;
+};
+
+/**
+ * The two programs, as source text, from a spine and the installed packages.
+ *
+ * `packages` are the objects `/effects/:id` answers with, each carrying its `manifest`
+ * and a `chunks` map of file name to text. A package with no `chunks` section in its
+ * manifest contributes nothing and is not an error: most of the sixteen shipped effects
+ * are parameters over code the spine already holds.
+ */
+export function assembleShaders(spine, packages) {
+  const joints = jointsOf(spine);
+  const stages = new Map([...joints.stages].map((name) => [name, []]));
+  const slots = new Map();
+  const services = new Map([...joints.services].map((name) => [name, []]));
+  const varyings = [];
+  const declared = new Set();
+
+  for (const pkg of packages) {
+    const manifest = pkg.manifest ?? {};
+    const consumes = new Map();
+    for (const c of manifest.consumes ?? []) {
+      if (!joints.services.has(c.service)) {
+        throw new Error(`effect ${pkg.id} consumes the service ${JSON.stringify(c.service)}, which this shader spine does not offer`);
+      }
+      if (typeof c.when !== 'string' || c.when.length === 0) {
+        throw new Error(`effect ${pkg.id} consumes ${c.service} without a \`when\`, so nothing would open the gate it needs`);
+      }
+      if (!Number.isFinite(c.gateOrder)) {
+        throw new Error(`effect ${pkg.id} consumes ${c.service} without a numeric \`gateOrder\`, and where its term sits in the condition decides the text`);
+      }
+      if (consumes.has(c.service)) {
+        throw new Error(`effect ${pkg.id} consumes ${c.service} twice, and one package gets one term in a gate`);
+      }
+      consumes.set(c.service, c);
+    }
+
+    for (const v of manifest.varyings ?? []) {
+      if (declared.has(v.name)) {
+        throw new Error(`${v.name} is declared by two effects - a varying is one channel, and two packages writing it would be two effects sharing one register`);
+      }
+      declared.add(v.name);
+      varyings.push({ ...v, id: pkg.id });
+    }
+
+    const filled = new Set();
+    for (const c of manifest.chunks ?? []) {
+      const text = chunkText(pkg, c.file);
+      if (c.slot !== undefined) {
+        if (!joints.slots.has(c.slot)) {
+          throw new Error(`effect ${pkg.id}'s ${c.file} claims the slot ${JSON.stringify(c.slot)}, which this shader spine does not hold`);
+        }
+        const held = slots.get(c.slot);
+        if (held) {
+          throw new Error(`${held.id} and ${pkg.id} both claim the slot ${c.slot} - a slot is a replacement, so two claimants is two programs`);
+        }
+        slots.set(c.slot, { id: pkg.id, text });
+        continue;
+      }
+      if (c.stage === undefined) {
+        throw new Error(`effect ${pkg.id}'s ${c.file} names neither a stage nor a slot, so nothing decides where it goes`);
+      }
+      // A chunk on a service stage takes its place from the `consumes` entry rather than
+      // from an `order` of its own: the term in the gate and the block inside it are one
+      // placement, and two numbers for one fact is the drift this design keeps refusing.
+      if (joints.services.has(c.stage)) {
+        const consumed = consumes.get(c.stage);
+        if (!consumed) {
+          throw new Error(`effect ${pkg.id}'s ${c.file} fills the ${c.stage} service without consuming it, so nothing would open the gate around it`);
+        }
+        if (c.order !== undefined) {
+          throw new Error(`effect ${pkg.id}'s ${c.file} carries an \`order\` as well as ${c.stage}'s \`gateOrder\` - the gate term and the block it opens are one placement`);
+        }
+        if (filled.has(c.stage)) {
+          throw new Error(`effect ${pkg.id} fills the ${c.stage} service twice, and one consumer gets one block`);
+        }
+        filled.add(c.stage);
+        services.get(c.stage).push({ id: pkg.id, order: consumed.gateOrder, when: consumed.when, text });
+        continue;
+      }
+      if (!joints.stages.has(c.stage)) {
+        throw new Error(`effect ${pkg.id}'s ${c.file} names the stage ${JSON.stringify(c.stage)}, which this shader spine does not hold`);
+      }
+      if (!Number.isFinite(c.order)) {
+        throw new Error(`effect ${pkg.id}'s ${c.file} joins ${c.stage} without a numeric \`order\`, and a stage's text is its chunks in order`);
+      }
+      stages.get(c.stage).push({ id: pkg.id, order: c.order, text });
+    }
+
+    for (const service of consumes.keys()) {
+      if (!filled.has(service)) {
+        throw new Error(`effect ${pkg.id} consumes ${service} and brings no chunk for it, so it would widen the gate and put nothing inside it`);
+      }
+    }
+  }
+
+  for (const list of stages.values()) list.sort(byOrder);
+  for (const list of services.values()) list.sort(byOrder);
+  varyings.sort(byOrder);
+
+  const emit = (program) => {
+    let out = '';
+    for (const entry of program) {
+      if (entry.text !== undefined) out += entry.text;
+      else if (entry.varyings === 'out') out += varyings.map((v) => `out ${v.type} ${v.name};\n`).join('');
+      else if (entry.varyings === 'in') out += varyings.map((v) => `in ${v.type} ${v.name};\n`).join('');
+      else if (entry.varyings === 'init') out += varyings.map((v) => `  ${v.name} = ${v.init};\n`).join('');
+      else if (entry.stage !== undefined) out += stages.get(entry.stage).map((c) => c.text).join('');
+      else if (entry.slot !== undefined) out += (slots.get(entry.slot)?.text ?? entry.fallback);
+      else if (entry.service !== undefined) {
+        const consumers = services.get(entry.service);
+        if (consumers.length === 0) continue;
+        out += `${entry.indent}if (${consumers.map((c) => c.when).join(' || ')}) {\n`;
+        out += entry.body;
+        out += consumers.map((c) => c.text).join('');
+        out += `${entry.indent}}\n`;
+      } else {
+        throw new Error(`the shader spine holds an entry of no kind this assembler knows: ${JSON.stringify(Object.keys(entry))}`);
+      }
+    }
+    return out;
+  };
+
+  return { vertexShader: emit(spine.vertex), fragmentShader: emit(spine.fragment) };
+}


### PR DESCRIPTION
Part 4 of the six-PR stack. Base: `effects-store`.

The two monolithic shaders are cut into spines — verbatim GLSL segments with joints between them — and every effect's GLSL moves into its package, assembled at boot by an import-free pure module. Four joint kinds: stages take any number of chunks in declared order, slots take one claimant and carry the core fallback used when nothing claims them, services open a gate generated from consumers' declared conditions (the cell grid, the region weight), and varyings generate from the manifests in all three places at once. The grade pass follows, cut from post-chain into its own spine; the assembler takes a map of program names to spines, so a chunk naming a joint nothing holds is refused by name rather than landing in no program. `gradeNeeded()` derives from the manifests' gate bindings instead of hand-enumerating.

Byte-identity is the rail throughout: a bare-node gate holds the assembled programs equal to the monoliths as git history holds them (retired in part 6), every moved mutation anchor is proven equivalent — mutated assembled text byte-identical against the monolith and against the split — and the ten-look probe is 150/150 at every commit. syntax-check learns the dead-copy class along the way: a slot's fallback is a second copy of shipped text, and every GLSL anchor must appear exactly once in the assembled programs and move one when applied.

Also here: the staging fix for three proof tools whose probe trees had silently stopped booting once the server began refusing a missing effects-builtin root, and the readiness fix that surfaced (the page's load event stopped implying `__kinect` exists once packages moved onto the wire).
