### PR TITLE
Add halation and film-stock grading

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -254,12 +254,13 @@ leak, so it is kept narrow and cyan. **`rim`** brightens depth discontinuities a
 subject its edge, but under additive blending plus bloom it washes broad surfaces white, so
 turn it down before turning down bloom.
 
-**The five Post terms share one pass, and the pass carries the tonemap.** `rgb split`,
-`raster.amount`, `grain.amount`, `streak.amount` and `vignette.amount` each switch it on, because a full-screen read and
+**The seven grade terms share one pass, and the pass carries the tonemap.** `rgb split`,
+`raster.amount`, `grain.amount`, `streak.amount`, `halation.amount`, `stock.amount` and
+`vignette.amount` each switch it on, because a full-screen read and
 write that changes nothing is worth skipping. What rides along with it is the highlight rolloff
-and the black-toe crush, so a look with all five at zero is not the same image without five
+and the black-toe crush, so a look with all seven at zero is not the same image without seven
 effects: it also has lifted blacks and no rolloff, and additive accumulation clips to flat
-white where it would otherwise keep its hue. Raising any one of the five brings the grade back.
+white where it would otherwise keep its hue. Raising any one of the seven brings the grade back.
 The vignette used to be part of that bundle and is now its own control, which is why a project
 saved before it existed loses its corner falloff until it names one.
 
@@ -277,6 +278,22 @@ sensor's own frame and has no square to mean it in. It is a gather over the curr
 than a buffer that accumulates across frames: a buffer would smear along whatever the camera did
 last, so an orbit would drag every streak sideways and a seek would arrive carrying the streak
 the scrub built rather than the one playback would have.
+
+**`halation.amount`** is the warm ring film puts around a highlight, with three settings under it
+in a `Halation` group of its own on the raster's precedent — a term that grows sub-controls gets
+a heading rather than crowding `Post`. What makes it worth having beside bloom is the colour. A bloom halo is the highlight's own colour spread
+outward, so a cold window blooms cold; on film the light goes through the emulsion, scatters off
+the base behind it and exposes it a second time, and what comes back is red-orange whatever
+colour went in. So what this gathers is a brightness and not a colour: sixteen taps on a disc
+around each pixel, each one counted by how far its luminance sits above `halation threshold` and
+by how far away it is, and the colour comes from `halation tint` alone — 0 is deep red, 1 is
+amber, and there is no hue control because a look asks how much of a ramp it wants rather than
+for a different ramp. `halation radius` is how wide the ring is, in pixels at the 1080p
+reference like every other screen-space term, and it widens the ring without dimming it: the
+taps are normalised by their own distance weights, so what the falloff decides is the ring's
+shape and not how much light is in it. Raise `halation threshold` and only the brightest things
+scatter; drop it and the whole frame starts to glow. The three settings are inert while the
+amount is at zero, which is what keeps them from switching the pass on by themselves.
 
 **`trails`** is the buffer that paragraph rules out, and the one look term whose length is
 counted in frames rather than in seconds. It hands its value straight to the afterimage pass's
@@ -586,10 +603,29 @@ through for the reason `contourWidth`'s two band edges are: taking the sine in t
 allowed to be a couple of thousandths off, and a raster meant to run along y then leaks a
 whisker of x.
 
+**`film stock`** is the emulsion's own colour, in a `Film stock` group of its own, and it keys
+on exposure rather than on distance. That is what separates it from the duotone above: the
+duotone is keyed to depth, replaces the colour outright and runs per point, where this biases
+the colour the assembled frame already has — so a point, the bloom halo around it and the
+halation ringing that halo are toned together, which nothing in the point program can do. It is
+built to leave exposure alone: the tint it applies is divided by its own luminance, so raising
+the master to 1 moves colour and not brightness (measured over three frames, mean luma 124.91 at
+one end of the balance against 125.06 at the other, a spread of 0.12%).
+
+`stock balance` is the axis between two stocks and **its two halves are different shapes**. At
+-1 it is a tungsten-balanced stock shot in daylight: shadows cool toward cyan-blue and highlights
+stay warm, which is the split most people mean by a film look. At +1 it is the mismatch the
+other way round and the whole frame sits warm, because both stocks put warm highlights up and
+what actually walks along the axis is the shadow. `stock split` is the luminance where cool
+becomes warm and `stock latitude` is how wide the crossover is either side of it — they go on
+deciding where and how wide across the whole axis, they simply stop straddling a hue boundary
+once the balance is past neutral. All three are settings of `stock.amount` and are inert while
+it is at zero.
+
 `crush` is the toe under the grade's Reinhard curve, promoted from a literal and defaulting to
-it. It is a sub-control of the grade pass rather than a fifth term gating it — raise it on its
-own and nothing happens, because the pass only runs when the split, the scanlines, the grain
-or the vignette asks for it. That asymmetry is deliberate: its default is not zero, so gating
+it. It is a sub-control of the grade pass rather than an eighth term gating it — raise it on its
+own and nothing happens, because the pass only runs when one of the seven terms above asks for
+it. That asymmetry is deliberate: its default is not zero, so gating
 on it would hold the pass open for every look there has ever been.
 
 The panel is generated from the registry at boot. A parameter is one entry naming its group

--- a/effects-builtin/halation/decl.grade.glsl
+++ b/effects-builtin/halation/decl.grade.glsl
@@ -1,0 +1,1 @@
+    uniform float halation, halationRadius, halationThreshold, halationTint;

--- a/effects-builtin/halation/manifest.json
+++ b/effects-builtin/halation/manifest.json
@@ -1,0 +1,100 @@
+{
+  "format": 1,
+  "id": "halation",
+  "version": "1.0.0",
+  "title": "Halation",
+  "params": {
+    "amount": {
+      "def": 0,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "halation",
+      "panel": {
+        "group": "halation",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "grade",
+        "uniform": "halation",
+        "gates": true
+      },
+      "role": "master"
+    },
+    "radius": {
+      "def": 22,
+      "min": 2,
+      "max": 90,
+      "step": 1,
+      "kind": "scalar",
+      "label": "halation radius",
+      "panel": {
+        "group": "halation",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "grade",
+        "uniform": "halationRadius"
+      },
+      "under": "amount"
+    },
+    "threshold": {
+      "def": 0.55,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "halation threshold",
+      "panel": {
+        "group": "halation",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "grade",
+        "uniform": "halationThreshold"
+      },
+      "under": "amount"
+    },
+    "tint": {
+      "def": 0.35,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "halation tint",
+      "panel": {
+        "group": "halation",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "grade",
+        "uniform": "halationTint"
+      },
+      "under": "amount"
+    }
+  },
+  "panelGroups": [
+    {
+      "key": "halation",
+      "label": "Halation",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "post",
+      "order": 200
+    }
+  ],
+  "chunks": [
+    {
+      "stage": "g.decl",
+      "order": 150,
+      "file": "decl.grade.glsl"
+    },
+    {
+      "stage": "g.body",
+      "order": 150,
+      "file": "scatter.grade.glsl"
+    }
+  ]
+}

