### PR TITLE
Drop-in effects: parking, the badge, export suppress, and runtime install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ captures
 exports
 projects
 presets
+# The effect store's user root, which is the same kind of runtime document store as the
+# two above: `PUT /effects/:id` lands a package here and `DELETE` takes it away, and
+# `effects-builtin/` beside it is the shipped half that this program never writes into.
+# Named before the first install rather than after, because an installed package is GLSL
+# and JSON that `syntax-check` would otherwise walk as though this repo shipped it.
+effects
 # Deliverables are the same kind of runtime document store as the two above and were
 # simply missed. `editor-check` writes two into it now, so the omission would have put an
 # untracked directory in everybody's `git status` the first time the suite ran.
@@ -21,6 +27,10 @@ deliverables
 # The staged tree monitor-check builds and deletes. It only survives a run that
 # threw, which is exactly when it is worth looking at and never worth committing.
 .monitor-check
+# And effect-check's, for the same reason plus one of its own: it is the only staged
+# tree in the suite that gets packages written into it, so a run that threw leaves
+# fifteen hostile fixtures and a probe effect on disk.
+.effect-check
 
 # Render-queue records. The queue is state a machine accumulates, not source.
 jobs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ exit code (rule 3).
 | `vcam-check.mjs` | the output to OBS, and the take it must not touch | port 8361 free |
 | `guard-check.mjs` | the socket's origin rule, the bind, the rebinding rule | port 8321 free |
 | `jobs-check.mjs` | the queue, the pin, a real render, a job this build cannot read | port 8231, a GPU browser, ffprobe |
+| `effect-check.mjs` | installing an effect: revisions, the door, the hotload, park and restore | port 8281 free, a GPU browser |
+| `effect-conformance-check.mjs` | every installed effect draws nothing at all when it is off | `--url`, a GPU browser |
 | `module-check.mjs` | the boundaries in `web/`: the import graph, what crosses it | nothing |
 | `syntax-check.mjs` | every shipped file parses, the cross-language constants agree, the citations resolve, every tool is named here | nothing |
 | `cpp-check.mjs` | both C++ files parse and typecheck, in all four pipeline configurations | a C++ compiler and turbojpeg's headers |
@@ -152,15 +154,17 @@ exit code (rule 3).
 | `registration-check.mjs` | our registration equals upstream's, bit for bit | a corpus from `grabber --dump-corpus` |
 | `release-gate-check.mjs` | the `.npmrc` supply-chain gate is actually armed | the npm registry |
 
-**Seven spawn their own server, so what they need is a free port rather than a running one** —
-`guard-check` on 8321, `jobs-check` on 8231, `level-check` on 8377, `monitor-check` on 8341,
-`vcam-check` on 8361, `boot-check` on 8391, and `library-check` across `--node-port` and
-`--mac-port`..`+16`, which default to 8210 and 8211..8227. The distinction is not bookkeeping: a
+**Eight spawn their own server, so what they need is a free port rather than a running one** —
+`guard-check` on 8321, `jobs-check` on 8231, `effect-check` on 8281, `level-check` on 8377,
+`monitor-check` on 8341, `vcam-check` on 8361, `boot-check` on 8391, and `library-check` across
+`--node-port` and `--mac-port`..`+16`, which default to 8210 and 8211..8227. The distinction is not bookkeeping: a
 tool that finds a stranger already listening on its port is answered by the stranger and asserts
 against whatever fixture *that* process staged, which is a green run proving nothing.
-`library-check` and `boot-check` ask the kernel first and exit 2 naming what is held; everywhere
-else check `pgrep -f "tools/.*-check.mjs"` yourself, because another agent's run is the normal
-state on this machine. `sensor-view-check` does both — `--url` for most of its run, and a private
+`library-check`, `boot-check` and `effect-check` ask the kernel first and exit 2 naming what is
+held; everywhere else check `pgrep -f "tools/.*-check.mjs"` yourself, because another agent's run
+is the normal state on this machine. **`effect-check` is the only tool that writes packages**, so
+it hands its staged server both store roots by name rather than letting them resolve — a run whose
+user root resolved to the checkout would leave seventeen fixtures in `effects/`. `sensor-view-check` does both — `--url` for most of its run, and a private
 server on 8131 for the section needing its own capture.
 
 **`module-check` needs nothing at all** — no port, no browser, no install — because every failure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,46 @@ proves.
 renderer class it will draw with. [Get a video out](../README.md#5-get-a-video-out) has the
 rest.
 
+## The effect store
+
+The look is not one program. Every effect is a package — a manifest and the GLSL chunks it
+splices into the shaders — and the page assembles both point-cloud programs, the grade pass, the
+parameter registry and the panel out of whatever the store holds. `server/effect-store.js` serves
+them and `web/shader-assembly.js` joins them.
+
+**Two roots, and the user's copy wins.** `effects-builtin/` is what the build ships with and
+nothing in this program writes into it; `effects/` is where an install lands. An id present in
+both resolves from the user's, which *is* the fork mechanism: install a package under a shipped
+id and it shadows the shipped one, delete that copy and the shipped one answers again. The
+shipped set is therefore always available to fall back to, which is why removing a builtin
+nothing forks is refused rather than performed. It is the same shape the preset store uses, and
+what makes it its own class rather than a fourth construction of that one is what is stored: a
+package is a directory of files, so a revision has to be computed over the set and a read has to
+say which files exist before a client can fetch them one at a time.
+
+```
+GET    /effects              every id either root holds, each with its files and revisions
+GET    /effects/:id          one package: the parsed manifest, the file index, the revision
+GET    /effects/:id/file/:n  one file's bytes, as text/plain
+PUT    /effects/:id          { manifest, chunks: { <file>: <text> } }  installs into effects/
+DELETE /effects/:id          removes the user's copy only
+```
+
+A revision is a hash of the bytes: `sha256` per file, and the package's own over the sorted
+`name hash` lines. Never a re-serialisation — a manifest that round-trips through `JSON.parse`
+is a different byte stream with the same meaning, and provenance is about bytes.
+
+**An install is atomic because a package is a directory.** The whole thing is written under
+`<id>.<seq>.tmp`, any existing copy is renamed to `<id>.<seq>.old`, the new one is renamed in and
+the old one deleted. Those suffixes carry a dot and an effect id may not, so a crashed install is
+invisible to every read by the same rule that decides what an id is — and the next install of
+that id sweeps what it left. What may be written at all is decided before any of it: the door in
+`server/effect-door.js` runs the real assembler against the set that would exist after the
+install, and a package that would not assemble, would bind a uniform no program declares or would
+name an identifier this build has not got is refused with the reason and never reaches disk. The
+alternative is a package that installs cleanly and breaks the *next* page load, where the only
+evidence is a console nobody has open.
+
 ## Program time is the edit coordinate
 
 Source time is a position inside the capture; program time a position inside the output.

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -2595,6 +2595,31 @@ arrived", because those are different findings. What it is *not* is a fixed `wai
 shape their own comments refuse, and a sleep tuned on this machine is a pass waiting for a
 slower one.
 
+**And the same publish race has a second door, where the guard is vacuous rather than
+absent.** `library-check` waited on
+`globalThis.__kinect?.timeline?.transport() !== null` after opening the editor. Read it
+against a page that has not published the handle: the optional chain answers `undefined`, and
+`undefined !== null` is **true**, so the wait resolves on its first tick having proved nothing
+and the unguarded read on the next line throws `Cannot read properties of undefined (reading
+'timeline')`. It was harmless for exactly as long as `load` meant the page was up. Measured
+when it bit: the run ended at 234 assertions with the section's own rows unasked, on a machine
+that had just finished two other proof tools, and `Boolean(...)` in place of the comparison
+took the same tool to 495 with none failed. Three waits in that file were written the same way
+and all three moved together.
+
+`editor-check` had the absent-guard form of it at one of its three reloads, and the two
+neighbours are what said so: the other two wait for `!!globalThis.__kinect` and *then* for the
+transport, and the third went straight at the transport. It died at 475 of 545 assertions,
+taking sections 16 through 22 with it, and printed `DID NOT RUN` — the honest verdict, and an
+expensive one, since the run before it had cost twenty minutes.
+
+**The general shape is worth more than either instance: a guard written with `?.` and compared
+against `null` is not a guard.** `?.` short-circuits to `undefined`, and every comparison
+except `== null` and `!= null` treats that as a value like any other — so the operator that
+looks like it is protecting the read is the operator that makes the predicate pass before the
+thing exists. Ask of any wait whether its predicate is *false* on a page that has not booted;
+if it is true, the timeout is unreachable and the wait is a comment.
+
 **A contended machine fails a check in a way that reads as a finding.** Two worktrees running
 proof tools at once produced four failed runs, and the quiet one is the dangerous one: under
 contention the preset-apply evaluate dies with `Resulting promise was garbage collected`, a

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -3067,6 +3067,35 @@ Two lessons, and the second is the one that generalises:
   `raster.amount: 0.35` for this reason; the glitch had no such arm because nobody had asked what
   the shipped document turns on. **Ask what the shipped look names, and render there.**
 
+### The same shape one level up: the difference between two registries was a parameter at its default
+
+`effect-check`'s section 6 holds a page that refused an install to the state it was in before
+it: the registry it had, the signature it had, the pool it was holding, and the three pinned
+positions rendering the images they rendered. The pixel rows are the ones that read like proof,
+and they are the ones that cannot see the defect. `rollback-keeps-the-new-registry` — the
+rollback that reloads the document and reloads it against the packages that just arrived — leaves
+the page assembled from the fork, and the fork differs from what it forks by exactly one added
+parameter, which is inert at its default because the door refuses a master that is not. So the
+program has a chunk more in it, and the chunk draws nothing, and the three hashes are identical
+on both builds.
+
+What separates them is the registry's own contents, the signature, and what a save writes — the
+last of those because the serialiser drops a parked key the moment its prefix reads installed, so
+a page holding the new registry writes a document with the parked work missing from it. Three
+rows about bookkeeping catch what three rows about pixels cannot, which inverts this repo's usual
+order and is worth remembering as an order rather than a rule: **a pixel is the right probe for a
+value, and the wrong one for which set of parameters exists**, because the parameters that
+distinguish two sets are exactly the ones a well-behaved package leaves at zero.
+
+The section's own control had the same defect one layer down and was found by running it rather
+than by reading it. It was written as section 4's row — the three positions render three
+different images — and it went red on a correct build. With the effect parked there is nothing
+keyed left to separate the positions: the pinned run is six frames at 33ms, so 0.6s and 1.2s
+both show the last of them. Section 4's three images differ because `probe.amount` is ramping
+across them, which is a fact about section 4's state and not about the reading. The control that
+means something here is a cross-state one — the parked hashes against the hashes the same
+positions gave while the effect was installed and raised.
+
 ## A number written into a document does not fail
 
 The nine shipped looks each named a different subset of the look values, so picking one

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -457,9 +457,9 @@ node tools/effect-check.mjs                               # installing an effect
 node tools/effect-check.mjs --mutate temporaries-are-visible # ... the id filter the store lists directories through, widened, so
                                                           #     a crashed install's `<id>.<seq>.tmp` becomes a package `/effects`
                                                           #     lists and `rootFor` resolves. Reddens exactly the two rows of
-                                                          #     section 6 that are about a half-written package, which is why
+                                                          #     section 7 that are about a half-written package, which is why
                                                           #     that section is last - staged earlier it would redden every
-                                                          #     section after it with a fault four sections away
+                                                          #     section after it with a fault five sections away
 node tools/effect-check.mjs --mutate rebuild-skips-the-panel # ... the panel built on the first run and never again, which is the
                                                           #     rebuild somebody writes who thinks of the panel as boot
                                                           #     furniture. `boot-check` stays green, because boot is the run
@@ -472,8 +472,19 @@ node tools/effect-check.mjs --mutate install-skips-the-uniform-cells # ... the J
 node tools/effect-check.mjs --mutate reinstall-leaves-it-parked # ... the parking predicate widened to every dotted name, so a
                                                           #     value belonging to an installed effect parks anyway. The badge
                                                           #     still appears on the uninstall, which is what makes it worth
-                                                          #     having: four rows across sections 4 and 5 redden and the
-                                                          #     badge-appeared row stays green
+                                                          #     having: nine rows redden, four across sections 4 and 5 and five
+                                                          #     more in section 6, and the badge-appeared row stays green. The
+                                                          #     document it leaves behind is one the loader refuses in both
+                                                          #     directions, so section 6's rebuild reddens on the rollback's own
+                                                          #     refusal rather than on the install's
+node tools/effect-check.mjs --mutate rollback-keeps-the-new-registry # ... the rollback runs the loader again and runs it against
+                                                          #     the packages that just arrived rather than the ones this page
+                                                          #     had - the half-rollback somebody writes who reads the failure as
+                                                          #     being about the document. Reddens exactly four rows of section 6:
+                                                          #     the sentence, the registry's contents, the signature, and what a
+                                                          #     save writes. The picture cannot see it, because the parameter the
+                                                          #     fork adds is inert at its default and the image is identical
+                                                          #     either way - which is why a pixel row is not enough to hold this
 node tools/effect-conformance-check.mjs --url http://localhost:8080 # the plugin contract: every installed effect draws nothing at all when it is off
 node tools/effect-conformance-check.mjs --mutate leaks-at-zero # ... a floor under the rain's master, so the package contributes at
                                                           #     the term it is meant to be absent at. Served over an
@@ -1826,11 +1837,33 @@ it, so seven rows fire and then the run stops — a verdict that put the crash f
 DID NOT RUN over a caught mutation, which is the census of exit codes `docs/instruments.md`
 already carries a case for.
 
-Baseline **43 assertions, 0 failed**, over six sections: the store's revisions against hashes
+Baseline **56 assertions, 0 failed**, over seven sections: the store's revisions against hashes
 the tool computes off the staged tree, seventeen hostile packages each refused with the sentence
 for its own rule, the hotload's registry-and-panel coherence including `boot-check`'s own
 control-vs-registry diff on a rebuilt page, the uninstall/reinstall pixel identity, the
-must-not-badge control, and — last, deliberately — what a crashed install leaves behind.
+must-not-badge control, an install this page cannot carry the open document onto, and — last,
+deliberately — what a crashed install leaves behind.
+
+**Section 6 is the one that asserts a failure.** It installs a fork of the probe package
+carrying one parameter more while the open document holds that effect parked, which makes the
+document a subset of the new manifest and so a document the loader refuses per effect — the
+refusal is correct and stays a refusal, because filling the added parameter from its default
+would be this build guessing at a look somebody else authored. What the thirteen rows hold is
+where the page is left standing: the server did take the install, the note names `probe.glow`
+and says which set the page is still running, the registry and the signature are the ones it
+had, the pool is untouched, the three pinned positions render the images they rendered before,
+a save still writes the parked keys byte for byte, and the document that save produces is one
+this same page will take back. **It is driven through `pollNow` rather than `reload`**, because
+the note is one of the things asserted and the poll is the only thing in the product that
+writes it.
+
+Its control row is a cross-state comparison rather than section 4's three-distinct-images, and
+the difference is worth keeping: with the effect parked there is nothing keyed left to separate
+the three positions from each other, so 0.6s and 1.2s both show the last of the six pinned
+frames and hash the same. The three images in section 4 differ because `probe.amount` is
+ramping across them. So the control here holds the parked hashes against the ones the same
+positions rendered while the effect was installed and raised — which is the state the rollback
+must not have left the page in.
 
 **`effect-conformance-check`** needs `--url` against a running server and a GPU browser, and no
 port of its own. Every hash is taken inside the run and none is written down: what it compares

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -130,6 +130,14 @@ node tools/export-check.mjs --url http://localhost:8080   # step 6: resolution, 
 node tools/export-check.mjs --mutate pointsize-absolute   # ... and must FAIL mutated
 node tools/export-check.mjs --mutate cropoutside-reaches-the-export # ... the crop box's faint pass, one edit from being in a deliverable
 node tools/export-check.mjs --mutate faint-survives-at-zero # ... and a cut point kept at alpha zero, invisible and still occluding
+node tools/export-check.mjs --mutate export-ignores-missing-effects # ... the door on a clip whose look this build cannot draw
+                                                          #     whole. Reddens the refusal row and the still-refused-for-the-other
+                                                          #     row, and leaves the suppress, record and complete rows green
+node tools/export-check.mjs --mutate suppress-is-global   # ... and the same door answering a per-effect question globally,
+                                                          #     which only the two-missing-effects row can see - with one
+                                                          #     missing, both implementations refuse nothing
+node tools/export-check.mjs --mutate deliverable-forgets-suppressed # ... and the record's half: a file that went without a
+                                                          #     layer of the look and does not say so. One row
 node tools/export-check.mjs --mutate bloom-buffer-sized   # ... the glow's chain following the buffer, which is the only live catcher
                                                           #     in this suite for the reference the chain is frozen at. Its sibling
                                                           #     `bloom-reference-1080` is NOT caught by anything here and is not a
@@ -223,6 +231,15 @@ node tools/library-check.mjs --mutate one-refusal-for-older-versions # ... one s
                                                                    #     older, later, and a version field that is
                                                                    #     not a number at all
 node tools/library-check.mjs --mutate open-ignores-format          # ... the capture's generation, at all four doors at once
+node tools/library-check.mjs --mutate save-forgets-the-parked-pool # ... a document opened on a machine without one of its
+                                                                   #     effects and saved back with that effect's values gone,
+                                                                   #     which is the destructive shape parking exists to
+                                                                   #     prevent. Reddens the reopen row and the three file rows;
+                                                                   #     the two load rows stay green, because the load half is
+                                                                   #     untouched - read the rows
+node tools/library-check.mjs --mutate save-forgets-the-parked-requires # ... and the same merge's other half, keeping the values
+                                                                   #     and dropping the claim. Reddens the entry row, the
+                                                                   #     reopen row, and the second-trip row that stands on it
 node tools/library-check.mjs --mutate shipped-look-drops-a-value   # ... a shipped look with a hole in it, which is the last look staying under the next one
 node tools/library-check.mjs --mutate complete-look-drops-a-group  # ... and the definition those documents are written against, which is code where they are data
 node tools/editor-check.mjs --url http://localhost:8080 --take fixture-1g # the editor's controls: that they exist, that pressing them changes something
@@ -239,6 +256,15 @@ node tools/editor-check.mjs --mutate aspect-skips-the-letterbox --no-render # ..
                                                                        #     the button that was just pressed, so a build
                                                                        #     that lights the control and reframes nothing
                                                                        #     fails here and passes on the attribute
+node tools/editor-check.mjs --mutate badge-counts-the-registry --no-render # ... the badge for a missing effect counting off
+                                                                       #     the registry rather than off the parked pool,
+                                                                       #     which prints `0 values, 0 tracks parked` - the
+                                                                       #     same line a build that *dropped* them would
+                                                                       #     print. Reddens the exact-sentence row of 15b
+node tools/editor-check.mjs --mutate suppress-toggle-is-a-latch --no-render # ... and the toggle beside it going only one
+                                                                       #     way, so a decision about one render becomes a
+                                                                       #     decision about the session. Reddens the
+                                                                       #     press-it-again row alone
 node tools/editor-check.mjs --mutate lanes-clear-siblings --no-render  # ... and must FAIL
 node tools/editor-check.mjs --mutate plant-unswept-control --no-render # ... and must FAIL
 node tools/editor-check.mjs --mutate ends-reaches-the-selection --no-render # ... `ends` shaping the selected key instead of the
@@ -475,6 +501,18 @@ node tools/jobs-check.mjs                                 # step 8: the queue, t
                                                           #   come back failed rather than rendered - the batch path
                                                           #   adopted past the version gate until it did
 node tools/jobs-check.mjs --mutate claim-ignores-renderer # ... and must FAIL mutated
+node tools/jobs-check.mjs --mutate envelope-takes-the-callers-requires # ... the effects a job needs, taken from the caller
+                                                          #     instead of derived from its project - a job that can lie
+                                                          #     about what it needs. Queue semantics, so `--no-render`.
+                                                          #     One row
+node tools/jobs-check.mjs --mutate worker-door-waved-open # ... the worker's door on an effect it has not got. It needs a
+                                                          #     render, like `heartbeat-stops-on-first-error`, and it
+                                                          #     reddens **one** row: the *reason*. The state row beside it
+                                                          #     stays green, because `exportClip` refuses the same clip
+                                                          #     from the other end and the job comes back failed either
+                                                          #     way. That is the split stated as a measurement - the two
+                                                          #     gates agree about whether the render happens and differ in
+                                                          #     what they say and in what it cost to say it
 node tools/module-check.mjs                               # the boundaries in web/: the import graph, what an import names, what crosses it
 node tools/module-check.mjs --mutate cycle-planted        # ... the import web/scene.js's own header says does not exist
 node tools/module-check.mjs --mutate cycle-through-a-second-spelling # ... and the same ring written the way the other page writes its imports

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -453,6 +453,35 @@ node tools/boot-check.mjs --mutate reset-before-the-panel-generator # ... the sh
                                                           #     are lying. Reddens exactly one row of nine and leaves the
                                                           #     write-sweep row beside it green, because that one is about the
                                                           #     live path and the fault is in the boot write - read the rows
+node tools/effect-check.mjs                               # installing an effect: revisions, the door, the hotload, park and restore
+node tools/effect-check.mjs --mutate temporaries-are-visible # ... the id filter the store lists directories through, widened, so
+                                                          #     a crashed install's `<id>.<seq>.tmp` becomes a package `/effects`
+                                                          #     lists and `rootFor` resolves. Reddens exactly the two rows of
+                                                          #     section 6 that are about a half-written package, which is why
+                                                          #     that section is last - staged earlier it would redden every
+                                                          #     section after it with a fault four sections away
+node tools/effect-check.mjs --mutate rebuild-skips-the-panel # ... the panel built on the first run and never again, which is the
+                                                          #     rebuild somebody writes who thinks of the panel as boot
+                                                          #     furniture. `boot-check` stays green, because boot is the run
+                                                          #     that builds it; one row of section 3 reddens
+node tools/effect-check.mjs --mutate install-skips-the-uniform-cells # ... the JavaScript cell a new binding needs, never minted.
+                                                          #     No shipped package notices - every one of the sixteen binds a
+                                                          #     uniform some hand-written table already holds - and a
+                                                          #     seventeenth throws inside the value walk. Reddens seven rows of
+                                                          #     section 3 and ends the run early; the count is a floor
+node tools/effect-check.mjs --mutate reinstall-leaves-it-parked # ... the parking predicate widened to every dotted name, so a
+                                                          #     value belonging to an installed effect parks anyway. The badge
+                                                          #     still appears on the uninstall, which is what makes it worth
+                                                          #     having: four rows across sections 4 and 5 redden and the
+                                                          #     badge-appeared row stays green
+node tools/effect-conformance-check.mjs --url http://localhost:8080 # the plugin contract: every installed effect draws nothing at all when it is off
+node tools/effect-conformance-check.mjs --mutate leaks-at-zero # ... a floor under the rain's master, so the package contributes at
+                                                          #     the term it is meant to be absent at. Served over an
+                                                          #     interception rather than written, because this tool runs against
+                                                          #     a server somebody else started and has no staged tree to edit.
+                                                          #     Reddens exactly one row - rain's drop equality - and no other
+                                                          #     effect's; the two arms that hold the master at zero cannot see
+                                                          #     it, because the sub-keys are behind the `rain > 0.0` gate
 node tools/monitor-check.mjs                              # step 9: the monitor's decimation, the take it must not touch, and the picture it shows
 node tools/monitor-check.mjs --mutate decimate-reaches-recorder  # ... and must FAIL mutated
 node tools/monitor-check.mjs --mutate bind-ignores-grid          # ... and must FAIL mutated
@@ -1775,6 +1804,49 @@ positions, so the move stays on the safe side; the mutated build boots both surf
 page errors. Its four exit-2 refusals were each probed by hand: an unknown name, an anchor
 matching zero times, an anchor matching 221 times, and a mutation staged for a module the
 recorder never requests.
+
+**`effect-check`** spawns its own server on **8281** and needs none running: a GPU browser, a
+free port, no capture, no sensor and no ffmpeg. It asks the kernel for the port before it
+stages anything and exits 2 naming the pid that holds it, because a run answered by a stranger
+asserts against whatever fixture that process staged. Its staged tree is `.effect-check/`,
+gitignored, and it copies `server/`, `tools/`, `web/`, `effects-builtin/` and `presets-builtin/`
+into it — the last of those because the page fetches the preset library while it boots and a
+staged tree without the shipped root answers 500, which lands in `pageErrors` and reddens the
+last row with a fault that has nothing to do with effects.
+
+**It is the only tool in the suite that writes packages, so it hands the server both store
+roots by name.** `--effects` and `--builtin-effects` are passed outright rather than left to
+resolve from the staged tree, because the failure that costs something is a run whose user root
+resolved to the checkout: seventeen fixtures, fifteen of them hostile, written into `effects/`.
+
+**Read the exit line rather than the code**, and this tool says more than most: a mutated run
+with failures is reported as caught however it ended, and it says whether it ended early.
+`install-skips-the-uniform-cells` leaves the page half-adopted and takes the driver down with
+it, so seven rows fire and then the run stops — a verdict that put the crash first would report
+DID NOT RUN over a caught mutation, which is the census of exit codes `docs/instruments.md`
+already carries a case for.
+
+Baseline **43 assertions, 0 failed**, over six sections: the store's revisions against hashes
+the tool computes off the staged tree, seventeen hostile packages each refused with the sentence
+for its own rule, the hotload's registry-and-panel coherence including `boot-check`'s own
+control-vs-registry diff on a rebuilt page, the uninstall/reinstall pixel identity, the
+must-not-badge control, and — last, deliberately — what a crashed install leaves behind.
+
+**`effect-conformance-check`** needs `--url` against a running server and a GPU browser, and no
+port of its own. Every hash is taken inside the run and none is written down: what it compares
+is three images the same process just rendered on the same GPU, so it means the same thing on
+every machine and there is nothing here to re-baseline. It enumerates from `GET /effects`, so a
+seventeenth package is asked its questions by existing.
+
+Baseline **99 assertions, 0 failed** with the shipped sixteen — six or seven rows per package
+depending on whether it carries GLSL of its own. Two of them are the controls: the raise has to
+reach the registry before its picture means anything, and the package's own longest line of GLSL
+has to leave the assembled program while it is hollow and come back after. That second row was
+added after the first version of this tool spent a run reporting eleven effects as unable to
+reach a pixel — `page.unroute` matches its matcher by reference, so a fresh arrow removed
+nothing, every package dropped stayed dropped, and the raise arm was asking hollowed packages to
+move a picture. One handler consulting a variable replaced sixteen routes, and the marker row is
+what would have said so.
 
 **`module-check`** needs nothing at all — no port, no server, no browser, no sensor and no
 install — and that is the point rather than a convenience. Every failure it is about is a

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -347,6 +347,47 @@ A queued render is the same rule with nobody watching. The job carries the effec
 requires, and a worker that has not got one of them **fails the job with a reason naming it**
 rather than rendering, unless the job was queued with `suppressEffects` covering it.
 
+### Installing an effect, and taking one away
+
+`PUT /effects/<id>` installs a package and `DELETE /effects/<id>` removes one. The body is
+`{manifest, chunks}` — the manifest as JSON and a map of file name to GLSL text — and the id in
+the path is the namespace its parameters carry, so a manifest declaring a different one is
+refused rather than guessed at.
+
+**An install lands in `effects/` and never in `effects-builtin/`**, which is the whole of the
+fork mechanism: a package installed under a shipped id shadows it, and deleting that copy brings
+the shipped one back. Nothing reachable from the network can edit or remove what the build shipped
+with, so there is always a package to fall back to — and a `DELETE` aimed at a builtin nothing is
+forking is refused by name rather than silently doing nothing. Deleting a package that exists only
+in `effects/` uninstalls it, at which point every open document's values under it park exactly as
+they would on a machine that never had it.
+
+**A package that this build could not compile is refused at the door, and the refusal names the
+rule it broke.** That matters more than it sounds: a package is GLSL spliced into two shader
+programs and a table of parameters spliced into the registry, and both of those are assembled
+while the page is still loading — so a bad package that landed would not fail its install, it
+would fail the *next page load*, with nothing on screen and the only evidence in a console nobody
+has open. So the door runs before a byte is written: the id and the manifest have to agree, the
+package format has to be one this build reads (a later one is refused rather than adapted), a file
+name has to be a bare name in the package's own directory, at most one parameter may be the
+master and its default has to be the value the effect is absent at, the kind and the binding have
+to be ones the registry implements, every uniform a parameter binds has to be declared by some
+program and every uniform the package declares has to be bound by one of its own parameters or
+listed under `hostDriven`, every joint a chunk names has to exist in a spine, and every identifier
+a chunk reaches for has to be something this build has. A refused package leaves nothing behind.
+
+**A page that is open when an install happens rebuilds itself.** Both shader programs are
+reassembled and swapped, the registry and the panel are rebuilt from the new set, and every value
+is written back through the same door a slider uses — so the controls show what the registry
+holds, the values in flight are where they were, and a newly installed effect's parked values
+come back and apply. Other browsers converge on their own within a few seconds; the poll stands
+down while an export, a preset gesture or a keyframe evaluation is running, because a rebuild
+between two frames of a render is a file that changes look halfway through.
+
+A fork may add parameters and retune the ones it inherits. It may not **drop** one: the panel's
+declaration order places every shipped parameter by hand, so a fork short of one is a build whose
+registry cannot assemble at all, and that is refused at the door with the names it dropped.
+
 ## Levelling a canted mount
 
 A sensor bolted to a dashboard shoots a room that arrives on its side, and nothing measures

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -316,6 +316,37 @@ handed to the deliverable, so it renders exactly what it rendered before. A hand
 of a shape the table has nothing for keeps its own size and lights no shape button, which is
 honest rather than tidy — the stage really is that shape.
 
+### A clip that needs an effect this build has not got
+
+A look parameter is named after the effect it belongs to — `rain.speed`, `glyph.tone` — and a
+document lists the effects it is built from. Open a clip whose list names one this machine
+does not have, and the clip **opens**: the installed part renders, and the values and keys
+under the missing effect are parked, which means they are carried and never evaluated. Saving
+writes them back exactly as they arrived, so working on somebody else's clip on a machine
+without their effects costs nothing and destroys nothing. A name this build simply does not
+know is still refused, and so is a name whose effect *is* here with a key that is not — a
+typo and a half-installed package are both broken, and only a whole effect that is absent
+gets parked.
+
+The application bar says so while such a clip is open: `missing: rain 1.0.0 — 4 values, 2
+tracks parked`, one entry per missing effect, quoting the version the document was authored
+against and counting what is being carried. Beside each entry is a **suppress** toggle.
+
+**Export is refused while anything the clip needs is missing**, and the refusal names the
+effects and their versions. That is the point of parking rather than the price of it: a video
+leaves this machine and nothing in it says a layer of the look was absent when it was made, so
+the one artifact that cannot explain itself is the one this build will not produce by accident.
+Pressing **suppress** on an entry is the operator saying that this render may go without that
+effect. It is per effect — suppress one while another is still missing and the export is still
+refused, naming the other — and it is session state rather than document state, so it never
+travels with the clip. The render's own record, the `.job.json` beside the video, carries a
+`suppressed` list of the ids and versions it went without, and keeps the parked values, so the
+file says what was skipped instead of pretending the clip never asked.
+
+A queued render is the same rule with nobody watching. The job carries the effects its project
+requires, and a worker that has not got one of them **fails the job with a reason naming it**
+rather than rendering, unless the job was queued with `suppressEffects` covering it.
+
 ## Levelling a canted mount
 
 A sensor bolted to a dashboard shoots a room that arrives on its side, and nothing measures

--- a/effects-builtin/rain/manifest.json
+++ b/effects-builtin/rain/manifest.json
@@ -84,6 +84,9 @@
       "order": 100
     }
   ],
+  "hostDriven": [
+    "rainPhase"
+  ],
   "varyings": [
     {
       "name": "vRain",

--- a/server/effect-door.js
+++ b/server/effect-door.js
@@ -1,0 +1,605 @@
+// The door an effect package has to get through before a byte of it lands on disk.
+//
+// **Everything a broken package could do, it does at boot, on somebody else's machine.**
+// A package is GLSL spliced into two programs plus a table of parameters spliced into the
+// registry, and both of those are assembled while `web/main.js` is still evaluating - so a
+// package that does not assemble does not fail an install, it fails the *next page load*,
+// with no `__kinect` published, every proof tool reporting DID NOT RUN, and the only
+// evidence a console line in a browser nobody has open. That is the failure this file
+// exists to move: a package is refused here, by name, with the reason, and the store never
+// writes it.
+//
+// **Every refusal names the silent failure it stands in front of**, in the voice the
+// assembler's own refusals use, because a message saying "invalid manifest" tells the
+// author to go and read this file and a message saying which uniform their slider would
+// have failed to move tells them what to fix.
+//
+// **The door does not reimplement assembly, and that is the load-bearing part.** The
+// joints a chunk may name, which services open scopes, what a slot collides with, whether
+// two packages declare one varying - all of that is `assembleShaders`, and the door asks it
+// by *running* it against the set that would exist after the install. A second copy of
+// those rules here would be the second implementation this repo keeps refusing, and it
+// would drift in the direction that matters: the door would accept what the page then
+// throws on. So what is written out below is only what assembly cannot see - the parameter
+// vocabulary, the manifest's own shape, the two ends of a uniform binding, and the
+// identifiers a chunk reaches for.
+//
+// Pure and synchronous: it is handed the candidate, the packages that would sit beside it
+// and the spines, and it answers a sentence or null. Nothing here touches the filesystem,
+// which is what lets `server/effect-store.js` call it before it has made a directory and
+// lets `test/effect-door.test.mjs` run the whole shipped set through it under bare node.
+
+import { MANIFEST_FORMAT, EFFECT_PARAM_KINDS, EFFECT_BIND_TABLES, EFFECT_BIND_TRANSFORMS } from '../web/effect-manifests.js';
+import { assembleShaders } from '../web/shader-assembly.js';
+
+// The same two shapes `server/effect-store.js` enforces on what it reads, restated here
+// rather than imported, because the door runs *before* the store has anything to read and
+// the store runs on what is already on disk. Two callers of one rule would be an import;
+// two rules asked at two different moments of one id's life is this.
+const VALID_EFFECT_ID = /^[a-z][a-z0-9]*$/;
+const VALID_FILE_NAME = /^[a-z0-9][a-z0-9._-]*$/i;
+
+// A GLSL name, which is what a uniform binding, a varying and an identifier all are.
+const GLSL_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// The parameter key a manifest declares, which becomes the half of a dotted registry name
+// after the dot. No dot of its own, because `effectOf` in `web/main.js` splits on the first
+// one - `rain.head.gap` would be read as the `rain` package's `head.gap` key by the
+// registry and as the `rain.head` package's `gap` key by anything splitting from the right,
+// and the two readings are a name that means different things to different halves of one
+// program.
+const VALID_PARAM_KEY = /^[a-z][A-Za-z0-9]*$/;
+
+/**
+ * The GLSL a package may write in, as vocabulary rather than as grammar.
+ *
+ * **This is not a parser and must not be read as one.** What the identifier rule below
+ * needs is the set of names that mean something without the package having declared them,
+ * so that anything left over is a name the author expected to find and this build does not
+ * have. Types and keywords are here because they appear where identifiers appear;
+ * the builtins are here because a chunk calling `mix` is calling the language.
+ *
+ * A name missing from these lists is a false refusal, which is the loud direction: the
+ * author sees "this build has no `roundEven`" and the list gains an entry. A name here
+ * that GLSL does not have costs nothing, because the driver would refuse it at compile
+ * time anyway. That asymmetry is why the lists are generous rather than exact.
+ */
+const GLSL_TYPES = [
+  'void', 'bool', 'int', 'uint', 'float', 'double',
+  'vec2', 'vec3', 'vec4', 'bvec2', 'bvec3', 'bvec4', 'ivec2', 'ivec3', 'ivec4',
+  'uvec2', 'uvec3', 'uvec4', 'dvec2', 'dvec3', 'dvec4',
+  'mat2', 'mat3', 'mat4', 'mat2x2', 'mat2x3', 'mat2x4',
+  'mat3x2', 'mat3x3', 'mat3x4', 'mat4x2', 'mat4x3', 'mat4x4',
+  'sampler2D', 'isampler2D', 'usampler2D', 'sampler3D', 'samplerCube',
+  'sampler2DArray', 'sampler2DShadow', 'samplerCubeShadow',
+];
+
+const GLSL_KEYWORDS = [
+  'if', 'else', 'for', 'while', 'do', 'return', 'break', 'continue', 'discard',
+  'const', 'uniform', 'in', 'out', 'inout', 'attribute', 'varying',
+  'flat', 'smooth', 'noperspective', 'centroid', 'layout', 'location', 'precision',
+  'highp', 'mediump', 'lowp', 'struct', 'switch', 'case', 'default', 'true', 'false',
+  'define', 'ifdef', 'ifndef', 'endif', 'version', 'else', 'elif', 'undef', 'error',
+];
+
+const GLSL_BUILTINS = [
+  // The trigonometric and exponential families, whole, because a package reaching for
+  // `atanh` and finding it refused would be this list's fault rather than the package's.
+  'radians', 'degrees', 'sin', 'cos', 'tan', 'asin', 'acos', 'atan',
+  'sinh', 'cosh', 'tanh', 'asinh', 'acosh', 'atanh',
+  'pow', 'exp', 'log', 'exp2', 'log2', 'sqrt', 'inversesqrt',
+  // The common ones, which is where nearly every chunk in the shipped set lives.
+  'abs', 'sign', 'floor', 'trunc', 'round', 'roundEven', 'ceil', 'fract', 'mod', 'modf',
+  'min', 'max', 'clamp', 'mix', 'step', 'smoothstep', 'isnan', 'isinf',
+  'floatBitsToInt', 'floatBitsToUint', 'intBitsToFloat', 'uintBitsToFloat', 'fma',
+  'length', 'distance', 'dot', 'cross', 'normalize', 'faceforward', 'reflect', 'refract',
+  'matrixCompMult', 'outerProduct', 'transpose', 'determinant', 'inverse',
+  'lessThan', 'lessThanEqual', 'greaterThan', 'greaterThanEqual', 'equal', 'notEqual',
+  'any', 'all', 'not',
+  'texture', 'textureProj', 'textureLod', 'textureOffset', 'texelFetch', 'texelFetchOffset',
+  'textureGrad', 'textureSize', 'textureGather', 'textureQueryLod',
+  // The ES 1.00 spellings, because the two programs this build compiles are not the same
+  // language: the point cloud's pair is `GLSL3` and the grade pass is whatever three.js
+  // compiles a `ShaderPass` as, which is ES 1.00 - so the shipped raster and streak
+  // chunks call `texture2D` where the cloud's call `texture`. A door knowing only one of
+  // them would refuse half the packages that ship.
+  'texture2D', 'texture2DProj', 'texture2DLod', 'textureCube', 'textureCubeLod',
+  'dFdx', 'dFdy', 'fwidth',
+  'packSnorm2x16', 'unpackSnorm2x16', 'packUnorm2x16', 'unpackUnorm2x16',
+  'bitfieldExtract', 'bitfieldInsert', 'bitCount', 'findLSB', 'findMSB', 'uaddCarry', 'usubBorrow',
+  // The builtin variables of the two stages this program has.
+  'gl_Position', 'gl_PointSize', 'gl_VertexID', 'gl_InstanceID',
+  'gl_FragCoord', 'gl_FrontFacing', 'gl_PointCoord', 'gl_FragDepth',
+];
+
+const LANGUAGE = new Set([...GLSL_TYPES, ...GLSL_KEYWORDS, ...GLSL_BUILTINS]);
+const TYPE_SET = new Set(GLSL_TYPES);
+
+/**
+ * GLSL with its comments taken out, so a name mentioned in prose is not a name used in
+ * code.
+ *
+ * The chunks in this repo carry more comment than code - the glyph field's alphabet is
+ * thirty lines of table under forty of argument - and every noun in those paragraphs would
+ * otherwise be an identifier the rule below has to account for. Stripped rather than
+ * excluded case by case, which is the same move `syntax-check` makes and for the same
+ * reason: a rule whose exemption list is written from the subject cannot be falsified by
+ * the subject.
+ */
+const withoutComments = (text) => text
+  .replace(/\/\*[\s\S]*?\*\//g, ' ')
+  .replace(/\/\/[^\n]*/g, ' ');
+
+/**
+ * Every identifier a piece of GLSL actually reads or writes.
+ *
+ * Two things are dropped and each is a bug this scan had while it was being written. A
+ * match preceded by a dot is a swizzle or a field - `wc.xz` is one identifier and not two,
+ * and counting `xz` would refuse every chunk in the shipped set. A match preceded by a
+ * digit is the tail of a literal: `0x00080800u` scans as `x00080800u` under any rule that
+ * does not look left, and the glyph field's alphabet is sixty-four of them.
+ */
+const identifiersIn = (text) => {
+  const src = withoutComments(text);
+  const found = new Set();
+  const re = /[A-Za-z_][A-Za-z0-9_]*/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const before = m.index === 0 ? '' : src[m.index - 1];
+    if (before === '.' || /[0-9]/.test(before)) continue;
+    found.add(m[0]);
+  }
+  return found;
+};
+
+/**
+ * Every name a piece of GLSL declares: uniforms, varyings, functions, constants and
+ * locals.
+ *
+ * **Vocabulary and not scope**, which is the approximation this rule is built on and is
+ * worth stating rather than leaving to be found. A name declared inside `main` counts as
+ * declared for a chunk spliced into the declaration block, so a chunk reaching a local it
+ * cannot see passes here and fails in the driver. What the rule closes is the other case -
+ * a name that exists nowhere in the build at all - and that one has no other reader: it
+ * compiles to a link error on a page nobody has open, where a scope error at least names
+ * the line.
+ *
+ * The declaration forms are the four that appear: a preprocessor define, a qualified
+ * declaration list (`uniform float a, b, c;`), a typed declaration or function head
+ * (`vec3 heatRamp(float t)`, `uvec2 GLYPHS[64]`), and a loop counter, which the typed form
+ * already covers.
+ */
+const declaredIn = (text) => {
+  const src = withoutComments(text);
+  const names = new Set();
+  for (const m of src.matchAll(/#\s*define\s+([A-Za-z_][A-Za-z0-9_]*)/g)) names.add(m[1]);
+  // A qualified list declares every name between the type and the semicolon, which is how
+  // `uniform float cropL, cropR, cropB, cropT;` declares four things rather than one.
+  const qualified = /\b(?:uniform|in|out|attribute|varying)\b(?:\s+(?:flat|smooth|noperspective|centroid|highp|mediump|lowp))*\s+[A-Za-z_][A-Za-z0-9_]*\s+([^;]*);/g;
+  for (const m of src.matchAll(qualified)) {
+    for (const part of m[1].split(',')) {
+      const name = part.trim().match(/^([A-Za-z_][A-Za-z0-9_]*)/);
+      if (name) names.add(name[1]);
+    }
+  }
+  // A type followed by a name is a declaration or a function head, and both of them
+  // introduce the name. Written against the type list rather than against a grammar,
+  // because the alternative is the hand-rolled lexer `docs/instruments.md` files nine
+  // rounds of one seam under.
+  const typed = new RegExp(`\\b(?:${GLSL_TYPES.join('|')})\\s+([A-Za-z_][A-Za-z0-9_]*)`, 'g');
+  for (const m of src.matchAll(typed)) names.add(m[1]);
+  return names;
+};
+
+/** Every `uniform` one piece of GLSL declares, which is one direction of the binding check. */
+const uniformsIn = (text) => {
+  const src = withoutComments(text);
+  const names = new Set();
+  const decl = /\buniform\s+(?:(?:highp|mediump|lowp)\s+)?[A-Za-z_][A-Za-z0-9_]*\s+([^;]*);/g;
+  for (const m of src.matchAll(decl)) {
+    for (const part of m[1].split(',')) {
+      const name = part.trim().match(/^([A-Za-z_][A-Za-z0-9_]*)/);
+      if (name) names.add(name[1]);
+    }
+  }
+  return names;
+};
+
+/** Every verbatim segment of every spine, as one string per program name. */
+const spineTextByProgram = (spines) => Object.fromEntries(
+  Object.entries(spines).map(([name, spine]) => [
+    name,
+    [...spine.vertex, ...spine.fragment]
+      .map((entry) => [entry.text, entry.fallback, entry.open, entry.body, entry.close].filter((t) => typeof t === 'string').join('\n'))
+      .join('\n'),
+  ]),
+);
+
+/**
+ * Which assembled program a binding's table writes into.
+ *
+ * `bind.on` names a uniform table and the tables are one per program, so this is the same
+ * fact read from the other end - `points` is the cloud's pair and `grade` is the grade
+ * pass. Written out because it is the one place the two vocabularies meet, and a build
+ * that grew a third program would fail here by name rather than by a binding quietly
+ * checked against the wrong text.
+ */
+const PROGRAM_OF_TABLE = { points: 'cloud', grade: 'grade' };
+
+const isInert = (value) => value === 0 || value === false;
+
+/**
+ * Whether a varying's `init` is a constant expression.
+ *
+ * The init is written into the prologue above the early returns, so it is what a shed point
+ * carries when nothing else writes the varying - which means it has to be a value rather
+ * than a computation over state that does not exist yet. Numbers and constructor calls over
+ * numbers, and nothing else: `0.0`, `vec3(0.0)`, `vec2(0.0, 1.0)`. An init reading a
+ * uniform would compile and would make a shed point's value depend on a slider, which is a
+ * look changing where the design says nothing is drawn.
+ */
+const isConstantExpression = (init) => {
+  if (typeof init !== 'string' || init.trim().length === 0) return false;
+  const src = init.trim();
+  if (/^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?[uf]?$/.test(src)) return true;
+  const call = src.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*\(([^()]*)\)$/);
+  if (!call || !TYPE_SET.has(call[1])) return false;
+  return call[2].split(',').every((arg) => /^\s*[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?[uf]?\s*$/.test(arg));
+};
+
+/**
+ * The one entry point: a sentence saying why this package is refused, or null.
+ *
+ * `candidate` is the wire envelope with its id attached - `{ id, manifest, chunks }`, the
+ * chunks a map of file name to text. `beside` is every package that would be installed
+ * alongside it once this one lands, the candidate excluded, in the shape `/effects/:id`
+ * answers with. `spines` is the map of program name to spine the page assembles from.
+ *
+ * The order of the rules is the order they can be asked in: shape before vocabulary,
+ * vocabulary before assembly, assembly before the two GLSL cross-checks, because each of
+ * those reads something the one before it has just established is there. A rule that ran
+ * out of order would report a missing `params` object as a chunk naming no stage.
+ */
+export function doorRefusal(candidate, { beside = [], spines }) {
+  const { id, manifest, chunks } = candidate;
+
+  // ---- the id and the envelope
+  if (typeof id !== 'string' || !VALID_EFFECT_ID.test(id)) {
+    return `${JSON.stringify(id)} is not an effect id - an id is the namespace its parameters carry, `
+      + 'so it is lowercase letters and digits with nothing in it that could read as a path';
+  }
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    return `effect ${id} arrives with no manifest object - a package is a manifest and its chunks, and half of that is not a package`;
+  }
+  if (!chunks || typeof chunks !== 'object' || Array.isArray(chunks)) {
+    return `effect ${id} arrives with no chunks map - a package with no chunks section still sends an empty one, because "no chunks" and "the chunks did not arrive" are different packages`;
+  }
+  if (manifest.id !== id) {
+    return `effect ${id} carries a manifest declaring id ${JSON.stringify(manifest.id)} - the id is the namespace `
+      + 'its parameters carry, so the two disagreeing means one of them is wrong and this door cannot know which';
+  }
+
+  // ---- the format, refused rather than adapted
+  //
+  // The whole of what this build will do about a package from a later one. A field this
+  // build reads as a number that a later build reads as a range, or a default this build
+  // takes as inert that a later one gates on, is a look rendering as something nobody
+  // authored - and there is no reader to write for a format that does not exist yet.
+  if (!Number.isInteger(manifest.format) || manifest.format < 1) {
+    return `effect ${id} declares no package format - this build reads generation ${MANIFEST_FORMAT}, `
+      + 'and a package that does not say which generation it is written in is one this door cannot place';
+  }
+  if (manifest.format > MANIFEST_FORMAT) {
+    return `effect ${id} is package format ${manifest.format} and this build reads ${MANIFEST_FORMAT} - `
+      + 'a package from a later build is refused rather than adapted, because a field this build '
+      + 'thinks it understands may mean something else there';
+  }
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    return `effect ${id} declares no version - a document's \`requires\` quotes it and the badge on a `
+      + 'machine without this package prints it, so a package with no version is one nobody can be told to install';
+  }
+  if (typeof manifest.title !== 'string' || manifest.title.length === 0) {
+    return `effect ${id} declares no title - the package list is what a person picks from, and an entry with no name is a row nobody can read`;
+  }
+
+  // ---- the file names, held before any path is built out of them
+  //
+  // The store validates what it reads and this validates what it is about to write, and
+  // the second is the one that decides whether a directory traversal ever gets a chance:
+  // a name with a separator in it reaches `join` and lands the bytes wherever it likes.
+  const declaredFiles = new Set((manifest.chunks ?? []).map((c) => c?.file));
+  for (const file of [...declaredFiles, ...Object.keys(chunks)]) {
+    if (typeof file !== 'string' || !VALID_FILE_NAME.test(file) || file.includes('..')) {
+      return `effect ${id} names the chunk file ${JSON.stringify(file)} - a package file is a bare name `
+        + 'in the package\'s own directory, and anything carrying a separator or a parent step is a write outside it';
+    }
+  }
+  if (Object.hasOwn(chunks, 'manifest.json')) {
+    return `effect ${id} sends a chunk called manifest.json - the manifest travels in its own field, and a second one `
+      + 'in the chunk map would be the file the store reads back disagreeing with the one this door checked';
+  }
+  for (const file of declaredFiles) {
+    if (typeof chunks[file] !== 'string') {
+      return `effect ${id} declares the chunk ${JSON.stringify(file)} and its text did not arrive - `
+        + 'a package assembled without one of its chunks is a program with a block missing';
+    }
+  }
+  for (const file of Object.keys(chunks)) {
+    if (!declaredFiles.has(file)) {
+      return `effect ${id} sends the file ${JSON.stringify(file)} and its manifest names no chunk for it - `
+        + 'a file nothing splices is text this build would store, serve and never compile, which is the shape a stale copy has';
+    }
+  }
+
+  // ---- the parameters
+  if (!manifest.params || typeof manifest.params !== 'object' || Array.isArray(manifest.params)
+      || Object.keys(manifest.params).length === 0) {
+    return `effect ${id} declares no parameters - an effect with nothing to move is a package the registry `
+      + 'would assemble no control from, and the panel group it asks for would be a heading with nothing under it';
+  }
+  let masters = 0;
+  for (const [short, spec] of Object.entries(manifest.params)) {
+    const name = `${id}.${short}`;
+    if (!VALID_PARAM_KEY.test(short)) {
+      return `effect ${id} declares the parameter key ${JSON.stringify(short)} - a key becomes the half of a `
+        + 'dotted registry name after the dot, so a key carrying a dot of its own is a name that means two different things to two halves of this program';
+    }
+    if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+      return `${name} is not a parameter declaration - the registry reads a bounds, a kind and a binding off it`;
+    }
+    if (!EFFECT_PARAM_KINDS.includes(spec.kind)) {
+      return `${name} is kind ${JSON.stringify(spec.kind)} and this registry implements ${EFFECT_PARAM_KINDS.join(' and ')} - `
+        + 'a kind nothing normalises would take the scalar branch and turn whatever arrived into a number nobody meant';
+    }
+    if (typeof spec.label !== 'string' || spec.label.length === 0) {
+      return `${name} carries no label - the panel draws the row from it, and a row with no words on it is a slider nobody can name`;
+    }
+    if (!spec.panel || typeof spec.panel.group !== 'string' || spec.panel.group.length === 0) {
+      return `${name} names no panel group - the generator builds a row for every parameter that names one, `
+        + 'so a parameter naming none is a look term with no control anywhere';
+    }
+    if (spec.kind === 'step') {
+      if (typeof spec.def !== 'boolean') {
+        return `${name} is a step parameter and its default is ${JSON.stringify(spec.def)} - a step takes a boolean, `
+          + 'and a number here would be stored as a boolean by one door and refused by another';
+      }
+    } else {
+      for (const field of ['def', 'min', 'max', 'step']) {
+        if (!Number.isFinite(spec[field])) {
+          return `${name} declares ${field} as ${JSON.stringify(spec[field])} - a scalar's bounds are finite numbers, `
+            + 'and a missing one makes every value the registry snaps NaN';
+        }
+      }
+      if (!(spec.min < spec.max)) {
+        return `${name} declares min ${spec.min} and max ${spec.max} - a range that does not open is a slider that cannot move`;
+      }
+      if (!(spec.step > 0)) {
+        return `${name} declares step ${spec.step} - the registry snaps every value onto this grid, and a step of zero divides by it`;
+      }
+      if (spec.def < spec.min || spec.def > spec.max) {
+        return `${name} defaults to ${spec.def}, outside its own ${spec.min}..${spec.max} - a default the bounds `
+          + 'clamp is a parameter that never sits where its own manifest says it starts';
+      }
+    }
+    const bind = spec.bind;
+    if (!bind || typeof bind !== 'object') {
+      return `${name} carries no binding - a parameter that writes no uniform is a control that moves nothing`;
+    }
+    if (!EFFECT_BIND_TABLES.includes(bind.on)) {
+      return `${name} binds on ${JSON.stringify(bind.on)} and this build holds ${EFFECT_BIND_TABLES.join(' and ')} - `
+        + 'a table nothing resolves is a write into undefined on the first slider move';
+    }
+    if (typeof bind.uniform !== 'string' || !GLSL_NAME.test(bind.uniform)) {
+      return `${name} binds the uniform ${JSON.stringify(bind.uniform)}, which is not a GLSL name`;
+    }
+    if (bind.transform !== undefined && !EFFECT_BIND_TRANSFORMS.includes(bind.transform)) {
+      return `${name} names the transform ${JSON.stringify(bind.transform)} and the applier implements `
+        + `${EFFECT_BIND_TRANSFORMS.join(' and ')} - an unknown transform throws on the first write rather than `
+        + 'landing the value unconverted, so this is the same refusal one door earlier';
+    }
+    if (bind.gates !== undefined && typeof bind.gates !== 'boolean') {
+      return `${name} declares gates as ${JSON.stringify(bind.gates)} - it says whether this term holds the grade pass open, which is a yes or a no`;
+    }
+    if (spec.role !== undefined) {
+      if (spec.role !== 'master') {
+        return `${name} declares the role ${JSON.stringify(spec.role)} - the only role this build knows is master, `
+          + 'which is the term an effect is absent at';
+      }
+      masters += 1;
+      if (!isInert(spec.def)) {
+        return `${name} is ${id}'s master and defaults to ${JSON.stringify(spec.def)} - a master is what the effect `
+          + 'is absent at, so a build with the package installed and every value at default has to draw exactly what a build without it draws';
+      }
+    }
+  }
+  if (masters > 1) {
+    return `effect ${id} declares ${masters} parameters with the role master - one package is absent at one term, `
+      + 'and two of them is two answers to whether this effect is contributing';
+  }
+
+  // ---- the varyings and the panel groups, which the assembler does not read for shape
+  for (const v of manifest.varyings ?? []) {
+    if (!v || !GLSL_NAME.test(v.name ?? '')) {
+      return `effect ${id} declares a varying named ${JSON.stringify(v?.name)}, which is not a GLSL name`;
+    }
+    if (!TYPE_SET.has(v.type)) {
+      return `effect ${id}'s ${v.name} is declared ${JSON.stringify(v.type)}, which is not a GLSL type - `
+        + 'the same word is written into the vertex `out` and the fragment `in`, so a type nothing knows is a link error at boot';
+    }
+    if (!isConstantExpression(v.init)) {
+      return `effect ${id}'s ${v.name} initialises to ${JSON.stringify(v.init)} - the init is written above the `
+        + 'early returns, so it is what a shed point carries, and anything but a constant makes that depend on state the prologue has not computed';
+    }
+    if (!Number.isFinite(v.order)) {
+      return `effect ${id}'s ${v.name} carries no numeric order, and where a varying sits decides the register layout of both stages`;
+    }
+  }
+  for (const g of manifest.panelGroups ?? []) {
+    if (!g || typeof g.key !== 'string' || !g.key.length) {
+      return `effect ${id} declares a panel group with no key - the group's rows are found by it`;
+    }
+    if (typeof g.after !== 'string' || !g.after.length) {
+      return `effect ${id}'s ${g.key} group anchors after ${JSON.stringify(g.after)} - a group with no anchor `
+        + 'would be appended wherever the splice happened to end, which is a package author\'s placement decision quietly overridden';
+    }
+    if (!Number.isFinite(g.order)) {
+      return `effect ${id}'s ${g.key} group carries no numeric order - two packages anchored at one place `
+        + 'would then be laid out by whichever was fetched first';
+    }
+  }
+
+  // ---- assembly, asked of the assembler
+  //
+  // Every joint rule in one call: a stage or a slot this spine does not hold, two packages
+  // claiming one slot, two declaring one varying, a service consumed without a `when`, a
+  // scope widened by a consumer that brings nothing to put inside it. Run against the set
+  // that would exist *after* the install, because half of those are collisions and a
+  // collision is a property of the set rather than of the package.
+  const packages = [...beside, candidate];
+  let programs;
+  try {
+    programs = assembleShaders(spines, packages);
+  } catch (err) {
+    return `effect ${id} does not assemble into this build's shaders: ${err.message}`;
+  }
+
+  // ---- the two ends of every uniform, per program
+  //
+  // **Both directions, and they are not the same question asked twice.** A binding whose
+  // uniform no program declares is a slider that moves nothing - three.js writes a key the
+  // shader never reads, every control works, and the picture does not change. A uniform a
+  // chunk declares that no parameter binds is the mirror image: the shader reads zero
+  // forever, because nothing on this side ever writes it.
+  //
+  // The first direction is asked against the assembled program and not against the
+  // package's own chunks, and that is a departure worth naming rather than a looseness.
+  // Thirteen of the sixteen shipped packages declare no GLSL at all - they are parameters
+  // over terms the spine already computes, `thermal` and `edges` and the whole duotone run
+  // - so a rule demanding a package declare its own uniform would refuse most of what ships.
+  // What the binding actually promises is that *the program* has somewhere to put the
+  // value, which is what this asks.
+  const declaredHere = new Set();
+  for (const text of Object.values(chunks)) for (const u of uniformsIn(text)) declaredHere.add(u);
+  const spineText = spineTextByProgram(spines);
+  const programUniforms = {};
+  for (const [program, text] of Object.entries(spineText)) {
+    programUniforms[program] = uniformsIn(text);
+  }
+  for (const pkg of packages) {
+    for (const text of Object.values(pkg.chunks ?? {})) {
+      // A chunk names a joint and never a program, so which program its uniforms land in
+      // is decided by which spine holds that joint - and asking that here would be the
+      // assembler reimplemented. Every chunk's uniforms are credited to every program
+      // instead, which is looser in the direction that produces no false refusal: a
+      // binding is being asked whether the value has anywhere to go, and a uniform
+      // declared in the cloud and bound on the grade would pass here and fail the driver.
+      for (const program of Object.keys(spineText)) {
+        for (const u of uniformsIn(text)) programUniforms[program].add(u);
+      }
+    }
+  }
+  const boundHere = new Set();
+  for (const [short, spec] of Object.entries(manifest.params)) {
+    const program = PROGRAM_OF_TABLE[spec.bind.on];
+    if (!programUniforms[program]?.has(spec.bind.uniform)) {
+      return `${id}.${short} binds the uniform ${JSON.stringify(spec.bind.uniform)} and the assembled `
+        + `${program} program declares no such uniform - the control would move, the value would be written, and nothing would read it`;
+    }
+    boundHere.add(spec.bind.uniform);
+  }
+  for (const u of declaredHere) {
+    if (boundHere.has(u)) continue;
+    // The other end of the same rule, and it has one legitimate shape: a uniform this
+    // package reads and the host writes. The rain's phase is the shipped instance - the
+    // render loop advances it once a frame, so it is the host's clock rather than
+    // anybody's parameter - and a package declaring one says so, because the alternative
+    // is that this direction cannot be enforced at all.
+    if ((manifest.hostDriven ?? []).includes(u)) continue;
+    return `effect ${id} declares the uniform ${JSON.stringify(u)} and binds no parameter to it - `
+      + 'nothing on this side would ever write it, so the shader reads zero for the life of the page. '
+      + 'A uniform this build\'s own render loop drives goes in `hostDriven`';
+  }
+  for (const u of manifest.hostDriven ?? []) {
+    if (!declaredHere.has(u)) {
+      return `effect ${id} lists ${JSON.stringify(u)} as host-driven and declares no such uniform - `
+        + 'the list says which of this package\'s own declarations the host writes, so a name not among them is a claim about nothing';
+    }
+  }
+
+  // ---- every identifier a chunk reaches for
+  //
+  // **The last thing between a package and a page that will not boot.** A chunk naming
+  // something this build has not got compiles to nothing at all: the shader fails to
+  // link, `buildPointCloud` throws while the module is still evaluating, `__kinect` never
+  // publishes, and every tool in the suite reports DID NOT RUN. There is no console
+  // anybody is watching at that moment, which is why the name is caught here.
+  //
+  // The core vocabulary is read out of the spine text rather than listed, so a term the
+  // spine grows next year is available to a package by existing and a term it loses is
+  // refused to one by the same act. A hand-written list here would be the copy that
+  // drifts, and it would drift in the direction that refuses correct packages.
+  //
+  // **Every name the spine *reaches for*, not only the ones it declares**, and the
+  // difference is three.js. `position`, `uv`, `modelMatrix`, `modelViewMatrix` and
+  // `projectionMatrix` are injected into a `ShaderMaterial`'s source at compile time, so
+  // they appear in no declaration anywhere in this repo and the vertex spine's very first
+  // line reads one. Taking the spine's declarations alone refused the shipped glitch for
+  // `position` and the shipped lattice for `modelMatrix` - two correct packages, for using
+  // the same names the text they splice into uses. Reading usage covers the injected set
+  // by the only route that does not hard-code somebody else's library, and it widens the
+  // vocabulary by exactly the names the spine already compiles against.
+  //
+  // Usage for the spine and declarations for the candidate, which is the asymmetry that
+  // keeps this rule from being vacuous: a package that could authorise a name by using it
+  // would authorise every name it misspells.
+  const spineNames = new Set();
+  for (const text of Object.values(spineText)) for (const n of identifiersIn(text)) spineNames.add(n);
+  const ownNames = new Set([
+    ...(manifest.varyings ?? []).map((v) => v.name),
+    ...Object.keys(manifest.params).map((short) => manifest.params[short].bind.uniform),
+    ...(manifest.hostDriven ?? []),
+  ]);
+  // A package's chunks see each other: the glyph field's alphabet table and its two
+  // helpers are declared in one file and read in another, and splitting a package's own
+  // vocabulary per file would refuse that.
+  for (const text of Object.values(chunks)) for (const n of declaredIn(text)) ownNames.add(n);
+  // And the varyings every *other* installed package declares, because a chunk may read
+  // one - the glyph field reads the rain's `vRain`, which is the whole of what its rain
+  // key is. Only the varyings: a varying is a declared channel with a name the manifest
+  // states, where another package's locals are an accident of its text.
+  for (const pkg of beside) {
+    for (const v of pkg.manifest?.varyings ?? []) ownNames.add(v.name);
+  }
+  for (const [file, text] of Object.entries(chunks)) {
+    for (const name of identifiersIn(text)) {
+      if (LANGUAGE.has(name) || spineNames.has(name) || ownNames.has(name)) continue;
+      return `effect ${id}'s ${file} uses ${JSON.stringify(name)}, which is not one of its own declarations, `
+        + 'not a name this build\'s shaders declare and not part of GLSL - a chunk naming something that is not '
+        + 'there does not fail this install, it fails the next page load with nothing on screen to say why';
+    }
+  }
+
+  return null;
+}
+
+/**
+ * What a package would have to keep to be a fork of another, or null.
+ *
+ * A user package shadows a builtin of the same id, which is the fork mechanism and is
+ * deliberate. What it must not do is drop a parameter, because the client's declaration
+ * order is a hand-written layout fact that places every parameter of the shipped set by
+ * name - and a name the order places that no installed package declares is a registry that
+ * cannot assemble, which is a page that does not boot rather than a fork that looks odd.
+ *
+ * Asked here rather than in `doorRefusal` because it needs both roots, which is a fact
+ * about the store rather than about the package.
+ */
+export function forkRefusal(candidate, shadowed) {
+  const dropped = Object.keys(shadowed.manifest.params)
+    .filter((short) => !Object.hasOwn(candidate.manifest.params, short));
+  if (dropped.length === 0) return null;
+  return `effect ${candidate.id} forks the shipped package and drops `
+    + `${dropped.map((s) => `${candidate.id}.${s}`).join(', ')} - the registry's declaration order places `
+    + `${dropped.length === 1 ? 'that name' : 'those names'} by hand, so a fork short of `
+    + `${dropped.length === 1 ? 'it' : 'them'} is a build whose registry cannot assemble at all. A fork adds and retunes; it does not remove`;
+}

--- a/server/effect-store.js
+++ b/server/effect-store.js
@@ -8,12 +8,21 @@
 // be computed over the set and a read has to say which files exist before a client
 // can fetch them one by one.
 //
-// Reads only, deliberately. Install and delete arrive with the surface that can
-// exercise them end to end; a write path nothing can drive before commit is the
-// class of code this repo refuses to carry.
+// **Install writes into the user root and never into the shipped one**, which is the
+// whole of the fork mechanism: `PUT /effects/rain` lands a package at `effects/rain`,
+// `rootFor` starts answering from there, and `DELETE /effects/rain` removes that copy and
+// brings the shipped one back. Nothing this program does can edit or remove
+// `effects-builtin/`, so there is always a package to fall back to and no install can
+// destroy what the build shipped with.
+//
+// What lands is what the door passed. `server/effect-door.js` is asked before a directory
+// exists, so a refused package never reaches the filesystem at all - there is no state
+// where a half-checked package sits where the store reads.
 
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import {
+  existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 // The same shape `VALID_ID` enforces for takes, restated for effect ids and package
@@ -127,5 +136,154 @@ export class EffectStore {
     const path = join(where.root, id, name);
     if (!existsSync(path) || !statSync(path).isFile()) return null;
     return readFileSync(path);
+  }
+
+  /**
+   * The shipped package behind an id, whatever is shadowing it - or null.
+   *
+   * The one read that deliberately skips the user root, and the install door is its only
+   * caller: a fork has to be held against what it forks, and `read` would hand back the
+   * fork itself once one is in place.
+   */
+  builtin(id) {
+    if (!VALID_EFFECT_ID.test(id) || !existsSync(join(this.builtinDir, id))) return null;
+    const dir = join(this.builtinDir, id);
+    const manifest = JSON.parse(readFileSync(join(dir, 'manifest.json'), 'utf8'));
+    const chunks = {};
+    for (const c of manifest.chunks ?? []) chunks[c.file] = readFileSync(join(dir, c.file), 'utf8');
+    return { id, manifest, chunks };
+  }
+
+  /**
+   * Every installed package with its chunk text, which is the set the door assembles
+   * against and the shape `assembleShaders` reads.
+   *
+   * `except` drops one id, because the question the door asks is what the build would look
+   * like *with the candidate in place of* whatever is there now - and reading the id being
+   * replaced would assemble the old package beside the new one, which collides with itself
+   * on every slot and varying it declares.
+   */
+  loaded(except = null) {
+    return this.list()
+      .filter((e) => e.id !== except)
+      .map((e) => {
+        const { manifest } = this.read(e.id);
+        const chunks = {};
+        for (const c of manifest.chunks ?? []) chunks[c.file] = this.file(e.id, c.file).toString('utf8');
+        return { id: e.id, manifest, chunks };
+      });
+  }
+
+  /**
+   * A package into the user root, atomically - and "atomically" here means that no reader
+   * ever sees a directory that is neither the old package nor the new one.
+   *
+   * **A package is a directory, so there is no rename of one file to make this safe.** The
+   * three writes below are the shape that has one: build the whole thing under a name no
+   * reader can resolve, swap the old one aside, swap the new one in. A crash at any point
+   * leaves either the old package or the new one where `rootFor` looks, and whatever
+   * temporary directories are lying around are swept by the next install.
+   *
+   * **The temporary names carry dots, and that is what makes them invisible rather than a
+   * convention.** `VALID_EFFECT_ID` has no dot in it, so `idsIn` filters `rain.4711.tmp`
+   * out of the listing and `rootFor` cannot resolve it - a half-written package is not a
+   * package this store can be asked for, by the same rule that decides what an id is. A
+   * suffix that read as an id would put the crashed copy in the list beside the good one.
+   *
+   * The old copy is removed after the swap rather than before it, because the window
+   * between the two renames is the only moment nothing is in place, and doing the removal
+   * first would widen it to however long a recursive delete takes.
+   */
+  install(id, manifest, chunks) {
+    if (!VALID_EFFECT_ID.test(id)) throw new Error(`${JSON.stringify(id)} is not an effect id`);
+    mkdirSync(this.dir, { recursive: true });
+    this.sweepTemporaries(id);
+    const seq = `${process.pid}.${Date.now().toString(36)}`;
+    const tmp = join(this.dir, `${id}.${seq}.tmp`);
+    const aside = join(this.dir, `${id}.${seq}.old`);
+    const live = join(this.dir, id);
+    mkdirSync(tmp, { recursive: true });
+    try {
+      // The manifest is written from the object rather than from whatever text arrived,
+      // because the store's own `read` parses this file and the door checked the parsed
+      // object - re-serialising is the one way the bytes on disk and the thing that was
+      // checked cannot be two different documents.
+      writeFileSync(join(tmp, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+      for (const [name, text] of Object.entries(chunks)) {
+        if (!VALID_FILE_NAME.test(name)) throw new Error(`${JSON.stringify(name)} is not a package file name`);
+        writeFileSync(join(tmp, name), text);
+      }
+    } catch (err) {
+      rmSync(tmp, { recursive: true, force: true });
+      throw err;
+    }
+    const replaced = existsSync(live);
+    if (replaced) renameSync(live, aside);
+    try {
+      renameSync(tmp, live);
+    } catch (err) {
+      // The one window worth unwinding: the new copy did not go in, so the old one goes
+      // back rather than leaving the id resolving to nothing on a machine that had a
+      // working package a millisecond ago.
+      if (replaced) renameSync(aside, live);
+      rmSync(tmp, { recursive: true, force: true });
+      throw err;
+    }
+    if (replaced) rmSync(aside, { recursive: true, force: true });
+    return { ...this.read(id), replaced };
+  }
+
+  /**
+   * The user's copy of an id, removed - and only ever the user's copy.
+   *
+   * Deleting a fork restores the shipped package, because the builtin root was never
+   * touched and `rootFor` simply starts answering from it again. Deleting a package that
+   * exists only in the user root uninstalls it, and the clients then park what their
+   * documents hold under it, which is the same condition a document from a machine with
+   * more installed already produces.
+   *
+   * A builtin with no fork is refused by name rather than silently doing nothing, because
+   * "there was nothing of yours to remove" and "this build refuses to remove what it
+   * shipped with" are different answers and only one of them is about the request.
+   */
+  remove(id) {
+    if (!VALID_EFFECT_ID.test(id)) return { error: `${JSON.stringify(id)} is not an effect id`, status: 400 };
+    const mine = join(this.dir, id);
+    if (!existsSync(mine)) {
+      if (existsSync(join(this.builtinDir, id))) {
+        return {
+          error: `effect ${id} is shipped with this build and nothing is forking it - `
+            + 'a builtin is what an install falls back to, so removing one would leave an id that '
+            + 'this build can never answer again',
+          status: 409,
+        };
+      }
+      return { error: `no effect ${id} here - GET /effects lists what is installed`, status: 404 };
+    }
+    this.sweepTemporaries(id);
+    const seq = `${process.pid}.${Date.now().toString(36)}`;
+    const aside = join(this.dir, `${id}.${seq}.old`);
+    // Renamed out of the way and then deleted, so the id stops resolving in one operation
+    // rather than over however long it takes to unlink a directory of files.
+    renameSync(mine, aside);
+    rmSync(aside, { recursive: true, force: true });
+    return { removed: id, restored: existsSync(join(this.builtinDir, id)) };
+  }
+
+  /**
+   * Whatever a crashed install left behind for this id, swept before the next one starts.
+   *
+   * They are invisible to every read, so nothing is broken by their being there - what
+   * they are is disk, and a machine that crashed mid-install ten times would carry ten
+   * copies of a package with nothing ever looking at them.
+   */
+  sweepTemporaries(id) {
+    if (!existsSync(this.dir)) return;
+    for (const entry of readdirSync(this.dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(`${id}.`) && /\.(tmp|old)$/.test(entry.name)) {
+        rmSync(join(this.dir, entry.name), { recursive: true, force: true });
+      }
+    }
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,14 @@ import {
   removeTake, renameTake, resolveMarks, revealSupport, revealTake, scanTakes,
 } from './library.js';
 import { EffectStore } from './effect-store.js';
+// The install door and the two spines it assembles a candidate against. Source text and
+// pure functions over it - nothing here touches a GPU, which is what lets the door run in
+// this process at all: it answers whether the page *would* boot with this package
+// installed, and the only way to ask that honestly is with the same assembler the page
+// runs.
+import { doorRefusal, forkRefusal } from './effect-door.js';
+import { cloudSpine } from '../web/cloud-shader.js';
+import { gradeSpine } from '../web/grade-shader.js';
 import { Recorder } from './recorder.js';
 import { JobStore } from './jobs.js';
 import { Webcam } from './webcam.js';
@@ -1086,6 +1094,53 @@ async function readDocument(res, store, name) {
   }
 }
 
+/**
+ * An effect package installed or removed, which is the one write in this program that
+ * changes what the *page* is rather than what a page is looking at.
+ *
+ * **The refusal comes before the filesystem, always.** `doorRefusal` is a pure function of
+ * the envelope and the packages that would sit beside it, so a package this build cannot
+ * assemble, cannot bind or cannot compile is answered with the sentence saying which of
+ * those it is and never reaches a directory. That ordering is the whole design: a package
+ * that lands and then breaks the next boot is a machine whose editor no longer opens, with
+ * the evidence in a browser console nobody has open.
+ *
+ * The envelope is `{ manifest, chunks }` and the id comes off the path, which is why the
+ * door holds the two to each other - a manifest declaring a different id is one of them
+ * being wrong and there is no way to know which.
+ */
+async function serveEffectWrite(req, res, [id]) {
+  if (req.method === 'DELETE') {
+    const answer = EFFECTS.remove(id);
+    if (answer.error) return sendJson(res, { error: answer.error }, answer.status);
+    return sendJson(res, answer);
+  }
+  let body;
+  try {
+    body = await readBody(req);
+  } catch (err) {
+    return sendJson(res, { error: err.message }, 400);
+  }
+  const candidate = { id, manifest: body.manifest, chunks: body.chunks ?? {} };
+  // Held against the shipped package rather than against the whole store, because this is
+  // the one rule that is about forking specifically - see `forkRefusal`.
+  const shadowed = candidate.manifest && typeof candidate.manifest === 'object' ? EFFECTS.builtin(id) : null;
+  const refusal = doorRefusal(candidate, {
+    beside: EFFECTS.loaded(id),
+    spines: { cloud: cloudSpine, grade: gradeSpine },
+  }) ?? (shadowed ? forkRefusal(candidate, shadowed) : null);
+  if (refusal) return sendJson(res, { error: refusal }, 409);
+  try {
+    return sendJson(res, EFFECTS.install(id, candidate.manifest, candidate.chunks));
+  } catch (err) {
+    // The door has already passed, so anything thrown here is the filesystem rather than
+    // the package - a full disk, a permission, a root that vanished. Reported as a 500
+    // with its own message rather than as a refusal, because the caller's package was
+    // fine and retrying it is the right next move.
+    return sendJson(res, { error: `effect ${id} could not be written: ${err.message}` }, 500);
+  }
+}
+
 async function writeDocument(req, res, store, name) {
   if (req.method === 'DELETE') {
     try {
@@ -1655,13 +1710,17 @@ const ROUTES = [
   // ---- documents
   { path: '/projects', pattern: /^\/projects\/?$/, read: (req, res) => listDocuments(res, PROJECTS) },
   { path: '/presets', pattern: /^\/presets\/?$/, read: (req, res) => listDocuments(res, PRESETS) },
-  // The effect packages, reads only: the list a client assembles from, one package's
-  // manifest and file index, and one file's raw bytes. Install and delete join when
-  // the surface that can drive them end to end exists; a write route nothing can
-  // exercise before commit is the class of code this table refuses to carry. The
-  // chunk route serves text/plain because what the tools anchor and the client
+  // The effect packages: the list a client assembles from, one package's manifest and
+  // file index, one file's raw bytes, and the two writes that install and remove one.
+  // The chunk route serves text/plain because what the tools anchor and the client
   // compiles is the file's own bytes - a content type that invited transformation
   // would be the wrong promise.
+  //
+  // **The write is registered on the same entry as the read**, which is what puts it
+  // behind `requireMutation` by existing rather than by anybody remembering: an install
+  // changes what every page of this build compiles, which is the largest consequence any
+  // route here has. `PUT` writes into the user root and `DELETE` removes from it, so the
+  // shipped packages are unreachable from the network in both directions.
   { path: '/effects', pattern: /^\/effects\/?$/, read: (req, res) => sendJson(res, { effects: EFFECTS.list() }) },
   {
     path: '/effects/:id',
@@ -1671,6 +1730,7 @@ const ROUTES = [
       if (!pkg) return sendJson(res, { error: `no effect ${args[0]} here - GET /effects lists what is installed` }, 404);
       return sendJson(res, pkg);
     },
+    write: { methods: ['PUT', 'DELETE'], run: serveEffectWrite },
   },
   {
     path: '/effects/:id/file/:name',

--- a/server/jobs.js
+++ b/server/jobs.js
@@ -163,7 +163,7 @@ export class JobStore {
    * the original" is a claim about identified footage, and a job naming a take by
    * id would reproduce whatever is at that id today.
    */
-  async enqueue({ project, deliverable = null, capture, renderer = null, output, width, height, fps, codec = 'h264' }) {
+  async enqueue({ project, deliverable = null, capture, renderer = null, output, width, height, fps, codec = 'h264', suppressEffects = [] }) {
     // The project is the document *body* - what `serialiseProject()` returns and
     // what `restoreProject` takes - not the `{ name, rev, body }` envelope the
     // document store hands back. One shape, checked here, because accepting both
@@ -190,6 +190,32 @@ export class JobStore {
         + `got ${JSON.stringify(renderer)} - and a pin nothing can equal is a job nothing can claim`,
       );
     }
+    // **The effects the job's look is built from, lifted out of the document at the
+    // door.** A worker has to answer "can this machine render this at all" before it
+    // opens a page, and a job whose answer lives inside a document body is a job the
+    // queue cannot reason about - it could not report a blocked job, and a claim could
+    // not be routed by what a machine has installed the way it is already routed by the
+    // rasteriser it has.
+    //
+    // **It is derived here and never accepted from the caller**, which is what makes the
+    // second spelling safe: `enqueue` is the only writer, and it writes what the project
+    // itself says. A `requires` a caller could set is a job that can lie about the
+    // document it carries. The two are held equal by `jobs-check` rather than trusted,
+    // on the same reading `syntax-check` holds `CAPTURE_FORMAT` to the grabber - two
+    // copies that cannot be one, compared instead of hoped about.
+    const requires = Array.isArray(project.requires) ? project.requires.map((e) => ({ ...e })) : [];
+    // And what this job is allowed to render without. Unlike `requires` this *is* the
+    // caller's, because it is a decision rather than a fact: somebody has said this
+    // render may go ahead on a machine missing that effect. Held to the id shape the
+    // packages use, because a name that could not be an effect id can never match one
+    // and would be a suppression that silently covers nothing.
+    if (!Array.isArray(suppressEffects)
+      || !suppressEffects.every((id) => typeof id === 'string' && /^[a-z][a-z0-9]*$/.test(id))) {
+      throw new Error(
+        `a job's suppressEffects is a list of effect ids, got ${JSON.stringify(suppressEffects)} - `
+        + 'an id is lowercase letters and digits, the prefix an effect\'s parameters carry',
+      );
+    }
     // All the export rules run at enqueue, so the queue refuses work it already
     // knows cannot run. The worker and the export socket must not be the place a
     // bad width, an odd h264 dimension, or an unknown codec is first discovered.
@@ -211,6 +237,8 @@ export class JobStore {
         version: JOB_VERSION,
         project,
         deliverable,
+        requires,
+        suppressEffects: [...suppressEffects],
         capture,
         renderer: renderer ?? null,
         output: String(output),

--- a/test/effect-door.test.mjs
+++ b/test/effect-door.test.mjs
@@ -1,0 +1,116 @@
+// The install door against the sixteen packages this build ships, under bare node.
+//
+// **This is the must-accept control, and without it every refusal the door makes is
+// worthless.** A door that refused everything would satisfy every hostile-package row
+// `tools/effect-check.mjs` drives - each of those asks "is this refused", and a rule that
+// always says yes passes all of them at once. The population that says the door is a door
+// rather than a wall is the one set of packages that must certainly get through, and this
+// repo has sixteen of them sitting on disk with no way to argue about whether they are
+// correct: they are what the shipped build compiles.
+//
+// It caught four false refusals the first time it was run, and each was a fact about GLSL
+// rather than about a package: `position` and `modelMatrix` are injected into a
+// `ShaderMaterial` by three.js and appear in no declaration anywhere in this tree,
+// `texture2D` is the ES 1.00 spelling the grade pass compiles against while the cloud's
+// pair are GLSL3, and the rain declares one uniform its own parameters do not write
+// because the render loop drives it. Three of those became vocabulary the door reads out
+// of the spine, and the fourth became a manifest field.
+//
+// Under bare node with no server, no browser and no GPU, because the door is a pure
+// function of an envelope and the two spines - which is what lets it run before the store
+// has made a directory, and what lets this file run in CI with nothing installed.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { doorRefusal, forkRefusal } from '../server/effect-door.js';
+import { cloudSpine } from '../web/cloud-shader.js';
+import { gradeSpine } from '../web/grade-shader.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILTIN = join(ROOT, 'effects-builtin');
+const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+
+const load = (id) => {
+  const dir = join(BUILTIN, id);
+  const manifest = JSON.parse(readFileSync(join(dir, 'manifest.json'), 'utf8'));
+  const chunks = {};
+  for (const c of manifest.chunks ?? []) chunks[c.file] = readFileSync(join(dir, c.file), 'utf8');
+  return { id, manifest, chunks };
+};
+
+const shipped = () => readdirSync(BUILTIN, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => load(e.name));
+
+// The set as the store would hand it over on an install: everything else that is
+// installed, with the candidate excluded, because a package replacing itself would
+// collide with itself on every slot and varying it declares.
+const beside = (all, id) => all.filter((p) => p.id !== id);
+
+test('every shipped package gets through the door it is held to', () => {
+  const all = shipped();
+  assert.ok(all.length >= 16, `only ${all.length} packages on disk - this control would pass on almost nothing`);
+  for (const pkg of all) {
+    assert.equal(doorRefusal(pkg, { beside: beside(all, pkg.id), spines: SPINES }), null,
+      `the shipped ${pkg.id} is refused by this build's own install door`);
+  }
+});
+
+// One hostile shape per rule, so a rule that stops firing is a red row here rather than a
+// hole nobody notices until `effect-check` next runs against a browser. The mutations are
+// applied to a shipped package rather than to a fixture written for the purpose, so what
+// the door is being asked is always "this, one field wrong" - which is the shape a real
+// broken package has, and the shape a fixture built to fail never quite is.
+const brokenBy = (id, edit) => {
+  const all = shipped();
+  const pkg = all.find((p) => p.id === id);
+  const candidate = { id, manifest: JSON.parse(JSON.stringify(pkg.manifest)), chunks: { ...pkg.chunks } };
+  edit(candidate);
+  return doorRefusal(candidate, { beside: beside(all, id), spines: SPINES });
+};
+
+test('the door names what it refuses, one rule at a time', () => {
+  const cases = [
+    ['a manifest declaring another id', 'thermal', (c) => { c.manifest.id = 'edges'; }, /declaring id "edges"/],
+    ['a format from a later build', 'thermal', (c) => { c.manifest.format = 99; }, /package format 99/],
+    ['no format at all', 'thermal', (c) => { delete c.manifest.format; }, /declares no package format/],
+    ['a kind nothing normalises', 'thermal', (c) => { c.manifest.params.amount.kind = 'ramp'; }, /kind "ramp"/],
+    ['a transform the applier has not got', 'thermal', (c) => { c.manifest.params.amount.bind.transform = 'toKelvin'; }, /transform "toKelvin"/],
+    ['a master that is not inert', 'thermal', (c) => { c.manifest.params.amount.def = 0.5; }, /master and defaults to 0\.5/],
+    // Inert *and* in range, so this row reaches the count rather than being answered by
+    // the bounds rule three lines above it - `rain.speed` starts at 0.05, and a master
+    // has to default to 0.
+    ['a second master', 'rain', (c) => { Object.assign(c.manifest.params.speed, { role: 'master', def: 0, min: 0 }); }, /2 parameters with the role master/],
+    ['a binding no program declares', 'thermal', (c) => { c.manifest.params.amount.bind.uniform = 'thermalll'; }, /declares no such uniform/],
+    ['a uniform no parameter writes', 'rain', (c) => { c.chunks['decl.frag.glsl'] += 'uniform float rainStray;\n'; }, /"rainStray" and binds no parameter/],
+    ['a chunk file naming a path', 'thermal', (c) => { c.manifest.chunks[0].file = '../out.glsl'; c.chunks['../out.glsl'] = ''; }, /"\.\.\/out\.glsl"/],
+    ['a joint no spine holds', 'thermal', (c) => { c.manifest.chunks[0].stage = 'f.elsewhere'; }, /does not assemble/],
+    ['an identifier that is nowhere', 'thermal', (c) => { c.chunks['heat.frag.glsl'] += '  col = vec3(qqNotHere);\n'; }, /"qqNotHere"/],
+    ['a varying init that reads state', 'rain', (c) => { c.manifest.varyings[0].init = 'rainPhase'; }, /initialises to "rainPhase"/],
+    ['a panel group anchored nowhere named', 'rain', (c) => { delete c.manifest.panelGroups[0].after; }, /anchors after undefined/],
+    ['a file the manifest never names', 'thermal', (c) => { c.chunks['spare.glsl'] = ''; }, /"spare\.glsl" and its manifest names no chunk/],
+    ['a chunk whose text did not arrive', 'thermal', (c) => { delete c.chunks['heat.frag.glsl']; }, /its text did not arrive/],
+  ];
+  for (const [what, id, edit, matches] of cases) {
+    const refusal = brokenBy(id, edit);
+    assert.ok(refusal, `the door accepted ${what}`);
+    assert.match(refusal, matches, `the door refused ${what} for the wrong reason: ${refusal}`);
+  }
+});
+
+test('a fork may add and retune, and may not drop', () => {
+  const all = shipped();
+  const noise = all.find((p) => p.id === 'noise');
+  const whole = { id: 'noise', manifest: JSON.parse(JSON.stringify(noise.manifest)), chunks: noise.chunks };
+  whole.manifest.version = '2.0.0';
+  whole.manifest.params.amount.max = 2;
+  assert.equal(forkRefusal(whole, noise), null, 'a fork that keeps every key is what forking is for');
+
+  const short = { id: 'noise', manifest: JSON.parse(JSON.stringify(noise.manifest)), chunks: noise.chunks };
+  delete short.manifest.params.speed;
+  assert.match(forkRefusal(short, noise), /drops noise\.speed/,
+    'a fork short of a placed name is a registry that cannot assemble');
+});

--- a/test/effect-manifests.test.mjs
+++ b/test/effect-manifests.test.mjs
@@ -22,7 +22,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { tableFromPackages } from '../web/effect-manifests.js';
+import { placeParams, tableFromPackages } from '../web/effect-manifests.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const BUILTIN = join(ROOT, 'effects-builtin');
@@ -65,4 +65,51 @@ test('the equality refuses one field one step off', async () => {
   const assembled = tableFromPackages(packages, orderOf(reference));
   assert.notEqual(JSON.stringify(assembled), JSON.stringify(reference),
     'a one-step drift in rain.speed must break the equality');
+});
+
+// ---- where a package the order has never heard of goes
+//
+// Installing an effect is the case the order list cannot be written for, and the
+// rule that answers it is `placeParams`. The two claims worth holding are that the
+// shipped set is untouched by the rule existing, and that a package the order does
+// not name lands in one defined place rather than wherever the objects were walked.
+// Both are asked under bare node, because both are arithmetic over two lists.
+
+const pkg = (id, keys) => ({ id, manifest: { params: Object.fromEntries(keys.map((k) => [k, {}])) } });
+
+test('the placed set is byte-stable, whatever else is installed', async () => {
+  const order = orderOf(await oldTable());
+  const shipped = packagesOnDisk();
+  assert.deepEqual(placeParams(shipped, order), order,
+    'the shipped sixteen are all placed, so the rule must return the order unchanged');
+  const placed = placeParams([...shipped, pkg('zzprobe', ['amount'])], order);
+  assert.deepEqual(placed.slice(0, order.length), order,
+    'a seventeenth effect must not move any of the forty-one the order places');
+});
+
+test('an unplaced package lands contiguous, in manifest order, after everything placed', () => {
+  const order = ['a.one', 'a.two'];
+  const packages = [
+    pkg('a', ['one', 'two']),
+    pkg('zeta', ['master', 'depth']),
+    pkg('beta', ['gain']),
+  ];
+  assert.deepEqual(placeParams(packages, order), [
+    'a.one', 'a.two',
+    // Packages by id, which is the only ordering two manifests can be compared by,
+    // and each package's own keys in the order it declared them - `master` before
+    // `depth`, which is neither alphabetical nor the order they were handed in.
+    'beta.gain', 'zeta.master', 'zeta.depth',
+  ]);
+});
+
+test('a fork that adds a key appends it rather than seating it beside its siblings', () => {
+  const order = ['rain.amount', 'rain.speed'];
+  const placed = placeParams([pkg('rain', ['amount', 'speed', 'gust'])], order);
+  assert.deepEqual(placed, ['rain.amount', 'rain.speed', 'rain.gust']);
+});
+
+test('the registry still refuses a placed name no package declares', () => {
+  assert.throws(() => tableFromPackages([pkg('a', ['one'])], ['a.one', 'a.two']),
+    /a\.two/, 'a name the order places and nothing declares has no entry to assemble');
 });

--- a/tools/boot-check.mjs
+++ b/tools/boot-check.mjs
@@ -100,28 +100,37 @@ const RECORDER_PATH = '/record';
  * control that fails everything cannot say which question it was asking, and one that
  * reproduces a *different* defect wearing the same colour is worse than none.
  *
+ * **Both halves live inside `adoptEffectPackages` now, and the mutation moved with them
+ * rather than being replaced.** The page used to generate the panel while the module
+ * evaluated and write `params.reset()` a few lines below it; installing an effect made
+ * both of those things that happen again while the page is up, so they are two steps of
+ * one function and boot is that function's first call. The fault is the same fault - the
+ * values written before the controls they are meant to paint exist - and it is put back
+ * the same way, by lifting `buildPanel()` from above the walk to below it.
+ *
  * **It boots, which took some care and is the whole reason it is aimed here.** The obvious
- * spelling of this mutation is dangerous: `params.reset()` writes every parameter while the
+ * spelling of this mutation is dangerous: the value walk writes every parameter while the
  * module is still evaluating, and `groupRevealChanged` and `transportWriting` are declared
  * as no-ops above the registry precisely so that write cannot reach `tracks` or
  * `withoutRepaint` in their temporal dead zone. A page that throws during module evaluation
  * publishes no `globalThis.__kinect` at all, every tool in the suite reports DID NOT RUN,
  * and an exit code with no assertion behind it is the outcome this repo has three times
  * written down as a bug found - `docs/instruments.md` names it under "A mutation whose only
- * effect is that the page refuses to boot is not a usable mutation". Moving the call from
- * after the generator to just before it stays on the safe side of that: `tracks` is declared
- * at `web/main.js`'s `const tracks = new Map()`, which is below both positions, so the
- * no-ops are still the no-ops and nothing moves into a dead zone. Measured rather than
- * reasoned about - the mutated build boots both surfaces with zero page errors.
+ * effect is that the page refuses to boot is not a usable mutation". Swapping two adjacent
+ * steps of one function stays on the safe side of that, because neither step moves across
+ * a declaration: `writeControl` and `refreshReset` both return early when the panel has no
+ * control by that name, which is exactly the state the mutated order puts them in.
+ * Measured rather than reasoned about - the mutated build boots both surfaces with zero
+ * page errors.
  */
 const MUTATIONS = {
   'reset-before-the-panel-generator': {
     file: 'web/main.js',
     edits: [
-      ['\nparams.reset();\n', '\n'],
+      ['\n  buildPanel();\n', '\n'],
       [
-        '\nfor (const group of PANEL_GROUPS) {\n  const groupNode = panelNode(',
-        '\nparams.reset();\n\nfor (const group of PANEL_GROUPS) {\n  const groupNode = panelNode(',
+        '    params.set(name, Object.hasOwn(held, name) ? held[name] : PARAMS[name].def);\n  }\n',
+        '    params.set(name, Object.hasOwn(held, name) ? held[name] : PARAMS[name].def);\n  }\n  buildPanel();\n',
       ],
     ],
   },

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -145,6 +145,45 @@ const VIEWPORT = { width: 1512, height: 900 };
 // ------------------------------------------------------------------- mutations
 
 const MUTATIONS = {
+  // ---- section 15b, the badge for an effect this build has not got ----
+  //
+  // **The counts taken off the registry instead of off the pool**, which is the wrong
+  // implementation somebody would actually write: `effectParamNames` is the helper every
+  // other line in that neighbourhood reaches for, and for an effect that is not installed
+  // it answers the empty list. The badge then appears, names the right effect at the right
+  // version, and reports `0 values, 0 tracks parked` - which is exactly what a build that
+  // had *dropped* the values would print, so the one number that distinguishes carrying
+  // from discarding stops distinguishing them.
+  //
+  // Must redden: the exact-sentence row of 15b, alone. The badge still comes up, the
+  // toggle still works, and the round trip is `library-check`'s claim rather than this
+  // one's - so a control that reddened those too would be breaking the parking rather
+  // than the badge.
+  'badge-counts-the-registry': {
+    file: 'web/main.js',
+    edits: [[
+      "  values: Object.keys(parkedLook.params).filter((n) => effectOf(n) === entry.id).length,\n"
+      + "  tracks: Object.keys(parkedLook.tracks).filter((n) => effectOf(n) === entry.id).length,",
+      '  values: effectParamNames(entry.id).length,\n'
+      + '  tracks: effectParamNames(entry.id).filter((n) => tracks.has(n)).length,',
+    ]],
+  },
+
+  // The toggle that only goes one way. Pressing suppress works, the export proceeds, and
+  // there is no way back to requiring the effect short of reloading - which turns a
+  // decision about one render into a decision about the session, on the one control whose
+  // whole design is that it is per effect and revocable.
+  //
+  // Must redden: the press-it-again row of 15b, alone. The first press still lands, so
+  // every row above it holds.
+  'suppress-toggle-is-a-latch': {
+    file: 'web/main.js',
+    edits: [[
+      '  if (suppressedEffects.has(id)) suppressedEffects.delete(id);\n  else suppressedEffects.add(id);',
+      '  suppressedEffects.add(id);',
+    ]],
+  },
+
   // ---- section 21, the collapsed panel and its dock ----
   //
   // The picture drawn full height under a bar drawn over it. `resize()` stops taking the
@@ -2560,6 +2599,19 @@ const DRIVER_RULES = [
     match: (row) => Boolean(row.reset),
   },
   {
+    key: 'suppress',
+    what: 'the control that lets a render go without an effect this build has not got',
+    // A rule rather than an id, because the badge draws one of these per missing effect
+    // and how many there are is a property of the document rather than of this file. Keyed
+    // on the effect the control carries, which is what makes it that kind of control -
+    // never on the chip around it, because a container rule adopts whatever the container
+    // grows next and the application bar's status slot is exactly where that has already
+    // happened twice, once to `appbar` and once to the row inside it.
+    by: 'section 15b stages a document naming a missing effect, presses this, and reads '
+      + 'the suppression back off the page and off the note',
+    match: (row) => Boolean(row.suppress),
+  },
+  {
     key: 'output',
     what: 'a program-out control',
     // Named because it is driven, not because it is exempt. `vcam-check` section 5
@@ -3029,6 +3081,22 @@ try {
   // door sections 4, 10 and 13 already use: `setMarks` writes no sidecar, so this
   // does not edit the take it measures.
   await page.evaluate("__kinect.editor.setMarks([{ id: 'sweep', sourceMs: 2000, label: 'sweep' }])");
+  // **And a missing effect, for exactly the reason the mark above is planted.** The
+  // badge's suppress toggle is a control that exists only on a document naming an effect
+  // this build has not got, and the fixture take names none - so a sweep of the page as
+  // it loads finds no such control, "no instance of this class" and "this class is not
+  // swept" read the same, and the rule written for it would sit here matching nothing.
+  // The document goes back the moment the sweep has been taken, and the row after the
+  // coverage rows asserts that it did: the parked pool reaches every later serialisation
+  // of this page, so leaving one behind is this file's own noise arriving in twenty
+  // sections' worth of documents.
+  const sweptClean = await page.evaluate('JSON.stringify(__kinect.library.serialiseProjectBody())');
+  await page.evaluate(`(() => {
+    const body = JSON.parse(${JSON.stringify(sweptClean)});
+    body.look.params['sparkle.amount'] = 0.6;
+    body.requires = [...(body.requires ?? []), { id: 'sparkle', version: '1.0.0' }];
+    __kinect.library.restoreProject(body);
+  })()`);
   const sweep = await page.evaluate(`(${((rules) => {
     // Anchors are in the list because the way out of this surface is two of them.
     // They were buttons calling `location.href` until the nav moved into the panel
@@ -3078,6 +3146,11 @@ try {
       // key with the empty string, so `??` keeps it and every reset would be credited
       // under the name of every other one.
       reset: el.dataset ? el.dataset.reset || null : null,
+      // The effect a suppress toggle is about, on the same terms as the two above: the
+      // badge draws one of these per missing effect, so there is no id to name and the
+      // property that makes it that kind of control is the effect it carries. `||` for
+      // the empty-string reason spelled out on `reset`.
+      suppress: el.dataset ? el.dataset.suppress || null : null,
       inTbar: Boolean(el.closest('.tbar')),
       // `.appmenu` is a class where the rest are ids, and it is here because the
       // `appbar` rule below needs to tell a menu from a button that merely shares the
@@ -3137,6 +3210,15 @@ try {
   check(unknown.length === 0,
     'every control the page renders is covered by a driver or a stated rule',
     unknown.length ? `${unknown.length} uncovered: ${unknown.map((r) => r.id || r.label).join(', ')}` : `${sweep.length} controls`);
+
+  // The staged missing effect goes back off, and the row says it did. Asserted rather
+  // than assumed for the reason section 14 gives about its own cleanup: what a left-behind
+  // pool costs is not visible here, it is visible twenty sections down as a `requires`
+  // entry in a document some other row is asserting about.
+  await page.evaluate(`__kinect.library.restoreProject(JSON.parse(${JSON.stringify(sweptClean)}))`);
+  check(await page.evaluate('__kinect.library.missingEffects().length') === 0,
+    'and the missing effect staged for that sweep is off the page again, so no later section serialises it',
+    'nothing parked');
   // The rule half of the claim, so a build that removed every panel control could not
   // satisfy the row above by having nothing left to cover.
   //
@@ -9809,6 +9891,121 @@ try {
     await settle();
   }
 
+  // ============ 15b. a document naming an effect this build has not got says so
+
+  console.log('\n[15b] the badge names the effects a document needs and this build has not got');
+
+  // **The refusals above and this are the two halves of one decision, and this is the
+  // half with a surface.** A look name whose dotted prefix names an effect that is not
+  // installed is not a typo and not a half-existing package - it is a document from a
+  // machine carrying something this one lacks - so it loads, the installed part renders,
+  // and what belongs to the missing effect is parked. The person at the screen then has
+  // no way at all to know a layer of the clip is being carried rather than drawn, unless
+  // something says so, and this badge is the something.
+  //
+  // Staged rather than uninstalled, because there is no uninstall in this build. The
+  // precondition row is what stops that being a hole: `sparkle` is a valid effect id and
+  // nothing ships under it, and the day something does, every row here would go on
+  // passing while asking nothing.
+  {
+    const original = await page.evaluate('JSON.stringify(__kinect.library.serialiseProjectBody())');
+    const declared = await page.evaluate(`(() => [...new Set(__kinect.params.names('look')
+      .filter((n) => n.includes('.')).map((n) => n.slice(0, n.indexOf('.'))))])()`);
+    check(!declared.includes('sparkle'),
+      'sparkle is not an effect this build has, which is what makes every row below about a missing one',
+      `${declared.length} installed: ${declared.join(', ')}`);
+
+    // **The must-not-badge control comes first**, on the document the editor is already
+    // holding: a badge that was always up would satisfy every row under it, and a badge
+    // read only after it has been made to appear cannot say it was ever absent.
+    const quiet = await page.evaluate(`(() => {
+      const el = document.getElementById('tMissing');
+      return { hidden: el.hidden, entries: el.querySelectorAll('.missingfx').length,
+        missing: __kinect.library.missingEffects().length };
+    })()`);
+    check(quiet.hidden === true && quiet.entries === 0 && quiet.missing === 0,
+      'a complete document badges nothing at all, so the bar is bare in the ordinary case',
+      `hidden ${quiet.hidden}, ${quiet.entries} entries, ${quiet.missing} missing`);
+
+    // Four values and two keyed tracks, which is the pair the badge has to count - and
+    // they are different numbers on purpose, because a painter that printed one count
+    // twice would read correctly against a fixture where they agree.
+    const staged = await page.evaluate(`(() => {
+      const body = JSON.parse(${JSON.stringify(original)});
+      body.look.params['sparkle.amount'] = 0.6;
+      body.look.params['sparkle.size'] = 3.25;
+      body.look.params['sparkle.hue'] = 210;
+      body.look.params['sparkle.jitter'] = 0.125;
+      body.look.tracks['sparkle.amount'] = [{ t: 0, value: 0 }, { t: 2, value: 0.9 }];
+      body.look.tracks['sparkle.hue'] = [{ t: 0.5, value: 10 }];
+      body.requires = [...(body.requires ?? []), { id: 'sparkle', version: '1.0.0' }];
+      try { __kinect.library.restoreProject(body); } catch (err) { return { threw: String(err?.message ?? err) }; }
+      const el = document.getElementById('tMissing');
+      return {
+        threw: null,
+        hidden: el.hidden,
+        entries: [...el.querySelectorAll('.missingfx')].map((e) => ({
+          effect: e.dataset.effect,
+          text: e.querySelector('b').textContent,
+          pressed: e.querySelector('button').getAttribute('aria-pressed'),
+        })),
+      };
+    })()`);
+    check(staged.threw === null,
+      'a document naming an effect this build has not got loads rather than being refused',
+      staged.threw ?? 'loaded');
+    check(staged.hidden === false && staged.entries.length === 1,
+      '  and the badge comes up, one entry for the one effect that is missing',
+      `hidden ${staged.hidden}, ${staged.entries?.length ?? 0} entries`);
+    // **The exact sentence, counts and all.** The counts are the part of this line that
+    // is evidence rather than decoration: a build that parked nothing would draw the
+    // identical picture and print zeroes here, and this is the only place the difference
+    // is visible before somebody saves the file over the top of the values.
+    check(staged.entries?.[0]?.text === 'missing: sparkle 1.0.0 — 4 values, 2 tracks parked',
+      '  and it reads the effect, the version out of the document\'s own requires entry, and what is parked under it',
+      JSON.stringify(staged.entries?.[0]?.text ?? null));
+    check(staged.entries?.[0]?.pressed === 'false',
+      '  with its suppress control up and not pressed, because nobody has said this render may go without it',
+      String(staged.entries?.[0]?.pressed));
+
+    // The control beside it, driven through the real button rather than through the set
+    // it writes: this is the credit `DRIVER_RULES` gives it, and a rule crediting a
+    // driver that does not drive is the attribution failure this file's own table has
+    // three case files about.
+    await page.click('#tMissing button[data-suppress="sparkle"]');
+    const pressed = await page.evaluate(`(() => ({
+      pressed: document.querySelector('#tMissing button[data-suppress="sparkle"]').getAttribute('aria-pressed'),
+      suppressed: __kinect.library.missingEffects()[0]?.suppressed ?? null,
+      note: document.getElementById('tNote').textContent,
+    }))()`);
+    check(pressed.pressed === 'true' && pressed.suppressed === true,
+      '  and pressing it is a suppression the page holds, rather than a control that only lights up',
+      `aria-pressed ${pressed.pressed}, suppressed ${pressed.suppressed}`);
+    // Read where a person would, because the consequence of this press is at the export
+    // and the export is a menu away - a switch whose effect only shows up when you next
+    // press something else is a switch nobody can check they pressed.
+    check(/sparkle/.test(pressed.note ?? '') && /without/.test(pressed.note ?? ''),
+      '  and it says so on the note, since what it changes is what the next export does',
+      JSON.stringify(pressed.note ?? null));
+    // And back, so the toggle is a toggle rather than a latch.
+    await page.click('#tMissing button[data-suppress="sparkle"]');
+    const released = await page.evaluate(`document.querySelector('#tMissing button[data-suppress="sparkle"]').getAttribute('aria-pressed')`);
+    check(released === 'false', '  and pressing it again requires the effect back', String(released));
+
+    // The cleanup, asserted rather than assumed, for the reason section 14 gives about
+    // its own: every section below this one serialises whatever the page is holding, and
+    // a pool left behind would put a `requires` entry into each of those documents.
+    await page.evaluate(`__kinect.library.restoreProject(JSON.parse(${JSON.stringify(original)}))`);
+    await settle();
+    const after = await page.evaluate(`(() => ({
+      missing: __kinect.library.missingEffects().length,
+      hidden: document.getElementById('tMissing').hidden,
+    }))()`);
+    check(after.missing === 0 && after.hidden === true,
+      '  and putting the clip back takes the badge away, which is the must-not-badge claim read a second time from the other side',
+      `${after.missing} missing, hidden ${after.hidden}`);
+  }
+
   // ================================ 16. a panel group is open because the clip says so
 
   console.log('\n[16] which panel groups are open is derived, and only disagreements are stored');
@@ -10195,6 +10392,16 @@ try {
       'a group shut while it is in use and a quiet one pinned open are two disagreements to survive, or the rows below test nothing',
       `stored ${JSON.stringify(beforeReload)}`);
     await page.reload({ waitUntil: 'load' });
+    // **`__kinect` first, which the two other reloads in this file already do and this one
+    // did not.** Since the effect packages moved onto the wire the handle publishes after
+    // the `load` event `reload` waits for, so the predicate below can run against a page
+    // where `globalThis.__kinect` is still undefined - and a predicate that *throws* is
+    // not caught by `waitForFunction`, so the thirty seconds it was given are never spent
+    // and the run dies with `Cannot read properties of undefined (reading 'timeline')`.
+    // Seen here at 475 of the run's assertions, taking every section from 16 onward with
+    // it. `docs/instruments.md` carries the class; the repair is the guarded read that
+    // leaves the timeout reachable, which is what these two lines are.
+    await page.waitForFunction('!!globalThis.__kinect', null, { timeout: 30000 });
     await page.waitForFunction('!!globalThis.__kinect.timeline.transport()', null, { timeout: 30000 });
     await settle();
     // Read straight out of storage, before anything else touches the page. This is the

--- a/tools/effect-check.mjs
+++ b/tools/effect-check.mjs
@@ -11,7 +11,7 @@
 // failure to the moment of the install, and about proving that a page which was up when
 // the install happened is still telling the truth afterwards.
 //
-// **Five claims, and each has something that must fail if it were not being done.**
+// **Six claims, and each has something that must fail if it were not being done.**
 //
 //  1. **A revision is a hash of the bytes on disk.** Per file and over the set, computed
 //     here from the staged tree and held against what the routes answer - so a store
@@ -41,6 +41,14 @@
 //     edit is what you can see. `reinstall-leaves-it-parked` is the control.
 //  5. **And a build with nothing missing says nothing.** A badge that appeared on every
 //     document would satisfy row 4's "the badge appeared" and mean nothing at all.
+//  6. **An install this page cannot adopt leaves it whole rather than half-migrated.** A
+//     fork adding a parameter makes the open document a subset of the new manifest, which
+//     the loader refuses per effect - correctly - *after* the registry has been swapped.
+//     The page has to go back: the registry it had, the signature it had, the pixels it
+//     drew, the pool it was holding, and a save that still writes the parked keys byte for
+//     byte. `rollback-keeps-the-new-registry` is the control, and it is worth reading which
+//     rows it reddens: not the picture, because the added parameter is inert at its
+//     default, and not the note, because the refusal is reported either way.
 //
 // **What is deliberately not here.** The export door on a clip whose look this build
 // cannot draw, and the per-effect suppress beside it, belong to `export-check` - one
@@ -51,6 +59,7 @@
 //   node tools/effect-check.mjs --mutate rebuild-skips-the-panel         # must FAIL
 //   node tools/effect-check.mjs --mutate install-skips-the-uniform-cells # must FAIL
 //   node tools/effect-check.mjs --mutate reinstall-leaves-it-parked      # must FAIL
+//   node tools/effect-check.mjs --mutate rollback-keeps-the-new-registry # must FAIL
 //
 // It spawns its own server on a port nothing else in the suite uses and needs none
 // running. A GPU browser, a free port 8281, no capture, no sensor and no ffmpeg.
@@ -99,6 +108,17 @@ const BASE = `http://127.0.0.1:${PORT}`;
  * value belonging to an effect that *is* installed parks anyway. The badge still appears
  * on the uninstall, which is what makes it worth having: a check reading only the badge
  * would call this build correct, and what fails is the restoration.
+ *
+ * `rollback-keeps-the-new-registry` is the half-rollback somebody writes who thinks of the
+ * failure as being about the document: the loader is run again, and the packages it is run
+ * against are the ones that just arrived rather than the ones this page had. The refusal is
+ * still reported and the badge still says what is parked, so a check reading only the note
+ * would call this build correct. What it leaves behind is the state the transaction exists
+ * to prevent - a registry the server's, a pool the page's - and the two rows that can see
+ * it are the registry's own contents and what a save writes, because the serialiser's
+ * filter drops parked keys the moment their prefix reads installed. The image cannot see
+ * it: the added parameter is inert at its default, so the picture is identical either way,
+ * which is exactly why a pixel row is not enough to hold this property.
  */
 const MUTATIONS = {
   'temporaries-are-visible': {
@@ -124,6 +144,13 @@ const MUTATIONS = {
     edits: [[
       '  return id !== null && !effectInstalled(id);',
       '  return id !== null;',
+    ]],
+  },
+  'rollback-keeps-the-new-registry': {
+    file: 'web/main.js',
+    edits: [[
+      '      adoptEffectPackages(heldPackages, heldPrograms, held);',
+      '      adoptEffectPackages(fetched, programs, held);',
     ]],
   },
 };
@@ -300,6 +327,42 @@ const probeChunks = () => ({
     + '  }\n',
 });
 const probePackage = () => ({ manifest: probeManifest(), chunks: probeChunks() });
+
+/**
+ * The same effect with one parameter more - the install a page holding this effect's
+ * values cannot be carried onto.
+ *
+ * **A fork that adds is the one shape that turns a good install into a bad page.** A
+ * document names every parameter of every effect it touches, because the loader's
+ * per-effect completeness rule refuses half of one; so a document written against the two
+ * parameters here names a subset of the three below, and the moment the third arrives the
+ * loader refuses that document by its own rule. Nothing is wrong with the package, nothing
+ * is wrong with the document, and the refusal is correct - what section 6 is about is
+ * where the page is left standing when it fires.
+ *
+ * The added parameter reaches a pixel and is inert at its default, both deliberately: it
+ * has to be a real parameter for the door to accept it and for the assembled program to
+ * declare its uniform, and it has to change nothing at zero so the image the rollback
+ * restores can be compared against the image before the install without the comparison
+ * turning into a question about the fork's own look.
+ */
+const forkedProbe = () => {
+  const pkg = probePackage();
+  pkg.manifest.version = '2.0.0';
+  pkg.manifest.params.glow = {
+    def: 0, min: 0, max: 1, step: 0.01, kind: 'scalar', label: 'probe glow',
+    panel: { group: 'probe', tab: 'look' },
+    bind: { on: 'points', uniform: 'probeGlow' },
+    under: 'amount',
+  };
+  pkg.chunks['decl.frag.glsl'] = 'uniform float probeAmount, probeHue, probeGlow;\n';
+  pkg.chunks['tone.frag.glsl'] =
+    '  if (probeAmount > 0.0) {\n'
+    + '    col = mix(col, vec3(probeHue, 1.0 - probeHue, probeHue * 0.5), probeAmount);\n'
+    + '    col += vec3(probeGlow * 0.25);\n'
+    + '  }\n';
+  return pkg;
+};
 const bent = (edit) => {
   const pkg = probePackage();
   edit(pkg);
@@ -743,16 +806,174 @@ try {
     quiet.hidden === true && quiet.missing.length === 0 && quiet.entries === 0,
     `hidden=${quiet.hidden}, ${quiet.missing.length} missing, ${quiet.entries} entries drawn`);
 
-  // =========================================== 6. what a crashed install leaves behind
+  // ================= 6. an install the open document cannot be carried onto, and the way back
+  //
+  // **The install that succeeds on the server and cannot be adopted by this page.** Every
+  // section above is about a rebuild that works; this one is about the one that does not,
+  // and the claim is that the page is left whole rather than half-migrated. A fork adding a
+  // parameter is the shape that produces it - the open document then names a subset of the
+  // new manifest, and the loader's per-effect completeness rule refuses it, correctly and by
+  // design. What must not happen is the page keeping the registry it just swapped in while
+  // its parked pool still describes the build before last: those two disagreeing about which
+  // names are live is a page no document can be saved from, and the serialiser reading a
+  // stale parked copy over a value the registry is rendering is how that costs somebody
+  // their work rather than their frame.
+  //
+  // **Driven through the poll rather than through `reload`**, because the note is one of the
+  // things being asserted and the poll is the only thing in the product that writes it. The
+  // rows below are the five separate facts a rollback has to leave true - the server did
+  // adopt the install, the page said so by name, the registry is the one it had, the pixels
+  // are the ones it drew, and a save is still byte-preserving per parked key - and they are
+  // separate rows because a build can get any four of them right.
+  console.log('\n[effect] 6. an install this page cannot carry the open document onto');
+
+  // The reading taken on both sides of the install, as one function handed to the page
+  // twice, so the before and the after cannot drift into being two different questions.
+  const readPage = async (positions) => {
+    const k = globalThis.__kinect;
+    const sha256 = async (bytes) => {
+      const digest = await crypto.subtle.digest('SHA-256', bytes);
+      return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+    };
+    k.drive.reset();
+    const hashes = [];
+    for (const t of positions) {
+      k.drive.stepTo(t);
+      hashes.push(await sha256(k.drive.readPixels()));
+    }
+    const badge = document.getElementById('tMissing');
+    const note = document.getElementById('tNote');
+    return {
+      hashes,
+      names: k.params.names(),
+      signature: k.effects.signature(),
+      pool: k.library.parkedLook(),
+      body: k.library.serialiseProjectBody(),
+      badgeHidden: badge?.hidden ?? null,
+      badgeText: badge?.textContent ?? '',
+      note: note?.textContent ?? '',
+    };
+  };
+
+  /** Everything a document says about the parked effect, as one comparable string. */
+  const parkedKeysOf = (body) => JSON.stringify({
+    params: Object.fromEntries(Object.entries(body.look.params).filter(([n]) => n.startsWith('probe.'))),
+    tracks: Object.fromEntries(Object.entries(body.look.tracks).filter(([n]) => n.startsWith('probe.'))),
+    requires: (body.requires ?? []).filter((e) => e.id === 'probe'),
+  });
+
+  // Caught in the page rather than allowed out, which is sections 3 and 4's shape and is
+  // load-bearing here for the same reason: a mutation that breaks the rebuild takes this
+  // driver down with it, and a run that stops on the way into this section stops before
+  // section 7 runs at all. `reinstall-leaves-it-parked` is the one that does it - it leaves
+  // a document the loader will not take in either direction, so the rollback's own refusal
+  // fires - and it should redden a row here and carry on, not end the run.
+  await del('probe');
+  const reParked = await page.evaluate(async () => {
+    try {
+      await globalThis.__kinect.effects.reload();
+      return { threw: null };
+    } catch (err) {
+      return { threw: String(err.message) };
+    }
+  });
+  ok('the effect comes off again and the page rebuilds without it', reParked.threw === null,
+    reParked.threw ?? 'no throw');
+  const beforeFork = await page.evaluate(readPage, POSITIONS);
+
+  ok('the effect is uninstalled again, so the document is holding it parked when the install below lands',
+    beforeFork.names.includes('probe.amount') === false
+      && Object.keys(beforeFork.pool.params).length === 2
+      && Object.keys(beforeFork.pool.tracks).length === 1
+      && beforeFork.badgeHidden === false,
+    `${Object.keys(beforeFork.pool.params).length} values and ${Object.keys(beforeFork.pool.tracks).length} tracks parked, `
+    + `badge hidden=${beforeFork.badgeHidden}`);
+  // **The control for the identity row below, and it is a cross-state one rather than the
+  // three-distinct-images row section 4 uses.** With the effect parked there is nothing
+  // keyed left to separate the three positions from each other: the pinned run is six
+  // frames at 33ms, so 0.6s and 1.2s both show the last of them and hash the same, and
+  // section 4's three images differed because `probe.amount` was ramping across them. What
+  // has to be shown here is that these hashes are a live reading of the look rather than a
+  // constant, so they are held against the same three positions taken while the effect was
+  // installed and raised - which is the state the rollback must *not* have left the page in.
+  ok('and the parked picture is not the picture the installed effect drew, so these hashes read the look rather than the frame',
+    JSON.stringify(beforeFork.hashes) !== JSON.stringify(authored.hashes),
+    `${beforeFork.hashes.map((h) => h.slice(0, 8)).join(' ')} against ${authored.hashes.map((h) => h.slice(0, 8)).join(' ')}`);
+
+  const fork = await put('probe', forkedProbe());
+  const forkServed = await getJson('/effects/probe');
+  ok('the fork installs: the server takes a package that is this effect with one parameter more',
+    fork.status === 200 && forkServed.status === 200 && forkServed.body.manifest?.version === '2.0.0',
+    `${fork.status}: ${fork.body.error ?? 'installed'}, the store now serves version ${forkServed.body.manifest?.version}`);
+
+  await page.evaluate(() => globalThis.__kinect.effects.pollNow());
+  const afterFork = await page.evaluate(readPage, POSITIONS);
+
+  ok('the page reports the refusal by name, and says which set it is still running',
+    /probe\.glow/.test(afterFork.note) && /still running the effects it had/.test(afterFork.note),
+    `"${afterFork.note.trim().slice(0, 120)}"`);
+  ok('and the registry is the one this page had rather than the one the server is serving',
+    JSON.stringify(afterFork.names) === JSON.stringify(beforeFork.names),
+    afterFork.names.includes('probe.glow')
+      ? 'probe.glow reached the registry, so the swap was kept'
+      : `${afterFork.names.length} parameters, the same ${beforeFork.names.length} as before the install`);
+  ok('and the signature with it, so nothing is left claiming to be assembled from a set it refused',
+    afterFork.signature === beforeFork.signature,
+    afterFork.signature === beforeFork.signature ? 'unchanged' : 'the page moved to the new set');
+  ok('the parked pool is exactly what it was: the same values, the same track, the same entry',
+    JSON.stringify(afterFork.pool) === JSON.stringify(beforeFork.pool),
+    `${Object.keys(afterFork.pool.params).length} values, ${Object.keys(afterFork.pool.tracks).length} tracks`);
+  ok('and the badge still quotes the version the edit was authored against rather than the one that just landed',
+    afterFork.badgeHidden === false && /probe 1\.0\.0/.test(afterFork.badgeText),
+    `hidden=${afterFork.badgeHidden}, "${afterFork.badgeText.trim().slice(0, 60)}"`);
+  ok('the three positions render the same three images they rendered before the install',
+    JSON.stringify(afterFork.hashes) === JSON.stringify(beforeFork.hashes),
+    afterFork.hashes.map((h, i) => `${h.slice(0, 8)}${h === beforeFork.hashes[i] ? '=' : '!='}${beforeFork.hashes[i].slice(0, 8)}`).join(' '));
+  ok('and a save afterwards writes the parked keys exactly as it wrote them before',
+    parkedKeysOf(afterFork.body) === parkedKeysOf(beforeFork.body) && /probe\.amount/.test(parkedKeysOf(beforeFork.body)),
+    parkedKeysOf(afterFork.body).slice(0, 110));
+
+  // The document the rolled-back page writes, handed back to the loader that refused the
+  // other one. A page whose pool and registry had gone out of step would write a document
+  // its own reader refuses - `refuseRequires` runs in both directions - so this asks the
+  // rollback for the property that actually matters rather than for the fields it left in
+  // place.
+  const reloadable = await page.evaluate(() => {
+    const k = globalThis.__kinect;
+    try {
+      k.library.restoreProject(k.library.serialiseProjectBody());
+      return { threw: null };
+    } catch (err) {
+      return { threw: String(err.message) };
+    }
+  });
+  ok('and the document it writes is one this same page will take back', reloadable.threw === null,
+    reloadable.threw ?? 'loaded');
+
+  // The fork off again, so the store and the page hold the same set before section 7 - and
+  // the row is worth having rather than being cleanup with an assertion stuck on it: the
+  // signature is how the poll decides there is anything to do, and a page that had quietly
+  // moved to the new set would converge here for the wrong reason.
+  await del('probe');
+  const converged = await page.evaluate(async () => {
+    await globalThis.__kinect.effects.pollNow();
+    return { signature: globalThis.__kinect.effects.signature() };
+  });
+  const storeNow = await getJson('/effects');
+  const storeSignature = storeNow.body.effects.map((e) => `${e.id} ${e.rev}`).join('\n');
+  ok('and with the fork taken back off, the page and the store are holding one set again',
+    converged.signature === storeSignature, converged.signature === storeSignature ? 'agreed' : 'still apart');
+
+  // =========================================== 7. what a crashed install leaves behind
   //
   // **Last, and the position is the finding rather than housekeeping.** Everything in
   // this block leaves a directory in the user root that is not a package, and under
   // `temporaries-are-visible` the store then cannot list at all - so a temporary staged
   // in section 1 would have reddened every row of every section after it with a fault
-  // whose cause is four sections away. Put here, the mutation reddens the two rows it is
+  // whose cause is five sections away. Put here, the mutation reddens the two rows it is
   // about and nothing else, which is the difference between a control that names a
   // property and one that fails everything.
-  console.log('\n[effect] 6. and what a crashed install leaves behind is invisible until it is swept');
+  console.log('\n[effect] 7. and what a crashed install leaves behind is invisible until it is swept');
 
   // Taken here rather than reused from section 1, because the probe is installed by now
   // and the count moved with it - a comparison against the boot listing would fail on a

--- a/tools/effect-check.mjs
+++ b/tools/effect-check.mjs
@@ -1,0 +1,828 @@
+#!/usr/bin/env node
+// Installing an effect: the store's revisions, the door a package has to get through, and
+// what happens on a page that is already up when one lands.
+//
+// **The failure this whole surface is built around is a page that will not boot.** A
+// package is GLSL spliced into two programs and a table of parameters spliced into the
+// registry, and both are assembled while `web/main.js` is still evaluating - so a package
+// that does not assemble does not fail its install, it fails the *next page load*, with no
+// `globalThis.__kinect` published, every tool in this suite reporting DID NOT RUN, and the
+// only evidence a line in a console nobody has open. Everything below is about moving that
+// failure to the moment of the install, and about proving that a page which was up when
+// the install happened is still telling the truth afterwards.
+//
+// **Five claims, and each has something that must fail if it were not being done.**
+//
+//  1. **A revision is a hash of the bytes on disk.** Per file and over the set, computed
+//     here from the staged tree and held against what the routes answer - so a store
+//     serving a rev it made up, or one it cached, is a red row. The control is a byte:
+//     one flipped in one chunk has to move that file's rev and its package's, and leave
+//     every other package's alone. And a half-written package has to be invisible to
+//     every read, which is what makes the install atomic rather than merely quick -
+//     `temporaries-are-visible` is that row's control.
+//  2. **The door refuses by name, and refuses on disk.** Fifteen hostile packages, one
+//     per rule, each of which must come back with the sentence for its own rule and must
+//     leave the user root exactly as it found it - no directory, no `.tmp`, no `.old`.
+//     **The must-accept package is what makes that mean anything**: a door that refused
+//     everything would pass all fifteen refusal rows at once, and the one package that
+//     has to land is the row it could not pass.
+//  3. **A page that is up adopts the install.** The group appears, the rows appear, the
+//     uniform cell the package binds is minted, the assembled program carries its text -
+//     and then `boot-check`'s own question is asked again on the rebuilt page: does every
+//     control show the value the registry holds. That is the invariant an install is most
+//     likely to break quietly, because a panel rebuilt without a value walk looks
+//     completely normal. `rebuild-skips-the-panel` and `install-skips-the-uniform-cells`
+//     are its two controls.
+//  4. **Uninstalling parks and reinstalling restores, exactly.** Values and a keyframed
+//     track go in, a playback hash is taken, the package is removed - the values park, the
+//     badge says so - and it is put back, at which point the pool is empty and the same
+//     three program positions hash to the same three images. A pixel identity rather than
+//     a value comparison, because what is being claimed is that the *edit* survived and an
+//     edit is what you can see. `reinstall-leaves-it-parked` is the control.
+//  5. **And a build with nothing missing says nothing.** A badge that appeared on every
+//     document would satisfy row 4's "the badge appeared" and mean nothing at all.
+//
+// **What is deliberately not here.** The export door on a clip whose look this build
+// cannot draw, and the per-effect suppress beside it, belong to `export-check` - one
+// claim, one place. This tool never renders a deliverable.
+//
+//   node tools/effect-check.mjs
+//   node tools/effect-check.mjs --mutate temporaries-are-visible         # must FAIL
+//   node tools/effect-check.mjs --mutate rebuild-skips-the-panel         # must FAIL
+//   node tools/effect-check.mjs --mutate install-skips-the-uniform-cells # must FAIL
+//   node tools/effect-check.mjs --mutate reinstall-leaves-it-parked      # must FAIL
+//
+// It spawns its own server on a port nothing else in the suite uses and needs none
+// running. A GPU browser, a free port 8281, no capture, no sensor and no ffmpeg.
+
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..');
+const argv = process.argv.slice(2);
+const flag = (name, fallback = null) => {
+  const at = argv.indexOf(name);
+  return at === -1 ? fallback : argv[at + 1];
+};
+const PORT = Number(flag('--port', '8281'));
+const MUTATE = argv.includes('--mutate') ? flag('--mutate') : null;
+const WORK = join(REPO, '.effect-check');
+const BASE = `http://127.0.0.1:${PORT}`;
+
+/**
+ * The mutations, and each one is a way of doing this feature that would look correct.
+ *
+ * `temporaries-are-visible` widens the id filter the store lists directories through, so
+ * the `<id>.<seq>.tmp` a half-finished install leaves behind becomes an entry in
+ * `/effects` and a package `rootFor` will resolve. That is the whole of what makes the
+ * install atomic: the temporary names carry a dot and an effect id may not, so a crashed
+ * install is invisible rather than merely unlikely to be read. A build without the filter
+ * serves a package with no manifest to whatever asks next.
+ *
+ * `rebuild-skips-the-panel` builds the panel on the first run and never again, which is
+ * the rebuild a person would write if they thought of the panel as boot furniture. Boot is
+ * unaffected - the map is empty exactly once - so `boot-check` stays green and the page
+ * carries on drawing; what breaks is the hotloaded page, where the registry has grown two
+ * parameters that no row on the panel shows.
+ *
+ * `install-skips-the-uniform-cells` stops minting the JavaScript cell a new binding needs.
+ * Every shipped package binds a uniform some hand-written table already holds, so nothing
+ * about the sixteen notices; a seventeenth throws on the first write of its own parameter,
+ * which the value walk performs, so the install fails rather than the slider.
+ *
+ * `reinstall-leaves-it-parked` widens the parking predicate to every dotted name, so a
+ * value belonging to an effect that *is* installed parks anyway. The badge still appears
+ * on the uninstall, which is what makes it worth having: a check reading only the badge
+ * would call this build correct, and what fails is the restoration.
+ */
+const MUTATIONS = {
+  'temporaries-are-visible': {
+    file: 'server/effect-store.js',
+    edits: [[
+      '.filter((e) => e.isDirectory() && VALID_EFFECT_ID.test(e.name))',
+      '.filter((e) => e.isDirectory())',
+    ]],
+  },
+  'rebuild-skips-the-panel': {
+    file: 'web/main.js',
+    edits: [['\n  buildPanel();\n', '\n  if (!panelControls.size) buildPanel();\n']],
+  },
+  'install-skips-the-uniform-cells': {
+    file: 'web/main.js',
+    edits: [[
+      "    table[bind.uniform] = { value: bind.transform === 'axisDeg' ? new THREE.Vector2() : 0 };",
+      '    if (Object.hasOwn(table, bind.uniform)) table[bind.uniform] = { value: 0 };',
+    ]],
+  },
+  'reinstall-leaves-it-parked': {
+    file: 'web/main.js',
+    edits: [[
+      '  return id !== null && !effectInstalled(id);',
+      '  return id !== null;',
+    ]],
+  },
+};
+
+if (argv.includes('--mutate') && !MUTATIONS[MUTATE]) {
+  console.log(`[effect] DID NOT RUN - no mutation named ${MUTATE ?? '(nothing was given)'};`
+    + ` this tool knows ${Object.keys(MUTATIONS).join(', ')}`);
+  process.exit(2);
+}
+
+// --- the port, asked of the kernel ------------------------------------------
+//
+// A tool that finds a stranger already listening is answered by the stranger and asserts
+// against whatever fixture *that* process staged, which is a green run proving nothing.
+// Asked before anything is staged, so the refusal costs nothing and names what is held.
+const portHeld = await new Promise((resolve) => {
+  const probe = spawn('lsof', ['-ti', `tcp:${PORT}`, '-sTCP:LISTEN'], { stdio: ['ignore', 'pipe', 'ignore'] });
+  let out = '';
+  probe.stdout.on('data', (c) => { out += c; });
+  probe.on('close', () => resolve(out.trim()));
+  probe.on('error', () => resolve(''));
+});
+if (portHeld) {
+  console.log(`[effect] DID NOT RUN - something is already listening on ${PORT} (pid ${portHeld.split('\n').join(', ')}). `
+    + 'A run answered by a stranger asserts against whatever that process staged.');
+  process.exit(2);
+}
+
+// --- the staged tree ---------------------------------------------------------
+//
+// A mutation applied in place and restored afterwards leaves a mutated working tree behind
+// any crash, which is the one state a proof tool must never produce. `server/` and `web/`
+// are copied rather than linked for the same reason - through a symlink every mutation
+// here would rewrite the repo's own source - and `effects-builtin/` joins them because the
+// store refuses to boot without its shipped root and because this tool flips a byte inside
+// it on purpose.
+//
+// `effects/` is made empty and handed to the server by name. **Both roots are passed
+// explicitly rather than left to resolve**, which matters more here than anywhere else in
+// the suite: this is the only tool that writes packages, and a root that resolved to the
+// checkout would put its fixtures - and its fifteen hostile ones - into the repo.
+rmSync(WORK, { recursive: true, force: true });
+mkdirSync(WORK, { recursive: true });
+// `presets-builtin` joins the list for the same class of reason `effects-builtin` does and
+// is worth naming rather than leaving to be rediscovered: the page fetches the preset
+// library while it boots, and a staged tree without the shipped root answers 500, which
+// lands in `pageErrors` and reddens the last row of section 5 with a fault that has
+// nothing to do with effects.
+for (const dir of ['server', 'tools', 'web', 'effects-builtin', 'presets-builtin']) {
+  cpSync(join(REPO, dir), join(WORK, dir), { recursive: true });
+}
+mkdirSync(join(WORK, 'effects'), { recursive: true });
+for (const name of ['node_modules', 'vendor']) {
+  const from = join(REPO, name);
+  if (existsSync(from)) symlinkSync(from, join(WORK, name));
+}
+// `native/` is deliberately absent, so the server spawns no grabber and the depth textures
+// stay whatever this tool plants in them. Section 4 hashes rendered frames, and a live
+// socket wipes a plant in well under a second.
+if (MUTATE) {
+  const spec = MUTATIONS[MUTATE];
+  const path = join(WORK, spec.file);
+  let source = readFileSync(path, 'utf8');
+  for (const [from, to] of spec.edits) {
+    const hits = source.split(from).length - 1;
+    if (hits !== 1) {
+      console.log(`[effect] DID NOT RUN - the ${MUTATE} anchor matched ${hits} times in ${spec.file}, `
+        + 'expected exactly 1, so nothing was mutated and this run would prove nothing');
+      process.exit(2);
+    }
+    source = source.replace(from, to);
+  }
+  writeFileSync(path, source);
+}
+
+const USER_ROOT = join(WORK, 'effects');
+const BUILTIN_ROOT = join(WORK, 'effects-builtin');
+
+// --- harness -----------------------------------------------------------------
+let checked = 0;
+let failed = 0;
+let crashed = null;
+let untested = null;
+const fired = [];
+const ok = (label, pass, detail = '') => {
+  checked++;
+  if (!pass) { failed++; fired.push(label); }
+  console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${label}${detail ? `  ${detail}` : ''}`);
+};
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const sha = (bytes) => `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+
+const servers = [];
+const start = () => new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, [
+    join(WORK, 'server/index.js'), '--port', String(PORT),
+    '--effects', USER_ROOT, '--builtin-effects', BUILTIN_ROOT,
+  ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  servers.push(child);
+  const log = [];
+  const onData = (c) => {
+    log.push(c.toString());
+    if (log.join('').includes('viewer on')) setTimeout(resolve, 200);
+  };
+  child.stdout.on('data', onData);
+  child.stderr.on('data', onData);
+  setTimeout(() => reject(new Error(`server never came up:\n${log.join('')}`)), 15000);
+});
+const stopAll = async () => {
+  for (const c of servers) c.kill('SIGKILL');
+  servers.length = 0;
+  await wait(150);
+};
+
+const getJson = async (path) => {
+  const res = await fetch(`${BASE}${path}`);
+  return { status: res.status, body: await res.json() };
+};
+const put = async (id, body) => {
+  const res = await fetch(`${BASE}/effects/${encodeURIComponent(id)}`, {
+    method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+};
+const del = async (id) => {
+  const res = await fetch(`${BASE}/effects/${encodeURIComponent(id)}`, {
+    method: 'DELETE', headers: { 'Content-Type': 'application/json' },
+  });
+  return { status: res.status, body: await res.json() };
+};
+
+/** Everything sitting in the user root, temporaries included - the residue test. */
+const userRootHolds = () => (existsSync(USER_ROOT) ? readdirSync(USER_ROOT).sort() : []);
+
+// --- the package this tool installs -------------------------------------------
+//
+// A whole effect rather than a stub: a master that is inert at zero, a second key under
+// it, its own panel group anchored into the spine, a declaration chunk and a chunk that
+// reaches a pixel. Everything section 3 and section 4 assert is about a package doing what
+// a package does, and a fixture that declared parameters and no GLSL would leave the
+// program swap, the minted uniform cell and the pixel identity all untested.
+const probeManifest = () => ({
+  format: 1,
+  id: 'probe',
+  version: '1.0.0',
+  title: 'Probe',
+  params: {
+    amount: {
+      def: 0, min: 0, max: 1, step: 0.01, kind: 'scalar', label: 'probe',
+      panel: { group: 'probe', tab: 'look' },
+      bind: { on: 'points', uniform: 'probeAmount' },
+      role: 'master',
+    },
+    hue: {
+      def: 0.5, min: 0, max: 1, step: 0.01, kind: 'scalar', label: 'probe hue',
+      panel: { group: 'probe', tab: 'look' },
+      bind: { on: 'points', uniform: 'probeHue' },
+      under: 'amount',
+    },
+  },
+  panelGroups: [
+    { key: 'probe', label: 'Probe', tab: 'look', lookgroup: true, collapses: true, after: 'post', order: 900 },
+  ],
+  chunks: [
+    { stage: 'f.decl', order: 900, file: 'decl.frag.glsl' },
+    { stage: 'f.tone', order: 900, file: 'tone.frag.glsl' },
+  ],
+});
+const probeChunks = () => ({
+  'decl.frag.glsl': 'uniform float probeAmount, probeHue;\n',
+  'tone.frag.glsl':
+    '  if (probeAmount > 0.0) {\n'
+    + '    col = mix(col, vec3(probeHue, 1.0 - probeHue, probeHue * 0.5), probeAmount);\n'
+    + '  }\n',
+});
+const probePackage = () => ({ manifest: probeManifest(), chunks: probeChunks() });
+const bent = (edit) => {
+  const pkg = probePackage();
+  edit(pkg);
+  return pkg;
+};
+
+/**
+ * A pinned run with no capture and no sensor: a handful of depth frames written here.
+ *
+ * The wire's own frame payload - depth byte count, colour byte count, a stamp, then the
+ * millimetres - which is what `drive.pin` parses. Colour is left at zero bytes, exactly as
+ * a pinned run does on a real take, because a JPEG decode is asynchronous and a hash taken
+ * across one would be a hash of whether it had landed yet.
+ *
+ * The surface is a plane that leans, so the picture has depth in it: a flat wall renders
+ * the same colour everywhere and a tone chunk mixing toward a colour would move every
+ * pixel by the same amount, which is a picture two builds can agree about for the wrong
+ * reason. The frames differ from each other so a track evaluated at three positions has
+ * three images to be right about.
+ */
+const DEPTH_W = 512;
+const DEPTH_H = 424;
+const pinnedBuffer = () => {
+  const FRAMES = 6;
+  const depthBytes = DEPTH_W * DEPTH_H * 2;
+  const out = Buffer.alloc(FRAMES * (16 + depthBytes));
+  for (let f = 0; f < FRAMES; f++) {
+    const at = f * (16 + depthBytes);
+    out.writeUInt32LE(depthBytes, at);
+    out.writeUInt32LE(0, at + 4);
+    out.writeBigUInt64LE(BigInt(f * 33), at + 8);
+    for (let y = 0; y < DEPTH_H; y++) {
+      for (let x = 0; x < DEPTH_W; x++) {
+        // 1.2m to 2.6m across the frame, drifting 40mm per frame so successive frames are
+        // genuinely different geometry rather than the same one restamped.
+        const mm = 1200 + Math.round((x / DEPTH_W) * 900 + (y / DEPTH_H) * 500) + f * 40;
+        out.writeUInt16LE(mm, at + 16 + (y * DEPTH_W + x) * 2);
+      }
+    }
+  }
+  return out;
+};
+
+const POSITIONS = [0.1, 0.6, 1.2];
+
+console.log(`[effect] ${MUTATE ? `MUTATED: ${MUTATE} (${MUTATIONS[MUTATE].file})` : 'unmutated tree'}\n`);
+
+let browser = null;
+try {
+  let chromium;
+  try {
+    ({ chromium } = await import(join(REPO, 'node_modules/playwright/index.mjs')));
+  } catch {
+    untested = 'playwright is not installed, and three of the five sections are about a page';
+    throw new Error(untested);
+  }
+
+  await start();
+
+  // ======================================================= 1. what a revision is
+  console.log('[effect] 1. the store\'s revisions, and a half-written package');
+
+  const listed = await getJson('/effects');
+  ok('the store lists the shipped packages', listed.status === 200 && listed.body.effects?.length >= 16,
+    `${listed.body.effects?.length ?? 0} packages`);
+  if (listed.status !== 200) throw new Error('the store would not list at all, so nothing below could be measured');
+
+  // The oracle: the hashes this tool computes off the staged tree, which is the only
+  // reading independent of the thing under test. A row comparing the store's rev against
+  // the store's own recomputation would agree with any implementation, correct or not.
+  let fileRevs = 0;
+  let packageRevs = 0;
+  let revMismatch = null;
+  for (const entry of listed.body.effects) {
+    const dir = join(BUILTIN_ROOT, entry.id);
+    for (const file of entry.files) {
+      const want = sha(readFileSync(join(dir, file.name)));
+      if (file.rev !== want) revMismatch ??= `${entry.id}/${file.name}`;
+      fileRevs++;
+    }
+    const want = sha(entry.files.map((f) => `${f.name} ${f.rev}\n`).join(''));
+    if (entry.rev !== want) revMismatch ??= `${entry.id} (the package)`;
+    packageRevs++;
+  }
+  ok('every file revision is the sha256 of the bytes on disk, and every package revision the hash over its file lines',
+    revMismatch === null, revMismatch ? `first disagreement at ${revMismatch}` : `${fileRevs} files across ${packageRevs} packages`);
+
+  // The control. A rev that was a name, a timestamp or a cached number would satisfy every
+  // row above on a tree nobody had touched.
+  const victim = join(BUILTIN_ROOT, 'thermal/heat.frag.glsl');
+  const original = readFileSync(victim);
+  const beforeFlip = await getJson('/effects/thermal');
+  const witnessBefore = await getJson('/effects/edges');
+  writeFileSync(victim, Buffer.concat([original, Buffer.from('\n')]));
+  const afterFlip = await getJson('/effects/thermal');
+  const witnessAfter = await getJson('/effects/edges');
+  const revOf = (pkg, name) => pkg.body.files.find((f) => f.name === name)?.rev;
+  ok('one byte changed on disk moves that file\'s revision',
+    revOf(beforeFlip, 'heat.frag.glsl') !== revOf(afterFlip, 'heat.frag.glsl'),
+    `${revOf(beforeFlip, 'heat.frag.glsl')?.slice(7, 19)} -> ${revOf(afterFlip, 'heat.frag.glsl')?.slice(7, 19)}`);
+  ok('and its package\'s revision with it', beforeFlip.body.rev !== afterFlip.body.rev,
+    `${beforeFlip.body.rev.slice(7, 19)} -> ${afterFlip.body.rev.slice(7, 19)}`);
+  ok('and leaves every other package where it was, so a revision is about its own bytes',
+    witnessBefore.body.rev === witnessAfter.body.rev, witnessAfter.body.rev.slice(7, 19));
+  writeFileSync(victim, original);
+  const restored = await getJson('/effects/thermal');
+  ok('and putting the byte back puts the revision back', restored.body.rev === beforeFlip.body.rev,
+    restored.body.rev.slice(7, 19));
+
+  // ================================================================= 2. the door
+  console.log('\n[effect] 2. the door, and the package that has to get through it');
+
+  const accepted = await put('probe', probePackage());
+  ok('a well-formed package lands - the row that stops every refusal below passing on a door that refuses everything',
+    accepted.status === 200 && accepted.body.id === 'probe', `answered ${accepted.status}: ${accepted.body.error ?? 'installed'}`);
+  const onDisk = existsSync(join(USER_ROOT, 'probe')) ? readdirSync(join(USER_ROOT, 'probe')).sort() : [];
+  ok('and its files are the ones it sent, in the user root',
+    onDisk.join(',') === 'decl.frag.glsl,manifest.json,tone.frag.glsl', onDisk.join(', ') || 'nothing');
+  const shadowCheck = await getJson('/effects/probe');
+  ok('and the store answers for it as a user package rather than a shipped one',
+    shadowCheck.status === 200 && shadowCheck.body.builtin === false, `builtin=${shadowCheck.body.builtin}`);
+
+  await del('probe');
+  const cleanRoot = userRootHolds();
+  ok('and removing it leaves the user root empty, so the refusals below start from nothing',
+    cleanRoot.length === 0, cleanRoot.join(', ') || 'empty');
+
+  // The shipped noise, whole, for the fork row.
+  //
+  // **A fork is held against what it forks, and reaching that rule takes some care.** Two
+  // earlier rules stand in front of it: a fork sent without its own chunks is refused for
+  // the chunk that did not arrive, and a fork of a package whose *own* GLSL declares the
+  // dropped parameter's uniform is refused for a uniform nothing binds. `noise` has
+  // neither problem - its chunk declares no uniforms of its own, they are all the spine's -
+  // so dropping one of its parameters reaches the rule this row is about. That is a fact
+  // about which package to use for the row, and it is written down because picking `rain`
+  // here produced a green row for the wrong reason.
+  const noiseDir = join(BUILTIN_ROOT, 'noise');
+  const noiseManifest = JSON.parse(readFileSync(join(noiseDir, 'manifest.json'), 'utf8'));
+  const noiseChunks = Object.fromEntries((noiseManifest.chunks ?? []).map((c) => [c.file, readFileSync(join(noiseDir, c.file), 'utf8')]));
+  const forkedNoise = (edit) => {
+    const manifest = JSON.parse(JSON.stringify(noiseManifest));
+    edit(manifest);
+    return { manifest, chunks: { ...noiseChunks } };
+  };
+
+  // One hostile package per rule. Each is the well-formed one with a single field wrong,
+  // which is the shape a real broken package has - a fixture written to fail is a fixture
+  // that can fail for a reason nobody intended.
+  const hostile = [
+    ['an id nothing could be', 'Probe1', probePackage(), /is not an effect id/],
+    ['a manifest declaring another id', 'probe', bent((p) => { p.manifest.id = 'other'; }), /declaring id "other"/],
+    ['a package format from a later build', 'probe', bent((p) => { p.manifest.format = 2; }), /package format 2/],
+    ['a package that says no format at all', 'probe', bent((p) => { delete p.manifest.format; }), /declares no package format/],
+    ['a chunk name that is a path', 'probe', bent((p) => {
+      p.manifest.chunks[0].file = '../escape.glsl';
+      p.chunks['../escape.glsl'] = p.chunks['decl.frag.glsl'];
+      delete p.chunks['decl.frag.glsl'];
+    }), /"\.\.\/escape\.glsl"/],
+    ['two parameters claiming the role master', 'probe', bent((p) => {
+      Object.assign(p.manifest.params.hue, { role: 'master', def: 0 });
+    }), /2 parameters with the role master/],
+    ['a master that is not inert at its default', 'probe', bent((p) => { p.manifest.params.amount.def = 0.5; }), /master and defaults to 0\.5/],
+    ['a kind this registry does not implement', 'probe', bent((p) => { p.manifest.params.hue.kind = 'ramp'; }), /kind "ramp"/],
+    ['a transform the applier has never heard of', 'probe', bent((p) => { p.manifest.params.hue.bind.transform = 'toKelvin'; }), /transform "toKelvin"/],
+    ['a binding whose uniform no program declares', 'probe', bent((p) => { p.manifest.params.hue.bind.uniform = 'probeHueee'; }), /declares no such uniform/],
+    ['a uniform declared and bound by nothing', 'probe', bent((p) => {
+      p.chunks['decl.frag.glsl'] = 'uniform float probeAmount, probeHue, probeStray;\n';
+    }), /"probeStray" and binds no parameter/],
+    ['a chunk naming a joint no spine holds', 'probe', bent((p) => { p.manifest.chunks[1].stage = 'f.elsewhere'; }), /does not assemble/],
+    ['an identifier that exists nowhere in this build', 'probe', bent((p) => {
+      p.chunks['tone.frag.glsl'] = '  col = mix(col, vec3(qqNotHere), probeAmount);\n';
+    }), /"qqNotHere"/],
+    ['a varying whose initial value reads state', 'probe', bent((p) => {
+      p.manifest.varyings = [{ name: 'vProbe', type: 'float', init: 'probeAmount', order: 900 }];
+    }), /initialises to "probeAmount"/],
+    ['a chunk the manifest names and did not send', 'probe', bent((p) => { delete p.chunks['tone.frag.glsl']; }), /its text did not arrive/],
+    ['a file the manifest never names', 'probe', bent((p) => { p.chunks['spare.glsl'] = '// nothing\n'; }), /"spare\.glsl" and its manifest names no chunk/],
+    ['a fork of a shipped package that drops one of its parameters', 'noise', forkedNoise((m) => {
+      m.version = '2.0.0';
+      delete m.params.speed;
+    }), /drops noise\.speed/],
+  ];
+
+  let refusedCount = 0;
+  let wrongReason = null;
+  let residue = null;
+  for (const [what, id, body, matches] of hostile) {
+    const answer = await put(id, body);
+    if (answer.status === 409 && matches.test(answer.body.error ?? '')) refusedCount++;
+    else wrongReason ??= `${what}: ${answer.status} ${answer.body.error ?? JSON.stringify(answer.body)}`;
+    const held = userRootHolds();
+    if (held.length !== 0) residue ??= `${what} left ${held.join(', ')}`;
+  }
+  ok(`every hostile package is refused with the sentence for its own rule - ${hostile.length} rules`,
+    refusedCount === hostile.length, wrongReason ?? `${refusedCount} of ${hostile.length}`);
+  ok('and none of them reaches the filesystem: no package, no .tmp, no .old left behind',
+    residue === null, residue ?? `user root ${userRootHolds().join(', ') || 'empty'}`);
+
+  const stillShipped = await getJson('/effects');
+  ok('and the shipped set is exactly what it was before the door was pushed at',
+    stillShipped.body.effects?.length === listed.body.effects.length,
+    `${stillShipped.body.effects?.length ?? 'no'} packages`);
+
+  const refuseBuiltin = await del('noise');
+  ok('a builtin nothing is forking refuses to be removed, by name',
+    refuseBuiltin.status === 409 && /shipped with this build/.test(refuseBuiltin.body.error ?? ''),
+    `${refuseBuiltin.status}: ${(refuseBuiltin.body.error ?? '').slice(0, 60)}`);
+
+  // ================================================== 3. a page adopts an install
+  console.log('\n[effect] 3. a page that is already up, adopting an install');
+
+  browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1100, height: 760 } });
+  const pageErrors = [];
+  page.on('pageerror', (e) => pageErrors.push(String(e)));
+  page.on('console', (m) => { if (m.type() === 'error') pageErrors.push(m.text()); });
+  await page.goto(`${BASE}/record`, { waitUntil: 'load' });
+  await page.waitForFunction('Boolean(globalThis.__kinect)', null, { timeout: 20000 });
+
+  const before = await page.evaluate(() => ({
+    params: globalThis.__kinect.params.names().length,
+    groups: document.querySelectorAll('#panelBody > [data-group]').length,
+    probeRows: document.querySelectorAll('[data-group="probe"] .row').length,
+  }));
+  ok('the page is up with no probe on it, so what happens below is the install rather than the page',
+    before.probeRows === 0 && before.params > 0, `${before.params} parameters, ${before.groups} generated groups`);
+
+  const installed = await put('probe', probePackage());
+  ok('the package installs while that page is open', installed.status === 200,
+    `${installed.status}: ${installed.body.error ?? 'installed'}`);
+
+  const adopted = await page.evaluate(async () => {
+    try {
+      await globalThis.__kinect.effects.reload();
+    } catch (err) {
+      return { threw: String(err.message) };
+    }
+    const k = globalThis.__kinect;
+    return {
+      params: k.params.names().length,
+      groups: document.querySelectorAll('#panelBody > [data-group]').length,
+      probeRows: document.querySelectorAll('[data-group="probe"] .row').length,
+      groupLabel: document.querySelector('[data-group="probe"] .grouphead label')?.textContent ?? null,
+      knows: k.params.names().includes('probe.amount') && k.params.names().includes('probe.hue'),
+      cell: Object.hasOwn(k.uniforms, 'probeAmount') && Object.hasOwn(k.uniforms, 'probeHue'),
+      inShader: k.effects.programs().cloud.fragmentShader.includes('probeHue'),
+      appended: k.params.names('look').slice(-2),
+    };
+  });
+  ok('the rebuild ran through the product\'s own path', !adopted.threw, adopted.threw ?? 'no throw');
+  ok('the registry grew exactly the package\'s two parameters',
+    adopted.params === before.params + 2 && adopted.knows, `${before.params} -> ${adopted.params}`);
+  ok('and they are at the end of the look order, which is where the placement rule puts a package nothing has a layout for',
+    JSON.stringify(adopted.appended) === JSON.stringify(['probe.amount', 'probe.hue']), JSON.stringify(adopted.appended));
+  ok('the panel grew the package\'s own group, with a row for each parameter',
+    adopted.groups === before.groups + 1 && adopted.probeRows === 2,
+    `${adopted.groups} groups, ${adopted.probeRows} probe rows, heading ${JSON.stringify(adopted.groupLabel)}`);
+  ok('the uniform cells its bindings need were minted, because no hand-written table holds them',
+    adopted.cell === true, `probeAmount and probeHue ${adopted.cell ? 'present' : 'missing'}`);
+  ok('and the assembled program carries its chunk text', adopted.inShader === true);
+
+  // ---- and now boot-check's own question, on the page that has just been rebuilt
+  //
+  // **This is the row an install is most likely to break silently.** A rebuild that
+  // replaced the registry and repainted nothing draws a completely normal panel showing
+  // the values from before the install, and no picture anywhere is wrong. The three rows
+  // below are `boot-check`'s three, asked of a page that got here by hotload rather than
+  // by boot - the same question, the other door.
+  const diff = await page.evaluate(() => {
+    const k = globalThis.__kinect;
+    const rows = [];
+    for (const name of k.params.names()) {
+      const el = document.getElementById(name);
+      if (!el) continue;
+      const registry = k.params.get(name);
+      const control = el.type === 'checkbox' ? el.checked : Number(el.value);
+      rows.push({ name, registry, control, agrees: String(registry) === String(control) });
+    }
+    return rows;
+  });
+  const diverge = diff.filter((r) => !r.agrees);
+  ok('every control on the rebuilt page shows the value the registry holds for it',
+    diff.length > 0 && diverge.length === 0,
+    diverge.length
+      ? `${diverge.length} of ${diff.length} diverge: ${diverge.slice(0, 5).map((r) => `${r.name} registry ${r.registry} vs control ${r.control}`).join('; ')}`
+      : `${diff.length} of ${diff.length} agree`);
+
+  // The comparison's own falsification, in run rather than by mutation: a diff whose two
+  // sides could not disagree would pass on any build at all.
+  const drive = await page.evaluate(() => {
+    const k = globalThis.__kinect;
+    let moved = 0;
+    let followed = 0;
+    for (const name of k.params.names()) {
+      const el = document.getElementById(name);
+      if (!el) continue;
+      const want = el.type === 'checkbox'
+        ? !k.params.get(name)
+        : (String(k.params.get(name)) === el.min ? Number(el.max) : Number(el.min));
+      k.params.set(name, want);
+      moved++;
+      const shown = el.type === 'checkbox' ? el.checked : Number(el.value);
+      if (String(shown) === String(k.params.get(name))) followed++;
+    }
+    return { moved, followed };
+  });
+  ok('and the comparison can separate two states: a write through the registry moves the control it belongs to',
+    drive.moved === diff.length && drive.followed === drive.moved,
+    `${drive.followed} of ${drive.moved} followed`);
+
+  // ============================================ 4. uninstall parks, reinstall restores
+  console.log('\n[effect] 4. an uninstall parks the edit, and a reinstall gives it back');
+
+  const buffer = pinnedBuffer();
+  await page.route('**/__effect-pinned.bin', (route) => route.fulfill({
+    status: 200, contentType: 'application/octet-stream', body: buffer,
+  }));
+  await page.evaluate(async () => {
+    const res = await fetch('/__effect-pinned.bin');
+    globalThis.__kinect.drive.pin(await res.arrayBuffer());
+  });
+
+  const authored = await page.evaluate(async (positions) => {
+    const k = globalThis.__kinect;
+    // Back to a known look first: the sweep above left every control at a bound.
+    k.params.reset();
+    k.params.set('probe.amount', 0.7);
+    k.params.set('probe.hue', 0.3);
+    k.keyframes.setTracks({ 'probe.amount': [{ t: 0, value: 0.15 }, { t: 1.4, value: 0.95 }] });
+    const sha256 = async (bytes) => {
+      const digest = await crypto.subtle.digest('SHA-256', bytes);
+      return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+    };
+    k.drive.reset();
+    const hashes = [];
+    for (const t of positions) {
+      k.drive.stepTo(t);
+      hashes.push(await sha256(k.drive.readPixels()));
+    }
+    return { hashes, track: k.keyframes.valueAt('probe.amount', 0.7), hue: k.params.get('probe.hue') };
+  }, POSITIONS);
+  ok('an edit is authored on the installed effect: two values and a track with keys',
+    authored.hue === 0.3 && authored.track !== null,
+    `hue ${authored.hue}, the track reads ${authored.track?.toFixed?.(3) ?? authored.track} at 0.7s`);
+  ok('and the three program positions render three different images, so the identity below is about something',
+    new Set(authored.hashes).size === POSITIONS.length,
+    authored.hashes.map((h) => h.slice(0, 8)).join(' '));
+
+  const removed = await del('probe');
+  ok('the package is removed', removed.status === 200 && removed.body.removed === 'probe',
+    `${removed.status}: ${removed.body.error ?? 'removed'}`);
+
+  const parked = await page.evaluate(async () => {
+    try {
+      await globalThis.__kinect.effects.reload();
+    } catch (err) {
+      return { threw: String(err.message) };
+    }
+    const k = globalThis.__kinect;
+    const badge = document.getElementById('tMissing');
+    return {
+      knows: k.params.names().includes('probe.amount'),
+      groups: document.querySelectorAll('[data-group="probe"]').length,
+      pool: k.library.parkedLook(),
+      missing: k.library.missingEffects(),
+      badgeHidden: badge?.hidden ?? null,
+      badgeText: badge?.textContent ?? '',
+    };
+  });
+  ok('the rebuild after the removal ran', !parked.threw, parked.threw ?? 'no throw');
+  ok('the registry and the panel no longer carry the effect',
+    parked.knows === false && parked.groups === 0, `${parked.groups} probe groups`);
+  ok('its values and its track are parked rather than dropped',
+    Object.keys(parked.pool?.params ?? {}).length === 2
+      && Object.keys(parked.pool?.tracks ?? {}).length === 1,
+    `${Object.keys(parked.pool?.params ?? {}).length} values, ${Object.keys(parked.pool?.tracks ?? {}).length} tracks: `
+    + `${JSON.stringify(parked.pool?.params)}`);
+  ok('and the badge says so, quoting the version the edit was authored against',
+    parked.badgeHidden === false && /probe/.test(parked.badgeText) && /1\.0\.0/.test(parked.badgeText),
+    `hidden=${parked.badgeHidden}, "${parked.badgeText.trim().slice(0, 70)}"`);
+  ok('and the pool\'s counts are what the badge is drawn from',
+    parked.missing?.length === 1 && parked.missing[0].values === 2 && parked.missing[0].tracks === 1,
+    JSON.stringify(parked.missing));
+
+  const reinstalled = await put('probe', probePackage());
+  ok('the package is installed again', reinstalled.status === 200,
+    `${reinstalled.status}: ${reinstalled.body.error ?? 'installed'}`);
+
+  const restoredRun = await page.evaluate(async (positions) => {
+    try {
+      await globalThis.__kinect.effects.reload();
+    } catch (err) {
+      return { threw: String(err.message) };
+    }
+    const k = globalThis.__kinect;
+    const sha256 = async (bytes) => {
+      const digest = await crypto.subtle.digest('SHA-256', bytes);
+      return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+    };
+    k.drive.reset();
+    const hashes = [];
+    for (const t of positions) {
+      k.drive.stepTo(t);
+      hashes.push(await sha256(k.drive.readPixels()));
+    }
+    const badge = document.getElementById('tMissing');
+    return {
+      hashes,
+      pool: k.library.parkedLook(),
+      hue: k.params.get('probe.hue'),
+      track: k.keyframes.valueAt('probe.amount', 0.7),
+      badgeHidden: badge?.hidden ?? null,
+    };
+  }, POSITIONS);
+  ok('the rebuild after the reinstall ran', !restoredRun.threw, restoredRun.threw ?? 'no throw');
+  ok('the parked pool is empty again, so nothing was left behind by the effect coming back',
+    Object.keys(restoredRun.pool?.params ?? {}).length === 0
+      && Object.keys(restoredRun.pool?.tracks ?? {}).length === 0,
+    JSON.stringify(restoredRun.pool?.params ?? {}));
+  ok('the values and the track came back through the registry\'s own door',
+    restoredRun.hue === 0.3 && Math.abs((restoredRun.track ?? 0) - (authored.track ?? -1)) < 1e-9,
+    `hue ${restoredRun.hue}, the track reads ${restoredRun.track?.toFixed?.(6)} against ${authored.track?.toFixed?.(6)}`);
+  ok('and the three positions render the same three images they rendered before the uninstall',
+    JSON.stringify(restoredRun.hashes) === JSON.stringify(authored.hashes),
+    restoredRun.hashes.map((h, i) => `${h.slice(0, 8)}${h === authored.hashes[i] ? '=' : '!='}${authored.hashes[i].slice(0, 8)}`).join(' '));
+
+  // ==================================================== 5. and nothing missing, no badge
+  console.log('\n[effect] 5. a document with everything it needs says nothing');
+
+  const quiet = await page.evaluate(() => {
+    const k = globalThis.__kinect;
+    const badge = document.getElementById('tMissing');
+    return {
+      missing: k.library.missingEffects(),
+      hidden: badge?.hidden ?? null,
+      entries: document.querySelectorAll('#tMissing .missingfx').length,
+    };
+  });
+  ok('with every effect the document names installed, the badge is not on screen',
+    quiet.hidden === true && quiet.missing.length === 0 && quiet.entries === 0,
+    `hidden=${quiet.hidden}, ${quiet.missing.length} missing, ${quiet.entries} entries drawn`);
+
+  // =========================================== 6. what a crashed install leaves behind
+  //
+  // **Last, and the position is the finding rather than housekeeping.** Everything in
+  // this block leaves a directory in the user root that is not a package, and under
+  // `temporaries-are-visible` the store then cannot list at all - so a temporary staged
+  // in section 1 would have reddened every row of every section after it with a fault
+  // whose cause is four sections away. Put here, the mutation reddens the two rows it is
+  // about and nothing else, which is the difference between a control that names a
+  // property and one that fails everything.
+  console.log('\n[effect] 6. and what a crashed install leaves behind is invisible until it is swept');
+
+  // Taken here rather than reused from section 1, because the probe is installed by now
+  // and the count moved with it - a comparison against the boot listing would fail on a
+  // correct build for a reason that has nothing to do with temporaries.
+  const beforeStale = await getJson('/effects');
+  const stale = join(USER_ROOT, 'probe.99999.tmp');
+  mkdirSync(stale, { recursive: true });
+  writeFileSync(join(stale, 'manifest.json'), '{"this is": "not a package"}');
+  ok('a half-written package is on disk, so the rows under this are about something',
+    existsSync(stale), 'probe.99999.tmp staged in the user root');
+  const withStale = await getJson('/effects');
+  ok('a half-written package is in no listing - its name carries a dot and an effect id may not',
+    withStale.status === 200
+      && withStale.body.effects?.length === beforeStale.body.effects?.length
+      && !withStale.body.effects.some((e) => e.id.includes('.')),
+    `answered ${withStale.status} with ${withStale.body.effects?.length ?? 'no'} packages, `
+    + `${beforeStale.body.effects?.length ?? 'no'} before it was staged`);
+  const staleRead = await getJson('/effects/probe.99999.tmp');
+  ok('and no read resolves it', staleRead.status === 404, `answered ${staleRead.status}`);
+  const sweeping = await put('probe', probePackage());
+  ok('and the next install of that id sweeps it, so a machine that crashed mid-install does not accumulate copies',
+    sweeping.status === 200 && !existsSync(stale),
+    `${sweeping.status}: ${sweeping.body.error ?? 'installed'}, user root ${userRootHolds().join(', ') || 'empty'}`);
+
+  ok('the page reported no error through any of it', pageErrors.length === 0,
+    pageErrors.slice(0, 2).join(' | '));
+} catch (err) {
+  crashed = err;
+  console.log(`\n  FAIL  the run did not finish: ${err.stack ?? err.message}`);
+} finally {
+  if (browser) await browser.close().catch(() => {});
+  await stopAll();
+  rmSync(WORK, { recursive: true, force: true });
+}
+
+console.log(`\n[effect] ${checked} assertions, ${failed} failed`);
+if (untested) {
+  console.log(`[effect] UNTESTED - ${untested}.`);
+  process.exit(2);
+}
+/**
+ * **The count decides, and it decides before the crash does.**
+ *
+ * A mutation here can leave the page half-adopted - `install-skips-the-uniform-cells`
+ * throws inside the value walk, so the registry is replaced and the panel is not - and a
+ * driver reaching into that page throws in turn. The obvious verdict order puts the crash
+ * first and reports DID NOT RUN over seven failed assertions that had already fired, which
+ * is the exact shape `docs/instruments.md` files under a census of exit codes: a caught
+ * mutation reported as a run that proved nothing, and the tool then reads as broken while
+ * it is working.
+ *
+ * So a mutated run with failures is caught however it ended, and it says that it ended
+ * early, because the rows after the crash did not run and the count is a floor rather than
+ * the whole picture. A run with no failures is the other way round: crashed means DID NOT
+ * RUN, and finishing cleanly means the mutation was not caught at all.
+ */
+if (MUTATE && failed > 0) {
+  console.log(`[effect] caught, as required (${failed} assertion${failed === 1 ? '' : 's'} fired)`);
+  if (crashed) console.log(`[effect] and the run ended early: ${crashed.message.split('\n')[0]} - the count is a floor`);
+  console.log(`[effect] rows that fired: ${fired.join(' | ')}`);
+  process.exit(1);
+}
+if (crashed) {
+  console.log(`[effect] DID NOT RUN - ${crashed.message.split('\n')[0]}. Nothing here is a finding: re-run it.`);
+  process.exit(2);
+}
+if (MUTATE) {
+  console.log('[effect] NOT CAUGHT - the check passed a build it should have rejected');
+  process.exit(1);
+}
+if (failed) { console.log('[effect] FAIL'); process.exit(1); }
+console.log('[effect] PASS');
+process.exit(0);

--- a/tools/effect-conformance-check.mjs
+++ b/tools/effect-conformance-check.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+// The plugin contract, as an instrument: every installed effect, asked whether it is
+// really absent when it is off.
+//
+// **One claim, of every package, and it is the claim the whole two-root design rests on.**
+// A build with sixteen effects installed and every value at its default has to draw
+// exactly what a build with none of them installed draws. If it does not, then installing
+// an effect changes the look of every clip on the machine, a preset authored here stops
+// meaning what it means anywhere else, and the sixteen shipped looks - all of which sit at
+// the defaults of most of the sixteen packages - are quietly a different grade from the one
+// they were graded as. Nothing in the assembler can hold that: a chunk is spliced whether
+// or not anybody raised its master, so "inert at zero" is a property of the GLSL each
+// package's author wrote and of nothing else.
+//
+// **Three renders per package, and the third is the one that costs something.**
+//
+//   1. **defaults** - every parameter of every package at its own default.
+//   2. **the master held at zero, everything the manifest says it gates raised** - the keys
+//      that declare themselves `under` the master pushed off their defaults while the term
+//      the effect is absent at stays where it is. A leak shows here as a picture that moved
+//      because a control under a switched-off effect was turned. `under` rather than "every
+//      other parameter", because one shipped package has a second amplitude in its
+//      namespace - `noise.region` - which the master does not gate and correctly does move
+//      the picture on its own.
+//   3. **the package gone** - its manifest served hollow, so it contributes no GLSL at
+//      all, and the page rebuilt from that. This is what "absent" actually means, and it
+//      is the arm the other two cannot replace: a term that leaks a constant is identical
+//      under 1 and 2 and different under 3.
+//
+// All three must be the same image, byte for byte.
+//
+// **Every hash is taken inside one run and none is written down.** A committed hash is a
+// claim about a rasteriser, a driver and a window size, and this suite already carries the
+// case file for what that costs; what is compared here is three images this process just
+// rendered on one GPU, which is a comparison that means the same thing on every machine.
+//
+// **The vacuity guard is what stops all of this passing on a dead effect.** An equality
+// between three renders is satisfied perfectly by a package whose GLSL reaches no pixel
+// under any value, so each package gets a fourth render with *its own* parameters raised,
+// and that one has to differ. A package that cannot move the picture is reported as a
+// failure rather than as three green rows.
+//
+// **The population comes off the store and is never named here.** `GET /effects` says what
+// is installed, so a seventeenth package is asked these questions by existing - which is
+// the whole point of a conformance check rather than a list of sixteen assertions.
+//
+//   node tools/effect-conformance-check.mjs --url http://localhost:8080
+//   node tools/effect-conformance-check.mjs --url http://localhost:8080 --mutate leaks-at-zero  # must FAIL
+//
+// Needs a running server and a GPU browser. No capture, no sensor, no ffmpeg and no port
+// of its own: the frames are planted and both interceptions - the hollowed manifest and the
+// mutated chunk - are served, so nothing this tool does touches a byte on disk.
+
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..');
+const argv = process.argv.slice(2);
+const flag = (name, fallback = null) => {
+  const at = argv.indexOf(name);
+  return at === -1 ? fallback : argv[at + 1];
+};
+const URL_BASE = flag('--url', 'http://localhost:8080');
+const MUTATE = argv.includes('--mutate') ? flag('--mutate') : null;
+
+/**
+ * The mutations, and this one is a defect rather than a switch.
+ *
+ * **`leaks-at-zero` is served rather than written**, which is a departure from every other
+ * tool in the suite and is forced by what this one is. It runs `--url` against a server
+ * somebody else started, so there is no staged tree to edit - and editing the checkout
+ * would leave a mutated working tree behind any crash, which is the one state a proof tool
+ * must never produce. So the mutation is a function over the text of one served chunk, and
+ * the page compiles what the interception hands it.
+ *
+ * A function rather than a `{ file, edits }` table on purpose: `syntax-check`'s anchor row
+ * recognises a function-shaped entry as one that redirects the oracle rather than anchoring
+ * on source text, which is exactly what this is. What replaces the anchor check is a row in
+ * the run itself - the tool asserts the served text actually changed, because a mutation
+ * that does nothing reads as a check that found nothing.
+ *
+ * The rain is the target because its lift is a multiply by `1.0 + rain * rainLift`,
+ * deliberately unconditional, so a floor under the master leaks into every frame the
+ * package draws into.
+ *
+ * **Measured rather than reasoned about, and the reasoning was wrong.** This was aimed at
+ * the rain expecting both the second and the third arm to see it, on the grounds that the
+ * rain has three sub-keys shaping `rainLift`. Run, it reddens the third arm alone - and the
+ * reason is the gate: `vRain` is computed inside the `cell` service under `rain > 0.0`, so
+ * at a master of zero the varying sits at the `0.0` the prologue writes, `fract(0.0)` is
+ * zero, and `smoothstep` returns zero whatever `rainTrail` and `rainSpan` are. The sub-keys
+ * are genuinely dead at zero, which is the package being correct, and the arm that can see
+ * a constant leak is the one that takes the package away. That is the whole argument for
+ * having the third arm: a leak that both other arms agree about is invisible to them.
+ */
+const MUTATIONS = {
+  'leaks-at-zero': (text, path) => (
+    path.endsWith('/effects/rain/file/lift.frag.glsl')
+      ? text.replace('col *= 1.0 + rain * rainLift;', 'col *= 1.0 + max(rain, 0.08) * rainLift;')
+      : text
+  ),
+};
+
+if (argv.includes('--mutate') && !MUTATIONS[MUTATE]) {
+  console.log(`[conformance] DID NOT RUN - no mutation named ${MUTATE ?? '(nothing was given)'};`
+    + ` this tool knows ${Object.keys(MUTATIONS).join(', ')}`);
+  process.exit(2);
+}
+
+// --- harness -----------------------------------------------------------------
+let checked = 0;
+let failed = 0;
+let crashed = null;
+let untested = null;
+// Which effect each failed row belongs to, because the whole claim of the method control
+// is that a leak in one package reddens that package's rows and no other's - and a count
+// cannot say that.
+const firedFor = new Map();
+const ok = (label, pass, detail = '', effect = null) => {
+  checked++;
+  if (!pass) {
+    failed++;
+    if (effect) firedFor.set(effect, [...(firedFor.get(effect) ?? []), label]);
+  }
+  console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${label}${detail ? `  ${detail}` : ''}`);
+};
+
+const DEPTH_W = 512;
+const DEPTH_H = 424;
+const POSITIONS = [0.15, 0.7, 1.3];
+
+/**
+ * The frames every arm renders, planted here rather than taken off a capture.
+ *
+ * A leaning plane, so the picture has range in it: on a flat wall every depth-keyed term
+ * writes the same value at every pixel, and a duotone or a thermal would move the whole
+ * frame by one constant - which two builds can agree about for reasons that have nothing to
+ * do with the term being read per point. The frames drift between each other so the three
+ * program positions are three geometries rather than one restamped.
+ */
+const pinnedBuffer = () => {
+  const FRAMES = 8;
+  const depthBytes = DEPTH_W * DEPTH_H * 2;
+  const out = Buffer.alloc(FRAMES * (16 + depthBytes));
+  for (let f = 0; f < FRAMES; f++) {
+    const at = f * (16 + depthBytes);
+    out.writeUInt32LE(depthBytes, at);
+    out.writeUInt32LE(0, at + 4);
+    // 200ms apart, so the eight of them span 1.4 seconds and every position below sits
+    // inside the run. A pinned source clamps past its last stamp, so positions beyond the
+    // end are the same frame twice - which reads as three arms agreeing and is two of them
+    // measuring one image.
+    out.writeBigUInt64LE(BigInt(f * 200), at + 8);
+    for (let y = 0; y < DEPTH_H; y++) {
+      for (let x = 0; x < DEPTH_W; x++) {
+        const mm = 1100 + Math.round((x / DEPTH_W) * 1400 + (y / DEPTH_H) * 700) + f * 60;
+        out.writeUInt16LE(mm, at + 16 + (y * DEPTH_W + x) * 2);
+      }
+    }
+  }
+  return out;
+};
+
+/**
+ * A colour image with structure in it, for the terms that key on one.
+ *
+ * `drive.pin` switches colour off, because a JPEG decode is asynchronous and a hash taken
+ * across one would be a hash of whether it had landed yet - so the arms that need colour
+ * get it planted instead. Half the shipped packages read `rgb`: the thermal takes its heat
+ * off luminance, the edges and the duotone key on it, and a flat grey is the identity for
+ * several of them at once, which would put four packages in a dead zone where the vacuity
+ * guard would correctly report them as unable to move a pixel.
+ */
+const COLOR_W = 64;
+const COLOR_H = 48;
+const plantedColour = () => {
+  const rgba = new Array(COLOR_W * COLOR_H * 4);
+  for (let y = 0; y < COLOR_H; y++) {
+    for (let x = 0; x < COLOR_W; x++) {
+      const i = (y * COLOR_W + x) * 4;
+      rgba[i] = (x * 4) % 256;
+      rgba[i + 1] = (y * 5) % 256;
+      rgba[i + 2] = ((x + y) * 3) % 256;
+      rgba[i + 3] = 255;
+    }
+  }
+  return rgba;
+};
+
+/**
+ * A value clearly off the default and inside the bounds, derived rather than tabulated.
+ *
+ * Three quarters of the way to whichever end is further from the default, which puts a
+ * master that starts at 0 well up its range and a parameter that starts mid-range decisively
+ * off centre. Not the bound itself: several of the shipped bounds are degenerate on purpose
+ * - an angle at its wrap point, a mask fully open, a span at the whole clip range - and a
+ * raise landing on one of those is a raise that can be inert for a reason about the bound
+ * rather than about the parameter. The registry snaps whatever this returns onto the
+ * parameter's own grid, so no rounding is done here.
+ */
+/**
+ * A line of a package's own GLSL that nothing else in the build writes.
+ *
+ * The longest line of its chunks with the comments taken out, which for every shipped
+ * package is a statement rather than a brace - long enough to be its own and short enough
+ * to be one line. Used only to ask whether the package's text is in the assembled program,
+ * so what matters is that it is present exactly when the package is and absent when it is
+ * not; a package with no chunks at all has no such line, and its rows say so rather than
+ * asserting against an empty string that every program contains.
+ */
+const markerOf = (pkg) => {
+  const lines = Object.values(pkg.chunks ?? {}).join('\n')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length >= 16 && !l.startsWith('//'));
+  return lines.sort((a, b) => b.length - a.length)[0] ?? null;
+};
+
+const raisedValue = (spec) => {
+  if (typeof spec.default === 'boolean') return !spec.default;
+  const far = (spec.default - spec.min) > (spec.max - spec.default) ? spec.min : spec.max;
+  return spec.default + (far - spec.default) * 0.75;
+};
+
+console.log(`[conformance] ${MUTATE ? `MUTATED: ${MUTATE} (served, not written)` : 'unmutated tree'}`);
+console.log(`[conformance] against ${URL_BASE}\n`);
+
+let browser = null;
+// Which package `/effects/:id` is currently answering hollow for, and the body it answers
+// with. Module state rather than a closure argument, because the one route handler
+// installed below outlives every package it serves.
+let hollowFor = null;
+let hollowBody = null;
+try {
+  let chromium;
+  try {
+    ({ chromium } = await import(join(REPO, 'node_modules/playwright/index.mjs')));
+  } catch {
+    untested = 'playwright is not installed, and every claim here is about a rendered frame';
+    throw new Error(untested);
+  }
+
+  // The population, off the store. Fetched here rather than read off the page, because the
+  // question below is whether the page is assembled from what the server holds - and a
+  // list taken from the page would be the page agreeing with itself.
+  const listed = await fetch(`${URL_BASE}/effects`);
+  if (!listed.ok) throw new Error(`GET /effects answered ${listed.status} - there is no population to check`);
+  const { effects } = await listed.json();
+  const packages = [];
+  for (const { id } of effects) {
+    const res = await fetch(`${URL_BASE}/effects/${encodeURIComponent(id)}`);
+    if (!res.ok) throw new Error(`GET /effects/${id} answered ${res.status}`);
+    const pkg = await res.json();
+    // The chunk text as well as the manifest, because the marker below is a line of the
+    // package's own GLSL and the manifest names the files rather than carrying them.
+    pkg.chunks = {};
+    for (const name of [...new Set((pkg.manifest.chunks ?? []).map((c) => c.file))]) {
+      const chunk = await fetch(`${URL_BASE}/effects/${encodeURIComponent(id)}/file/${encodeURIComponent(name)}`);
+      if (!chunk.ok) throw new Error(`GET /effects/${id}/file/${name} answered ${chunk.status}`);
+      pkg.chunks[name] = await chunk.text();
+    }
+    packages.push(pkg);
+  }
+
+  browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 900, height: 600 } });
+  const pageErrors = [];
+  page.on('pageerror', (e) => pageErrors.push(String(e)));
+  page.on('console', (m) => { if (m.type() === 'error') pageErrors.push(m.text()); });
+  // No socket, so nothing overwrites the planted frames: a live sensor wipes a plant in
+  // well under a second, and every arm here is a hash of a planted geometry.
+  await page.routeWebSocket(/.*/, () => {});
+
+  // The mutation, served. Every chunk fetch goes through here whatever the mutation is, so
+  // the unmutated path and the mutated one differ in one function call rather than in
+  // whether an interception is installed at all.
+  let mutatedText = 0;
+  await page.route((url) => /\/effects\/[^/]+\/file\//.test(url.pathname), async (route) => {
+    const res = await route.fetch();
+    const text = await res.text();
+    const next = MUTATE ? MUTATIONS[MUTATE](text, route.request().url()) : text;
+    if (next !== text) mutatedText++;
+    await route.fulfill({ status: 200, contentType: 'text/plain; charset=utf-8', body: next });
+  });
+
+  // **One handler over `/effects/:id`, consulting a variable.** Which package is served
+  // hollow changes sixteen times in a run and the interception does not: a route added and
+  // removed per package cannot be removed at all, because `page.unroute` matches the
+  // matcher by reference and every call would hand it a fresh arrow.
+  await page.route((url) => /^\/effects\/[a-z][a-z0-9]*$/.test(url.pathname), async (route) => {
+    const id = new URL(route.request().url()).pathname.split('/')[2];
+    if (id !== hollowFor) return route.continue();
+    return route.fulfill({ status: 200, contentType: 'application/json; charset=utf-8', body: hollowBody });
+  });
+
+  await page.goto(`${URL_BASE}/record`, { waitUntil: 'load' });
+  await page.waitForFunction('Boolean(globalThis.__kinect)', null, { timeout: 20000 });
+
+  /** All four assembled shader strings, as one, for the marker rows. */
+  const assembled = () => page.evaluate(() => {
+    const p = globalThis.__kinect.effects.programs();
+    return `${p.cloud.vertexShader}${p.cloud.fragmentShader}${p.grade.vertexShader}${p.grade.fragmentShader}`;
+  });
+
+  if (MUTATE) {
+    // **Before believing a mutation was missed, confirm it did something.** A served
+    // mutation whose target text has moved changes nothing at all, and a run of it would
+    // report the check as having found nothing when what happened is that nothing was
+    // done to it.
+    ok(`the ${MUTATE} mutation reached the text it is about`, mutatedText > 0,
+      `${mutatedText} served chunk${mutatedText === 1 ? '' : 's'} rewritten`);
+  }
+
+  const buffer = pinnedBuffer();
+  await page.route('**/__conformance-pinned.bin', (route) => route.fulfill({
+    status: 200, contentType: 'application/octet-stream', body: buffer,
+  }));
+  await page.evaluate(() => { document.getElementById('panel').style.display = 'none'; });
+  await page.evaluate(async () => {
+    const res = await fetch('/__conformance-pinned.bin');
+    globalThis.__kinect.drive.pin(await res.arrayBuffer());
+  });
+  await page.evaluate(({ rgba, w, h }) => globalThis.__kinect.drive.plantColor(rgba, w, h),
+    { rgba: plantedColour(), w: COLOR_W, h: COLOR_H });
+
+  /**
+   * One render of one look, hashed at three program positions.
+   *
+   * The camera is written every time rather than once, because the arms that drop a
+   * package rebuild the whole page in between and a pose left to persist is a pose one arm
+   * could be measuring a different value of. `drive.reset` rewinds the pinned source and
+   * clears both accumulators, so each arm starts from the state a page that had just
+   * booted is in - which is what makes three renders taken minutes apart comparable at all.
+   */
+  const renderLook = (values, positions) => page.evaluate(async ({ v, ts }) => {
+    const k = globalThis.__kinect;
+    const sha256 = async (bytes) => {
+      const digest = await crypto.subtle.digest('SHA-256', bytes);
+      return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+    };
+    k.params.reset();
+    if (Object.keys(v).length) k.params.apply(v);
+    k.drive.reset();
+    k.freeCamera.position.set(0, 0.1, 1.6);
+    k.freeCamera.lookAt(0, 0, -2.2);
+    k.freeCamera.updateMatrixWorld(true);
+    const hashes = [];
+    for (const t of ts) {
+      k.drive.stepTo(t);
+      hashes.push(await sha256(k.drive.readPixels()));
+    }
+    // **What the registry actually stored, handed back with the hashes.** An arm that
+    // asked for a raise and got a clamp, a snap or a refusal renders the defaults and
+    // looks exactly like an effect that cannot move a pixel - which is a vacuity row
+    // firing about the tool rather than about the build. The caller compares against what
+    // it asked for, so the two cases are told apart at the point they differ.
+    return { hashes, stored: Object.fromEntries(Object.keys(v).map((n) => [n, k.params.get(n)])) };
+  }, { v: values, ts: positions });
+
+  const same = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+  const brief = (hs) => hs.map((h) => h.slice(0, 8)).join(' ');
+
+  // ---- the reference: every package installed, every value at its own default
+  const { hashes: defaults } = await renderLook({}, POSITIONS);
+  ok('the defaults render, and the three positions are three different images',
+    new Set(defaults).size === POSITIONS.length, brief(defaults));
+
+  // What the page says each parameter's bounds are, so the raise is derived from the
+  // registry the build actually holds rather than from the manifests read above. The two
+  // agree by construction; asking the page is what makes a raise land inside the bounds
+  // the page will clamp it to.
+  const specs = await page.evaluate(() => Object.fromEntries(
+    globalThis.__kinect.params.names('look').map((n) => [n, globalThis.__kinect.params.spec(n)]),
+  ));
+
+  console.log('');
+  const raiseless = [];
+  const vacuous = [];
+  for (const pkg of packages) {
+    const id = pkg.id;
+    const own = Object.keys(pkg.manifest.params).map((short) => `${id}.${short}`);
+    const masterShort = Object.entries(pkg.manifest.params).find(([, s]) => s.role === 'master')?.[0];
+    const master = masterShort ? `${id}.${masterShort}` : null;
+    const known = own.filter((n) => specs[n]);
+    if (known.length !== own.length) {
+      ok(`${id}: every parameter it declares is in this build's registry`, false,
+        `${known.length} of ${own.length}: ${own.filter((n) => !specs[n]).join(', ')}`, id);
+      continue;
+    }
+
+    const mark = markerOf(pkg);
+
+    // ---- arm 2: the master where it is absent, everything under it raised
+    //
+    // **Only the keys the manifest says the master gates**, which is `under` and is a field
+    // the packages already carry. Raising every non-master parameter was the obvious rule
+    // and it is wrong about one shipped package: `noise.region` declares no `under`, because
+    // it is a second amplitude in the same namespace - the region's scramble, which reuses
+    // the turbulence field's scale and speed and is gated by itself rather than by
+    // `noise.amount`. Raising it under a master at zero moves the picture correctly, and a
+    // rule that did not read `under` would report that as the noise package leaking.
+    //
+    // The parameters that are neither the master nor under it are named in the row's own
+    // detail rather than quietly skipped, because a deliberate exclusion that nobody can
+    // see is the shape this repo has three holes filed under.
+    const under = known.filter((n) => pkg.manifest.params[n.split('.').slice(1).join('.')].under === masterShort);
+    const ungated = known.filter((n) => n !== master && !under.includes(n));
+    const held = Object.fromEntries(under.map((n) => [n, raisedValue(specs[n])]));
+    for (const n of [...(master ? [master] : []), ...ungated]) held[n] = specs[n].default;
+    const { hashes: atZero } = await renderLook(held, POSITIONS);
+    if (under.length === 0) raiseless.push(id);
+    ok(`${id} at its inert master draws exactly what the defaults draw`
+      + `${under.length === 0 ? ' (nothing declares itself under the master, so this arm is the defaults arm)' : ` (${under.length} key${under.length === 1 ? '' : 's'} raised under it)`}`,
+    same(atZero, defaults), `${same(atZero, defaults) ? brief(defaults) : `${brief(atZero)} against ${brief(defaults)}`}`
+      + `${ungated.length ? ` - held at its default beside the master: ${ungated.join(', ')}` : ''}`, id);
+
+    // ---- arm 3: the package not there at all
+    //
+    // **Served hollow rather than dropped from the list**, and the difference is the
+    // difference between measuring absence and measuring a page that will not boot. The
+    // client's declaration order places every shipped parameter by name, so a package
+    // missing from the list is a registry that cannot assemble - and the glyph field reads
+    // the rain's varying, so a rain with no varying is a program that will not compile.
+    // What "absent" means for a shader is that the package contributes no GLSL: the chunks
+    // go, the services it consumes go with them so nothing widens a gate around an empty
+    // block, and the parameters and varyings stay - the parameters so the registry still
+    // assembles, the varyings so a reader in another package still has its channel, pinned
+    // at the inert value the prologue writes, which is what a build without this package
+    // would see there anyway.
+    //
+    // **The interception is one handler consulting a variable rather than a route added and
+    // removed per package**, and that is a bug this tool shipped for exactly one run.
+    // `page.unroute` matches the matcher it is given by reference, so a fresh arrow removes
+    // nothing - every package dropped stayed dropped, and by the end the raise arm was
+    // asking a hollowed package to move a picture. It reads as eleven effects that cannot
+    // reach a pixel, which is a finding-shaped output from an instrument that had quietly
+    // stopped putting anything back. The marker rows below are what makes that visible now.
+    hollowFor = id;
+    hollowBody = JSON.stringify({ ...pkg, manifest: { ...pkg.manifest, chunks: [], consumes: [] } });
+    const rebuilt = await page.evaluate(async () => {
+      try {
+        await globalThis.__kinect.effects.reload();
+        return null;
+      } catch (err) { return String(err.message); }
+    });
+    let dropped = null;
+    let goneWhileHollow = null;
+    if (rebuilt === null) {
+      goneWhileHollow = mark ? !(await assembled()).includes(mark) : null;
+      dropped = (await renderLook({}, POSITIONS)).hashes;
+    }
+    hollowFor = null;
+    const back = await page.evaluate(async () => {
+      try {
+        await globalThis.__kinect.effects.reload();
+        return null;
+      } catch (err) { return String(err.message); }
+    });
+    const backWhileWhole = mark && back === null ? (await assembled()).includes(mark) : null;
+
+    ok(`${id} can be taken out of the served set and put back, so the arm above is about a rebuild rather than a refusal`,
+      rebuilt === null && back === null, [rebuilt, back].filter(Boolean).join(' | ') || 'both rebuilds ran', id);
+    // **Assert against the program, not against the interception.** A route that did not
+    // fire, a hollowing that did not hollow and an unroute that did not restore all render
+    // a picture equal to the defaults, which is the answer this arm is looking for - so the
+    // arm on its own cannot tell a package that is genuinely absent from a package that
+    // never left. The marker is the package's own longest line of GLSL, which is in the
+    // assembled program when it is installed and is not when it is not.
+    if (mark) {
+      ok(`${id}'s own text really does leave the assembled program while it is hollow, and comes back after`,
+        goneWhileHollow === true && backWhileWhole === true,
+        `while hollow: ${goneWhileHollow === true ? 'gone' : 'still there'}; after: ${backWhileWhole === true ? 'back' : 'missing'}`, id);
+    }
+    if (dropped) {
+      ok(`${id} contributing no GLSL at all draws exactly what the defaults draw`,
+        same(dropped, defaults), same(dropped, defaults) ? brief(defaults) : `${brief(dropped)} against ${brief(defaults)}`, id);
+    }
+
+    // ---- the guard: raise everything it owns, and the picture has to move
+    const raised = Object.fromEntries(known.map((n) => [n, raisedValue(specs[n])]));
+    const { hashes: loud, stored } = await renderLook(raised, POSITIONS);
+    // **The raise has to have landed before its picture means anything.** A value the
+    // registry clamped, snapped away or refused renders the defaults, and a vacuity row
+    // reading only the picture would report that as an effect that cannot move a pixel.
+    const short = Object.keys(raised).filter((n) => Math.abs(stored[n] - raised[n]) > (specs[n].step ?? 0) + 1e-9);
+    ok(`${id}'s raise reaches the registry, so the row under it is about the effect rather than about the raise`,
+      short.length === 0,
+      short.length ? short.map((n) => `${n} asked ${raised[n]} and holds ${stored[n]}`).join('; ')
+        : Object.entries(stored).map(([n, x]) => `${n.split('.')[1]}=${x}`).join(' '), id);
+    const moves = !same(loud, defaults);
+    if (!moves) vacuous.push(id);
+    ok(`${id} raised off its defaults moves the picture, so the three equalities above are not about a dead effect`,
+      moves, moves ? `${brief(loud)} against ${brief(defaults)}` : `${brief(loud)} - identical to the defaults`, id);
+  }
+
+  const { hashes: restored } = await renderLook({}, POSITIONS);
+  ok('and after every drop and restore the defaults still render what they rendered at the start',
+    same(restored, defaults), same(restored, defaults) ? brief(defaults) : `${brief(restored)} against ${brief(defaults)}`);
+
+  console.log('');
+  if (raiseless.length) {
+    console.log(`[conformance] ${raiseless.length} package${raiseless.length === 1 ? ' has' : 's have'} no sub-key, `
+      + `so their inert-master arm is the defaults arm and only the drop arm can see a leak: ${raiseless.join(', ')}`);
+  }
+  if (vacuous.length) {
+    console.log(`[conformance] ${vacuous.length} package${vacuous.length === 1 ? '' : 's'} could not move a pixel from `
+      + `this fixture, so their equalities prove nothing: ${vacuous.join(', ')}`);
+  }
+
+  ok('the page reported no error through any of it', pageErrors.length === 0,
+    pageErrors.slice(0, 2).join(' | '));
+} catch (err) {
+  crashed = err;
+  console.log(`\n  FAIL  the run did not finish: ${err.stack ?? err.message}`);
+} finally {
+  if (browser) await browser.close().catch(() => {});
+}
+
+console.log(`\n[conformance] ${checked} assertions, ${failed} failed`);
+if (untested) {
+  console.log(`[conformance] UNTESTED - ${untested}.`);
+  process.exit(2);
+}
+// The count decides before the crash does, for the reason `tools/effect-check.mjs` sets
+// out at the same place: a mutation that half-breaks a page takes the driver down with it,
+// and reporting DID NOT RUN over rows that had already fired is a caught mutation recorded
+// as a run that proved nothing.
+if (MUTATE && failed > 0) {
+  console.log(`[conformance] caught, as required (${failed} assertion${failed === 1 ? '' : 's'} fired)`);
+  if (crashed) console.log(`[conformance] and the run ended early: ${crashed.message.split('\n')[0]} - the count is a floor`);
+  for (const [effect, rows] of firedFor) console.log(`[conformance] ${effect}: ${rows.join(' | ')}`);
+  console.log(`[conformance] effects with a red row: ${[...firedFor.keys()].join(', ') || 'none'}`);
+  process.exit(1);
+}
+if (crashed) {
+  console.log(`[conformance] DID NOT RUN - ${crashed.message.split('\n')[0]}. Nothing here is a finding: re-run it.`);
+  process.exit(2);
+}
+if (MUTATE) {
+  console.log('[conformance] NOT CAUGHT - the check passed a build it should have rejected');
+  process.exit(1);
+}
+if (failed) {
+  for (const [effect, rows] of firedFor) console.log(`[conformance] ${effect}: ${rows.join(' | ')}`);
+  console.log('[conformance] FAIL');
+  process.exit(1);
+}
+console.log('[conformance] PASS');
+process.exit(0);

--- a/tools/export-check.mjs
+++ b/tools/export-check.mjs
@@ -385,6 +385,50 @@ const MUTATIONS = {
   // matters found the tolerances moving by nothing at all under a divergent chain, which
   // is the reading that says these rows have one guard rather than two.
   //
+  // **The export door on a clip whose look this build cannot draw whole.** The refusal
+  // goes and everything else stays, so the parking, the badge and the record are all
+  // still correct - what is left is a render that writes a file with a layer of the look
+  // absent and nothing in the file saying so, which is the artifact this whole band
+  // exists to refuse. It must redden the refusal row and the still-refused-for-the-other
+  // row, and leave the suppress-proceeds, the record and the complete-document rows
+  // green: a mutation that reddened those too would be breaking the export rather than
+  // the door.
+  'export-ignores-missing-effects': { file: 'web/main.js', edits: [[
+    '  const blocking = missing.filter((m) => !suppress.has(m.id));',
+    '  const blocking = [];',
+  ]] },
+  // And the same door answering a per-effect question globally, which is the reachable
+  // wrong implementation rather than an invented one: suppress reads naturally as a
+  // switch, and written as one it lets the *second* missing effect through on the
+  // strength of a decision somebody made about the first. Invisible with one effect
+  // missing - both implementations refuse nothing - so only the two-effect row can see
+  // it, and that is the row it must redden alone.
+  'suppress-is-global': { file: 'web/main.js', edits: [[
+    '  const blocking = missing.filter((m) => !suppress.has(m.id));',
+    '  const blocking = suppress.size ? [] : missing;',
+  ]] },
+  // The record's own half. The render still refuses and still proceeds in the right
+  // cases, and the file it writes carries no note that a layer was skipped - so the one
+  // artifact that leaves this machine stops being able to say what it is a render of.
+  // One row, the deliverable's record.
+  'deliverable-forgets-suppressed': { file: 'web/main.js', edits: [[
+    '      project: serialiseProjectBody(suppressed.length ? { suppressed } : {}),',
+    '      project: serialiseProjectBody(),',
+  ]] },
+  // The wiring between the badge and the door, which every other row here steps over by
+  // calling `export.run` with a list of its own. The rule is unchanged and the badge is
+  // unchanged; what goes is the click handler handing over what the badge holds, so an
+  // operator can suppress an effect, watch the toggle light, press Export and be refused.
+  //
+  // Must redden two: the row that names it, and the `no page errors` sweep at the foot.
+  // The second is the refusal itself - `showTimelineError` writes every sentence it shows
+  // the operator to `console.error` as well - so it is noise this mutation creates rather
+  // than a second finding, and it exists only on the mutated build: the clean run reports
+  // no page errors at all, so there is nothing here to drain and nothing to exempt.
+  'export-button-drops-the-suppression': { file: 'web/main.js', edits: [[
+    '      suppressEffects: [...suppressedEffects],',
+    '      suppressEffects: [],',
+  ]] },
   // Only the split reverts, so the claim cannot be carried by the other two.
   'rgbsplit-absolute': { file: 'effects-builtin/rgbsplit/split.grade.glsl', edits: [[
     'vec2 off = dir * rgbSplit * texel * 8.0;',
@@ -2982,6 +3026,205 @@ console.log('\n[7] a failed export leaves the previous file and its record exact
     await server.close();
     await noEncoder.close();
     rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+// ------------------------ 7. a clip needing an effect this build has not got
+
+console.log('\n[8] an export is refused while the clip needs an effect this build lacks, and a suppression is per effect');
+
+// **The missing effect is staged rather than uninstalled, and it has to be.** There is
+// no uninstall in this build - that arrives later - so the shape under test is reached
+// the way a document from another machine reaches it: a look name whose dotted prefix is
+// a perfectly valid effect id that nothing here has ever shipped. `sparkle` and
+// `drizzle` are those, and the first row of this section is that they really are absent,
+// because the day somebody ships a package under either name every row below stops
+// asking anything while still printing a pass.
+//
+// Two of them rather than one, because the claim that separates a per-effect suppression
+// from a global one cannot be made with a single missing effect: suppressing the only
+// one there is looks identical under both implementations.
+const MISSING_A = { id: 'sparkle', version: '1.0.0' };
+const MISSING_B = { id: 'drizzle', version: '2.1.0' };
+
+/**
+ * The document under test, built out of the page's own serialiser rather than typed
+ * here.
+ *
+ * A hand-written project is a fixture that stops being what `restoreProject` accepts the
+ * first time the loader gains a rule - `jobs-check` has that lesson written into its own
+ * fixture twice over - so this takes whatever the open clip currently is and adds the one
+ * thing under test: four values and two keyed tracks under an effect that is not here,
+ * with the `requires` entry the writer would have derived for them.
+ */
+const PARKED_ARM = `((opts) => {
+  const k = globalThis.__kinect;
+  const base = k.library.serialiseProjectBody();
+  const doc = JSON.parse(JSON.stringify(base));
+  for (const m of opts.missing) {
+    doc.look.params[m.id + '.amount'] = 0.6;
+    doc.look.params[m.id + '.size'] = 3.25;
+    doc.look.params[m.id + '.hue'] = 210;
+    doc.look.params[m.id + '.jitter'] = 0.125;
+    doc.look.tracks[m.id + '.amount'] = [
+      { t: 0, value: 0, easeOut: [[0.42, 0]], easeIn: [[0.58, 1]] },
+      { t: 2, value: 0.9, easeOut: [[0.42, 0]], easeIn: [[0.58, 1]] },
+    ];
+    doc.look.tracks[m.id + '.hue'] = [{ t: 0.5, value: 10, easeOut: [[0.1, 0.2]], easeIn: [[0.3, 0.4]] }];
+    doc.requires = [...(doc.requires ?? []), { id: m.id, version: m.version }];
+  }
+  return { base, doc };
+})`;
+
+const parkedRun = await onFreshPage('the missing-effect export run', async (page) => {
+  const attempt = async (project, options) => page.evaluate(`(async (a) => {
+    globalThis.__kinect.library.restoreProject(a.project);
+    await globalThis.__kinect.timeline.settled();
+    try {
+      const done = await globalThis.__kinect.export.run(a.options);
+      return { ok: true, output: done.output, frames: done.frames, frameHashes: done.frameHashes };
+    } catch (err) {
+      return { ok: false, error: String(err.message ?? err) };
+    }
+  })(${JSON.stringify({ project: project, options: options })})`);
+
+  // The effect ids this build actually declares, read off the registry the way the page
+  // itself decides what is installed - so the precondition row below is asking the same
+  // question the parking asks rather than a second reading of it.
+  const declared = await page.evaluate(`(() => {
+    const k = globalThis.__kinect;
+    return [...new Set(k.params.names('look').filter((n) => n.includes('.')).map((n) => n.slice(0, n.indexOf('.'))))];
+  })()`);
+  const one = await page.evaluate(`${PARKED_ARM}(${JSON.stringify({ missing: [MISSING_A] })})`);
+  const two = await page.evaluate(`${PARKED_ARM}(${JSON.stringify({ missing: [MISSING_A, MISSING_B] })})`);
+
+  const shot = { width: STAGE.width, height: STAGE.height, fps: EXPORT_FPS, from: 0, to: 2, codec: 'lossless' };
+  return {
+    declared,
+    // The complete document first, so the pictures the rows below compare against were
+    // taken on the same page with the same camera and the same playhead.
+    complete: { ...await attempt(one.base, { ...shot, name: 'check-missing-none' }), doc: one.base },
+    refused: await attempt(one.doc, { ...shot, name: 'check-missing-refused' }),
+    suppressed: await attempt(one.doc, { ...shot, name: 'check-missing-suppressed', suppressEffects: [MISSING_A.id] }),
+    partial: await attempt(two.doc, { ...shot, name: 'check-missing-partial', suppressEffects: [MISSING_A.id] }),
+    badge: await page.evaluate(`(() => [...document.querySelectorAll('#tMissing .missingfx')]
+      .map((e) => ({ effect: e.dataset.effect, text: e.querySelector('b').textContent })))()`),
+    // **The one seam every row above steps over: what the export *button* hands the
+    // rule.** `exportClip` takes the suppression as an argument so that the page and the
+    // render worker can each supply their own, and the page's answer is read at the click
+    // - so a build whose handler forgot to pass the badge's set would satisfy every row
+    // that calls `export.run` directly and refuse every export a person could ask for.
+    // Driven through the two controls a hand uses, in the order the surface allows.
+    throughTheUi: await (async () => {
+      await page.evaluate(`(() => {
+        globalThis.__kinect.library.restoreProject(${JSON.stringify(one.doc)});
+      })()`);
+      await page.evaluate('globalThis.__kinect.timeline.settled()');
+      await page.click('#tMissing button[data-suppress="sparkle"]');
+      const pressed = await page.evaluate(
+        `document.querySelector('#tMissing button[data-suppress="sparkle"]').getAttribute('aria-pressed')`,
+      );
+      await page.locator('#outputMenuButton').click();
+      await page.locator('#menuExport').click();
+      await page.fill('#tExportName', 'check-missing-ui');
+      await page.locator('#tExport').click();
+      // The note is where the export reports itself, refusal and success alike, so it is
+      // the one place a driver can read which of the two happened without asking the
+      // function it just pressed a button to reach.
+      await page.waitForFunction(
+        `!/starting|frame /.test(document.getElementById('tExportNote').textContent)`,
+        null, { timeout: 180000 },
+      );
+      return { pressed, note: await page.evaluate("document.getElementById('tExportNote').textContent") };
+    })(),
+  };
+});
+
+if (!parkedRun.ok) {
+  check(false, 'the missing-effect run completed', parkedRun.error);
+} else {
+  const r = parkedRun.value;
+  // The precondition, and it is a row rather than an assumption for the reason
+  // `docs/instruments.md` gives about a fixture that cannot hold the property: an arm
+  // whose "missing" effect turned out to be installed would pass every refusal row by
+  // never producing one.
+  const clash = [MISSING_A.id, MISSING_B.id].filter((id) => r.declared.includes(id));
+  check(clash.length === 0,
+    'the two effects these rows are about really are absent from this build',
+    `${r.declared.length} installed: ${r.declared.join(', ')}${clash.length ? ` - and ${clash.join(', ')} is among them` : ''}`);
+
+  check(r.refused.ok === false
+    && String(r.refused.error).includes(`${MISSING_A.id} ${MISSING_A.version}`),
+  'a clip whose requires name a missing effect refuses to export, naming the id and the version',
+  r.refused.ok ? 'the export ran' : r.refused.error);
+
+  // And the badge said so on the surface, with the version out of the document's own
+  // requires entry - the same fact the refusal quotes, read where a person would.
+  const said = r.badge.find((e) => e.effect === MISSING_B.id);
+  check(r.badge.length === 2 && said?.text.includes(`${MISSING_B.id} ${MISSING_B.version}`),
+    'and the badge names each of them with the version the document asked for',
+    r.badge.map((e) => e.text).join(' | ') || 'no badge entries');
+
+  check(r.suppressed.ok === true,
+    'and with that effect suppressed the export proceeds and writes a file',
+    r.suppressed.ok ? `${r.suppressed.frames} frames to ${r.suppressed.output}` : r.suppressed.error);
+
+  if (r.suppressed.ok) {
+    const record = JSON.parse(readFileSync(`${r.suppressed.output}.job.json`, 'utf8'));
+    const got = record.project?.suppressed;
+    check(Array.isArray(got) && got.length === 1
+      && got[0].id === MISSING_A.id && got[0].version === MISSING_A.version,
+    'and the deliverable\'s own document records what that render went without',
+    JSON.stringify(got ?? null));
+    // The parked values are still in the record, which is the half a reader of the file
+    // needs: `suppressed` says what was left out of the *render*, and the document is
+    // still the document. A record that had shed them would say the clip never wanted
+    // the effect at all.
+    const kept = Object.keys(record.project?.look?.params ?? {}).filter((n) => n.startsWith(`${MISSING_A.id}.`));
+    check(kept.length === 4,
+      'and it still carries the parked values, so the record says what was skipped rather than rewriting the clip',
+      `${kept.length} parked keys in the deliverable's document: ${kept.join(', ')}`);
+  }
+
+  // **The installed part of the look really rendered**, asserted as an equality against
+  // the same document without the parked keys. Bit-identical rather than close: the
+  // parked values never reach the registry, so the two documents leave it in exactly the
+  // same state and any difference at all would mean one of them had touched something.
+  if (r.suppressed.ok && r.complete.ok) {
+    const a = r.complete.frameHashes ?? [];
+    const b = r.suppressed.frameHashes ?? [];
+    const same = a.length > 0 && a.length === b.length && a.every((h, i) => h === b[i]);
+    check(same, 'and what it drew is the same picture the document without those keys draws',
+      `${a.filter((h, i) => h === b[i]).length}/${a.length} frames identical`);
+  }
+
+  check(r.partial.ok === false
+    && String(r.partial.error).includes(`${MISSING_B.id} ${MISSING_B.version}`)
+    && !String(r.partial.error).includes(`${MISSING_A.id} `),
+  'suppressing one missing effect leaves the export refused for the other, and names only the other',
+  r.partial.ok ? 'the export ran' : r.partial.error);
+
+  // The falsification control for every row above: a build that simply refused to export
+  // would satisfy all three refusals, and one that recorded a suppression unconditionally
+  // would satisfy the record row. A complete document has to go straight through and has
+  // to leave no `suppressed` key behind it.
+  // And the same suppression made through the surface a person has, spent by the button
+  // a person presses. The note is the whole assertion: a build whose handler dropped the
+  // badge's set prints the refusal here instead of a filename, with every row above it
+  // still green.
+  check(r.throughTheUi?.pressed === 'true'
+    && /check-missing-ui/.test(r.throughTheUi?.note ?? '')
+    && !/refused|failed/.test(r.throughTheUi?.note ?? ''),
+  'and a suppression pressed in the badge is the one the export button spends, driven through both controls',
+  `aria-pressed ${r.throughTheUi?.pressed}, note ${JSON.stringify(r.throughTheUi?.note ?? null)}`);
+
+  check(r.complete.ok === true, 'a complete document exports with no refusal at all',
+    r.complete.ok ? `${r.complete.frames} frames to ${r.complete.output}` : r.complete.error);
+  if (r.complete.ok) {
+    const record = JSON.parse(readFileSync(`${r.complete.output}.job.json`, 'utf8'));
+    check(!Object.hasOwn(record.project ?? {}, 'suppressed'),
+      'and its deliverable records no suppression, because there was nothing to suppress',
+      `suppressed ${JSON.stringify(record.project?.suppressed ?? null)}`);
   }
 }
 

--- a/tools/jobs-check.mjs
+++ b/tools/jobs-check.mjs
@@ -166,6 +166,37 @@ const MUTATIONS = {
     '  const spec = Object.hasOwn(CODECS, codec) ? CODECS[codec] : null;\n  if (!spec) throw new Error(`unknown codec ${codec}`);',
     '  const spec = CODECS[codec];\n  if (!CODECS[codec]) throw new Error(`unknown codec ${codec}`);',
   ]] },
+  // **The worker's door waved open.** The job still fails, because `exportClip` refuses
+  // the same clip from the other end - so the *outcome* rows on either side of this stay
+  // green and only the reason row moves. That is the point of aiming it here: the two
+  // gates agree about whether the render happens and differ in what they say and in what
+  // it cost to say it, and the row that carries the claim is the one asserting the
+  // sentence. A control reddening the state row as well would mean this door was the only
+  // thing standing between a missing effect and a file, which it is not and must not be
+  // mistaken for.
+  'worker-door-waved-open': { file: 'tools/render-worker.mjs', edits: [[
+    "    return (job.requires ?? []).filter((e) => !installed.has(e.id) && !allowed.has(e.id));",
+    '    return [];',
+  ]] },
+  // The envelope's own half, and it is aimed at the derivation rather than at the field.
+  // Taking the caller's list instead of the document's leaves every job this file queues
+  // recorded correctly - none of them asks for one - and admits a job that can lie about
+  // what it needs, which is a worker's door answered by the thing it is a door against.
+  //
+  // Two edits, because the caller's list has to be let into the function before it can be
+  // preferred: a spec that only rewrote the derivation would be reading a name that is
+  // not in scope, which is a mutated build that does not run rather than one that runs
+  // wrong.
+  'envelope-takes-the-callers-requires': { file: 'server/jobs.js', edits: [
+    [
+      "codec = 'h264', suppressEffects = [] }) {",
+      "codec = 'h264', suppressEffects = [], requires: asked = null }) {",
+    ],
+    [
+      '    const requires = Array.isArray(project.requires) ? project.requires.map((e) => ({ ...e })) : [];',
+      '    const requires = asked ?? (Array.isArray(project.requires) ? project.requires.map((e) => ({ ...e })) : []);',
+    ],
+  ] },
   // The beat that stops for good after one dropped connection, which is how it
   // shipped: any rejection cleared the interval and nothing ever re-armed it. It is
   // aimed at the one line both the interval and the first beat go through, so a
@@ -337,6 +368,37 @@ const PROJECT = {
   outputSize: '1280x720',
   appliedPreset: null,
 };
+// **The same project with four values and two keyed tracks under an effect nothing here
+// has ever shipped**, which is how a document from a machine carrying something this one
+// lacks is staged without an uninstall to do it with. `sparkle` is a syntactically valid
+// effect id and no package in `effects-builtin/` is called that; the render section
+// asserts as much before it leans on it, because the day somebody ships one every row
+// about a missing effect stops asking anything while still printing a pass.
+//
+// It is a *loadable* document rather than a broken one - `restoreProject` parks these and
+// opens the clip - which is the whole point: the worker's door is about a job it cannot
+// draw whole, not about a job it cannot read.
+const PARKED_PROJECT = {
+  ...PROJECT,
+  requires: [{ id: 'sparkle', version: '1.0.0' }],
+  look: {
+    params: {
+      ...PROJECT.look.params,
+      'sparkle.amount': 0.6,
+      'sparkle.size': 3.25,
+      'sparkle.hue': 210,
+      'sparkle.jitter': 0.125,
+    },
+    tracks: {
+      'sparkle.amount': [
+        { t: 0, value: 0, easeOut: [[0.42, 0]], easeIn: [[0.58, 1]] },
+        { t: 2, value: 0.9, easeOut: [[0.42, 0]], easeIn: [[0.58, 1]] },
+      ],
+      'sparkle.hue': [{ t: 0.5, value: 10, easeOut: [[0.1, 0.2]], easeIn: [[0.3, 0.4]] }],
+    },
+  },
+};
+
 // Version 2, and no `outputFps`. The rate moved onto the project, so a deliverable naming
 // one is a version 1 document - and this fixture was one, which mattered more than it
 // looks: `applyDeliverable` refuses those, the worker used to adopt with a bare assignment
@@ -500,13 +562,47 @@ try {
   check(lossless.status === 200,
     'and lossless takes the odd dimension it has no reason to refuse, so that rule is a property of the codec rather than of every export',
     `${lossless.status} ${(lossless.body.error ?? '').slice(0, 40)}`);
+  // **The effects a job's look is built from, on the envelope, derived rather than
+  // taken.** A worker has to answer "can this machine draw this at all" before it opens
+  // a page, and it cannot do that from a field buried inside a document body - so the
+  // record carries the list, and it carries the *project's* list rather than one the
+  // caller supplied. That is a second spelling of a fact the record already holds, which
+  // is the shape this repo refuses everywhere it can and compares everywhere it cannot:
+  // `syntax-check` holds `CAPTURE_FORMAT` to the grabber the same way. So the row asks
+  // for the two to be equal entry for entry, and the row beside it asks what happens
+  // when a caller tries to write its own.
+  const withParked = await enqueue({ project: PARKED_PROJECT, output: 'check-parked-envelope' });
+  check(withParked.status === 200
+    && JSON.stringify(withParked.body.requires) === JSON.stringify(PARKED_PROJECT.requires),
+  'a job\'s envelope carries the effects its project requires, entry for entry',
+  `${withParked.status} ${JSON.stringify(withParked.body.requires ?? withParked.body.error)}`);
+  const lying = await enqueue({
+    project: PARKED_PROJECT, output: 'check-parked-lying', requires: [{ id: 'nothing', version: '9.9.9' }],
+  });
+  check(lying.status === 200
+    && JSON.stringify(lying.body.requires) === JSON.stringify(PARKED_PROJECT.requires),
+  'and it is derived from the document rather than accepted from the caller, so a job cannot lie about what it needs',
+  `asked for nothing 9.9.9, recorded ${JSON.stringify(lying.body.requires ?? lying.body.error)}`);
+  // And the operator's half, which *is* the caller's because it is a decision rather
+  // than a fact. Held to the id shape, because a suppression naming something that could
+  // never be an effect id covers nothing and would read as covering something.
+  const badSuppress = await enqueue({ project: PARKED_PROJECT, output: 'check-parked-bad', suppressEffects: ['Sparkle!'] });
+  const goodSuppress = await enqueue({ project: PARKED_PROJECT, output: 'check-parked-good', suppressEffects: ['sparkle'] });
+  check(refusedBecause(badSuppress, 'suppressEffects')
+    && goodSuppress.status === 200
+    && JSON.stringify(goodSuppress.body.suppressEffects) === '["sparkle"]',
+  'a suppression is a list of effect ids, refused when it is not one and carried when it is',
+  `${badSuppress.status} ${(badSuppress.body.error ?? '').slice(0, 60)}; then ${goodSuppress.status} `
+  + `${JSON.stringify(goodSuppress.body.suppressEffects ?? goodSuppress.body.error)}`);
+
   // Everything this block queued goes back off, records and all, because the section
   // below reasons about exactly what is queued and asserts it is one job. Removed by
   // unlinking the file rather than through a route, since there is no route that deletes
   // a job - and a record is a file, which is the same door the planted records further
   // down go through.
-  for (const id of [...strays, goodCodec.body.id, lossless.body.id]) {
-    rmSync(join(jobsDir, `${id}.json`), { force: true });
+  for (const id of [...strays, goodCodec.body.id, lossless.body.id,
+    withParked.body.id, lying.body.id, goodSuppress.body.id]) {
+    if (typeof id === 'string') rmSync(join(jobsDir, `${id}.json`), { force: true });
   }
 
   section('the queue hands a job only to a machine that can reproduce it');
@@ -777,6 +873,65 @@ try {
     check(/version 1/.test(String(refusedRecord.error ?? '')),
       '  and the reason it carries is the version rather than something it failed at later',
       String(refusedRecord.error ?? 'no reason recorded').slice(0, 100));
+    // **The other job this build cannot read, and it fails for a different reason at a
+    // different moment.** The version gate above is about a document whose shape this
+    // build cannot place; this is about a document it can place perfectly and cannot
+    // *draw* - the look names an effect nothing here has installed, so the values under
+    // it would be parked and the file would come out missing a layer with nothing in it
+    // to say so.
+    //
+    // The precondition first, because a fixture that cannot hold the property proves
+    // nothing while looking exactly like a proof: if `sparkle` is ever shipped, both rows
+    // below stop being about a missing effect and go on passing.
+    const packages = (await get('/effects')).effects ?? [];
+    check(!packages.some((p) => p.id === 'sparkle'),
+      'sparkle is not a package this build ships, which is what makes the two rows below about a missing effect',
+      `${packages.length} installed: ${packages.map((p) => p.id).join(', ')}`);
+    const missingJob = await enqueue({
+      capture: take.hash, output: 'jobs-check-missing', width: 320, height: 180, project: PARKED_PROJECT,
+    });
+    check(missingJob.status === 200,
+      'a job whose look names an effect this worker has not got is queued, because the queue is not where that is decided either',
+      missingJob.body.id ?? missingJob.body.error);
+    const doorman = spawn(process.execPath, [join(root, 'tools/render-worker.mjs'),
+      '--url', URL_, '--name', 'jobs-check-missing', '--drain', '--max', '1'], { stdio: 'ignore' });
+    await new Promise((done) => doorman.on('close', done));
+    const missingRecord = await get(`/jobs/${missingJob.body.id}`);
+    check(missingRecord.state === 'failed',
+      '  and the worker refuses it rather than rendering a file with a layer of the look absent',
+      `state ${missingRecord.state}${missingRecord.error ? `, ${missingRecord.error.slice(0, 80)}` : ''}`);
+    // **The reason is the assertion and not the outcome**, and that is what keeps this
+    // door separable from the page's own refusal. `exportClip` refuses the same clip from
+    // the other end, so a build with this door waved open still comes back `failed` - the
+    // rows would agree and one of the two gates would be doing all the work. What differs
+    // is the sentence and what it cost to produce: the door names the ids and versions off
+    // the envelope before a take is resolved or a page is loaded.
+    check(/sparkle 1\.0\.0/.test(String(missingRecord.error ?? ''))
+      && /this worker has no/.test(String(missingRecord.error ?? '')),
+    '  and the reason enumerates the effect and the version off the envelope, before any page was opened',
+    String(missingRecord.error ?? 'no reason recorded').slice(0, 120));
+
+    // The positive twin, in this file's own idiom: a door that refused everything would
+    // satisfy both rows above. Trimmed by its deliverable so the twin costs a handful of
+    // frames rather than a second whole take.
+    const allowedJob = await enqueue({
+      capture: take.hash,
+      output: 'jobs-check-suppressed',
+      width: 320,
+      height: 180,
+      project: PARKED_PROJECT,
+      deliverable: { ...DELIVERABLE, out: 0.5 },
+      suppressEffects: ['sparkle'],
+    });
+    const allowed = spawn(process.execPath, [join(root, 'tools/render-worker.mjs'),
+      '--url', URL_, '--name', 'jobs-check-suppressed', '--drain', '--max', '1'], { stdio: 'ignore' });
+    await new Promise((done) => allowed.on('close', done));
+    const allowedRecord = await get(`/jobs/${allowedJob.body.id}`);
+    check(allowedRecord.state === 'done' && Number(allowedRecord.frames) > 0,
+      '  while the same job carrying suppressEffects for it renders, so the door refuses a job rather than every job',
+      `state ${allowedRecord.state}, ${allowedRecord.frames ?? 0} frames`
+      + `${allowedRecord.error ? `, ${allowedRecord.error.slice(0, 70)}` : ''}`);
+
     let probed = '';
     try {
       probed = execFileSync('ffprobe', ['-v', 'error', '-show_entries', 'stream=width,height,nb_frames',

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -287,11 +287,11 @@ const MUTATIONS = {
   // byte-for-byte rows, the requires row, and the second-trip row.
   'save-forgets-the-parked-pool': { file: 'web/main.js', edits: [
     [
-      '      params: { ...lookParams, ...parkedLook.params },',
+      '      params: { ...lookParams, ...parked.params },',
       '      params: { ...lookParams },',
     ],
     [
-      '        ...parkedLook.tracks,\n      },',
+      '        ...parked.tracks,\n      },',
       '      },',
     ],
   ] },
@@ -308,7 +308,7 @@ const MUTATIONS = {
   // the values really do come back - which is the split that says this control and
   // `save-forgets-the-parked-pool` are asking different questions.
   'save-forgets-the-parked-requires': { file: 'web/main.js', edits: [[
-    '  const requires = [...requiresFor(kept), ...parkedLook.requires];',
+    '  const requires = [...requiresFor(kept), ...parked.requires];',
     '  const requires = [...requiresFor(kept)];',
   ]] },
   // **The capture format's band comes off.** A take whose hello declares a generation

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -275,6 +275,42 @@ const MUTATIONS = {
     '  if (project.version !== PROJECT_VERSION) {',
     '  if (false) {',
   ]] },
+  // **The parked pool never reaching the file again.** The clip still opens, the badge
+  // still says what is missing, the installed half still renders and still round-trips -
+  // and the save quietly drops the one part of the document this machine had no business
+  // touching. That is the destructive shape parking exists to prevent, and it is silent
+  // by construction: nothing on screen changes and the loss only shows up on the machine
+  // that had the effect.
+  //
+  // Aimed at the merge rather than at the pool, so the load half stays exactly as it is
+  // and the rows about parking-on-load stay green. What must redden is the file: the two
+  // byte-for-byte rows, the requires row, and the second-trip row.
+  'save-forgets-the-parked-pool': { file: 'web/main.js', edits: [
+    [
+      '      params: { ...lookParams, ...parkedLook.params },',
+      '      params: { ...lookParams },',
+    ],
+    [
+      '        ...parkedLook.tracks,\n      },',
+      '      },',
+    ],
+  ] },
+  // The other half of the same merge, and it has its own control because the row about
+  // the `requires` entry stays green under the one above: that mutation keeps the entry
+  // and drops the values, this one keeps the values and drops the entry. Both write a
+  // file the loader refuses on its next read, for opposite reasons - which is the
+  // both-directions rule in `refuseRequires` being the thing that catches each of them.
+  //
+  // **Three rows, and the third is the fixture rather than the claim.** The entry row and
+  // the reopen row carry it; the second-trip row goes with them because that reload is
+  // what it reads, and a mutation that stops the file reopening takes every row standing
+  // on the reopened document with it. The two byte-comparison rows stay green, because
+  // the values really do come back - which is the split that says this control and
+  // `save-forgets-the-parked-pool` are asking different questions.
+  'save-forgets-the-parked-requires': { file: 'web/main.js', edits: [[
+    '  const requires = [...requiresFor(kept), ...parkedLook.requires];',
+    '  const requires = [...requiresFor(kept)];',
+  ]] },
   // **The capture format's band comes off.** A take whose hello declares a generation
   // this build has never read is opened on this build's assumptions instead of being
   // refused - which is the whole of the failure the format number exists to prevent,
@@ -5442,7 +5478,21 @@ async function runChecks() {
     // are genuinely about a take run on a page that has one.
     {
       const { page: takePage, errors: takeErrors } = await openPage(browser, editorPage(macUrl, 'local-clip'), { width: 640, height: 400 });
-      await takePage.waitForFunction('globalThis.__kinect?.timeline?.transport() !== null', null, { timeout: 40000 });
+      // **`!== null` here was vacuously true and the wait returned before the page had
+      // booted.** `globalThis.__kinect?.timeline?.transport()` answers `undefined` while
+      // the module is still evaluating, and `undefined !== null` is true - so the guard
+      // resolved on its first tick and the unguarded read on the next line threw
+      // `Cannot read properties of undefined (reading 'timeline')`, which ends the run
+      // with the section's own rows unasked. It was harmless for as long as `load` meant
+      // the page was up; `docs/instruments.md` records the commit that stopped being
+      // true, when the effect packages moved onto the wire and `__kinect` began
+      // publishing after the event `goto` waits for. Measured here at 234 of the run's
+      // assertions, on a machine that had just finished two other proof tools.
+      //
+      // `Boolean(...)` is the whole fix and it keeps the timeout reachable, which is what
+      // separates a page that is slow from a page that never boots. Three waits in this
+      // file were written the same way and all three moved together.
+      await takePage.waitForFunction('Boolean(globalThis.__kinect?.timeline?.transport())', null, { timeout: 40000 });
       await takePage.evaluate('globalThis.__kinect.timeline.settled()');
       check(await takePage.evaluate('globalThis.__kinect.library.takeHash()')
         === (await getJson(`${macUrl}/library/takes`)).takes.find((t) => t.id === 'local-clip').hash,
@@ -5559,6 +5609,136 @@ async function runChecks() {
     check(JSON.parse(readFileSync(join(WORK, 'projects/own-footage.json'), 'utf8')).take?.hash?.startsWith('sha256:'),
       'and a project saved from the editor names its footage by content hash rather than by path');
 
+    // ---- a document naming an effect this build has not got
+    //
+    // **The round trip that has to be lossless is the one this build cannot read.** A
+    // machine without an effect still has to be able to open a clip, work on the part it
+    // does have, and save - and if the parts it cannot read do not come back out of that
+    // save exactly as they went in, opening a colleague's clip is a destructive act, and
+    // it destroys precisely the work nobody on this machine can redo.
+    //
+    // Staged rather than uninstalled, because there is no uninstall here: `sparkle` is a
+    // valid effect id and no package ships under it. The row asserting that comes first,
+    // since an arm whose missing effect turned out to be installed would pass every row
+    // below by never parking anything.
+    const installedIds = await page.evaluate(`(() => [...new Set(globalThis.__kinect.params.names('look')
+      .filter((n) => n.includes('.')).map((n) => n.slice(0, n.indexOf('.'))))])()`);
+    check(!installedIds.includes('sparkle'),
+      'sparkle is not an effect this build has, which is what makes the rows below about a missing one',
+      `${installedIds.length} installed: ${installedIds.join(', ')}`);
+
+    // Four values and two keyed tracks, one of the tracks carrying ease handles, because
+    // a handle is the part of a key this build cannot check and therefore the part most
+    // likely to be quietly rewritten by something that thought it understood it.
+    const PARKED_VALUES = {
+      'sparkle.amount': 0.6,
+      'sparkle.size': 3.25,
+      'sparkle.hue': 210,
+      'sparkle.jitter': 0.125,
+    };
+    const PARKED_TRACKS = {
+      'sparkle.amount': [
+        { t: 0, value: 0, easeOut: [[0.42, 0]], easeIn: [[0.58, 1]] },
+        { t: 2, value: 0.9, easeOut: [[0.42, 0]], easeIn: [[0.58, 1]] },
+      ],
+      'sparkle.hue': [{ t: 0.5, value: 10, easeOut: [[0.1, 0.2]], easeIn: [[0.3, 0.4]] }],
+    };
+    const parkedFixture = { values: PARKED_VALUES, tracks: PARKED_TRACKS, id: 'sparkle', version: '1.0.0' };
+    // **Each step's outcome is reported separately, because they fail for different
+    // reasons and a shared flag makes one row answer for another.** The first version of
+    // this returned one `error` for the whole block, so a build that loaded the document
+    // perfectly and then saved a file its own next load refuses reddened the row saying
+    // the document *loads* - a row whose sentence stayed true while it went red, which is
+    // the shape `docs/instruments.md` names as a defect in the row rather than a finding.
+    // The reload is where that damage shows, so the reload gets a row.
+    const parked = await page.evaluate(`(async (f) => {
+      const k = globalThis.__kinect;
+      const clean = k.library.serialiseProject();
+      const doc = JSON.parse(JSON.stringify(clean));
+      Object.assign(doc.look.params, f.values);
+      Object.assign(doc.look.tracks, f.tracks);
+      doc.requires = [...(doc.requires ?? []), { id: f.id, version: f.version }];
+      const out = { clean };
+      try {
+        k.library.restoreProject(doc);
+        out.loaded = true;
+        out.missing = k.library.missingEffects();
+      } catch (e) { out.loaded = false; out.loadError = String(e.message ?? e); return out; }
+      const body = k.library.serialiseProject();
+      out.put = (await fetch('/projects/parked-round-trip', {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+      })).status;
+      // And straight back in, so what the rows below compare is a document that has been
+      // through the loader twice rather than one the serialiser happened to hand back.
+      const again = await (await fetch('/projects/parked-round-trip')).json();
+      try {
+        k.library.restoreProject(again.body);
+        out.reloaded = true;
+        out.second = k.library.serialiseProjectBody();
+      } catch (e) { out.reloaded = false; out.reloadError = String(e.message ?? e); }
+      return out;
+    })(${JSON.stringify(parkedFixture)})`);
+
+    check(parked.loaded === true,
+      'a document with values and tracks under an effect this build has not got loads rather than being refused',
+      parked.loadError ?? `PUT ${parked.put}`);
+    check(JSON.stringify(parked.missing) === JSON.stringify([{
+      id: 'sparkle', version: '1.0.0', values: 4, tracks: 2, suppressed: false,
+    }]),
+    'and what it could not read is parked rather than dropped - four values, two tracks, at the version the document asked for',
+    JSON.stringify(parked.missing ?? null));
+    // **The file it saves has to open again, and on a build that sheds the pool it does
+    // not.** `requires` is derived from the values, so a save that keeps the entry and
+    // drops the values writes a document the loader's own both-directions rule refuses -
+    // which means the damage is not only a silent loss on the machine without the effect,
+    // it is a file nothing anywhere can open afterwards. That is a different claim from
+    // the byte comparison below and it is the one that fires first.
+    check(parked.reloaded === true,
+      'and the file it saves is a document this build can open again',
+      parked.reloadError ?? 'reopened');
+
+    // **The claim, read off the file on disk.** Compared as text in the document's own
+    // key order rather than field by field, because "byte-preserving" is what was
+    // promised: a comparison that rebuilt each value would pass a build that had
+    // renormalised them, which is exactly the damage a machine without the effect is not
+    // entitled to do.
+    const parkedFile = JSON.parse(readFileSync(join(WORK, 'projects/parked-round-trip.json'), 'utf8'));
+    const pick = (from, keys) => JSON.stringify(Object.fromEntries(keys.map((k) => [k, from?.[k]])));
+    const valueKeys = Object.keys(PARKED_VALUES);
+    const trackKeys = Object.keys(PARKED_TRACKS);
+    check(pick(parkedFile.look?.params, valueKeys) === pick(PARKED_VALUES, valueKeys),
+      'the parked values come back out of the saved file byte for byte',
+      pick(parkedFile.look?.params, valueKeys));
+    check(pick(parkedFile.look?.tracks, trackKeys) === pick(PARKED_TRACKS, trackKeys),
+      'and so do the parked tracks, ease handles and all',
+      pick(parkedFile.look?.tracks, trackKeys).slice(0, 120));
+    // The `requires` entry survives with them, because the values are still in the
+    // document - a file that kept the values and dropped the claim would be refused by
+    // its own next load, which is the loader's own rule read from the other side.
+    check(JSON.stringify((parkedFile.requires ?? []).find((e) => e.id === 'sparkle')) === '{"id":"sparkle","version":"1.0.0"}',
+      'and the requires entry stays with them, at the version the document was authored against',
+      JSON.stringify(parkedFile.requires ?? null));
+    // Twice through the loader, so the property is stability rather than one lucky pass.
+    check(pick(parked.second?.look?.params, valueKeys) === pick(PARKED_VALUES, valueKeys)
+      && pick(parked.second?.look?.tracks, trackKeys) === pick(PARKED_TRACKS, trackKeys),
+    'and a second trip through the loader moves them no further than the first did',
+    pick(parked.second?.look?.params, valueKeys));
+
+    // **And the page goes back to a document with nothing parked in it, asserted rather
+    // than assumed.** Every row below this one serialises whatever the page is holding,
+    // and a pool left behind puts a `requires` entry into each of those documents - so
+    // under a build that sheds the pool on save, the refusals block's own positive
+    // control reddens for a reason that has nothing to do with it. That is this file's
+    // own noise reaching a later sweep, and the rule is to move the noise: section 14 of
+    // `editor-check` asserts its cleanup landed for exactly this reason, and so does this.
+    const cleaned = await page.evaluate(`(async (clean) => {
+      globalThis.__kinect.library.restoreProject(clean);
+      return globalThis.__kinect.library.missingEffects();
+    })(${JSON.stringify(parked.clean ?? null)})`);
+    check(Array.isArray(cleaned) && cleaned.length === 0,
+      'and putting the clip back leaves nothing parked, so the rows below serialise a document with no missing effect in it',
+      JSON.stringify(cleaned));
+
     // ---- the three refusals, built as source rather than through JSON, because
     // JSON.stringify turns NaN and undefined into null and a case labelled NaN
     // would silently be testing null a second time.
@@ -5629,6 +5809,14 @@ async function runChecks() {
       ['a reading that is not a number', 'p.look.params.readBlackwall = "1";'],
       ['a retime rate of zero or less', 'p.composition.retime.rate = 0;'],
       ['a preset stamp that is not a name and a rev', 'p.appliedPreset = { name: 42 };'],
+      // The record a deliverable's embedded document carries, which arrives here whenever
+      // somebody opens a render's own `.job.json` body. It is a list of `{ id, version }`
+      // naming the effects that render went without, and a malformed one is a document
+      // this build cannot place for the same reason a malformed `requires` is - the two
+      // are the same kind of claim about the same namespace.
+      ['a suppressed list that is not a list', 'p.suppressed = "sparkle";'],
+      ['a suppressed entry with no version', 'p.suppressed = [{ id: "sparkle" }];'],
+      ['a suppressed entry whose id could not be an effect id', 'p.suppressed = [{ id: "Sparkle!", version: "1.0.0" }];'],
     ];
     const results = [];
     for (const [label, source] of cases) results.push(await refuse(label, source));
@@ -5640,6 +5828,27 @@ async function runChecks() {
     const good = await refuse('an unmodified project', '');
     check(good.message === 'ACCEPTED', 'and an unmodified project still loads',
       good.message === 'ACCEPTED' ? '' : good.message.slice(0, 80));
+
+    // **The other half of the `suppressed` rule, and it is the half with no throw in it.**
+    // A well-formed record has to load - it is what a deliverable's own document looks
+    // like - and it has to change nothing, because it is a statement about a render that
+    // already happened rather than a decision this editor inherits. A build that adopted
+    // it would answer the export refusal with a file somebody else wrote, so the row reads
+    // the suppression back off the page rather than only checking that nothing threw.
+    const adopted = await page.evaluate(`(() => {
+      const k = globalThis.__kinect;
+      const p = k.library.serialiseProject();
+      p.suppressed = [{ id: 'sparkle', version: '1.0.0' }];
+      try { k.library.restoreProject(p); } catch (e) { return { threw: String(e.message ?? e) }; }
+      return {
+        threw: null,
+        suppressed: k.library.missingEffects().filter((m) => m.suppressed).length,
+        body: Object.hasOwn(k.library.serialiseProjectBody(), 'suppressed'),
+      };
+    })()`);
+    check(adopted.threw === null && adopted.suppressed === 0 && adopted.body === false,
+      'a well-formed suppressed record loads and is not adopted - it says what a render went without, not what this editor may skip',
+      adopted.threw ?? `${adopted.suppressed} suppressed on the page, key written back: ${adopted.body}`);
 
     // Straight at the registry, because the load path is one of four doors into it
     // and the other three were gated the same wrong way. `spec`, `get`, `normalise`
@@ -5688,7 +5897,7 @@ async function runChecks() {
   console.log('\n[library] presets carry look and a provenance stamp');
   {
     const { page, errors } = await openPage(browser, editorPage(macUrl, 'local-clip'), { width: 640, height: 400 });
-    await page.waitForFunction('globalThis.__kinect?.timeline?.transport() !== null', null, { timeout: 40000 });
+    await page.waitForFunction('Boolean(globalThis.__kinect?.timeline?.transport())', null, { timeout: 40000 });
     await page.evaluate('globalThis.__kinect.timeline.settled()');
 
     // A preset saved off a Blackwall clip whose values have then been moved away from
@@ -6053,7 +6262,7 @@ async function runChecks() {
   console.log('\n[library] marks on the editor\'s scrubber, through the retime curve');
   {
     const { page, errors } = await openPage(browser, editorPage(macUrl, 'local-clip'), { width: 1100, height: 700 });
-    await page.waitForFunction('globalThis.__kinect?.timeline?.transport() !== null', null, { timeout: 40000 });
+    await page.waitForFunction('Boolean(globalThis.__kinect?.timeline?.transport())', null, { timeout: 40000 });
     await page.evaluate('globalThis.__kinect.timeline.settled()');
 
     // **`timeline.settled()` settles the transport, and the marks are not on it.**

--- a/tools/render-worker.mjs
+++ b/tools/render-worker.mjs
@@ -122,6 +122,47 @@ try {
   const renderer = await page.evaluate(() => globalThis.__kinect.export.rendererClass());
 
   /**
+   * The effect packages this worker's server holds, read once at start.
+   *
+   * Read off `/effects` rather than off the page, because that route is what the
+   * registry itself assembles from - so this asks the same source the browser would,
+   * one step earlier and without a document open.
+   */
+  const installed = new Set(
+    ((await (await fetch(`${URL_}/effects`)).json()).effects ?? []).map((e) => e.id),
+  );
+
+  /**
+   * Whether this worker can render a job at all, answered off the job envelope before
+   * a page is opened.
+   *
+   * **This is a second gate over the same condition the page refuses on, and saying so
+   * is the honest description.** `exportClip` refuses a clip whose look it cannot draw
+   * whole, and it is the gate that cannot be got round - it sees what was actually
+   * parked after the document was restored, so a job reaching it is refused there
+   * whatever this function did. What this one buys is not a second opinion on the
+   * outcome. It is the *sentence* and the *cost*: a job refused here comes back naming
+   * the effects and versions the envelope declares, before a take is resolved, a page
+   * is loaded and a minute of GPU is spent producing the identical refusal from the
+   * other end. A queue that only finds out inside the render is a queue that cannot
+   * report why a machine is the wrong machine.
+   *
+   * The two are separable by a run rather than by argument, which is what stops this
+   * being the two-gates-that-agree shape: `jobs-check` asserts *which* refusal a job
+   * came back with, so a build with this door waved open fails with the page's sentence
+   * and a build with it fails with this one.
+   *
+   * **An absent `requires` is nothing required.** A job queued before the envelope
+   * carried the field is a job whose look names no effect this build has to have - and
+   * where that is wrong, the page's own refusal is what catches it, which is the reason
+   * an additive field can mean "absent is allowed" here at all.
+   */
+  const cannotResolve = (job) => {
+    const allowed = new Set(job.suppressEffects ?? []);
+    return (job.requires ?? []).filter((e) => !installed.has(e.id) && !allowed.has(e.id));
+  };
+
+  /**
    * A job names its capture by content hash, and the page opens a take by id, so
    * this is where one becomes the other.
    *
@@ -178,6 +219,20 @@ try {
     // lines is how one of them ends up being the one that forgets to null it.
     const stopBeating = () => { if (beat) { clearInterval(beat); beat = null; } };
     try {
+      // Asked first, because everything below it costs: a take resolution, a page load,
+      // a settle and a render. A job this machine cannot draw whole is refused here with
+      // the ids and versions its envelope names.
+      const unresolved = cannotResolve(job);
+      if (unresolved.length) {
+        throw new Error(
+          `this worker has no ${unresolved.map((e) => `${e.id} ${e.version}`).join(', ')}, which `
+          + `${unresolved.length === 1 ? 'is' : 'are'} required by this job's look: the values under `
+          + `${unresolved.length === 1 ? 'it' : 'them'} would be parked and nothing would draw them, `
+          + 'so the render would be a file missing part of the look with nothing in it to say so. '
+          + 'Install the package on this worker, or queue the job with suppressEffects naming '
+          + `${unresolved.length === 1 ? 'it' : 'each of them'}.`,
+        );
+      }
       // Reopened per job rather than once, because two jobs in a queue are two
       // edits and nothing says they are against the same footage. The page reloads
       // at `/edit` with the take in the query, which is the same door the editor uses.
@@ -338,6 +393,12 @@ try {
           codec: j.codec,
           in: j.deliverable?.in,
           out: j.deliverable?.out,
+          // The job's own list, handed to the same parameter the export button hands
+          // the badge's. Without it a suppressed job reaches the page and is refused
+          // there - the door above having let it through on the operator's say-so, and
+          // the render still not happening, which is a suppression that suppresses
+          // nothing.
+          suppressEffects: j.suppressEffects ?? [],
         });
       }, job);
       if (errors.length) throw new Error(`the page errored during the render: ${errors[0]}`);

--- a/web/effect-manifests.js
+++ b/web/effect-manifests.js
@@ -14,16 +14,106 @@
 // exactly what must not matter.
 
 /**
- * The flat table the registry assembles from, one entry per name in the order
- * given. The order is a full list of dotted names rather than of effect ids,
- * because the registry's declaration order interleaves below effect granularity -
- * `noise.region` sits in the region run beside the push and the mask it works
- * with, three entries away from its own master - and that placement is the
- * client's layout fact: the scramble coupling and the panel's row order both fall
- * out of it, and nothing in a package can know where the whole build wants each
- * parameter. Validated both ways: a name the order lists that no package
- * declares, and a package parameter the order never places, are refusals rather
- * than guesses, so the list and the shipped set are held equal at boot.
+ * The generation of the package format this build reads. A manifest declaring a
+ * higher number is refused at the install door rather than adapted, on the same
+ * argument `format.js` makes about a capture: a package written against a later
+ * build may mean something different by a field this one thinks it understands,
+ * and reading it anyway is how a look renders as something nobody authored. A
+ * manifest declaring nothing is refused too, because unlike a capture there is no
+ * archive of packages shot before the field existed - every package that has ever
+ * existed carries it.
+ */
+export const MANIFEST_FORMAT = 1;
+
+/**
+ * The closed vocabularies a manifest is written in, stated once because both ends
+ * consume them.
+ *
+ * The install door refuses a manifest outside these sets, and the client's applier
+ * implements exactly them - and those have to be one statement rather than two
+ * agreeing lists, because the failure a second list produces is precisely the one the
+ * door exists to prevent. A transform the door allowed and the applier did not know
+ * would install cleanly and throw on its first write; a kind the door allowed and
+ * `normalise` did not know would take the scalar branch and turn a boolean into NaN.
+ * So `effectApply` in `web/main.js` reads `EFFECT_BIND_TRANSFORMS` rather than
+ * spelling its two names again, and the door reads the same binding.
+ *
+ * `kind` is two entries and not three: `pose` is the camera's, it is core rather than
+ * an effect's, and there is no uniform a pose could be bound to. `on` names which of
+ * the two uniform tables a write lands on - the point cloud's or the grade pass's -
+ * which is the only choice a binding has about where it goes.
+ *
+ * Frozen, because they cross a module boundary and a closed set that anybody could push
+ * onto is not a closed set - the door would go on reporting the vocabulary it was given
+ * while accepting whatever had been added to it.
+ */
+export const EFFECT_PARAM_KINDS = Object.freeze(['scalar', 'step']);
+export const EFFECT_BIND_TABLES = Object.freeze(['points', 'grade']);
+export const EFFECT_BIND_TRANSFORMS = Object.freeze(['axisDeg', 'degToRad']);
+
+/**
+ * Every declared parameter name, in the order the registry declares them: the ones
+ * the client's order places, in that order, and then everything else.
+ *
+ * **The placed set is byte-stable and the appendix is where a package the order has
+ * never heard of goes.** The order is a hand-written layout fact about the sixteen
+ * shipped effects - the scramble coupling coupled to it, the panel builds a group's
+ * rows in it - so it may not be regenerated, reordered or grown by a package
+ * arriving at runtime. But a seventeenth effect has to land somewhere, and until
+ * this rule existed it landed in a refusal: `tableFromPackages` treated a declared
+ * name the order did not place as a parameter the registry would silently skip, which
+ * is the right answer for a manifest edit and the wrong one for an install.
+ *
+ * So the appendix, and the rule is written out here because "deterministic" has to
+ * mean one arrangement rather than whatever `Object.keys` happened to yield. Packages
+ * are taken by id in lexical order, each package's unplaced parameters keep their
+ * manifest declaration order, and the whole appendix follows the last placed name.
+ * Contiguous per package, because a package's own parameters are the one grouping a
+ * manifest can be sure of - its master and the keys under it read as a unit on the
+ * panel, and interleaving two packages the order does not know would be this file
+ * inventing a layout decision it has just finished saying it cannot make.
+ *
+ * **A fork that adds a parameter appends it rather than seating it beside its
+ * siblings**, and that is a consequence worth stating rather than discovering. Fork
+ * `rain` with a fifth key and the four the order places stay exactly where they are;
+ * the fifth goes to the appendix, so it is last in the rain group rather than next to
+ * `trail`. Seating it would mean guessing which of the placed names it belongs after,
+ * and a guess about layout is the thing the order exists to make somebody state.
+ *
+ * With the shipped sixteen installed the appendix is empty and this returns the
+ * order unchanged, which is what keeps every number downstream of it - the registry's
+ * declaration order, the panel's rows, the scramble table - the bytes they were.
+ */
+export const placeParams = (packages, order) => {
+  const placed = new Set(order);
+  const appendix = [];
+  for (const p of [...packages].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))) {
+    for (const short of Object.keys(p.manifest.params)) {
+      const name = `${p.id}.${short}`;
+      if (!placed.has(name)) appendix.push(name);
+    }
+  }
+  return [...order, ...appendix];
+};
+
+/**
+ * The flat table the registry assembles from, one entry per declared parameter, in
+ * the order `placeParams` decides. The order handed in is a full list of dotted names
+ * rather than of effect ids, because the registry's declaration order interleaves
+ * below effect granularity - `noise.region` sits in the region run beside the push
+ * and the mask it works with, three entries away from its own master - and that
+ * placement is the client's layout fact: the scramble coupling and the panel's row
+ * order both fall out of it, and nothing in a package can know where the whole build
+ * wants each parameter.
+ *
+ * **One direction is still a refusal and the other became a placement**, and the two
+ * used to be symmetric. A name the order lists that no installed package declares is
+ * a registry that cannot assemble the entry, so it throws as it always did; the
+ * install door is what keeps that unreachable, by refusing a fork that drops a
+ * parameter the package it shadows declares. A declared name the order does not place
+ * used to throw on the same reasoning and cannot any more, because that is exactly
+ * what installing an effect nobody had written a layout for looks like - see
+ * `placeParams` for where it goes instead.
  */
 export const tableFromPackages = (packages, order) => {
   const declared = new Map();
@@ -37,13 +127,8 @@ export const tableFromPackages = (packages, order) => {
     throw new Error(`the effect order names ${missing.join(', ')} and no installed package declares `
       + `${missing.length === 1 ? 'it' : 'them'} - the registry cannot assemble entries it has no parameters for`);
   }
-  const unplaced = [...declared.keys()].filter((name) => !order.includes(name));
-  if (unplaced.length) {
-    throw new Error(`${unplaced.join(', ')} is installed and the effect order does not place `
-      + `${unplaced.length === 1 ? 'it' : 'them'} - a parameter the registry silently skipped would be a control that exists nowhere`);
-  }
   const table = {};
-  for (const name of order) {
+  for (const name of placeParams(packages, order)) {
     const p = declared.get(name);
     const entry = {
       def: p.def, min: p.min, max: p.max, step: p.step, kind: p.kind, label: p.label,

--- a/web/index.html
+++ b/web/index.html
@@ -764,6 +764,12 @@
   #tNote:empty { display: none; }
   #tResume { border: none; background: none; padding: 0; }
   #tResumeOpen { padding: 5px 10px; }
+  /* One missing effect, one entry: its sentence and the control that lets a render go
+     without it, kept together so two of them cannot read as one. `inline-flex` rather
+     than `block` for the same reason the chip around it is one - the button has to sit
+     on the text's baseline, and the chip stays a single row of the application bar
+     whatever it holds. `paintMissingEffects` carries why it does not stack. */
+  .missingfx { display: inline-flex; align-items: center; gap: 7px; }
   /* `hidden` on a chip, which needs saying because `.tchip` already sets a display and
      an author rule beats the `[hidden] { display: none }` in the browser's own sheet.
      Without this a chip marked hidden stays on screen with nothing in it, which is the
@@ -1165,11 +1171,20 @@
          `openTake` is the only caller that can decide it, because deciding needs the
          take's hash.
 
+         `#tMissing` is the effects this document names that this build has not got. It
+         is the fourth thing in the slot and it belongs here for the reason `#tResume`
+         does: it is a statement about the session, and it is the only place the person
+         at the screen is told that part of the clip is being carried rather than drawn.
+         Empty it hides itself the way the note does, so an ordinary document leaves the
+         bar exactly as bare as it was; `paintMissingEffects` fills it, one line per
+         missing effect, each with the toggle that lets an export go without that one.
+
          `#appStatus` is the sensor and the rate coming in. `paintStatus` has been writing
          it since the bar arrived and there was nothing here to write to. -->
     <div class="appstatus" id="appStatusSlot">
       <span class="tchip" id="tNote"></span>
       <span class="tchip" id="tResume" hidden><b id="tResumeWhen"></b><button id="tResumeOpen" type="button">restore autosave</button></span>
+      <span class="tchip warn" id="tMissing" hidden></span>
       <span id="appStatus"></span>
     </div>
   </header>

--- a/web/main.js
+++ b/web/main.js
@@ -3241,6 +3241,53 @@ function toggleKey(name) {
 
 // ------------------------------------------------------------------- the project
 
+/**
+ * The values and tracks of effects this build does not have, held exactly as the
+ * document wrote them.
+ *
+ * **A document naming an effect that is not installed is not a broken document, and
+ * this pool is what says so.** The three answers a look name can get are decided by
+ * one line - `isParkedName` - and only the third comes here: a bare name the registry
+ * does not know is a typo and is refused, a dotted name whose effect *is* installed
+ * but whose key is not is refused too, because a package cannot half-exist, and a
+ * dotted name whose effect is simply absent is parked. The viewer then loads, the
+ * installed part renders, and what belongs to the missing effect is never evaluated
+ * and never destroyed.
+ *
+ * **Never evaluated is why nothing here is validated.** A key's shape is checked
+ * against the parameter's own spec - kind, bounds, step - and there is no spec for a
+ * parameter this build has never declared. So a parked value is carried rather than
+ * inspected, which is the only honest thing to do with a number whose meaning lives
+ * in a package that is not here; `serialiseProjectBody` writes it back byte for byte
+ * and a build that has the effect is the first reader that can say anything about it.
+ *
+ * `requires` holds the document's own entries for the missing effects rather than
+ * ids, because an entry carries the version - and the badge quotes it, so the person
+ * reading it learns which build of the effect the clip was authored against rather
+ * than only that something is absent. An entry may also carry a `rev`, which is why
+ * the entry is kept whole instead of being rebuilt from an id.
+ *
+ * Replaced whole by `restoreProject` and by nothing else, so the pool is always the
+ * open document's rather than an accumulation across the documents a session opened.
+ */
+let parkedLook = { params: {}, tracks: {}, requires: [] };
+
+/**
+ * The effects the operator has said to render without, which is session state and
+ * deliberately not in the document.
+ *
+ * An export whose project requires an effect this build lacks is refused, and this is
+ * the answer to that refusal: a decision about *this render on this machine*, which is
+ * the same kind of thing the deliverable is and not the same kind of thing the clip is.
+ * A suppression written into the project would travel to the machine that has the
+ * effect and quietly render there without it, which is the failure the refusal exists
+ * to prevent arriving through the document.
+ *
+ * Pruned rather than cleared when a document loads, because every undo goes through
+ * `restoreProject` and clearing would spend the operator's decision on each one.
+ */
+let suppressedEffects = new Set();
+
 // Everything an edit *is*, as one plain object. A project file, an undo snapshot
 // and step 6's export job all start here, which is why this is one function rather
 // than a serialiser per consumer that would each learn about a new track kind
@@ -3260,7 +3307,17 @@ function toggleKey(name) {
 // ordinary look parameters now, so `params.values(params.names('look'))` carries them
 // and there is no second list to forget.
 
-function serialiseProjectBody() {
+/**
+ * `suppressed` is the one option, and it is for the export path alone: a deliverable
+ * rendered without an effect this build lacks records which ones it went without, so
+ * the file's own record says what it is a render *of* rather than leaving somebody to
+ * compare its look against a document that claims more than the render contains.
+ *
+ * It is not a project field. `history.snapshot` and every save call this with nothing,
+ * so no document on disk ever grows the key, and a suppression stays what it is - a
+ * decision about one render on one machine.
+ */
+function serialiseProjectBody({ suppressed = null } = {}) {
   const lookNames = params.names('look');
   const lookParams = params.values(lookNames);
   // The save rule, the same one `presetFromCurrentLook` applies and for the same
@@ -3278,20 +3335,40 @@ function serialiseProjectBody() {
     for (const n of mine) delete lookParams[n];
   }
   const kept = Object.keys(lookParams);
-  const requires = requiresFor(kept);
+  // **The parked effects' entries, whole, and appended rather than interleaved.** The
+  // list is one entry per effect and `refuseRequires` reads it as a set, so position
+  // carries nothing - what has to survive is the version, and the `rev` where a
+  // document pins one, which is why the document's own entry is carried instead of an
+  // id being handed back to `requiresFor`. A parked effect keeps its entry because its
+  // values are still in the document: the list stays derived from what the look names,
+  // which is the property both directions of `refuseRequires` rest on.
+  const requires = [...requiresFor(kept), ...parkedLook.requires];
   return {
     version: PROJECT_VERSION,
     ...(requires.length ? { requires } : {}),
+    ...(suppressed ? { suppressed } : {}),
     look: {
       // Look parameters only; the registry separates look from view and from the
       // camera, so an undo snapshot or a render job does not carry render scale or
       // the free camera's orbit.
-      params: lookParams,
-      tracks: Object.fromEntries(
-        kept
-          .filter((n) => tracks.has(n))
-          .map((n) => [n, tracks.get(n).serialise()]),
-      ),
+      //
+      // **And the parked pool merged back verbatim.** A build without an effect has to
+      // be able to open a document, save it, and leave the parts it cannot read exactly
+      // as it found them - anything else makes opening a clip on the wrong machine a
+      // destructive act, and it destroys precisely the work nobody on that machine can
+      // redo. Spread after rather than before, so a parked name can never overwrite a
+      // registry value: the two sets are disjoint by construction, and if they ever
+      // stop being, the installed reading is the one that renders and so the one that
+      // must win.
+      params: { ...lookParams, ...parkedLook.params },
+      tracks: {
+        ...Object.fromEntries(
+          kept
+            .filter((n) => tracks.has(n))
+            .map((n) => [n, tracks.get(n).serialise()]),
+        ),
+        ...parkedLook.tracks,
+      },
     },
     composition: {
       // Retime is the source-to-program mapping, and the camera track is the one
@@ -3581,12 +3658,39 @@ function restoreProject(project) {
     ...Object.keys(project.look.params),
     ...Object.keys(project.look.tracks),
   ]);
+  // **Where the missing-effect split happens, and it is one predicate rather than a
+  // load-time special case.** Everything below asks `isParkedName`, which answers on
+  // the one fact that decides: the dotted prefix names an effect this build has not
+  // installed. A bare name the registry does not know is a typo and still throws at
+  // `params.spec`; a dotted name whose effect *is* here but whose key is not throws
+  // there too, because a package cannot half-exist and half a package is a build that
+  // is wrong rather than a build that is short. Only the third case parks, and it parks
+  // through this set so that uninstalling an effect later - which is the same condition
+  // arriving from the other direction - reaches the same code by being the same
+  // question.
+  const parkedNames = new Set(
+    [...Object.keys(project.look.params), ...Object.keys(project.look.tracks)].filter(isParkedName),
+  );
+  const parkedIds = [...new Set([...parkedNames].map(effectOf))];
+  // The entries the document itself wrote for those effects. `refuseRequires` above has
+  // already held the list and the values to each other in both directions, so an id that
+  // is parked has an entry here by construction and finding none would be that refusal
+  // having stopped working rather than a document to accommodate.
+  const parkedRequires = parkedIds.map((id) => (project.requires ?? []).find((e) => e.id === id));
   // And each effect it touches, whole - the readings rule one namespace over. The
   // reset below hands an omitted parameter its default, so half a glyph field would
   // load as a blend of the document and the defaults that nothing on screen says is
   // a blend. The writer saves whole effects, so the reader demands what the writer
   // meets.
-  for (const id of effectIdsIn(Object.keys(project.look.params))) {
+  //
+  // **Asked of the installed effects only, and the exclusion is a fact rather than a
+  // convenience.** `effectParamNames` filters the registry, so for an effect that is not
+  // here it answers the empty list and this loop would pass an effect vacuously - which
+  // is the shape `docs/instruments.md` calls a hole with a justification on it. Written
+  // out, the honest statement is that nothing in this build knows how many parameters a
+  // missing effect has, so there is no completeness to demand: the machine that has the
+  // package is the first reader that can ask.
+  for (const id of effectIdsIn(Object.keys(project.look.params)).filter((n) => !parkedIds.includes(n))) {
     const short = effectParamNames(id).filter((n) => !Object.hasOwn(project.look.params, n));
     if (short.length) {
       throw new Error(
@@ -3610,8 +3714,20 @@ function restoreProject(project) {
   // since this step - a quaternion that is not of unit length. Routing keys through
   // it is the whole of why a hand-edited camera track cannot reach `poseAt`.
   const restoredLook = [];
+  const parkedTracks = {};
   for (const [name, keys] of Object.entries(project.look.tracks)) {
     if (!Array.isArray(keys)) throw new Error(`look track ${name} is not an array of keys`);
+    // **A track under a missing effect is parked before it is asked anything.** The
+    // shape checks below - the kind, the bounds, the ease handles, the fold - are all
+    // asked of `params.spec(name)`, and there is no spec for a parameter this build has
+    // never declared. So the keys are carried rather than inspected: this build cannot
+    // evaluate them and cannot judge them either, and the one thing it can do without
+    // guessing is hand them back unchanged. The array is not copied, and that is the
+    // point - `serialiseProjectBody` writes exactly the object it was given.
+    if (parkedNames.has(name)) {
+      parkedTracks[name] = keys;
+      continue;
+    }
     // Names the registry does not know are refused rather than dropped. A track
     // silently discarded is an edit silently lost, and the file is more likely to
     // be from a build this one cannot read than to be harmlessly extra.
@@ -3675,7 +3791,23 @@ function restoreProject(project) {
   // and `apply` cannot, because it is itself one of the writes. A project carrying a
   // parameter this build has since removed has to be refused with nothing touched, and
   // that is earlier than the registry can see.
-  for (const name of Object.keys(project.look.params)) params.spec(name);
+  //
+  // **The parked half is split out here rather than filtered at the write**, because
+  // this loop is the refusal and the write below is the consequence: a name that skips
+  // the refusal has to skip the write too, and one partition taken once is what stops
+  // those two lists being able to disagree. `applied` is what reaches the registry;
+  // `parkedValues` is what nothing in this build will look at again until it is written
+  // back out.
+  const applied = {};
+  const parkedValues = {};
+  for (const [name, value] of Object.entries(project.look.params)) {
+    if (parkedNames.has(name)) {
+      parkedValues[name] = value;
+      continue;
+    }
+    params.spec(name);
+    applied[name] = value;
+  }
 
   const restoredCamera = project.composition.camera.map((k) => {
     const key = restoreKey('track camera', k, params.spec('camera').kind);
@@ -3706,6 +3838,28 @@ function restoreProject(project) {
   const stamp = project.appliedPreset ?? null;
   if (stamp !== null && (typeof stamp.name !== 'string' || typeof stamp.rev !== 'string')) {
     throw new Error(`appliedPreset is ${JSON.stringify(stamp)}: it is null, or a name and a rev`);
+  }
+
+  // **A deliverable's embedded document carries what its render went without, and this
+  // reader checks it and then leaves it alone.** `suppressed` is a record about a file
+  // rather than a statement about the clip: adopting it here would mean opening a render
+  // record and silently inheriting somebody else's decision to go without an effect,
+  // which is the export refusal being answered by a document instead of by a person. So
+  // the shape is refused when it is wrong - a malformed record is a document this build
+  // cannot place, exactly as a malformed `requires` is - and a well-formed one changes
+  // nothing, which is why there is no branch below reading it.
+  if (project.suppressed !== undefined) {
+    const ok = Array.isArray(project.suppressed) && project.suppressed.every((e) => e
+      && typeof e === 'object' && !Array.isArray(e)
+      && typeof e.id === 'string' && /^[a-z][a-z0-9]*$/.test(e.id)
+      && typeof e.version === 'string' && e.version.length > 0);
+    if (!ok) {
+      throw new Error(
+        `this project carries ${JSON.stringify(project.suppressed)} where its suppressed list belongs: `
+        + 'it is a list of { id, version } entries naming the effects a render was allowed to go '
+        + 'without, and it is a record of that render rather than anything this editor adopts',
+      );
+    }
   }
 
   // A saved project may carry its undo history. Undo snapshots and render jobs do
@@ -3778,8 +3932,23 @@ function restoreProject(project) {
   }
 
   params.reset(params.names('look'));
-  params.apply(project.look.params);
+  params.apply(applied);
   appliedPreset = stamp;
+  // **The pool is replaced whole, here, with the rest of the writes.** Nothing above
+  // this line has changed anything, so a document refused for any of the seventeen
+  // reasons up there leaves the editor holding the clip it already had - including
+  // whatever that clip had parked. Assigned rather than merged for the same reason
+  // `params.reset` precedes `params.apply`: what is parked is a property of the open
+  // document, and a pool that accumulated across documents would be carrying values
+  // from a clip nobody has open into the next file somebody saves.
+  parkedLook = {
+    params: parkedValues,
+    tracks: parkedTracks,
+    requires: parkedRequires,
+  };
+  // Pruned rather than cleared, because undo arrives here too - see the declaration.
+  suppressedEffects = new Set([...suppressedEffects].filter((id) => parkedIds.includes(id)));
+  paintMissingEffects();
 
   tracks.clear();
   for (const [name, keys] of restoredLook) trackFor(name).keys = keys;
@@ -6497,6 +6666,45 @@ function parseSize(text) {
 async function exportClip(options = {}) {
   if (!timeline) throw new Error('there is no clip open to export');
   if (exporting) throw new Error('an export is already running');
+  // **A clip whose look this build cannot render whole is refused before anything is
+  // encoded, and the file is the reason.** The editor can carry a missing effect: the
+  // parked values sit there, nothing evaluates them, and the person at the screen has a
+  // badge saying so. A deliverable carries none of that. It is a video, it leaves this
+  // machine, and nothing in it says a layer of the look was absent when it was made - so
+  // an export that quietly went ahead would produce exactly the artifact that cannot be
+  // told from a correct one, which is the failure this program refuses everywhere else it
+  // appears.
+  //
+  // **Suppress is the answer to it and it is per effect, deliberately.** The decision a
+  // person is actually making is "this render may go without *that*", and a global
+  // override would answer a question nobody asked - it would carry past the next missing
+  // effect, which by then might be the one that matters. So the list is intersected with
+  // what is missing rather than consulted as a flag, and an effect that is still missing
+  // and still unsuppressed refuses the export naming itself.
+  //
+  // The list arrives as an argument rather than being read off `suppressedEffects` here,
+  // because two callers each own their own answer: the export button hands over what the
+  // badge holds, and `tools/render-worker.mjs` hands over what the job carries. One rule,
+  // two callers, and neither of them is a second implementation of the rule.
+  const suppress = new Set(options.suppressEffects ?? []);
+  const missing = missingEffects();
+  const blocking = missing.filter((m) => !suppress.has(m.id));
+  if (blocking.length) {
+    throw new Error(
+      `this clip requires ${blocking.map((m) => `${m.id} ${m.version}`).join(', ')}, which `
+      + `${blocking.length === 1 ? 'is' : 'are'} not installed here: its values are parked and `
+      + 'nothing is drawing them, so a render would be a file missing part of the look with '
+      + `nothing in it to say so. Install ${blocking.length === 1 ? 'it' : 'them'}, or suppress `
+      + `${blocking.length === 1 ? 'it' : 'each of them'} in the badge to render without.`,
+    );
+  }
+  // What this render is going without, recorded in the document the deliverable embeds.
+  // Only the effects that were actually missing here: a suppression naming an effect this
+  // build has is a decision about nothing, and writing it down would make the record claim
+  // a hole the file does not have.
+  const suppressed = missing
+    .filter((m) => suppress.has(m.id))
+    .map(({ id, version }) => ({ id, version }));
   ensureActiveDeliverable();
   const d = activeDeliverable;
   // **The one place the two halves of the split are checked against each other.** The
@@ -6605,7 +6813,7 @@ async function exportClip(options = {}) {
       // worker restoring it renders the file that was asked for rather than the one the
       // project would produce today. It also means `trails`, whose length is counted in
       // output frames, decays over the same span on the replay as it did here.
-      project: serialiseProjectBody(),
+      project: serialiseProjectBody(suppressed.length ? { suppressed } : {}),
       capture: timeline.source.index.hash,
       renderer: rendererClass(),
     });
@@ -6724,6 +6932,7 @@ const ui = {
   resume: document.getElementById('tResume'),
   resumeWhen: document.getElementById('tResumeWhen'),
   resumeOpen: document.getElementById('tResumeOpen'),
+  missing: document.getElementById('tMissing'),
   recGo: document.getElementById('recGo'),
   recMark: document.getElementById('recMark'),
   recNote: document.getElementById('recNote'),
@@ -6734,6 +6943,87 @@ const ui = {
 // The rates, built from `OUTPUT_RATES` rather than written into the markup, so the list
 // the validator refuses against and the list the control offers are one object.
 for (const rate of OUTPUT_RATES) ui.fps?.appendChild(new Option(String(rate), String(rate)));
+
+/**
+ * The badge that says which effects this document names and this build has not got, and
+ * the one control beside each of them.
+ *
+ * **A person looking at the picture has no other way to know.** The clip renders, and
+ * what renders is the installed part of it - so without this the surface is a document
+ * quietly missing a layer, which is the failure the whole parking design exists to
+ * replace with a sentence. The line quotes the version out of the document's own
+ * `requires` entry rather than saying only that something is absent, because the useful
+ * next step is installing a particular build of a particular effect.
+ *
+ * **The counts come from the pool and are the point of the line**, not decoration: they
+ * are what says the values were kept. A build that dropped them on the way in would draw
+ * the identical picture and print `0 values, 0 tracks parked` here, which is the one
+ * place the difference is visible before somebody saves the file and loses the work.
+ *
+ * The toggle is `aria-pressed` with a constant label, which is `camView`'s shape and the
+ * app's ordinary voice for a switch. What it buys is stated in the `title` rather than in
+ * a second line of text: an export is refused while an effect the clip needs is missing,
+ * and pressing this is the person saying that this render may go without that one. Per
+ * effect and never global - suppressing one while another is still missing leaves the
+ * export refused, naming the other, which is the whole reason the state is a set of ids
+ * rather than a flag.
+ *
+ * Rebuilt rather than patched, because the set it draws changes only when a document is
+ * loaded or a toggle is pressed, and a painter that edited in place would be a second
+ * statement of which effects are missing.
+ *
+ * **One entry per missing effect, laid along the bar rather than stacked, and the reason
+ * is the bar's height.** Each effect gets its own `.missingfx` element carrying its own
+ * sentence and its own control, which is what "one line per effect" is for - nothing is
+ * concatenated and no version or count belongs to two effects at once. What it is not is
+ * a column: this chip lives in the application bar's status slot, which is one ellipsised
+ * row, and a chip that grew downward would take the bar's height with it. That moves
+ * every fixed overlay on the page, which `docs/instruments.md` records costing four proof
+ * tools a round each when the letterbox did it. Two missing effects at once is the rare
+ * case and it ellipsises; the badge's job is to say that something is parked, and the
+ * hook beside it is what anything needing the whole list should read.
+ */
+function paintMissingEffects() {
+  if (!ui.missing) return;
+  const missing = missingEffects();
+  ui.missing.hidden = missing.length === 0;
+  ui.missing.replaceChildren(...missing.map((m) => {
+    const entry = document.createElement('span');
+    entry.className = 'missingfx';
+    entry.dataset.effect = m.id;
+    const line = document.createElement('b');
+    const values = `${m.values} value${m.values === 1 ? '' : 's'}`;
+    const parked = `${m.tracks} track${m.tracks === 1 ? '' : 's'} parked`;
+    line.textContent = `missing: ${m.id} ${m.version} — ${values}, ${parked}`;
+    const go = document.createElement('button');
+    go.type = 'button';
+    go.dataset.suppress = m.id;
+    go.textContent = 'suppress';
+    go.setAttribute('aria-pressed', String(m.suppressed));
+    go.title = m.suppressed
+      ? `Exports may render without ${m.id}. Press again to require it.`
+      : `Export is refused while ${m.id} is missing. Press to let a render go without it.`;
+    entry.append(line, go);
+    return entry;
+  }));
+}
+
+// One listener on the chip rather than one per button, because the buttons are rebuilt
+// by the painter above every time this fires - a handler bound to the element would be
+// binding to the element it is about to replace.
+ui.missing?.addEventListener('click', (event) => {
+  const id = event.target?.dataset?.suppress;
+  if (!id) return;
+  if (suppressedEffects.has(id)) suppressedEffects.delete(id);
+  else suppressedEffects.add(id);
+  paintMissingEffects();
+  // Said on the note beside it, because the consequence of this press is at the export
+  // and the export is a menu away: a switch whose effect is only visible when you next
+  // press something else is a switch nobody trusts.
+  say(suppressedEffects.has(id)
+    ? `${id} suppressed: an export will render without it`
+    : `${id} required again: an export is refused while it is missing`);
+});
 
 aspectButtons = buildAspectSegments(ui.projectAspects);
 
@@ -9274,6 +9564,17 @@ let appliedPreset = null;
  * door to pick between: one subset in, one subset out.
  */
 function presetFromCurrentLook(names) {
+  // **The parked pool is not in here, and it is absent by construction rather than by a
+  // filter.** `params.values` walks registry names, and a parked value never reached the
+  // registry - so there is nothing to exclude and no list that could fall out of step.
+  // The reason it must stay absent is worth stating anyway, because the merge two hundred
+  // lines up does the opposite for a project. A project is *this clip*, and a clip that
+  // opened on a machine without an effect is still a clip that uses it, so carrying the
+  // values back out is what keeps the file whole. A preset is *a look somebody chose to
+  // reuse*, authored out of what is on screen - and what is on screen has none of this in
+  // it. Writing them into a preset would ship a document whose `requires` names an effect
+  // nobody here can render, applied to clips nobody can check it against, out of values
+  // this build never bound-checked because it has no spec to check them with.
   const values = params.values(names ?? params.names('look'));
   // The save rule: a whole look sheds every effect it holds at defaults. Lossless by
   // construction rather than by argument - an effect's master defaults inert, and the
@@ -9326,6 +9627,50 @@ const effectIdsIn = (names) => [...new Set(names.map(effectOf).filter(Boolean))]
 
 /** The ids of every effect the registry currently declares. */
 const effectIds = () => effectIdsIn(params.names('look'));
+
+/**
+ * Whether an effect id names a package this build actually has.
+ *
+ * Read off the registry rather than off the `/effects` listing the page fetched, and
+ * the difference is what a document cares about: a value has to reach `PARAMS` to do
+ * anything at all, so a package that was served and whose parameters did not land is
+ * not installed as far as any document is concerned. One reading, so the thing that
+ * parks a value and the thing that refuses one cannot disagree about what is here.
+ */
+const effectInstalled = (id) => effectIds().includes(id);
+
+/**
+ * Whether a look name belongs to an effect this build does not have - the one line the
+ * three-way split turns on.
+ *
+ * `effectOf` answers null for a bare name, which is why a typo can never reach here: a
+ * core parameter the registry does not know is refused at `params.spec` as it always
+ * was. What this separates is the two dotted cases, and the separation is the whole
+ * design - a prefix that is installed with a suffix that is not is a half-existing
+ * package and stays a refusal, and a prefix that is simply absent is a document from a
+ * machine carrying something this one lacks.
+ */
+const isParkedName = (name) => {
+  const id = effectOf(name);
+  return id !== null && !effectInstalled(id);
+};
+
+/**
+ * What the open document needs and this build has not got, as the badge reads it: the
+ * document's own `requires` entry per missing effect, with what is parked under it
+ * counted.
+ *
+ * Counted off the pool rather than off the document, because the pool *is* what was
+ * parked - a count taken from the file would be a second reading of the same question
+ * and would go on printing four when the parking had dropped one.
+ */
+const missingEffects = () => parkedLook.requires.map((entry) => ({
+  id: entry.id,
+  version: entry.version,
+  values: Object.keys(parkedLook.params).filter((n) => effectOf(n) === entry.id).length,
+  tracks: Object.keys(parkedLook.tracks).filter((n) => effectOf(n) === entry.id).length,
+  suppressed: suppressedEffects.has(entry.id),
+}));
 
 /**
  * The core half of a whole look: the look tag less its framing and less every
@@ -12572,6 +12917,11 @@ ui.exportGo.addEventListener('click', async () => {
   sayExport(`export ${outputSize ?? '1920x1080'} starting`);
   try {
     const done = await exportClip({
+      // What the badge holds, at the moment of the press. The set is session state and
+      // the press is the gesture that spends it, so it is read here rather than reached
+      // for inside `exportClip` - which is what leaves the worker free to hand over the
+      // job's own list through the same parameter.
+      suppressEffects: [...suppressedEffects],
       onProgress: (n, total) => {
         sayExport(`export ${Math.round((n / total) * 100)}% · frame ${n}/${total}`);
       },
@@ -14585,6 +14935,19 @@ globalThis.__kinect = {
      * finding. Measured exactly once, on `editor-check` at 238 of 274.
      */
     presetGestureRunning: () => presetGesture,
+    /**
+     * What the open document names that this build has not got, as the badge reads it -
+     * id, version, and how much is parked under each.
+     *
+     * Published because a check has no other way to ask the question at its own scale.
+     * The badge's text is the same facts rendered, so a row reading only the badge is a
+     * row about the painter; a row reading only this is a row about the pool. Both are
+     * worth having and they fail differently, which is why this is a hook rather than a
+     * suggestion to parse the chip.
+     */
+    missingEffects,
+    /** The parked pool itself, so a round-trip row can compare what went in and out. */
+    parkedLook: () => JSON.parse(JSON.stringify(parkedLook)),
     marks: () => takeMarks.map((m) => ({ ...m })),
     markHere,
     takeId: () => openTakeId,

--- a/web/main.js
+++ b/web/main.js
@@ -46,7 +46,7 @@ import { clipIn, clipOut, clipBoundOrThrow, writeClipRange } from './clip-range.
 // nothing at all, which is what lets a check pull an older revision of it out of `git show`
 // and evaluate that text under bare node with no page standing around it. What turns a row
 // of it into the closure the registry stores is `effectApply`, beside `PARAMS`.
-import { tableFromPackages, withEffectGroups } from './effect-manifests.js';
+import { EFFECT_BIND_TRANSFORMS, tableFromPackages, withEffectGroups } from './effect-manifests.js';
 // One number out of the halo, and nothing else. `bloom-pass.js` holds the pass and
 // `post-chain.js` is what constructs it; what this file still needs is the reference the
 // chain is frozen at, because `resize` sizes that chain and `resize` lives here. The two
@@ -83,7 +83,7 @@ import {
 // banner below, so the moment a composer takes a pair of full-size render targets off the
 // GPU is a line in this file rather than a position in this list.
 import {
-  composer, renderPass, afterimage, bloom, grade, buildPostChain,
+  composer, renderPass, afterimage, bloom, grade, buildPostChain, setGradeProgram,
 } from './post-chain.js';
 // What a point is made of and how it is addressed: the geometry, the uniform table both
 // shaders are driven through, the material and the cloud itself. Last of the render core
@@ -98,7 +98,7 @@ import {
 // is not state leaking across a boundary - it is the only way three.js can be told
 // anything, and a setter per term would be the registry below spelled a second time.
 import {
-  geometry, uniforms, material, cloud, buildPointCloud, setAdditive,
+  geometry, uniforms, material, cloud, buildPointCloud, setAdditive, setCloudProgram,
   CLIP_NEAR_DEFAULT, CLIP_FAR_DEFAULT, CROP_LIMIT, cropReach, croppedOut,
 } from './point-cloud.js';
 // The text those two builders compile, and the concatenator that makes it. Source text and
@@ -135,7 +135,13 @@ import { assembleShaders } from './shader-assembly.js';
 // `assembleShaders` refuses a package whose text is missing: fetching the two apart would
 // open a window in which a package exists and cannot be assembled, and the boot this await
 // exists to close is the one place that window could be entered.
-const effectPackages = await (async () => {
+// A function rather than the expression it was, because there are two callers now and
+// they must be one: boot reads the store here, and a rebuild after an install reads it
+// again. A second fetch written at the install site would be the copy that stops
+// following a chunk into a second file, or stops de-duplicating, or stops refusing a
+// package that half-arrived - and the failure it produced would be a program with a
+// block missing, on a page that had been fine a second earlier.
+async function fetchEffectPackages() {
   const listed = await fetch('/effects');
   if (!listed.ok) throw new Error(`GET /effects answered ${listed.status} - the registry cannot assemble without its packages`);
   const { effects } = await listed.json();
@@ -154,7 +160,16 @@ const effectPackages = await (async () => {
     pkg.chunks = Object.fromEntries(names.map((name, i) => [name, texts[i]]));
     return pkg;
   }));
-})();
+}
+
+// **`let` and not `const`, which is the whole of what an install changes about this
+// module.** What is installed is no longer decided once at boot: `PUT /effects/:id` and
+// `DELETE /effects/:id` change the answer while the page is up, and everything assembled
+// out of these two bindings - both shader programs, the parameter table, the panel - is
+// rebuilt from them by `adoptEffectPackages` below. Nothing outside that function
+// reassigns either, which is what keeps "the packages" one answer rather than a set of
+// consumers each holding whatever it was handed.
+let effectPackages = await fetchEffectPackages();
 
 // Every program this page compiles, in one call, before either builder runs.
 //
@@ -169,7 +184,12 @@ const effectPackages = await (async () => {
 //
 // It sits beside the fetch that feeds it rather than inside either builder, because the two
 // builders run seven hundred lines apart and the packages are one answer to one question.
-const shaderPrograms = assembleShaders({ cloud: cloudSpine, grade: gradeSpine }, effectPackages);
+//
+// The spine map is named rather than written out at the call, because a rebuild assembles
+// against exactly the same map and two literals would be the way a build ends up
+// assembling two different sets of spines depending on when it was asked.
+const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+let shaderPrograms = assembleShaders(SPINES, effectPackages);
 
 // Which of the two surfaces this page is, decided by the path. One document still
 // serves both, because there is one renderer and one image pipeline and splitting
@@ -1062,7 +1082,25 @@ const EFFECT_PARAM_ORDER = [
   'vignette.amount',
 ];
 
-const EFFECT_PARAMS = tableFromPackages(effectPackages, EFFECT_PARAM_ORDER);
+// **The list is the placement of the shipped set and never a census of what is
+// installed.** A package the list has never heard of is placed by `placeParams` rather
+// than refused - its parameters land contiguously after everything here, in manifest
+// order - so installing a seventeenth effect changes nothing about where any of the
+// forty-one above sit. That was a refusal until installs existed, and it had to stop
+// being one: `tableFromPackages` treated a declared name this list did not place as a
+// control the registry would silently skip, which is the right answer for somebody
+// editing a shipped manifest and the only possible answer to an install.
+//
+// Assigned by `adoptEffectPackages` rather than here, with everything else that is a
+// function of which packages are installed.
+let EFFECT_PARAMS;
+
+// The names the list above does not place, which is where a newly installed package's
+// parameters are: `placeParams` puts them after every placed name, so this is the tail
+// of the assembled table and `PARAMS` spreads it in one run at the end of the effects.
+// Empty with the shipped sixteen installed, which is what keeps the registry's
+// declaration order the bytes it was.
+const effectAppendix = () => Object.keys(EFFECT_PARAMS).slice(EFFECT_PARAM_ORDER.length);
 
 // `reveals` is the escape hatch beside it, and exactly one group needs one. A group's
 // default rule is that it is in use when its own parameters are, and `Reading · detail`
@@ -1188,7 +1226,7 @@ const CORE_PANEL_GROUPS = [
 // The spine plus every group the installed packages declare, spliced at their
 // anchors - the list every consumer below iterates, under the name they have
 // always iterated it by.
-const PANEL_GROUPS = withEffectGroups(CORE_PANEL_GROUPS, effectPackages);
+let PANEL_GROUPS;
 
 /**
  * The effect a dotted name belongs to, or null for a core parameter. The dot is the
@@ -1236,6 +1274,14 @@ const effectOf = (name) => {
  * and lands in a uniform that wanted radians, with every picture still changing and every
  * slider still moving.
  *
+ * **The two names are `EFFECT_BIND_TRANSFORMS` and the install door refuses anything
+ * else**, which is what makes the throw below unreachable from a package rather than a
+ * fence somebody could climb. The set is one binding read at both ends: a transform the
+ * door allowed and this function did not know would install cleanly and throw on its
+ * first write, which is a page that boots and then dies under a slider - the worst of the
+ * three places this could fail. The throw stays anyway, because the door is not the only
+ * way a binding reaches here.
+ *
  * The gate is composed on top rather than spelled into each of the five writes. Each post
  * pass costs a full-screen read and write whether or not it changes anything, so a term of
  * the grade at zero has to shut its pass rather than run it as a no-op - and `gradeNeeded`
@@ -1255,7 +1301,8 @@ function effectApply(bind) {
   } else if (bind.transform) {
     throw new Error(
       `the binding for ${bind.uniform} names the transform ${JSON.stringify(bind.transform)}, `
-      + 'which this applier does not know: its value would land unconverted',
+      + `which this applier does not know - it implements ${EFFECT_BIND_TRANSFORMS.join(' and ')}, `
+      + 'and an unknown one would land its value unconverted',
     );
   } else {
     write = (v) => { table()[bind.uniform].value = v; };
@@ -1294,7 +1341,26 @@ const effectSlice = (first, last) => {
   }));
 };
 
-const PARAMS = {
+/**
+ * The registry, rebuilt. `PARAMS` is a function of which packages are installed, and
+ * installing one is something that happens while the page is up - so this is a function
+ * rather than the object literal it was, and `adoptEffectPackages` is the only caller.
+ *
+ * **Every closure in it captures nothing that a rebuild replaces**, which is what makes
+ * rebuilding safe rather than a second registry sitting beside the first. An `apply`
+ * resolves its uniform table when the write happens, reads module bindings by name and
+ * holds no reference to the table it was declared in - so a control built against the old
+ * `PARAMS` and never rebuilt would still write the right cell, and one built against the
+ * new one writes the same cell. The one thing that would break that is a closure capturing
+ * `PARAMS` itself, and none does.
+ *
+ * An arrow returning the literal rather than a function with a `return` inside it, so the
+ * three hundred lines below keep the indentation they were written at. Every proof tool in
+ * the suite anchors mutations into this file by exact text, and re-indenting a table to
+ * gain a level would go stale on dozens of them at once - which `syntax-check`'s anchor row
+ * would catch, and which would still be a diff nobody could read.
+ */
+const buildParams = () => ({
   // Pixels at 1080p, not pixels. The unit changed exactly once, when the screen-
   // space terms went resolution-relative, and every value here changed with it:
   // this default and both presets are their old values times 1080/600, the 600
@@ -1607,6 +1673,23 @@ const PARAMS = {
     group: 'viewer', label: 'render %',
     apply: (v) => { renderScale = v / 100; resize(); } },
 
+  // Every parameter of every package the declaration order above has never heard of,
+  // which is where an installed effect's controls are.
+  //
+  // **Last, and that is the placement rather than an absence of one.** The seven runs
+  // above interleave the shipped effects with the core parameters because the panel
+  // builds a group's rows in registry order and the shipped groups are stages of the
+  // pipeline - and nothing here can know which stage a package that arrived this morning
+  // belongs to. What it does know is that a package's own parameters are one unit, so they
+  // arrive contiguous and in the order the manifest declares them, and the group they draw
+  // into is spliced at the anchor the package itself names. A new effect's rows are
+  // therefore in the right group and at the end of it, which is a defined place; guessing
+  // at a better one would be this file making a layout decision on a package's behalf.
+  //
+  // Empty for the shipped sixteen, so this line contributes nothing at all to the
+  // registry the presets and the scramble table are written against.
+  ...(effectAppendix().length ? effectSlice(effectAppendix()[0], effectAppendix().at(-1)) : {}),
+
   // The one composition parameter, and the only pose. The camera track reads its
   // kind off this entry rather than off a second table beside the path editor, and
   // the render path writes the evaluated pose through the same door every other
@@ -1624,13 +1707,21 @@ const PARAMS = {
         programCamera.updateProjectionMatrix();
       }
     } },
-};
+});
 
-// The readings, read off the registry rather than written down a second time. Every
-// use of the set - the shader's uniforms, the panel group, the sweep arms a proof
-// tool builds - goes through this, so adding a sixth reading means adding one
-// registry entry and nothing else discovers it late.
-const READINGS = Object.keys(PARAMS).filter((n) => PARAMS[n].reading);
+/**
+ * The registry itself, and the readings read off it rather than written down a second
+ * time. Every use of the reading set - the shader's uniforms, the panel group, the sweep
+ * arms a proof tool builds - goes through it, so adding a sixth reading means adding one
+ * registry entry and nothing else discovers it late.
+ *
+ * Both assigned by `adoptEffectPackages`. `READINGS` is a `let` beside `PARAMS` although
+ * no package can change it - a reading is core and there is no manifest that could declare
+ * one - because it is derived from a table that is rebuilt, and a set derived once from a
+ * table that is replaced is the copy that goes on describing the build before last.
+ */
+let PARAMS;
+let READINGS;
 
 /**
  * Which of the five readings a document does not name, asked at both doors a document
@@ -1663,53 +1754,66 @@ function missingReadings(values) {
   return READINGS.filter((n) => !Object.hasOwn(values, n));
 }
 
-// Each reading needs a uniform of its own name, and the two are now written in different
-// files - the registry here, the shader source in `web/cloud-shader.js` - so nothing about
-// reading one puts the other in front of you. A reading declared in the registry with no
-// uniform behind it would fail as a slider that moves nothing rather than as an
-// error. That is the shape this file keeps rejecting - a control that appears to
-// work - so it is an assertion, on the same reasoning as the age ceiling below.
-for (const name of READINGS) {
-  if (!Object.hasOwn(uniforms, name)) {
-    throw new Error(`the reading ${name} has no uniform: its slider would move nothing`);
+/**
+ * Everything the registry has to be true of, asked of the table that has just been built
+ * rather than of the one this file was written against.
+ *
+ * **They ran at module scope until installs existed, and moving them is the whole reason
+ * to bother saying so.** Each of the four is a claim about the registry and the packages
+ * agreeing, and the moment a package can arrive at runtime, a check that only ever ran
+ * while the module evaluated is a check about the sixteen this build shipped with. The
+ * install that goes wrong is by definition the one that was not there at boot.
+ *
+ * Cheap enough to run per rebuild that the count is not worth thinking about: four walks
+ * of a table of eighty, against an install that has just recompiled two shader programs.
+ */
+function refuseRegistryDisagreement() {
+  // Each reading needs a uniform of its own name, and the two are now written in different
+  // files - the registry here, the shader source in `web/cloud-shader.js` - so nothing about
+  // reading one puts the other in front of you. A reading declared in the registry with no
+  // uniform behind it would fail as a slider that moves nothing rather than as an
+  // error. That is the shape this file keeps rejecting - a control that appears to
+  // work - so it is an assertion, on the same reasoning as the age ceiling below.
+  for (const name of READINGS) {
+    if (!Object.hasOwn(uniforms, name)) {
+      throw new Error(`the reading ${name} has no uniform: its slider would move nothing`);
+    }
   }
-}
 
-// The table and the registry hold the same forty-one names, asked in both directions,
-// because the two failures are different and neither is loud on its own.
-//
-// A run left out of the seven spreads above is nine parameters that silently do not exist:
-// no slider, no track, and a project naming one refused by `specOf` as an unknown parameter
-// a long way from the line that dropped it. And a dotted name written out inline again is
-// the second implementation this file keeps refusing - it would work, which is exactly the
-// problem, because the copy is what drifts off the table the presets and the applier agree
-// on. `effectOf` draws the line between the two halves and this asks against that same
-// line, so an effect parameter added on either side is checked by existing rather than by
-// somebody remembering to come back here.
-for (const name of Object.keys(EFFECT_PARAMS)) {
-  if (!Object.hasOwn(PARAMS, name)) {
-    throw new Error(
-      `${name} is declared by an installed effect and reaches no registry entry: it would `
-      + 'be a look term with no slider and no track, and a document naming it would be refused',
-    );
+  // The table and the registry hold the same names, asked in both directions,
+  // because the two failures are different and neither is loud on its own.
+  //
+  // A run left out of the seven spreads above is nine parameters that silently do not exist:
+  // no slider, no track, and a project naming one refused by `specOf` as an unknown parameter
+  // a long way from the line that dropped it. And a dotted name written out inline again is
+  // the second implementation this file keeps refusing - it would work, which is exactly the
+  // problem, because the copy is what drifts off the table the presets and the applier agree
+  // on. `effectOf` draws the line between the two halves and this asks against that same
+  // line, so an effect parameter added on either side is checked by existing rather than by
+  // somebody remembering to come back here.
+  for (const name of Object.keys(EFFECT_PARAMS)) {
+    if (!Object.hasOwn(PARAMS, name)) {
+      throw new Error(
+        `${name} is declared by an installed effect and reaches no registry entry: it would `
+        + 'be a look term with no slider and no track, and a document naming it would be refused',
+      );
+    }
   }
-}
-for (const name of Object.keys(PARAMS)) {
-  if (effectOf(name) !== null && !Object.hasOwn(EFFECT_PARAMS, name)) {
-    throw new Error(
-      `${name} is an effect parameter written out in the registry rather than declared in `
-      + 'a manifest: it is a second copy of a binding, and the copy is what drifts',
-    );
+  for (const name of Object.keys(PARAMS)) {
+    if (effectOf(name) !== null && !Object.hasOwn(EFFECT_PARAMS, name)) {
+      throw new Error(
+        `${name} is an effect parameter written out in the registry rather than declared in `
+        + 'a manifest: it is a second copy of a binding, and the copy is what drifts',
+      );
+    }
   }
-}
 
-// The surface memory's age ceiling has to cover the longest persistence the two
-// sliders can ask for, or a ray that stops swapping pins its age below its own
-// life and sheds forever. The ceiling and the refusal about it are the memory's, so
-// what happens here is the registry handing over the one number only it can compute -
-// and it happens here rather than at the memory's own banner because `PARAMS` is
-// declared above this line and not above that one.
-refuseAgeCeiling((PARAMS.fade.max + PARAMS.wake.max) / 1000);
+  // The surface memory's age ceiling has to cover the longest persistence the two
+  // sliders can ask for, or a ray that stops swapping pins its age below its own
+  // life and sheds forever. The ceiling and the refusal about it are the memory's, so
+  // what happens here is the registry handing over the one number only it can compute.
+  refuseAgeCeiling((PARAMS.fade.max + PARAMS.wake.max) / 1000);
+}
 
 // Range inputs snap to their step grid and clamp to their bounds, and the registry
 // has to do the same arithmetic rather than lean on the DOM for it - otherwise a
@@ -1800,6 +1904,26 @@ const panelControls = new Map();
 // `const` read before its own declaration is a TDZ error rather than an empty map, so
 // the map that gets read during boot has to be declared where boot can already see it.
 const resetButtons = new Map();
+
+// What each parameter is worth in a project nobody has touched, computed once per
+// registry.
+//
+// **Through `normalise`, not against `PARAMS[n].def` raw**, and the difference is a
+// class rather than a case. `normalise` clamps, snaps to a grid anchored at `min` and
+// rounds to the decimals `min` and `step` imply, and every scalar default this build
+// declares happens to land on its own grid - so raw equality is correct today and
+// would go on being correct right up until somebody adds a parameter whose default is
+// not on its step. That group would then read as touched from boot, on a fresh page,
+// with nothing anywhere saying why. Doing it once per rebuild is what keeps the
+// arithmetic off the evaluator's path, where this is asked several times a frame - and
+// an installed effect is exactly the way a default that is not on its own step arrives,
+// since nothing about a package author's numbers went through review here.
+//
+// Declared beside the two maps above rather than beside the predicate that reads it,
+// for the reason the note on `resetButtons` gives: `buildPanel` fills it while the
+// module is still evaluating, and a `const` read before its own declaration is a TDZ
+// error rather than an empty map.
+const groupDefaults = new Map();
 
 /**
  * What a reset puts back, asked of the same function that decides what `set` stores.
@@ -2315,7 +2439,37 @@ function panelHead(group) {
 }
 
 let panelRowsEmitted = 0;
-for (const group of PANEL_GROUPS) {
+
+/**
+ * The panel, generated out of the registry - all of it, every time.
+ *
+ * **Rebuilt whole rather than patched, and that is the same argument `paintMissingEffects`
+ * makes one scale up.** An install adds a group and its rows, an uninstall takes one away,
+ * and a generator that edited in place would be a second statement of which parameters
+ * exist - the one that has to be taught about every shape of change, where this one is
+ * taught about none. The cost is a few dozen elements built twice a session, against a
+ * page that has just recompiled two shader programs.
+ *
+ * **Everything the last pass left behind is dropped first, and each of the seven maps is
+ * a name the panel is found again by.** A generated group carries `data-group` and a
+ * hand-written one carries an id, which is what makes the selector below able to remove
+ * exactly what this function made - the distinction was drawn for a different reason
+ * (id collisions) and is what makes a rebuild possible at all. A map left with its old
+ * entries is worse than a stale element: `panelControls` would hand `writeControl` an
+ * input that is no longer in the document, so every write would repaint a row nobody can
+ * see and the row that is there would show the value it had before.
+ */
+function buildPanel() {
+  for (const node of document.querySelectorAll('#panelBody > [data-group]')) node.remove();
+  panelControls.clear();
+  keyButtons.clear();
+  resetButtons.clear();
+  panelGroupNodes.clear();
+  panelGroupParams.clear();
+  panelTail.clear();
+  groupDefaults.clear();
+  panelRowsEmitted = 0;
+  for (const group of PANEL_GROUPS) {
   const groupNode = panelNode('div', group.lookgroup ? 'group lookgroup' : 'group');
   // A data attribute and not an id, because the hand-written groups in the markup
   // are already `#cameraGroup`, `#sensorGroup`, `#monitorGroup`, `#programOutGroup`,
@@ -2404,20 +2558,19 @@ for (const group of PANEL_GROUPS) {
 
   if (group.after) groupNode.append(...group.after());
   panelPlace(group, groupNode);
-}
+  }
 
-// The count, asserted rather than inferred - and this is what the old boot loop's
-// throw turned into rather than a tidier spelling of it. That loop looked a control
-// up by id and threw when it found none, which stops being able to fail the moment
-// the same pass creates the control it then looks for: a generator that filtered one
-// parameter out would produce a smaller panel that worked perfectly and said nothing.
-//
-// Counted against the registry from the other side, so a row lost anywhere in the
-// loop above - a group key nobody declared, a filter that dropped one, a `continue`
-// that ran once too often - is a refusal to boot with both numbers in it. The stray
-// check above names the parameter where it can; this one catches the cases that have
-// no name to give.
-{
+  // The count, asserted rather than inferred - and this is what the old boot loop's
+  // throw turned into rather than a tidier spelling of it. That loop looked a control
+  // up by id and threw when it found none, which stops being able to fail the moment
+  // the same pass creates the control it then looks for: a generator that filtered one
+  // parameter out would produce a smaller panel that worked perfectly and said nothing.
+  //
+  // Counted against the registry from the other side, so a row lost anywhere in the
+  // loop above - a group key nobody declared, a filter that dropped one, a `continue`
+  // that ran once too often - is a refusal to boot with both numbers in it. The stray
+  // check above names the parameter where it can; this one catches the cases that have
+  // no name to give.
   const owned = params.names().filter((n) => PARAMS[n].tag !== 'composition');
   const stray = owned.filter((n) => !PANEL_GROUPS.some((g) => g.key === PARAMS[n].group));
   if (stray.length) {
@@ -2433,7 +2586,244 @@ for (const group of PANEL_GROUPS) {
     throw new Error(`the panel generator emitted ${panelRowsEmitted} rows for ${owned.length} `
       + 'parameters: a panel that is not the registry is a look nothing can reach');
   }
+
+  // What a fresh project is worth per parameter, taken here because here is where the
+  // rows the question is about were emitted - the same argument the evidence set beside
+  // each group is recorded on.
+  for (const names of panelGroupParams.values()) {
+    for (const name of names) groupDefaults.set(name, params.normalise(name, PARAMS[name].def));
+  }
 }
+
+// ------------------------------------------------- adopting a set of packages
+//
+// Everything downstream of "which effects are installed", in one function, called once at
+// boot and again after every install and every uninstall.
+
+/**
+ * What the store looked like when this page last read it, as one comparable string.
+ *
+ * The package rev is a hash over the sorted `name hash` lines of the package's own files,
+ * so an id and its rev together say everything a client needs to know about whether it is
+ * holding the current package - and a change of any byte of any file moves it. Joined into
+ * one string because the question is "has anything moved", and comparing one string is the
+ * cheapest honest way to ask it.
+ *
+ * **Declared here rather than beside the poll that reads it**, which is the third time this
+ * file has had to write that sentence and the second time it was found by a boot rather
+ * than by a reading. `adoptEffectPackages` below writes the signature, boot calls it while
+ * the module is still evaluating, and a `const` five hundred lines further down is in its
+ * temporal dead zone at that moment: `Cannot access 'revSignature' before initialization`,
+ * no `__kinect` published at all, and every tool in the suite reporting DID NOT RUN.
+ * Measured exactly once, immediately, which is the only reason it is a paragraph rather
+ * than a commit.
+ */
+const revSignature = (effects) => effects.map((e) => `${e.id} ${e.rev}`).join('\n');
+let effectSignature;
+
+/**
+ * A uniform cell for every binding the registry holds, minted where the tables have none.
+ *
+ * **The one thing a package cannot bring with it.** A manifest declares the GLSL that
+ * reads a uniform and the parameter that writes it, and both of those travel; what does
+ * not is the JavaScript cell three.js copies from - `uniforms` in `web/point-cloud.js` and
+ * the grade pass's table are written out by hand, so a seventeenth effect's first slider
+ * move would be `undefined.value = v` and the page would throw inside the registry's
+ * single write path. That is the failure this function exists for, and it is not
+ * hypothetical: it is what every install did before this line was here.
+ *
+ * Minted rather than refused, because the alternative is that no effect can ever be
+ * installed without editing this build. Seeded at zero rather than at the parameter's
+ * default, since the value walk at the end of the adoption writes every parameter through
+ * `params.set` a moment later and the write is what the cell is for - a seed that tried to
+ * be the default would be a second application of `effectApply`'s conversions, which is
+ * where a unit gets applied twice.
+ *
+ * The `axisDeg` transform is the one shape that cannot be a bare number: it writes
+ * `.value.set(sin, cos)` into a two-component cell, so a cell holding `0` would throw on
+ * the first write with a message about `set` rather than about a uniform.
+ */
+function seedUniformCells() {
+  for (const name of Object.keys(EFFECT_PARAMS)) {
+    const bind = EFFECT_PARAMS[name];
+    const table = bind.on === 'grade' ? grade.uniforms : uniforms;
+    if (Object.hasOwn(table, bind.uniform)) continue;
+    table[bind.uniform] = { value: bind.transform === 'axisDeg' ? new THREE.Vector2() : 0 };
+  }
+}
+
+/**
+ * The programs, the registry, the panel and every value - rebuilt from one set of
+ * packages.
+ *
+ * **This is the boot path, and it is the install path, and there is one of them.** Boot
+ * calls it below with what it fetched; `reloadEffects` calls it with what it fetched
+ * after a `PUT` or a `DELETE`. That matters for one property in particular, which
+ * `boot-check` is the instrument for: the last thing this does is walk every parameter
+ * through `params.set`, so every control on the panel shows the value the registry holds
+ * *by construction* rather than because two code paths were kept in step. A separate boot
+ * assembly would be the second implementation, and the one that drifts is always the one
+ * that runs on somebody else's machine.
+ *
+ * **`held` is what survives, and defaults are what does not.** An install must not move a
+ * slider the operator has set, so the values in flight are handed back in; a parameter the
+ * new set introduces has no held value and takes its default. A parameter the new set
+ * *removed* is simply not walked - it is gone from `PARAMS`, so `specOf` refuses it and
+ * `values` is pruned below, which is what stops the registry answering for a control that
+ * is no longer on screen.
+ *
+ * The order is the order the dependencies run in and each step needs the one above it. The
+ * shaders are swapped before the registry is rebuilt, because `seedUniformCells` mints
+ * cells the swapped programs declare; the panel is built before the value walk, because
+ * `writeControl` paints the row the walk is about.
+ */
+function adoptEffectPackages(packages, programs, held = {}) {
+  effectPackages = packages;
+  shaderPrograms = programs;
+  // What the store looked like when these packages were read, so the poll below compares
+  // against the set the page is actually assembled from. Written here rather than beside
+  // the poll because this is the one line that changes which packages the page holds.
+  effectSignature = revSignature(packages);
+
+  // **The materials are mutated rather than replaced, and the identity is the point.**
+  // Everything downstream holds them: the cloud is a `THREE.Points` built on the point
+  // material, `composer` has the grade pass in its chain, `gradeNeeded` gates it, and
+  // `setAdditive` flips its blend. Building a new one would leave every one of those
+  // pointing at the program before last. Both writes are the owning module's own door
+  // rather than a reach into an imported object - see `setCloudProgram` and
+  // `setGradeProgram` for why that boundary is where it is.
+  setCloudProgram(programs.cloud);
+  setGradeProgram(programs.grade);
+
+  EFFECT_PARAMS = tableFromPackages(packages, EFFECT_PARAM_ORDER);
+  PANEL_GROUPS = withEffectGroups(CORE_PANEL_GROUPS, packages);
+  PARAMS = buildParams();
+  READINGS = Object.keys(PARAMS).filter((n) => PARAMS[n].reading);
+  refuseRegistryDisagreement();
+  seedUniformCells();
+
+  // Values the registry no longer declares, dropped. `params.get` refuses an unknown
+  // name, so a stale entry is unreachable through the door - but `values` is what
+  // `params.values()` serialises, and an entry that outlived its parameter would be
+  // written into the next project as a look term nothing on this build can apply.
+  // Whatever a document held for the departed effect is in the parked pool by then,
+  // which is where it belongs and where it round-trips.
+  for (const name of [...values.keys()]) {
+    if (!Object.hasOwn(PARAMS, name)) values.delete(name);
+  }
+
+  buildPanel();
+
+  // **The walk that makes the invariant hold by construction.** Every parameter, through
+  // the one write path, in registry order - so `apply` reaches its uniform, `writeControl`
+  // paints the row that was just built, and `refreshReset` decides whether the row offers
+  // a revert. A rebuild that painted the panel and left the values where they were would
+  // be a set of controls showing the build before last, which is exactly what `boot-check`
+  // exists to refuse.
+  for (const name of Object.keys(PARAMS)) {
+    params.set(name, Object.hasOwn(held, name) ? held[name] : PARAMS[name].def);
+  }
+}
+
+// Boot's own call, and the first run of the path above. Everything from here down reads a
+// registry and a panel that exist because this line ran.
+adoptEffectPackages(effectPackages, shaderPrograms);
+
+/**
+ * The store read again, and everything on this page rebuilt from what it says.
+ *
+ * **The document goes out through the serialiser and comes back through the loader, and
+ * that is the whole of the parking half.** An install has to unpark what the arriving
+ * effect owns and an uninstall has to park what the departing one owned, and both of
+ * those are the three-way split `restoreProject` already performs against whatever
+ * registry it happens to be looking at - a bare name is a typo and is refused, a dotted
+ * name whose effect is installed is validated and applied, a dotted name whose effect is
+ * absent is parked. So the pair of writes below is the pair of reads that already exists:
+ * `serialiseProjectBody` hands over the open document with the parked pool merged back
+ * verbatim, the registry is replaced underneath it, and the loader re-splits the same
+ * document against the new one. An effect that has just arrived finds its parked values
+ * in `look.params` and applies them; an effect that has just left finds its values
+ * unrecognised and parks them, with the `requires` entry the serialiser wrote on the way
+ * out - which is where the version the badge quotes comes from, at the moment the package
+ * was still here to be asked.
+ *
+ * Writing that as two loops over the pool would have been the second implementation of
+ * the split, and it would have had to re-derive the entry, re-validate the keys, re-prune
+ * the suppressions and repaint the badge - four things this loader does and the loop
+ * would have had to be taught.
+ *
+ * **Nothing is written until the new set assembles.** The fetch and the assembly happen
+ * before the first assignment, so a store that answers a package this build cannot
+ * assemble leaves the page exactly as it was and the caller gets the assembler's own
+ * sentence. That is the last line of defence behind the install door rather than a
+ * duplicate of it: the door refuses the package on the machine it was installed on, and
+ * this refuses a set that arrived some other way.
+ */
+async function reloadEffects() {
+  const fetched = await fetchEffectPackages();
+  const programs = assembleShaders(SPINES, fetched);
+  const open = serialiseProjectBody();
+  // Every value in flight, view state included, so an install does not move a slider.
+  const held = params.values(params.names());
+  adoptEffectPackages(fetched, programs, held);
+  // The swapped programs and the additive variant, compiled here rather than on the frame
+  // that first reaches them - which is the same 83ms stall `warmPrograms` was written for,
+  // arriving at a moment nobody would connect to an install.
+  warmPrograms();
+  restoreProject(open);
+  refreshGroups();
+  requestRepaint();
+  return fetched.map((p) => ({ id: p.id, version: p.manifest.version, rev: p.rev }));
+}
+
+/**
+ * Every client converges, because one of them installing does not tell the others.
+ *
+ * A slow poll rather than a socket message, and the interval is deliberately unhurried:
+ * an install is a thing a person does a handful of times, the cost of noticing it a few
+ * seconds late is that a second browser draws the old look for a few seconds, and the
+ * cost of a socket message would be a second channel carrying state that the store
+ * already answers for. `GET /effects` reads sixteen directories and hashes their files,
+ * which is the whole of what a tick costs when nothing has changed.
+ *
+ * **A tick stands down rather than queues while anything is mid-gesture.** A rebuild
+ * replaces both shader programs and rewrites every value, so one landing inside an export
+ * would change the look between two frames of one file, one landing inside a preset
+ * gesture would fight the bulk write that gesture is making, and one landing inside track
+ * evaluation would be refused by `params.apply`'s own guard with a throw nobody asked
+ * for. Standing down costs one interval, and the signature is still whatever it was, so
+ * the next tick asks again.
+ */
+const EFFECT_POLL_MS = 6000;
+let effectReloading = false;
+async function pollEffects() {
+  if (effectReloading || exporting || presetGesture || evaluating) return;
+  let listed;
+  try {
+    const res = await fetch('/effects');
+    if (!res.ok) return;
+    listed = (await res.json()).effects;
+  } catch {
+    // A server that is restarting is not a reason to say anything: the next tick asks
+    // again, and the page goes on drawing what it has.
+    return;
+  }
+  if (revSignature(listed) === effectSignature) return;
+  effectReloading = true;
+  try {
+    await reloadEffects();
+    say('the installed effects changed - this page has been rebuilt from them');
+  } catch (err) {
+    // Reported and not retried on a timer. The set on the server is the one this page
+    // could not adopt, so a retry is the same failure once every six seconds; the
+    // signature is left alone so a later fix is picked up by the same comparison.
+    console.warn('could not rebuild from the installed effects:', err.message);
+    say(`the installed effects changed and this page could not adopt them: ${err.message}`);
+  } finally {
+    effectReloading = false;
+  }
+}
+setInterval(pollEffects, EFFECT_POLL_MS);
 
 // The four Pencil inspectors are views over the one registry-built panel. Groups are
 // tagged where they are declared above, so adding a parameter to a group inherits its
@@ -2468,8 +2858,6 @@ function showInspector() {
 
 // On the record surface, initialize the tabs immediately since they're always visible.
 if (!EDITING) setPanelTab(activePanelTab);
-
-params.reset();
 
 // ------------------------------------------------------------------- presets
 
@@ -2900,20 +3288,6 @@ function storeGroupOverride() {
   }
 }
 
-// What each parameter is worth in a project nobody has touched, computed once.
-//
-// **Through `normalise`, not against `PARAMS[n].def` raw**, and the difference is a
-// class rather than a case. `normalise` clamps, snaps to a grid anchored at `min` and
-// rounds to the decimals `min` and `step` imply, and every scalar default this build
-// declares happens to land on its own grid - so raw equality is correct today and
-// would go on being correct right up until somebody adds a parameter whose default is
-// not on its step. That group would then read as touched from boot, on a fresh page,
-// with nothing anywhere saying why. Doing it once at module scope is what keeps the
-// arithmetic off the evaluator's path, where this is asked several times a frame.
-const groupDefaults = new Map();
-for (const names of panelGroupParams.values()) {
-  for (const name of names) groupDefaults.set(name, params.normalise(name, PARAMS[name].def));
-}
 
 /**
  * Whether one parameter carries evidence that somebody has been here: a keyframe track
@@ -9784,14 +10158,25 @@ function refuseRequires(what, requires, names) {
   }
 }
 
-// Until the effects are packages with manifests of their own, every effect this build
-// declares is at 1.0.0: the version a requires entry names belongs to the package, and
-// the packages do not exist yet - the registry is still one table. The constant moves
-// into the manifests when they arrive, and nothing else should learn this number.
-const EFFECT_VERSION = '1.0.0';
+/**
+ * What version of an effect this build has, off the package that answered for it.
+ *
+ * This was the constant `1.0.0` with a comment saying it would move into the manifests
+ * when the manifests arrived. They have arrived, and the constant had become a lie
+ * waiting for its first fork: `PUT /effects/rain` can install a package declaring 2.0.0,
+ * and every document saved afterwards would have gone on claiming to need 1.0.0 - which
+ * is the one field the badge on a machine without the package prints, so the person told
+ * to install it would be told the wrong thing. Every shipped package declares 1.0.0, so
+ * this changes no document any build has written.
+ *
+ * An id with no package is `unknown` rather than a throw, because the caller is a
+ * serialiser: refusing to save a document over a version it cannot look up would lose
+ * work over a field nothing renders.
+ */
+const versionOf = (id) => effectPackages.find((p) => p.id === id)?.manifest.version ?? 'unknown';
 
 /** The requires list a set of value names derives, one entry per effect touched. */
-const requiresFor = (names) => effectIdsIn(names).map((id) => ({ id, version: EFFECT_VERSION }));
+const requiresFor = (names) => effectIdsIn(names).map((id) => ({ id, version: versionOf(id) }));
 
 // ------------------------------------------- which look values a preset carries
 
@@ -14476,6 +14861,31 @@ globalThis.__kinect = {
   // is exactly what `level-check --mutate tilt-ignored` does.
   worldTilt: () => cloud.quaternion.toArray(),
   resetWorldRotation,
+
+  /**
+   * The installed effects, and the rebuild an install triggers.
+   *
+   * **`reload` is the product's own path and not a driver's shortcut**, which is the
+   * whole reason it is exposed rather than left to the poll. A check installing a package
+   * has two ways to see the page adopt it: wait out an interval that is deliberately slow,
+   * or call the thing the interval calls. The first makes every row in the tool six
+   * seconds longer and turns a rebuild that threw into a timeout with nothing to read; the
+   * second is the same function, so a row that passes here is a row about the shipped
+   * rebuild. `pollNow` is the interval's own body, for the one claim that is about the
+   * poll rather than about the rebuild: that a page nobody touched converges on its own.
+   *
+   * `packages` answers with the manifests as the page holds them, which is what lets a
+   * row ask whether the page is assembled from the package the server is serving rather
+   * than from the one it booted on.
+   */
+  effects: {
+    reload: reloadEffects,
+    pollNow: pollEffects,
+    packages: () => effectPackages.map((p) => ({ id: p.id, version: p.manifest.version, rev: p.rev })),
+    signature: () => effectSignature,
+    /** The assembled source both programs were compiled from, for a row about the text. */
+    programs: () => JSON.parse(JSON.stringify(shaderPrograms)),
+  },
 
   // The live cloud's draw-rate cap, in hertz, readable and settable so the rate can be
   // swept on the node it was chosen for. A getter and a setter over the one binding the

--- a/web/main.js
+++ b/web/main.js
@@ -2758,21 +2758,93 @@ adoptEffectPackages(effectPackages, shaderPrograms);
  * sentence. That is the last line of defence behind the install door rather than a
  * duplicate of it: the door refuses the package on the machine it was installed on, and
  * this refuses a set that arrived some other way.
+ *
+ * **And nothing stays written unless every step lands, which is the half of it the
+ * assembly guard above could not reach.** The adoption is not the last thing that can
+ * throw: `restoreProject` runs after it and refuses a document for seventeen reasons, and
+ * one of them is reachable by exactly the gesture this function exists to serve. Install a
+ * fork that *adds* a parameter while a document holds that effect - parked or open - and
+ * the document then names a subset of the new manifest, which the per-effect completeness
+ * rule refuses. The page that came out of that was new registry, new panel, new programs,
+ * and a parked pool still describing the build before last: a state no document was ever
+ * saved from and none can be saved into, because the pool and the registry disagree about
+ * which names are live.
+ *
+ * So everything needed to come back is captured before the first mutation and the whole
+ * thing rolls back on any throw after it. The rollback is a second call to the same
+ * adoption with the packages and the programs this page was already running, followed by
+ * the same document going back through the same loader - **no fetch and no re-assembly**,
+ * because the moment there is nothing left to fall back to is the wrong moment to need the
+ * network, and because staying synchronous is what keeps the half-swapped state
+ * unobservable: from any other task the page is either the old set or the old set, never
+ * the pair mid-swap.
+ *
+ * **The completeness refusal stays a refusal**, and that is the decision this rollback is
+ * built around rather than a limitation of it. Filling the parameter the fork added from
+ * its default would be this build guessing at a look somebody else authored, which is the
+ * adaptation every other door here refuses; the honest answer is that the page cannot
+ * carry *this* document onto that package, said out loud, with the page still drawing what
+ * it drew.
  */
 async function reloadEffects() {
-  const fetched = await fetchEffectPackages();
-  const programs = assembleShaders(SPINES, fetched);
-  const open = serialiseProjectBody();
-  // Every value in flight, view state included, so an install does not move a slider.
+  // Captured before anything moves, and read from the live bindings rather than re-derived:
+  // these two are the objects the renderer is holding right now, so putting them back is a
+  // return rather than a reconstruction.
+  const heldPackages = effectPackages;
+  const heldPrograms = shaderPrograms;
+  // Every value in flight, view state included, so an install does not move a slider - and
+  // so the rollback restores the same values the forward attempt was handed.
   const held = params.values(params.names());
+  let fetched;
+  let programs;
+  let open;
+  try {
+    fetched = await fetchEffectPackages();
+    programs = assembleShaders(SPINES, fetched);
+    open = serialiseProjectBody();
+  } catch (err) {
+    // Nothing has been written, so there is nothing to undo - only a sentence to frame.
+    // The assembler's own message says what did not assemble and says nothing about why
+    // this page was asking, and the chip it lands on holds one line.
+    throw new Error(`the installed effects changed and this page could not read them: ${err.message}`);
+  }
+
   adoptEffectPackages(fetched, programs, held);
-  // The swapped programs and the additive variant, compiled here rather than on the frame
-  // that first reaches them - which is the same 83ms stall `warmPrograms` was written for,
-  // arriving at a moment nobody would connect to an install.
-  warmPrograms();
-  restoreProject(open);
+  let failure = null;
+  try {
+    // The swapped programs and the additive variant, compiled here rather than on the frame
+    // that first reaches them - which is the same 83ms stall `warmPrograms` was written for,
+    // arriving at a moment nobody would connect to an install.
+    warmPrograms();
+    restoreProject(open);
+  } catch (err) {
+    failure = err;
+    try {
+      adoptEffectPackages(heldPackages, heldPrograms, held);
+      restoreProject(open);
+    } catch (stuck) {
+      // **The corner where there is no repair, reported rather than papered over.** The
+      // document that could not be loaded onto the new registry could not be loaded back
+      // onto the old one either, which means the failure is in the document rather than in
+      // the pairing - and this page is now holding a registry it cannot restore anything
+      // into. Nothing is repainted on the way out, because a panel repainted over a state
+      // no document describes is a page that looks well and is not.
+      throw new Error(
+        'the installed effects changed, this page could not carry the open document across to them, '
+        + `and it could not put itself back either - reload the page: ${stuck.message}`,
+      );
+    }
+  }
   refreshGroups();
   requestRepaint();
+  // Thrown after the repaint rather than before it, so the page the operator is looking at
+  // is the rolled-back one by the time the sentence describing it arrives.
+  if (failure) {
+    throw new Error(
+      'the server installed the effects it was asked for, but this page could not carry the open '
+      + `document across to them, so it is still running the effects it had: ${failure.message}`,
+    );
+  }
   return fetched.map((p) => ({ id: p.id, version: p.manifest.version, rev: p.rev }));
 }
 
@@ -2816,9 +2888,17 @@ async function pollEffects() {
   } catch (err) {
     // Reported and not retried on a timer. The set on the server is the one this page
     // could not adopt, so a retry is the same failure once every six seconds; the
-    // signature is left alone so a later fix is picked up by the same comparison.
+    // signature is left alone so a later fix is picked up by the same comparison - and a
+    // rollback puts the old signature back by re-adopting the old set, so the two ways of
+    // failing converge on one behaviour rather than on two.
+    //
+    // **The sentence is the one the reload composed, printed rather than framed again.**
+    // Every way out of `reloadEffects` now carries a whole sentence naming what failed and
+    // what state that leaves this page in, and a prefix added here would say a third time
+    // what the message already says twice - on a chip that ellipsises, where the width the
+    // prefix takes is the width the refusal loses.
     console.warn('could not rebuild from the installed effects:', err.message);
-    say(`the installed effects changed and this page could not adopt them: ${err.message}`);
+    say(err.message);
   } finally {
     effectReloading = false;
   }
@@ -3662,6 +3742,37 @@ let parkedLook = { params: {}, tracks: {}, requires: [] };
  */
 let suppressedEffects = new Set();
 
+/**
+ * The parked pool as it may be written out - which is the pool less anything the registry
+ * has since started answering for.
+ *
+ * **Defence in depth against one shape of bug, and it is worth saying which.** The pool
+ * and the registry are disjoint by construction: `restoreProject` partitions the document
+ * once, on `isParkedName`, and assigns both halves in the same breath. Every way the
+ * registry moves goes back through that loader, so a name cannot be in the pool and in
+ * `PARAMS` at the same time - unless something swapped the registry and then failed to
+ * re-split the document, which is precisely the half-migrated page `reloadEffects` now
+ * rolls back rather than leaves behind.
+ *
+ * If that ever happens again, the write is where it would cost work rather than pixels. A
+ * stale parked copy of a name the build now has would be merged over the value the
+ * registry is rendering, so the file on disk would claim a look nobody is looking at, and
+ * the installed effect's own value - the one on screen, the one somebody just set - would
+ * be the copy that lost. Filtering here is the cheap half of that; `reloadEffects` is the
+ * half that stops the state existing.
+ *
+ * `requires` is filtered on the same fact, and it has to be filtered together with the
+ * keys rather than left alone: an entry for an effect whose parked keys have just been
+ * dropped is either a duplicate of the one `requiresFor` derives, or a claim on an effect
+ * the look no longer names - and `refuseRequires` refuses both, so a pool half-filtered
+ * would write a document this build's own loader would not take back.
+ */
+const writableParked = () => ({
+  params: Object.fromEntries(Object.entries(parkedLook.params).filter(([n]) => isParkedName(n))),
+  tracks: Object.fromEntries(Object.entries(parkedLook.tracks).filter(([n]) => isParkedName(n))),
+  requires: parkedLook.requires.filter((entry) => !effectInstalled(entry.id)),
+});
+
 // Everything an edit *is*, as one plain object. A project file, an undo snapshot
 // and step 6's export job all start here, which is why this is one function rather
 // than a serialiser per consumer that would each learn about a new track kind
@@ -3709,6 +3820,9 @@ function serialiseProjectBody({ suppressed = null } = {}) {
     for (const n of mine) delete lookParams[n];
   }
   const kept = Object.keys(lookParams);
+  // The pool, filtered down to the names this build genuinely cannot answer for - see
+  // `writableParked` for the state that filter is defence against.
+  const parked = writableParked();
   // **The parked effects' entries, whole, and appended rather than interleaved.** The
   // list is one entry per effect and `refuseRequires` reads it as a set, so position
   // carries nothing - what has to survive is the version, and the `rev` where a
@@ -3716,7 +3830,7 @@ function serialiseProjectBody({ suppressed = null } = {}) {
   // id being handed back to `requiresFor`. A parked effect keeps its entry because its
   // values are still in the document: the list stays derived from what the look names,
   // which is the property both directions of `refuseRequires` rest on.
-  const requires = [...requiresFor(kept), ...parkedLook.requires];
+  const requires = [...requiresFor(kept), ...parked.requires];
   return {
     version: PROJECT_VERSION,
     ...(requires.length ? { requires } : {}),
@@ -3730,18 +3844,23 @@ function serialiseProjectBody({ suppressed = null } = {}) {
       // be able to open a document, save it, and leave the parts it cannot read exactly
       // as it found them - anything else makes opening a clip on the wrong machine a
       // destructive act, and it destroys precisely the work nobody on that machine can
-      // redo. Spread after rather than before, so a parked name can never overwrite a
-      // registry value: the two sets are disjoint by construction, and if they ever
-      // stop being, the installed reading is the one that renders and so the one that
-      // must win.
-      params: { ...lookParams, ...parkedLook.params },
+      // redo.
+      //
+      // **The installed reading wins, and the filter above is what makes that true rather
+      // than the spread order.** The two sets are disjoint by construction and the spread
+      // is the cheap way to join them; what the spread cannot do is decide a collision, and
+      // it decides one the wrong way round - a parked copy landing second overwrites the
+      // value the registry is rendering. `writableParked` drops the collision instead of
+      // ordering it, so the sentence this comment has always made is enforced by the line
+      // above rather than asserted by this one.
+      params: { ...lookParams, ...parked.params },
       tracks: {
         ...Object.fromEntries(
           kept
             .filter((n) => tracks.has(n))
             .map((n) => [n, tracks.get(n).serialise()]),
         ),
-        ...parkedLook.tracks,
+        ...parked.tracks,
       },
     },
     composition: {

--- a/web/point-cloud.js
+++ b/web/point-cloud.js
@@ -419,6 +419,36 @@ export function buildPointCloud(sourceCells, program) {
  * its own pipeline object - which is why `warmPrograms` in `web/main.js` presses this both
  * ways at boot rather than trusting one variant to cover the other.
  */
+/**
+ * The two shader programs this material draws with, replaced.
+ *
+ * **The material is mutated rather than rebuilt, and the identity is what the caller is
+ * buying.** `cloud` is a `THREE.Points` built on this material and already in the scene,
+ * `setAdditive` flips its blend, and `web/main.js` holds neither by any route but the
+ * imported bindings - so constructing a new `ShaderMaterial` here would leave the drawn
+ * cloud on the program before last with nothing anywhere saying so. `needsUpdate` is what
+ * makes three.js recompile, which is the same flag and the same reason as the blend switch
+ * below.
+ *
+ * It lives here rather than at the call site because the call site imports this material
+ * and may not write into it: an imported object anybody can reach into is the channel
+ * `tools/module-check.mjs` refuses in general, on the grounds that the module holding the
+ * state cannot see the write. `uniforms` is the one exemption and it is a table of cells
+ * the GPU reads; a shader program is the module's own construction, so the write belongs
+ * to the module.
+ *
+ * The uniform table is deliberately untouched. A swapped program declares a different set
+ * of uniforms, and three.js resolves a material's uniforms against whatever the compiled
+ * program actually holds - so a key with no uniform behind it costs nothing and a uniform
+ * with no key reads zero, which is the same standing obligation the header above states
+ * and which `web/main.js` meets by minting the cells a new package's bindings need.
+ */
+export function setCloudProgram(program) {
+  material.vertexShader = program.vertexShader;
+  material.fragmentShader = program.fragmentShader;
+  material.needsUpdate = true;
+}
+
 export function setAdditive(on) {
   material.blending = on ? THREE.AdditiveBlending : THREE.NormalBlending;
   material.depthWrite = !on;

--- a/web/post-chain.js
+++ b/web/post-chain.js
@@ -189,3 +189,27 @@ export function buildPostChain(gradeProgram) {
 
   composer.addPass(new OutputPass());
 }
+
+/**
+ * The grade's program, replaced without replacing the pass.
+ *
+ * **The pass's identity is what the chain is built out of.** `composer` holds it at a
+ * position between the bloom and the output that this file's whole argument is about,
+ * `gradeNeeded` in `web/main.js` switches it on and off, and every one of the nine
+ * uniforms the look writes is a cell in `GRADE_UNIFORMS` that this pass's material
+ * composed by reference. Building a new `ShaderPass` would put the new program in a pass
+ * that is in no chain, leaving the drawn image on the old one - which is the shape of
+ * failure this program keeps writing case files about, because the picture still comes out
+ * and nothing says which program drew it.
+ *
+ * Here rather than at the call site for the same reason `setCloudProgram` is: `grade` is
+ * an exported binding, and a module reaching into an imported object is the channel
+ * `tools/module-check.mjs` refuses. Its uniform table is exempt there and is written from
+ * `web/main.js` on every look parameter; the material is not, and swapping a program is
+ * this file's own business.
+ */
+export function setGradeProgram(gradeProgram) {
+  grade.material.vertexShader = gradeProgram.vertexShader;
+  grade.material.fragmentShader = gradeProgram.fragmentShader;
+  grade.material.needsUpdate = true;
+}


### PR DESCRIPTION
Part 5 of the six-PR stack — the payoff. Base: `effects-shaders`.

A document naming an effect this build does not have stops being refused: its values and tracks park in a pool nothing evaluates and nothing destroys, the installed part renders identically, a badge names each missing effect with its version and parked counts, and the round trip preserves every parked key. Export refuses by default naming the missing effects; a per-effect suppress latch lets it proceed with the effect stripped, recorded in the deliverable. The render worker refuses a job naming an effect it cannot resolve before any GPU is spent.

Packages install at runtime: `PUT /effects/:id` behind a door of named refusals — id and format gates, path containment, binding and identifier cross-checks against the real assembler, master-must-be-inert, a fork may add but never drop a shipped parameter — with atomic installs whose temporaries are invisible to the store by construction. `DELETE` removes a user package (restoring a shadowed builtin) and parks what the open document owned. Hotload and boot are one code path: adopt rebuilds registry, panel and uniform cells and ends by walking every value through `params.set`, and a failed adoption rolls back — registry, programs, document — leaving the page exactly where it stood, with the refusal named. Pages converge on a six-second rev poll that stands down during exports, preset gestures and evaluation.

Two instruments land and are named in the proof-tool table: `effect-check` (the store's revs, the door's refusals, hotload coherence through boot-check's own diff, the uninstall/reinstall round trip on identical playback hashes, crashed-install invisibility) and `effect-conformance-check` (the plugin contract: every listed effect renders identically at defaults, at an inert master, and served hollow — with marker rows proving the GLSL actually left and returned, and a vacuity guard that a raise moves the picture).