--- a/effects-builtin/halation/scatter.grade.glsl
+++ b/effects-builtin/halation/scatter.grade.glsl
@@ -1,0 +1,56 @@
+      // Light that got through the emulsion scatters off the film base behind it and comes
+      // back to expose it a second time, so a bright area rings the things around it with a
+      // red-orange glow. **The colour is the whole of what this term says, and it is the
+      // thing the bloom in web/bloom-pass.js cannot say.** A halo out of that pass is the
+      // highlight's own colour spread outward, so a cold window blooms cold; the same window
+      // on film rings warm, because the base scatters whatever reached it and has no opinion
+      // about what colour that was. So what is gathered below is a scalar - how far each tap
+      // sits above the threshold - and every bit of the colour comes from the tint.
+      //
+      // It sits at 150, above the streak at 100 and below everything drawn over the picture,
+      // and the placement is an argument rather than a free slot. The streak's smear is
+      // light that reached the emulsion, so it scatters too, and gathering before it ran
+      // would ring the highlight while leaving the smear it drags across the frame cold. The
+      // raster and the grain are marks made on top of the picture and have nothing to
+      // scatter, which is why they sit below this rather than above it.
+      //
+      // Sixteen taps on a golden-angle disc, the distance taken as the square root of the
+      // tap's share of the disc so the samples spread evenly over the area instead of
+      // crowding the middle, and the offsets are in reference pixels through texel for the
+      // reason the streak's are: a glow whose radius grew with the window would be the
+      // nearly resolution-independent look that is worse than an honestly dependent one.
+      //
+      // **The normaliser is the sum of the distance weights and never the sum of the
+      // luminance weights**, which is the one place this block could have been written to
+      // divide by zero. Dividing by the summed excess would make the result the mean colour
+      // of whatever was bright - and on a frame with nothing above the threshold, which is
+      // most of a take shot in a dark room, that sum is exactly zero and the whole halo
+      // comes out NaN in the one situation nobody is watching for it. Written this way the
+      // denominator is a sum of sixteen positive numbers that depend only on the geometry,
+      // so it cannot vanish at any radius, and a frame with no highlight in it contributes a
+      // glow of zero rather than a hole.
+      //
+      // The same normalisation is why the radius widens the ring without dimming it: a
+      // constant factor over every weight cancels top and bottom, so what the falloff
+      // decides is the shape of the ring and not how much light is in it. That is a look
+      // control behaving the way a person expects rather than the physics of a thicker base,
+      // and it is deliberate - the amount is the term that says how much.
+      //
+      // Guarded on the master for the reason every package here is guarded on its own: a
+      // build with this installed and the amount at zero has to draw exactly what a build
+      // without it draws, which is what tools/effect-conformance-check.mjs takes the package
+      // away to measure.
+      if (halation > 0.0) {
+        vec3 glowTint = mix(vec3(0.94, 0.16, 0.05), vec3(1.00, 0.56, 0.20), halationTint);
+        float scattered = 0.0;
+        float weights = 0.0;
+        for (int i = 0; i < 16; i++) {
+          float span = sqrt((float(i) + 0.5) / 16.0) * halationRadius;
+          float turn = float(i) * 2.39996323;
+          vec3 tap = texture2D(tDiffuse, vUv + vec2(cos(turn), sin(turn)) * span * texel).rgb;
+          float weight = 1.0 / (1.0 + span * 0.08);
+          scattered += max(dot(tap, vec3(0.299, 0.587, 0.114)) - halationThreshold, 0.0) * weight;
+          weights += weight;
+        }
+        col += glowTint * (scattered / weights) * halation;
+      }

--- a/effects-builtin/stock/curve.grade.glsl
+++ b/effects-builtin/stock/curve.grade.glsl
@@ -1,0 +1,72 @@
+      // The emulsion's own colour, keyed to exposure, and one parameter walks both poles
+      // between a tungsten stock and a daylight one. At the tungsten end the shadows sit
+      // cool and the highlights sit warm, which is most of what a colour negative balanced
+      // for lamplight does to daylight before anybody grades it; at the daylight end the
+      // whole frame sits warm instead, which is the same mismatch read the other way round.
+      //
+      // **This is not the duotone, and that deserves the paragraph because "why is this not
+      // the duotone" is the first question a reader has.** The duotone is keyed to *depth*,
+      // it replaces the colour outright between two poles, and it runs in the point program
+      // in web/cloud-shader.js - so it decides what a point is coloured by, and it decides it
+      // per point. This is keyed to *luminance*, it biases the colour that is already there
+      // by a multiply, and it runs in the grade over the assembled frame - so a point, the
+      // bloom halo around it and the halation ringing that halo are all toned together,
+      // which nothing in the point program can reach. Two terms mixing toward two poles
+      // would be the drifting twin this design keeps refusing if they keyed on the same
+      // thing. They do not, and neither one can be written as the other.
+      //
+      // It sits at 350, after the grain at 300 and before the vignette at 400, and both
+      // halves are an argument rather than a free slot. The curve is what the emulsion did
+      // to the light and the grain is the emulsion's own texture, so the curve reads over
+      // the grain it carries rather than the grain being laid over a stock it is part of.
+      // And it sits before the vignette because the vignette is the lens: the emulsion saw
+      // the picture through it rather than after it, so a corner the lens put out has to
+      // come out of a frame this has already toned.
+      //
+      // The luminance is read with the same three weights the grain a step above uses, and
+      // that is the one place this file could grow a second opinion about how bright a pixel
+      // is. Two readings of that in one pass would drift apart the first time somebody tuned
+      // one of them, and the grade would then have a shadow that the grain thinks is a
+      // highlight.
+      //
+      // **The tint is divided by its own luminance, which is what makes the claim that this
+      // moves colour and not exposure arithmetic rather than taste.** Four hand-tuned
+      // triples can be checked for neutrality at the two balances and the two ends somebody
+      // happened to look at, and every crossover between them is then a guess - so a stock
+      // raised to 1 would quietly rebrighten the frame, and the operator would take the
+      // exposure back down and lose the grade they were reaching for. Dividing by the dot
+      // makes every combination of balance and crossover luminance-preserving by
+      // construction under the same weights the reading above uses. The denominator cannot
+      // vanish: all four poles sit within about a fifth of unity in every channel, so the
+      // dot stays near 1 and never near 0.
+      //
+      // The poles themselves are baked rather than exposed, for the reason
+      // effects-builtin/duotone/tone.frag.glsl states about its own two: a look
+      // parameterises how much of a ramp it wants, not the ramp.
+      //
+      // **The balance is an axis and the two halves of it are not the same shape**, which is
+      // the correction this pair carries rather than the design it was written with. The
+      // daylight poles were first a gentler version of the tungsten ones - shadows still
+      // biased blue, highlights still warm - and that is a parameter that runs from very cool
+      // to slightly cool and never arrives anywhere. Graded side by side on a real take, a
+      // frame at +1 read as a less blue version of the frame at -1 rather than as a different
+      // stock, and the luminance neutralisation below correctly cancelled most of what warmth
+      // was left. So the negative half is the shadow-cool, highlight-warm split a
+      // tungsten-balanced stock shows in daylight, and the positive half is a warm cast over
+      // the whole frame with the same crossover still in it - `stockSplit` and
+      // `stockLatitude` go on deciding where the crossover falls and how wide it is, they
+      // simply stop straddling a hue boundary once the balance is past neutral. That is the
+      // control being useful across its whole range instead of across half of it.
+      //
+      // Guarded on the master, so a build with this installed and the amount at zero draws
+      // exactly what a build without it draws - the property
+      // tools/effect-conformance-check.mjs takes the package away to measure.
+      if (stock > 0.0) {
+        float lum = dot(col, vec3(0.299, 0.587, 0.114));
+        float e = smoothstep(stockSplit - stockLatitude * 0.5, stockSplit + stockLatitude * 0.5, lum);
+        float day = stockBalance * 0.5 + 0.5;
+        vec3 shadowTint = mix(vec3(0.82, 0.97, 1.22), vec3(1.06, 1.00, 0.93), day);
+        vec3 highlightTint = mix(vec3(1.16, 1.02, 0.84), vec3(1.14, 1.02, 0.85), day);
+        vec3 tint = mix(shadowTint, highlightTint, e);
+        col = mix(col, col * (tint / dot(tint, vec3(0.299, 0.587, 0.114))), stock);
+      }

--- a/effects-builtin/stock/decl.grade.glsl
+++ b/effects-builtin/stock/decl.grade.glsl
@@ -1,0 +1,1 @@
+    uniform float stock, stockBalance, stockSplit, stockLatitude;

--- a/effects-builtin/stock/manifest.json
+++ b/effects-builtin/stock/manifest.json
@@ -1,0 +1,100 @@
+{
+  "format": 1,
+  "id": "stock",
+  "version": "1.0.0",
+  "title": "Film stock",
+  "params": {
+    "amount": {
+      "def": 0,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "film stock",
+      "panel": {
+        "group": "stock",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "grade",
+        "uniform": "stock",
+        "gates": true
+      },
+      "role": "master"
+    },
+    "balance": {
+      "def": 0,
+      "min": -1,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "stock balance",
+      "panel": {
+        "group": "stock",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "grade",
+        "uniform": "stockBalance"
+      },
+      "under": "amount"
+    },
+    "split": {
+      "def": 0.45,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "stock split",
+      "panel": {
+        "group": "stock",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "grade",
+        "uniform": "stockSplit"
+      },
+      "under": "amount"
+    },
+    "latitude": {
+      "def": 0.3,
+      "min": 0.02,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "stock latitude",
+      "panel": {
+        "group": "stock",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "grade",
+        "uniform": "stockLatitude"
+      },
+      "under": "amount"
+    }
+  },
+  "panelGroups": [
+    {
+      "key": "stock",
+      "label": "Film stock",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "post",
+      "order": 300
+    }
+  ],
+  "chunks": [
+    {
+      "stage": "g.decl",
+      "order": 350,
+      "file": "decl.grade.glsl"
+    },
+    {
+      "stage": "g.body",
+      "order": 350,
+      "file": "curve.grade.glsl"
+    }
+  ]
+}

--- a/tools/module-check.mjs
+++ b/tools/module-check.mjs
@@ -1378,7 +1378,7 @@ const EXEMPTIONS = [
   {
     module: 'web/post-chain.js',
     binding: 'grade',
-    why: 'The one combined grade pass. Ten look parameters write their term into `uniforms` and five of them gate `enabled` on whether any term is up - which five read off the packages\' `gates` bindings rather than listed - and that is the reason the pass is one rather than four.',
+    why: 'The one combined grade pass. Eighteen look parameters write their term into `uniforms` and seven of them gate `enabled` on whether any term is up - which seven read off the packages\' `gates` bindings rather than listed - and that is the reason the pass is one rather than four.',
   },
   // The one entry in this table that is not a three.js object with a published interface,
   // and the only one that needed arguing rather than citing. A uniform is a cell the GPU

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -338,10 +338,10 @@ const MUTATIONS = {
   // the number at the uniform, so the landing row is the only thing that can fail here.
   //
   // **It anchors a branch of the shared applier now rather than this parameter's own
-  // closure, and that costs it nothing.** The forty-one effect parameters are declared as
+  // closure, and that costs it nothing.** The forty-nine effect parameters are declared as
   // data in the effect manifests and `effectApply` in `web/main.js` is what turns a
   // binding into a write, so there is no `duotoneHue` line left to anchor. `degToRad` is
-  // the transform of exactly one of the forty-one - this hue - so mutating the branch and
+  // the transform of exactly one of the forty-nine - this hue - so mutating the branch and
   // mutating the parameter are still the same act, and the row set below is unchanged.
   'duotone-hue-in-degrees': {
     file: 'web/main.js',
@@ -552,7 +552,7 @@ const MUTATIONS = {
   //
   // **This control got broader when the effect parameters became data, and the widening is
   // a real loss of resolution rather than a stronger check.** There is no `streakAxis` line
-  // left to anchor: the forty-one are declared in the effect manifests and `effectApply`
+  // left to anchor: the forty-nine are declared in the effect manifests and `effectApply`
   // in `web/main.js` builds the write, with `axisDeg` stated once for the two angles that
   // take it. So the anchor is that one branch, and mutating it feeds degrees to both
   // `streak.angle` and `raster.angle`. The name is kept because it is what
@@ -654,8 +654,8 @@ const MUTATIONS = {
     fails: 'seven rows: the pass-gate row for crush, all five reading rows of 1b (each at 6 of '
       + '6 frames and about three quarters of every frame), and the boot comparison, whose '
       + 'landing diff names rgbsplit.amount, raster.amount and grain.amount moving from '
-      + '[0,false] to [0,true]. **`GRADE_GATES` holds five terms and this line used to say '
-      + 'four** - grain, scanlines, rgbSplit, streak and vignette, derived from the packages\' '
+      + '[0,false] to [0,true]. **`GRADE_GATES` holds seven terms and this line used to say '
+      + 'four** - grain, scanlines, rgbSplit, streak, halation, stock and vignette, derived from the packages\' '
       + '`gates` bindings rather than counted by hand, which is the whole point of deriving '
       + 'them: the boot row names the three whose landing actually moves, and the number of '
       + 'gates is a fact about the installed set rather than about this comment',
@@ -1600,6 +1600,28 @@ const LANDING = {
   // rather than a term beside it, so switching the pass on to point a streak nobody raised
   // is the no-op the gate matrix refuses by name.
   'streak.angle': '[k.grade.uniforms.streakAxis.value.x, k.grade.uniforms.streakAxis.value.y].map((v) => Number(v.toFixed(9)))',
+  // The halation's master, which gates the pass on the streak's terms exactly, and its
+  // three settings, which do not - the same shape the raster's four have, and the absence
+  // of `k.grade.enabled` on the three is as much the assertion as its presence on the
+  // master: widening a ring nobody asked for has to leave the pass shut.
+  //
+  // The radius is reference pixels on both sides of this row. Nothing converts it on the
+  // way through, which is what the row says: the shader divides by `texel` to reach the
+  // frame it is drawn at, so an apply that scaled it here would be doing that twice and
+  // against a buffer size the document does not carry.
+  'halation.amount': '[k.grade.uniforms.halation.value, k.grade.enabled]',
+  'halation.radius': 'k.grade.uniforms.halationRadius.value',
+  'halation.threshold': 'k.grade.uniforms.halationThreshold.value',
+  'halation.tint': 'k.grade.uniforms.halationTint.value',
+  // The stock's four, on the same terms: the master carries the gate and the three under it
+  // do not. `stock.balance` is the one of the three that spans zero, and it lands as the
+  // signed value the slider holds rather than as the 0..1 the shader mixes on - the remap
+  // is arithmetic inside the block, so an apply that did it here would put a tungsten
+  // balance of -1 into a uniform reading 0 and the row would still look like a number.
+  'stock.amount': '[k.grade.uniforms.stock.value, k.grade.enabled]',
+  'stock.balance': 'k.grade.uniforms.stockBalance.value',
+  'stock.split': 'k.grade.uniforms.stockSplit.value',
+  'stock.latitude': 'k.grade.uniforms.stockLatitude.value',
   'vignette.amount': '[k.grade.uniforms.vignette.value, k.grade.enabled]',
   // The fifth term in that pass, and **the missing `k.grade.enabled` beside it is the
   // assertion**. The four above gate the pass and so each has to carry whether it is on;
@@ -1729,20 +1751,23 @@ const EXPECT = {
   'rain.trail': (v) => v,
   bloom: (v) => [v, v > 0],
   trails: (v) => [v, v > 0],
-  // The five that share one pass, so each one's landing carries whether the pass is on
-  // and every one of them has to name the other four. `vignette` joined them when it
-  // stopped being a literal applied whenever the pass happened to run, and `streak` joined
-  // by being written.
+  // The seven that share one pass, so each one's landing carries whether the pass is on
+  // and every one of them has to name the other six. `vignette` joined them when it
+  // stopped being a literal applied whenever the pass happened to run, `streak` joined by
+  // being written, and `halation` and `stock` joined the same way.
   //
-  // **Every row here gained `streak` and not only the new one.** The scrambled set happens
-  // to raise all five at once, so leaving the older four alone would have passed today and
-  // gone on passing - right up until a set that raised the streak alone, where four rows
+  // **Every row here gained `streak` and not only the new one, and every row gained the
+  // two after it for the same reason.** The scrambled set happens to raise all seven at
+  // once, so leaving the older rows alone would have passed today and gone on passing -
+  // right up until a set that raised one of the new terms alone, where the other six rows
   // would expect a shut pass against an open one and read as findings about terms that had
   // not changed. The gate is one condition and each row states the whole of it.
   'rgbsplit.amount': (v, all) => [v, v > 0 || all['raster.amount'] > 0 || all['grain.amount'] > 0
-    || all['vignette.amount'] > 0 || all['streak.amount'] > 0],
+    || all['vignette.amount'] > 0 || all['streak.amount'] > 0 || all['halation.amount'] > 0
+    || all['stock.amount'] > 0],
   'raster.amount': (v, all) => [v, all['rgbsplit.amount'] > 0 || v > 0 || all['grain.amount'] > 0
-    || all['vignette.amount'] > 0 || all['streak.amount'] > 0],
+    || all['vignette.amount'] > 0 || all['streak.amount'] > 0 || all['halation.amount'] > 0
+    || all['stock.amount'] > 0],
   // Same double arithmetic three's `degToRad` does, so the equality is exact rather than
   // near - and written out here rather than read back off the page, because a tool that
   // asked the page what conversion it used could never see a wrong one.
@@ -1759,9 +1784,11 @@ const EXPECT = {
   'raster.pitch': (v) => v,
   'raster.hard': (v) => v,
   'grain.amount': (v, all) => [v, all['rgbsplit.amount'] > 0 || all['raster.amount'] > 0 || v > 0
-    || all['vignette.amount'] > 0 || all['streak.amount'] > 0],
+    || all['vignette.amount'] > 0 || all['streak.amount'] > 0 || all['halation.amount'] > 0
+    || all['stock.amount'] > 0],
   'streak.amount': (v, all) => [v, all['rgbsplit.amount'] > 0 || all['raster.amount'] > 0
-    || all['grain.amount'] > 0 || all['vignette.amount'] > 0 || v > 0],
+    || all['grain.amount'] > 0 || all['vignette.amount'] > 0 || v > 0
+    || all['halation.amount'] > 0 || all['stock.amount'] > 0],
   // The same double arithmetic the registry does on the way through, written out here
   // rather than read back off the page for `raster.angle`'s reason two rows up: a tool that
   // asked the page which axis it built could never see a wrong one. Rounded on both sides,
@@ -1769,8 +1796,31 @@ const EXPECT = {
   // and a ULP apart is not a finding, where an axis built in degrees still is.
   'streak.angle': (v) => [Math.sin(v * (Math.PI / 180)), Math.cos(v * (Math.PI / 180))]
     .map((x) => Number(x.toFixed(9))),
+  // The halation's master on the terms of the six it shares the pass with, and its three
+  // settings straight through. The radius is reference pixels here and reference pixels at
+  // the uniform, which is the whole of what its row has to say - the conversion into the
+  // frame's own pixels happens in the shader against a buffer size no document carries, so
+  // an apply that scaled it here would be doing it twice.
+  'halation.amount': (v, all) => [v, all['rgbsplit.amount'] > 0 || all['raster.amount'] > 0
+    || all['grain.amount'] > 0 || all['vignette.amount'] > 0 || all['streak.amount'] > 0
+    || v > 0 || all['stock.amount'] > 0],
+  'halation.radius': (v) => v,
+  'halation.threshold': (v) => v,
+  'halation.tint': (v) => v,
+  // The stock's four, and `balance` is the one worth the sentence: it arrives signed and
+  // lands signed. The remap onto the 0..1 the two poles are mixed across is arithmetic
+  // inside the shader block, so a build that did it in the apply would land 0.5 for a
+  // balance the document says is 0 - a perfectly ordinary number in a perfectly ordinary
+  // cell, and a stock nobody chose.
+  'stock.amount': (v, all) => [v, all['rgbsplit.amount'] > 0 || all['raster.amount'] > 0
+    || all['grain.amount'] > 0 || all['vignette.amount'] > 0 || all['streak.amount'] > 0
+    || all['halation.amount'] > 0 || v > 0],
+  'stock.balance': (v) => v,
+  'stock.split': (v) => v,
+  'stock.latitude': (v) => v,
   'vignette.amount': (v, all) => [v, all['rgbsplit.amount'] > 0 || all['raster.amount'] > 0
-    || all['grain.amount'] > 0 || v > 0 || all['streak.amount'] > 0],
+    || all['grain.amount'] > 0 || v > 0 || all['streak.amount'] > 0
+    || all['halation.amount'] > 0 || all['stock.amount'] > 0],
   // Reads its own value and nothing else, because it shares the pass without gating it -
   // so unlike the four above it names none of the others and none of them name it.
   crush: (v) => v,
@@ -2044,6 +2094,49 @@ const SCRAMBLE = {
   // noise; a direction on a right angle would be one a build with four choices rather than
   // an angle would answer correctly.
   'streak.angle': 113,
+  // The halation well up, because the three under it are only observable through it - the
+  // argument the raster's three settings and the duotone's four are set on. At an amount of
+  // 0 the gather never runs, so the radius, the threshold and the tint would land in the
+  // no-pixel bucket together looking like parameters that do nothing.
+  'halation.amount': 0.58,
+  // Well clear of the 22 it defaults to and not a doubling of it, so a build that halved or
+  // rounded the radius draws a visibly different ring. The gather is a disc, so the number
+  // of pixels it reaches goes as the square of this - 55 reference pixels covers about six
+  // times the area the default does, which is a ring the drop-one sweep cannot mistake for
+  // sampling noise.
+  'halation.radius': 55,
+  // Well *below* its 0.55 default, and that direction is the whole of why the row is safe.
+  // The fixture is a point cloud on an empty background, so most of the frame is black and
+  // only the bloomed cores of the brighter points climb far up the range: a threshold
+  // scrambled upward could put every tap under the bar, which is a glow of exactly zero and
+  // three parameters landing in the no-pixel bucket for a reason about the fixture rather
+  // than about the build. At 0.21 there is real light above the bar and reverting the
+  // parameter takes most of it away.
+  'halation.threshold': 0.21,
+  // Near the amber pole and nowhere near the 0.35 it defaults to, so reverting it swings the
+  // ring back toward deep red across the whole of what the gather found. A tint a hair off
+  // its default would be a parameter the drop-one sweep could not separate from the grain.
+  'halation.tint': 0.86,
+  // The stock up for the reason the halation above it is: its three settings are inert while
+  // the master is at zero, so a master left at its default would take all three into the
+  // no-pixel bucket with it.
+  'stock.amount': 0.66,
+  // Hard toward the tungsten pole, where its default sits exactly between the two stocks.
+  // Reverting it therefore walks both poles half the distance to daylight at once rather
+  // than nudging one of them, which is what a drop-one sweep can see and what a value near
+  // the middle would not give.
+  'stock.balance': -0.74,
+  // Below the 0.45 it defaults to, and low for the same reason the halation's threshold is:
+  // the frame is mostly dark, so a crossover placed high in the range sits above nearly
+  // every pixel and both this and the latitude below it would be deciding where a boundary
+  // falls in a part of the picture that has no pixels in it. At 0.28 the crossover runs
+  // through the bloom haloes, which is where this fixture's luminance actually lives.
+  'stock.split': 0.28,
+  // Down to about half the default width, so the crossover is a visible edge through those
+  // haloes rather than a ramp spread across the whole range. Reverting it therefore softens
+  // an edge instead of nudging one, which is the same argument `duotone.span` two dozen rows
+  // up is set on and the same one `raster.pitch` is scrambled below its default for.
+  'stock.latitude': 0.14,
   'vignette.amount': 0.73,
   // Well above the 0.018 it defaults to, and the four terms above hold the pass open so
   // it is reachable at all - a toe inside a pass nothing switched on is the dead zone
@@ -2705,6 +2798,23 @@ const GOLDEN_ABSENT = new Set([
   // section 1b renders at parameter defaults, where a streak of 0 keeps the block shut
   // whichever way the axis points.
   'streak.angle',
+  // The halation's four and the stock's four, excused on the plainest version of these
+  // terms: neither package existed in any form at the pinned revision, so the earlier arm
+  // answers undefined for all eight and there is nothing to hold them to. Both masters
+  // default to zero and both blocks are guarded on their own master, so a build carrying
+  // them draws exactly what a build without them drew.
+  //
+  // **Section 1b covers the two masters and cannot vouch for the six keys under them**,
+  // which is the same warning `duotone.motion` and six of the glyph and rain keys carry and
+  // is worth repeating rather than inheriting. 1b renders at parameter defaults, where both
+  // masters are 0 and each gates its own block, so a term added *inside* one of them is
+  // unreached by that hash whichever way its own default behaves - the hole the glitch
+  // flare's compensating default fell through. What holds the six instead is the drop-one
+  // sweep at the foot of this file, where both masters are up and every one of them has to
+  // move the image when it is dropped, and `effect-conformance-check`, which raises each of
+  // the six under a master held at zero and requires the frame not to move.
+  'halation.amount', 'halation.radius', 'halation.threshold', 'halation.tint',
+  'stock.amount', 'stock.balance', 'stock.split', 'stock.latitude',
   // The program-out size, on the same terms and for the same reason: not a registry
   // parameter, no such control at the earlier revision, and its own bounds live in the
   // handler that parses it rather than in the markup. What it is held to is
@@ -3560,6 +3670,24 @@ console.log('\n[registry] the side effects that are not a uniform write');
     // pass shut. Gating it would switch a full-screen read and write on to aim an effect
     // whose amount is zero, which is precisely the no-op the gate exists to refuse.
     [{ 'streak.angle': 90 }, { bloom: false, trails: false, grade: false }],
+    // The halation and the stock, each of which has to bring the pass up on its own for the
+    // streak's plain reason: both default to zero, so a look that never asks for either pays
+    // nothing, and a term that could only be had by raising one of its neighbours is the
+    // failure the vignette row above was written for.
+    [{ 'halation.amount': 0.02 }, { bloom: false, trails: false, grade: true }],
+    [{ 'stock.amount': 0.02 }, { bloom: false, trails: false, grade: true }],
+    // And their six settings, on the raster angle's terms exactly. Two of these would fail
+    // loudest if they gated, and for the reason `raster.pitch` does: `halation.radius`
+    // defaults to 22 and `stock.split` to 0.45, so a build gating on non-zero would hold the
+    // pass open for every document there has ever been. The other four would merely switch a
+    // full-screen read and write on to shape an effect whose master is off, which is the
+    // no-op these rows exist to refuse.
+    [{ 'halation.radius': 80 }, { bloom: false, trails: false, grade: false }],
+    [{ 'halation.threshold': 0.9 }, { bloom: false, trails: false, grade: false }],
+    [{ 'halation.tint': 1 }, { bloom: false, trails: false, grade: false }],
+    [{ 'stock.balance': -1 }, { bloom: false, trails: false, grade: false }],
+    [{ 'stock.split': 0.9 }, { bloom: false, trails: false, grade: false }],
+    [{ 'stock.latitude': 1 }, { bloom: false, trails: false, grade: false }],
   ]) {
     const r = await setAndRead(values);
     const got = { bloom: r.bloom, trails: r.trails, grade: r.grade };

--- a/web/effect-manifests.js
+++ b/web/effect-manifests.js
@@ -82,10 +82,10 @@ export const CORE_PANEL_GROUP_KEYS = Object.freeze([
  * the client's order places, in that order, and then everything else.
  *
  * **The placed set is byte-stable and the appendix is where a package the order has
- * never heard of goes.** The order is a hand-written layout fact about the sixteen
+ * never heard of goes.** The order is a hand-written layout fact about the eighteen
  * shipped effects - the scramble coupling coupled to it, the panel builds a group's
  * rows in it - so it may not be regenerated, reordered or grown by a package
- * arriving at runtime. But a seventeenth effect has to land somewhere, and until
+ * arriving at runtime. But a nineteenth effect has to land somewhere, and until
  * this rule existed it landed in a refusal: `tableFromPackages` treated a declared
  * name the order did not place as a parameter the registry would silently skip, which
  * is the right answer for a manifest edit and the wrong one for an install.
@@ -106,7 +106,7 @@ export const CORE_PANEL_GROUP_KEYS = Object.freeze([
  * `trail`. Seating it would mean guessing which of the placed names it belongs after,
  * and a guess about layout is the thing the order exists to make somebody state.
  *
- * With the shipped sixteen installed the appendix is empty and this returns the
+ * With the shipped eighteen installed the appendix is empty and this returns the
  * order unchanged, which is what keeps every number downstream of it - the registry's
  * declaration order, the panel's rows, the scramble table - the bytes they were.
  *

--- a/web/grade-shader.js
+++ b/web/grade-shader.js
@@ -17,19 +17,20 @@
 // **What the split costs is the pairing**, the same obligation `web/cloud-shader.js` names:
 // every `uniform` in the assembled program has to have a key in `GRADE_UNIFORMS` in
 // `web/post-chain.js`, and nothing enforces that in either direction at runtime - three.js
-// writes the keys it is given and reads zero for the rest. Measured across the split: 13
-// distinct uniforms in the assembled program, 13 keys there, and the two sets are equal both
-// ways - 8 declared in the segments below and 5 in the raster and streak packages' own
-// declaration chunks. `test/cloud-shader.test.mjs` asks it of both programs separately, so a
-// term arriving in a package is inside the question and a grade term that drifted into the
-// point cloud's table is outside both.
+// writes the keys it is given and reads zero for the rest. Measured across the split: 21
+// distinct uniforms in the assembled program, 21 keys there, and the two sets are equal both
+// ways - 8 declared in the segments below and 13 in the raster, streak, halation and stock
+// packages' own declaration chunks. `test/cloud-shader.test.mjs` asks it of both programs
+// separately, so a term arriving in a package is inside the question and a grade term that
+// drifted into the point cloud's table is outside both.
 //
 // **Three joints, and the run they sit in is the pass's order.** The order of the terms
 // below is the whole of this shader's opinion and is the same kind of decision the four
-// `addPass` calls in `web/post-chain.js` are: the streak is a thing that happened to the
-// light and sits above the tonemap, the raster and the grain are drawn over the picture, and
-// the vignette closes the corners down before any of it is rolled off. Each chunk carries
-// its own argument for where it sits.
+// `addPass` calls in `web/post-chain.js` are: the streak and the halation are things that
+// happened to the light and sit above the tonemap, the raster and the grain are drawn over
+// the picture, the stock is the colour of the emulsion carrying that grain, and the vignette
+// closes the corners down before any of it is rolled off. Each chunk carries its own
+// argument for where it sits.
 
 // Each entry frozen as well as the list, for the reason the cloud's spine gives: the spine
 // is read by the page's pass and by the gate, and a segment trimmed in place would move the
@@ -59,11 +60,13 @@ export const gradeSpine = Object.freeze({
     // `vignette`) and two of them core (`crush`, which is a sub-control inside the grade
     // rather than a term beside it, and `time`) - and splitting a comma-separated
     // declaration moves bytes, which is the one thing this whole split may not do. So four
-    // packages have their master declared in the spine, and the two that carry further terms
-    // - the raster's axis, pitch and hardness, and the streak's amount and axis - declare
-    // those here. That reads as an inconsistency and is a measurement: the alternative is a
-    // second declaration stage wrapped around a fragment of one line, bought for four names
-    // that cost nothing to leave where they are. The streak's own amount is here rather than
+    // packages have their master declared in the spine, and every package carrying terms
+    // that line does not name declares them here - the raster's axis, pitch and hardness,
+    // the streak's amount and axis, and the halation's and the stock's four each, masters
+    // included, because a master added to the stay-behind line is that line rewritten. That
+    // reads as an inconsistency and is a measurement: the alternative is a second
+    // declaration stage wrapped around a fragment of one line, bought for four names that
+    // cost nothing to leave where they are. The streak's own amount is here rather than
     // above only because that is where the monolith put it.
     { stage: 'g.decl' },
     { text: /* glsl */ `\
@@ -113,10 +116,11 @@ export const gradeSpine = Object.freeze({
 `,
     },
     // Everything drawn over the picture or done to the light, in the order the pass runs
-    // them: the streak at 100, the raster at 200, the grain at 300 and the vignette at 400.
-    // A stage rather than four slots because these compose - each one takes the colour the
-    // one above it produced and hands it on - and because a build with none of them
-    // installed should be the tonemap alone rather than four branches on four zeros.
+    // them: the streak at 100, the halation at 150, the raster at 200, the grain at 300, the
+    // stock at 350 and the vignette at 400. A stage rather than a run of slots because these
+    // compose - each one takes the colour the one above it produced and hands it on - and
+    // because a build with none of them installed should be the tonemap alone rather than
+    // six branches on six zeros.
     { stage: 'g.body' },
     { text: /* glsl */ `\
       // Roll highlights off per channel instead of letting additive accumulation

--- a/web/main.js
+++ b/web/main.js
@@ -52,7 +52,7 @@ import {
 } from './plan-geometry.js';
 import { ZOOM_PER_NOTCH, TICK_STEPS, tickLabel, makeViewWindow } from './view-window.js';
 import { clipIn, clipOut, clipBoundOrThrow, writeClipRange } from './clip-range.js';
-// The forty-one effect parameters as data: which uniform each one writes, on which of the
+// The forty-nine effect parameters as data: which uniform each one writes, on which of the
 // two tables, and what conversion it takes on the way. It belongs to the block above rather
 // than to the render core below because it is the purest thing in that block - it imports
 // nothing at all, which is what lets a check pull an older revision of it out of `git show`
@@ -1310,14 +1310,16 @@ const EFFECT_PARAM_ORDER = [
   'rain.amount', 'rain.speed', 'rain.span', 'rain.trail',
   'rgbsplit.amount', 'raster.amount', 'raster.angle', 'raster.pitch',
   'raster.hard', 'grain.amount', 'streak.amount', 'streak.angle',
+  'halation.amount', 'halation.radius', 'halation.threshold', 'halation.tint',
+  'stock.amount', 'stock.balance', 'stock.split', 'stock.latitude',
   'vignette.amount',
 ];
 
 // **The list is the placement of the shipped set and never a census of what is
 // installed.** A package the list has never heard of is placed by `placeParams` rather
 // than refused - its parameters land contiguously after everything here, in manifest
-// order - so installing a seventeenth effect changes nothing about where any of the
-// forty-one above sit. That was a refusal until installs existed, and it had to stop
+// order - so installing a nineteenth effect changes nothing about where any of the
+// forty-nine above sit. That was a refusal until installs existed, and it had to stop
 // being one: `tableFromPackages` treated a declared name this list did not place as a
 // control the registry would silently skip, which is the right answer for somebody
 // editing a shipped manifest and the only possible answer to an install.
@@ -1329,7 +1331,7 @@ let EFFECT_PARAMS;
 // The names the list above does not place, which is where a newly installed package's
 // parameters are: `placeParams` puts them after every placed name, so this is the tail
 // of the assembled table and `PARAMS` spreads it in one run at the end of the effects.
-// Empty with the shipped sixteen installed, which is what keeps the registry's
+// Empty with the shipped eighteen installed, which is what keeps the registry's
 // declaration order the bytes it was.
 const effectAppendix = () => Object.keys(EFFECT_PARAMS).slice(EFFECT_PARAM_ORDER.length);
 
@@ -1462,8 +1464,8 @@ let PANEL_GROUPS;
 /**
  * The write one effect parameter's binding describes, as the closure the registry stores.
  *
- * Forty-one parameters do the same thing - one number into one uniform - and they used to
- * do it as forty-one hand-written closures, where the ordinary case could be got subtly
+ * Forty-nine parameters do the same thing - one number into one uniform - and they used to
+ * do it as forty-nine hand-written closures, where the ordinary case could be got subtly
  * wrong in a way nothing reads back and where a reader had to check every one to find out
  * which cases there were. the manifests declare them as data now, and this is the
  * one place that data becomes behaviour.
@@ -1525,15 +1527,15 @@ function effectApply(bind) {
 /**
  * One contiguous run of `EFFECT_PARAMS`, as registry entries ready to spread into `PARAMS`.
  *
- * The forty-one are interleaved with the core parameters in seven runs, because the panel
+ * The forty-nine are interleaved with the core parameters in seven runs, because the panel
  * builds a group's rows in registry order and the groups are stages of the pipeline rather
  * than subject headings. So the registry keeps the positions and the table keeps the
  * declarations, and a run is named by its two ends rather than by listing its members - one
  * effect parameter added to a manifest between two ends lands in `PARAMS` at
  * the right place by existing, which is the whole reason not to restate the names here.
  *
- * `tag: 'look'` is constant across all forty-one and is added here rather than repeated
- * forty-one times: an effect parameter that was not part of the clip would not be an effect
+ * `tag: 'look'` is constant across all forty-nine and is added here rather than repeated
+ * forty-nine times: an effect parameter that was not part of the clip would not be an effect
  * parameter. Everything else is the binding's own, in the key order the inline entries held.
  */
 const effectSlice = (first, last) => {
@@ -1837,7 +1839,7 @@ const buildParams = () => ({
   ...effectSlice('rain.amount', 'rain.trail'),
   // Each post pass costs a full-screen read and write whether or not it changes
   // anything, so a zero value switches its pass off rather than running it as a
-  // no-op. The five terms that gate the grade share one pass, so they gate it together -
+  // no-op. The seven terms that gate the grade share one pass, so they gate it together -
   // three when this was written, and the count is checkable in one place now that it is a
   // `gates` flag rather than a line repeated in each of their applies.
   bloom: { def: 0, min: 0, max: 6, step: 0.05, kind: 'scalar', tag: 'look',
@@ -1847,12 +1849,12 @@ const buildParams = () => ({
     group: 'motion', label: 'trails',
     apply: (v) => { afterimage.uniforms.damp.value = v; afterimage.enabled = v > 0; } },
   // Every term of the one combined grade pass except its toe, which is `crush` below and is
-  // the one of the nine that must not gate the pass. Five of these do gate it, and which
-  // five is a `gates` flag in the manifests rather than a line of wiring repeated
-  // five times here.
+  // the one of the eighteen that must not gate the pass. Seven of these do gate it, and
+  // which seven is a `gates` flag in the manifests rather than a line of wiring repeated
+  // seven times here.
   ...effectSlice('rgbsplit.amount', 'vignette.amount'),
   // The toe under the grade's Reinhard curve, and **the one term sharing that pass which
-  // deliberately does not gate it** - the five that do carry `gates` in
+  // deliberately does not gate it** - the seven that do carry `gates` in
   // the manifests, and this one is written out here with no such flag anywhere,
   // because it is a core parameter rather than an effect's. That is the whole of its wiring
   // and it is worth the paragraph, because the symmetry is the thing a reader will reach to
@@ -1897,7 +1899,7 @@ const buildParams = () => ({
   // therefore in the right group and at the end of it, which is a defined place; guessing
   // at a better one would be this file making a layout decision on a package's behalf.
   //
-  // Empty for the shipped sixteen, so this line contributes nothing at all to the
+  // Empty for the shipped eighteen, so this line contributes nothing at all to the
   // registry the presets and the scramble table are written against.
   ...(effectAppendix().length ? effectSlice(effectAppendix()[0], effectAppendix().at(-1)) : {}),
 
@@ -1972,7 +1974,7 @@ function missingReadings(values) {
  * **They ran at module scope until installs existed, and moving them is the whole reason
  * to bother saying so.** Each of the four is a claim about the registry and the packages
  * agreeing, and the moment a package can arrive at runtime, a check that only ever ran
- * while the module evaluated is a check about the sixteen this build shipped with. The
+ * while the module evaluated is a check about the eighteen this build shipped with. The
  * install that goes wrong is by definition the one that was not there at boot.
  *
  * Cheap enough to run per rebuild that the count is not worth thinking about: four walks
@@ -2912,7 +2914,7 @@ let refusedEffectSignature = null;
  * **The one thing a package cannot bring with it.** A manifest declares the GLSL that
  * reads a uniform and the parameter that writes it, and both of those travel; what does
  * not is the JavaScript cell three.js copies from - `uniforms` in `web/point-cloud.js` and
- * the grade pass's table are written out by hand, so a seventeenth effect's first slider
+ * the grade pass's table are written out by hand, so a nineteenth effect's first slider
  * move would be `undefined.value = v` and the page would throw inside the registry's
  * single write path. That is the failure this function exists for, and it is not
  * hypothetical: it is what every install did before this line was here.
@@ -3317,7 +3319,7 @@ async function reloadEffects() {
  * an install is a thing a person does a handful of times, the cost of noticing it a few
  * seconds late is that a second browser draws the old look for a few seconds, and the
  * cost of a socket message would be a second channel carrying state that the store
- * already answers for. `GET /effects` reads sixteen directories and hashes their files,
+ * already answers for. `GET /effects` reads eighteen directories and hashes their files,
  * which is the whole of what a tick costs when nothing has changed.
  *
  * **A tick stands down rather than queues while anything is mid-gesture.** A rebuild

--- a/web/post-chain.js
+++ b/web/post-chain.js
@@ -138,6 +138,31 @@ const GRADE_UNIFORMS = {
   // reference pixel - so an angle here means what an angle means, and turning it 90
   // degrees turns the streak 90 degrees on the glass.
   streakAxis: { value: new THREE.Vector2(0, 1) },
+  // The halation's four. Light that reached the emulsion scatters off the base behind it
+  // and exposes it again, so a highlight rings whatever surrounds it - and the ring is
+  // warm whatever colour the highlight was, which is the one thing the bloom above cannot
+  // say: its halo is the highlight's own colour spread outward. The radius is in reference
+  // pixels at 1080p like every other screen-space term in that pass, the threshold is the
+  // luminance above which light scatters at all, and the tint walks one warm ramp from
+  // deep red to amber rather than offering a hue, on the terms the duotone's two poles are
+  // baked for.
+  halation: { value: 0 },
+  halationRadius: { value: 22 },
+  halationThreshold: { value: 0.55 },
+  halationTint: { value: 0.35 },
+  // The stock's four, which are the emulsion's colour rather than a thing that happened to
+  // the light. The balance is an axis between two stocks and its halves are different
+  // shapes: at the tungsten end the shadows go cool and the highlights warm, and at the
+  // daylight end the whole frame goes warm - which is the same film-under-the-wrong-light
+  // mismatch read from either side. **Keyed to luminance and deliberately not to
+  // depth** - the depth-keyed term is the duotone in `web/cloud-shader.js`, which replaces
+  // the colour outright a point at a time, where this biases the colour the whole
+  // assembled frame already has, halos and all. The split is the luminance where cool
+  // becomes warm and the latitude is how wide the crossover is either side of it.
+  stock: { value: 0 },
+  stockBalance: { value: 0 },
+  stockSplit: { value: 0.45 },
+  stockLatitude: { value: 0.3 },
   crush: { value: 0.018 },
   time: { value: 0 },
   resolution: { value: new THREE.Vector2(1, 1) },


### PR DESCRIPTION
Adds two installed grading effects on top of the effects stack.

- Halation gathers highlight luminance into a warm red-to-amber ring.
- Film stock biases shadows and highlights by luminance without moving exposure.
- Both travel through the existing manifest, binding, gate, and shader-assembly path.

Verification:
- `node tools/syntax-check.mjs`: 77 files, 0 failed; 18 packages parsed
- `npm run test:unit`: 124 passed
- `node tools/module-check.mjs`: 61 assertions, 0 failed
- `node tools/registry-check.mjs --url http://127.0.0.1:8503`: 145 assertions, 0 failed
- Headed 1440x960 browser run on `captures/sample.knct`; halation driven to 0.70, 0 console errors

Base: #81.