### PR TITLE
Add a scalable effect rack

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,15 @@ to start. **save** writes yours to `presets/`, and **export** and **import** mov
 between machines as JSON. Every scalar underneath is still yours to move, and a row you have
 changed grows a **↺** that puts just that one back.
 
+Package effects start out of the sidebar. Press **+ add effect** to search the installed
+packages and keep one in reach. A project, preset, value or keyframe that uses an effect
+reveals it automatically, so the rack cannot hide work. **Remove** is the only way to take
+an effect back out: when it carries values or keyframes the editor asks first, then resets
+all of its values and deletes all of its tracks as one undoable edit. The rack choice is a
+local panel preference and is not written into the project.
+
 **The effects those sliders drive are packages on disk, and they follow the same two-root
-rule.** Sixteen ship in `effects-builtin/`, each a manifest beside the GLSL it splices into the
+rule.** Eighteen ship in `effects-builtin/`, each a manifest beside the GLSL it splices into the
 shaders, and the page assembles both point-cloud programs, the grade pass, the parameter
 registry and the panel out of whatever is installed. `effects/` is the writable root: a package
 installed there under a shipped id shadows it, and deleting that copy brings the shipped one

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -328,6 +328,10 @@ node tools/editor-check.mjs --mutate import-saves-before-validating --no-render 
 node tools/editor-check.mjs --mutate picker-ignores-the-boxes --no-render # ... the subset a preset is written with
 node tools/editor-check.mjs --mutate readings-tick-alone --no-render   # ... and the five weights that move as one
 node tools/editor-check.mjs --mutate apply-says-nothing --no-render    # ... and that applying one says so, on the control that inherited the gesture
+node tools/editor-check.mjs --mutate effect-rack-shows-every-effect --no-render # ... a fresh sidebar showing every installed package without Add. Reddens eight rack rows
+node tools/editor-check.mjs --mutate effect-rack-ignores-touched --no-render # ... active values and tracks left hidden because they were not added. Reddens three rack rows
+node tools/editor-check.mjs --mutate effect-rack-remove-keeps-tracks --no-render # ... Remove resetting values while leaving the effect's keyframes behind. Reddens one rack row
+node tools/editor-check.mjs --mutate effect-rack-reset-forgets-effect --no-render # ... reset making the last touched effect disappear under the pointer. Reddens one rack row
 node tools/editor-check.mjs --mutate group-never-reveals --no-render      # ... a panel group is open because the clip says so
 node tools/editor-check.mjs --mutate reveal-ignores-tracks --no-render    # ... and a keyframe counts where the value does not
 node tools/editor-check.mjs --mutate override-prunes-only-on-toggle --no-render # ... and the override the document, not the toggle, has caught up with
@@ -475,6 +479,8 @@ node tools/boot-check.mjs --mutate reset-before-the-panel-generator # ... the sh
                                                           #     are lying. Reddens exactly one row of nine and leaves the
                                                           #     write-sweep row beside it green, because that one is about the
                                                           #     live path and the fault is in the boot write - read the rows
+node tools/boot-check.mjs --mutate effect-rack-shows-every-effect # ... every installed package row shown on a fresh recorder.
+                                                          #     Reddens exactly the package-row visibility assertion
 node tools/effect-check.mjs                               # installing an effect: revisions, the door, the hotload, park and restore
 node tools/effect-check.mjs --mutate temporaries-are-visible # ... the id filter the store lists directories through, widened, so
                                                           #     a crashed install's `<id>.<seq>.tmp` becomes a package `/effects`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -446,7 +446,8 @@ with either refused by name. A refused package leaves nothing behind.
 reassembled and swapped, the registry and the panel are rebuilt from the new set, and every value
 is written back through the same door a slider uses — so the controls show what the registry
 holds, the values in flight are where they were, and a newly installed effect's parked values
-come back and apply. What you were looking at survives it: the tab that was up stays up, a group
+come back and apply. A newly installed package stays out of the sidebar until it is added or used.
+What you were looking at survives it: the tab that was up stays up, a group
 you had collapsed stays collapsed, and the preset picker still lists what it listed. Each of
 those was read once at boot before, so after the first install the panel either lost them or went
 on reporting a state it no longer had. A package that changed no GLSL is adopted without recompiling anything,
@@ -630,8 +631,11 @@ on it would hold the pass open for every look there has ever been.
 
 The panel is generated from the registry at boot. A parameter is one entry naming its group
 and label, and the row, bounds, readout and keyframe control are built from that, so an
-effect cannot get a control the registry does not own. The generator refuses to boot if the
-rows it emitted are not the parameters that were declared.
+effect cannot get a control the registry does not own. Package-effect rows are hidden until
+the effect is added with **+ add effect** or any of its values or tracks carries work.
+Removing one resets every value and deletes every track in one confirmed, undoable edit.
+The local rack preference is panel state, not project state. The generator refuses to boot
+if the rows it emitted are not the parameters that were declared.
 
 ## Presets
 

--- a/tools/boot-check.mjs
+++ b/tools/boot-check.mjs
@@ -64,6 +64,7 @@
 //
 //   node tools/boot-check.mjs
 //   node tools/boot-check.mjs --mutate reset-before-the-panel-generator   # ... and must FAIL
+//   node tools/boot-check.mjs --mutate effect-rack-shows-every-effect      # ... and must FAIL
 //
 // Needs a GPU browser and a free port. No capture, no sensor, no server already running.
 
@@ -133,6 +134,17 @@ const MUTATIONS = {
         '    params.set(name, Object.hasOwn(held, name) ? held[name] : PARAMS[name].def);\n  }\n  buildPanel();\n',
       ],
     ],
+  },
+  // The second half of first paint: package rows exist because the registry owns them,
+  // but none belongs in a fresh sidebar. Returning true here restores the permanent
+  // all-effects panel while leaving the registry/control value diff perfectly green.
+  // Must redden exactly the package-row visibility assertion below.
+  'effect-rack-shows-every-effect': {
+    file: 'web/main.js',
+    edits: [[
+      'function effectPresent(id) {\n  return rackedEffects.has(id) || effectTouched(id);\n}',
+      'function effectPresent(id) {\n  return true;\n}',
+    ]],
   },
 };
 
@@ -337,11 +349,14 @@ async function main() {
       }
       return {
         name,
+        effect: k.effectOf(name),
         kind: k.params.spec ? k.params.spec(name).kind : null,
+        tag: k.params.spec ? k.params.spec(name).tag : null,
         pose: value !== null && typeof value === 'object',
         control: el ? el.type : null,
         registry: (value !== null && typeof value === 'object') ? null : value,
         shown: !el ? null : (el.type === 'checkbox' ? el.checked : el.value),
+        rowHidden: el?.closest('.row, .checkrow')?.hidden ?? null,
         unwritten,
       };
     });
@@ -366,6 +381,17 @@ async function main() {
   const posedControls = poses.filter((r) => r.control !== null);
   check(posedControls.length === 0, 'and a pose is the only thing the panel does not draw a control for',
     `${poses.length} poses: ${poses.map((r) => r.name).join(', ') || 'none'}`);
+
+  const packageRows = scalars.filter((r) => r.effect !== null);
+  const coreRows = scalars.filter((r) => r.effect === null && r.tag === 'look');
+  const hiddenCoreRows = coreRows.filter((r) => r.rowHidden !== false);
+  check(packageRows.length > 0 && packageRows.every((r) => r.rowHidden === true),
+    'every installed package effect starts out of the sidebar',
+    `${packageRows.filter((r) => r.rowHidden === true).length} of ${packageRows.length} rows hidden`);
+  check(coreRows.length > 0 && hiddenCoreRows.length === 0,
+    'and every basic clip control remains in it',
+    `${coreRows.length - hiddenCoreRows.length} of ${coreRows.length} rows retained`
+      + (hiddenCoreRows.length ? `; hidden: ${hiddenCoreRows.map((r) => r.name).join(', ')}` : ''));
 
   // ------------------------------------------------------- 2. the diff this file is for
   //

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -82,6 +82,10 @@
 //   node tools/editor-check.mjs --mutate reset-collapses-the-slot --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate reset-strands-focus     --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate reset-writes-around-the-registry --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate effect-rack-shows-every-effect --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate effect-rack-ignores-touched --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate effect-rack-remove-keeps-tracks --no-render # must FAIL
+//   node tools/editor-check.mjs --mutate effect-rack-reset-forgets-effect --no-render # must FAIL
 //   node tools/editor-check.mjs --mutate export-ignores-name              # must FAIL
 //
 // `--no-render` drops the real-export rows and says so in the verdict, the way
@@ -793,6 +797,67 @@ const MUTATIONS = {
     ]],
   },
 
+  // The rack claims every installed effect is present, which puts all package rows back
+  // into a fresh sidebar. The section below asks the row and the package-only group,
+  // before it has touched a value or pressed Add, so this cannot pass as a remembered
+  // local choice.
+  //
+  // Must redden: **eight rack rows** - fresh absence; the value and track leaving again;
+  // search and Add; focus after Add; confirmed removal making the row leave; and the
+  // final local-preference equality. Measured 2026-08-25: `563 assertions, 11 failed`,
+  // including the same three unrelated gesture rows the unmutated run fired.
+  'effect-rack-shows-every-effect': {
+    file: 'web/main.js',
+    edits: [[
+      'function effectPresent(id) {\n  return rackedEffects.has(id) || effectTouched(id);\n}',
+      'function effectPresent(id) {\n  return true;\n}',
+    ]],
+  },
+
+  // The other half of presence is removed: only the local preference is consulted, so a
+  // value or keyframe restored from a document can be active while its controls remain
+  // hidden. The rack section drives both forms independently and clears each before it
+  // moves on, which tells a missing value term from a missing track term.
+  //
+  // Must redden: **three rack rows** - the value reveal, the track reveal, and undo
+  // restoring work without restoring visibility. Measured 2026-08-25: `563 assertions,
+  // 6 failed`, including the unmutated run's same three unrelated gesture rows.
+  'effect-rack-ignores-touched': {
+    file: 'web/main.js',
+    edits: [[
+      'function effectPresent(id) {\n  return rackedEffects.has(id) || effectTouched(id);\n}',
+      'function effectPresent(id) {\n  return rackedEffects.has(id);\n}',
+    ]],
+  },
+
+  // Removing an effect resets its values but leaves its tracks behind. The panel still
+  // shows it because a track is work, so the row about disappearing and the direct track
+  // count both catch the half-delete while undo remains able to complete the run.
+  //
+  // Must redden: **one rack row**, the confirmed removal's joined value/track/presence
+  // assertion. Measured 2026-08-25: `563 assertions, 4 failed`, including the unmutated
+  // run's same three unrelated gesture rows.
+  'effect-rack-remove-keeps-tracks': {
+    file: 'web/main.js',
+    edits: [['  for (const name of names) tracks.delete(name);\n', '']],
+  },
+
+  // The reset writes the default without retaining the effect first. On the last touched
+  // value that makes the effect and its control leave under the pointer, which is the
+  // moving-panel failure the rack is required to prevent. The proof clears the track
+  // first so this one gesture is the only evidence holding the effect in the sidebar.
+  //
+  // Must redden: **one rack row**, the reset-retains assertion. Measured 2026-08-25:
+  // `563 assertions, 4 failed`, including the unmutated run's same three unrelated
+  // gesture rows.
+  'effect-rack-reset-forgets-effect': {
+    file: 'web/main.js',
+    edits: [[
+      "  button.addEventListener('click', () => {\n    retainEffectFor(name);\n    params.set(name, resetTarget(name));",
+      "  button.addEventListener('click', () => {\n    params.set(name, resetTarget(name));",
+    ]],
+  },
+
   // The falsification control for the derived half of section 16: every collapsible
   // group answers "nobody has been here" whatever the document holds, so a group
   // carrying live values renders shut and stays shut.
@@ -1259,12 +1324,12 @@ const MUTATIONS = {
       ['const resetButtons = new Map();', 'const resetButtons = new Map();\nconst resetTouched = new Set();'],
       ['  const modified = value !== resetTarget(name);', '  const modified = resetTouched.has(name);'],
       [
-        'function writeFromControl(name, value) {\n  const applied = params.set(name, value);',
-        'function writeFromControl(name, value) {\n  resetTouched.add(name);\n  const applied = params.set(name, value);',
+        'function writeFromControl(name, value) {\n  retainEffectFor(name);\n  const applied = params.set(name, value);',
+        'function writeFromControl(name, value) {\n  retainEffectFor(name);\n  resetTouched.add(name);\n  const applied = params.set(name, value);',
       ],
       [
-        '    params.set(name, resetTarget(name));\n    history.commit();',
-        '    resetTouched.delete(name);\n    params.set(name, resetTarget(name));\n    history.commit();',
+        '    retainEffectFor(name);\n    params.set(name, resetTarget(name));\n    history.commit();',
+        '    retainEffectFor(name);\n    resetTouched.delete(name);\n    params.set(name, resetTarget(name));\n    history.commit();',
       ],
     ],
   },
@@ -2553,10 +2618,10 @@ const DRIVER_RULES = [
   },
   {
     key: 'shelldialogs',
-    what: 'a control in the Project settings, Export, OBS, or state dialog',
+    what: 'a control in the Project settings, Export, OBS, effect-rack, or state dialog',
     by: 'section 1 opens each application dialog, drives every enabled control, and '
       + 'asserts every format the export dialog offers is one the server encodes',
-    match: (row) => inGroup(row, '#projectDialog', '#exportDialog', '#obsDialog'),
+    match: (row) => inGroup(row, '#projectDialog', '#exportDialog', '#obsDialog', '#effectRackDialog'),
   },
   {
     key: 'paneltabs',
@@ -2712,6 +2777,7 @@ const DRIVER_IDS = {
   tPlay: 'section 2 - toggles playback and the state is read back',
   tRate: 'section 4 - the anchor rows and the seek-storm row',
   tCamView: 'section 1 - looks through the program camera and reads the orbit back',
+  effectRackOpen: 'section 1 - opens the installed-effect search, adds every effect, and removes one',
   tRateKey: 'section 5 - plants and removes a retime key',
   // `tFps` is deliberately not here. It moved into Project settings with the rate itself,
   // so the `shelldialogs` rule covers it and section 1 drives it - which is a credit that
@@ -3070,6 +3136,269 @@ try {
   console.log('\n[1] every control the editor renders is one this file knows how to drive');
   // =====================================================================
   //
+  // Package effects are a rack rather than a second permanent panel. Ask its absence
+  // before any gesture, then ask both forms of derived presence before pressing Add:
+  // a value and a track. Row.hidden is the reading rather than checkVisibility because
+  // the group's own collapse is a separate layer and a quiet group is meant to be shut.
+  const rackFresh = await page.evaluate(() => {
+    const k = globalThis.__kinect;
+    const ids = k.effectIds();
+    const rowFor = (name) => document.getElementById(name)?.closest('.row, .checkrow') ?? null;
+    const packageGroups = [...document.querySelectorAll('#panelBody > [data-group]')]
+      .filter((group) => {
+        const names = [...group.querySelectorAll('input[id]')]
+          .map((input) => input.id).filter((name) => k.params.names().includes(name));
+        return names.length > 0 && names.every((name) => k.effectOf(name) !== null);
+      });
+    const effectRows = ids.flatMap((id) => k.effectParamNames(id).map(rowFor)).filter(Boolean);
+    const coreRows = k.params.names('look').filter((name) => k.effectOf(name) === null)
+      .map(rowFor).filter(Boolean);
+    return {
+      ids,
+      effectRows: effectRows.length,
+      hiddenEffectRows: effectRows.filter((row) => row.hidden).length,
+      coreRows: coreRows.length,
+      hiddenCoreRows: coreRows.filter((row) => row.hidden).length,
+      packageGroups: packageGroups.length,
+      emptyPackageGroups: packageGroups.filter((group) => group.classList.contains('rackempty')).length,
+    };
+  });
+  check(rackFresh.ids.length > 0
+    && rackFresh.effectRows === rackFresh.hiddenEffectRows
+    && rackFresh.packageGroups === rackFresh.emptyPackageGroups,
+  'a fresh clip keeps every installed package effect out of the sidebar',
+  `${rackFresh.hiddenEffectRows} of ${rackFresh.effectRows} effect rows hidden, `
+    + `${rackFresh.emptyPackageGroups} of ${rackFresh.packageGroups} package groups empty`);
+  check(rackFresh.coreRows > 0 && rackFresh.hiddenCoreRows === 0,
+    'and the basic clip controls remain in it',
+    `${rackFresh.coreRows - rackFresh.hiddenCoreRows} of ${rackFresh.coreRows} core rows retained`);
+
+  await page.evaluate("__kinect.params.set('grain.amount', 0.4)");
+  await settle();
+  const valueRevealed = await page.evaluate(`(() => {
+    const row = document.getElementById('grain.amount')?.closest('.row, .checkrow');
+    return row ? !row.hidden : false;
+  })()`);
+  check(valueRevealed,
+    'a value restored without an Add gesture reveals the effect that owns it',
+    `grain row visible=${valueRevealed}`);
+  await page.evaluate(`(() => {
+    const k = globalThis.__kinect;
+    const spec = k.params.spec('grain.amount');
+    k.params.set('grain.amount', k.params.normalise('grain.amount', spec.default));
+  })()`);
+  await settle();
+  const valueCleared = await page.evaluate(`(() => {
+    const row = document.getElementById('grain.amount')?.closest('.row, .checkrow');
+    return row ? row.hidden : false;
+  })()`);
+  check(valueCleared,
+    'and it leaves again when that programmatic value carries no work and was never added',
+    `grain row hidden=${valueCleared}`);
+
+  await page.evaluate(`(() => {
+    const k = globalThis.__kinect;
+    k.keyframes.setTracks({ 'grain.amount': [{ t: 0, value: k.params.get('grain.amount') }] });
+  })()`);
+  await settle();
+  const trackRevealed = await page.evaluate(`(() => {
+    const row = document.getElementById('grain.amount')?.closest('.row, .checkrow');
+    return row ? !row.hidden : false;
+  })()`);
+  check(trackRevealed,
+    'a keyframe track reveals its effect even where the parked value equals the default',
+    `grain row visible=${trackRevealed}`);
+  await page.evaluate('__kinect.keyframes.setTracks({})');
+  await settle();
+  const trackCleared = await page.evaluate(`(() => {
+    const row = document.getElementById('grain.amount')?.closest('.row, .checkrow');
+    return row ? row.hidden : false;
+  })()`);
+  check(trackCleared,
+    'and clearing that track removes the otherwise idle effect again',
+    `grain row hidden=${trackCleared}`);
+
+  // The add path is the surface a person uses: open, search, press the result, and read
+  // both the row and the focus it hands back. The conditional keeps the mutation that
+  // incorrectly makes every effect present from ending the run before its failed rows
+  // can be counted.
+  await page.locator('#effectRackOpen').click();
+  check(await page.evaluate('document.getElementById("effectRackDialog").open'),
+    'the add button opens the installed-effect search');
+  await page.locator('#effectRackSearch').fill('halation');
+  const searched = await page.evaluate(`(() => ({
+    rows: [...document.querySelectorAll('#effectRackList [data-effect-rack]')]
+      .map((row) => row.dataset.effectRack),
+    add: document.querySelector('[data-effect-add="halation"]')?.dataset.effectAdd ?? null,
+  }))()`);
+  check(JSON.stringify(searched.rows) === JSON.stringify(['halation']) && searched.add === 'halation',
+    'search narrows the installed list to the matching effect and offers Add',
+    `${searched.rows.join(', ') || 'no rows'}, add=${searched.add}`);
+  const halationAdd = page.locator('[data-effect-add="halation"]');
+  const couldAddHalation = await halationAdd.count() === 1;
+  if (couldAddHalation) await halationAdd.click();
+  else {
+    await page.locator('#effectRackClose').click();
+    await page.evaluate("document.querySelector('[data-group-toggle=halation]')?.click()");
+  }
+  await page.waitForTimeout(50);
+  const halationAdded = await page.evaluate(`(() => {
+    const row = document.getElementById('halation.amount')?.closest('.row, .checkrow');
+    let stored = [];
+    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    return {
+      hidden: row?.hidden ?? null,
+      stored,
+      focused: document.activeElement?.id ?? null,
+      dialogOpen: document.getElementById('effectRackDialog').open,
+    };
+  })()`);
+  check(couldAddHalation && halationAdded.hidden === false
+    && halationAdded.stored.includes('halation') && !halationAdded.dialogOpen,
+  'Add closes the search and retains the effect in the sidebar without changing its value',
+  `add=${couldAddHalation}, hidden=${halationAdded.hidden}, stored=${JSON.stringify(halationAdded.stored)}`);
+  check(halationAdded.focused === 'halation.amount',
+    'and the first control receives the caret, so Add lands where the work starts',
+    `focused ${JSON.stringify(halationAdded.focused)}`);
+
+  // Give the effect a value and a track through its real controls, then drive both
+  // confirmation choices. The destructive press must make one history entry for all
+  // values and tracks; the direct track read is the term a reset-only implementation
+  // cannot satisfy.
+  await page.evaluate(`(() => {
+    const input = document.getElementById('halation.amount');
+    input.value = '0.7';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  })()`);
+  if (couldAddHalation) {
+    await page.locator('button[aria-label="halation.amount keyframe"]').click();
+  } else {
+    await page.evaluate(`document.querySelector('button[aria-label="halation.amount keyframe"]').click()`);
+  }
+  if (couldAddHalation) await page.locator('#effectRackOpen').click();
+  else await page.evaluate("document.getElementById('effectRackOpen').click()");
+  await page.locator('#effectRackSearch').fill('halation');
+  await page.locator('[data-effect-remove="halation"]').click();
+  const confirmation = await page.evaluate(`(() => ({
+    confirm: Boolean(document.querySelector('[data-effect-confirm-remove="halation"]')),
+    value: globalThis.__kinect.params.get('halation.amount'),
+    keyed: globalThis.__kinect.keyframes.names().includes('halation.amount'),
+  }))()`);
+  check(confirmation.confirm && confirmation.value === 0.7 && confirmation.keyed,
+    'Remove asks before destroying an effect that carries a value or keyframe, and the first press changes nothing',
+    `confirm=${confirmation.confirm}, value=${confirmation.value}, keyed=${confirmation.keyed}`);
+  await page.getByRole('button', { name: 'cancel', exact: true }).click();
+  check(await page.locator('[data-effect-remove="halation"]').count() === 1,
+    'Cancel returns to the effect without changing it');
+  await page.locator('[data-effect-remove="halation"]').click();
+  const beforeRemoveDepth = await page.evaluate('__kinect.keyframes.undo.depth()');
+  await page.locator('[data-effect-confirm-remove="halation"]').click();
+  await settle();
+  const removedEffect = await page.evaluate(`(() => {
+    const k = globalThis.__kinect;
+    const row = document.getElementById('halation.amount')?.closest('.row, .checkrow');
+    const spec = k.params.spec('halation.amount');
+    let stored = [];
+    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    return {
+      atDefault: k.params.get('halation.amount') === k.params.normalise('halation.amount', spec.default),
+      keyed: k.keyframes.names().includes('halation.amount'),
+      hidden: row?.hidden ?? null,
+      stored,
+      depth: k.keyframes.undo.depth(),
+    };
+  })()`);
+  check(removedEffect.atDefault && !removedEffect.keyed && removedEffect.hidden
+    && !removedEffect.stored.includes('halation'),
+  'the confirmed removal resets every value, deletes every track, and takes the effect out of the sidebar',
+  `default=${removedEffect.atDefault}, keyed=${removedEffect.keyed}, hidden=${removedEffect.hidden}, `
+    + `stored=${JSON.stringify(removedEffect.stored)}`);
+  check(removedEffect.depth === beforeRemoveDepth + 1,
+    'and all of that is one undoable edit',
+    `history ${beforeRemoveDepth} -> ${removedEffect.depth}`);
+  await page.locator('#effectRackClose').click();
+  await page.evaluate('__kinect.keyframes.undo.pop()');
+  await settle();
+  const undoRemoval = await page.evaluate(`(() => {
+    const k = globalThis.__kinect;
+    const row = document.getElementById('halation.amount')?.closest('.row, .checkrow');
+    return {
+      value: k.params.get('halation.amount'),
+      keyed: k.keyframes.names().includes('halation.amount'),
+      hidden: row?.hidden ?? null,
+    };
+  })()`);
+  check(undoRemoval.value === 0.7 && undoRemoval.keyed && undoRemoval.hidden === false,
+    'undo restores the value, the track, and the visible effect together',
+    `value=${undoRemoval.value}, keyed=${undoRemoval.keyed}, hidden=${undoRemoval.hidden}`);
+
+  // Clear the restored track without a user gesture, leaving the value as the only
+  // evidence. The reset itself must retain the effect before it removes that evidence,
+  // or the row disappears under the pointer.
+  await page.evaluate('__kinect.keyframes.setTracks({})');
+  if (undoRemoval.hidden === true) {
+    await page.evaluate(`document.querySelector('button[aria-label="halation.amount reset to default"]').click()`);
+  } else {
+    await page.locator('button[aria-label="halation.amount reset to default"]').click();
+  }
+  await settle();
+  const resetRetained = await page.evaluate(`(() => {
+    const k = globalThis.__kinect;
+    const row = document.getElementById('halation.amount')?.closest('.row, .checkrow');
+    const spec = k.params.spec('halation.amount');
+    let stored = [];
+    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    return {
+      atDefault: k.params.get('halation.amount') === k.params.normalise('halation.amount', spec.default),
+      hidden: row?.hidden ?? null,
+      stored,
+    };
+  })()`);
+  check(resetRetained.atDefault && resetRetained.hidden === false
+    && resetRetained.stored.includes('halation'),
+  'resetting the last touched value keeps the effect in the sidebar until Remove is pressed',
+  `default=${resetRetained.atDefault}, hidden=${resetRetained.hidden}, stored=${JSON.stringify(resetRetained.stored)}`);
+
+  // Rack the rest through Add rather than by writing the preference. That makes every
+  // installed row available to the existing control sweep and leaves the dialog open so
+  // its generated Remove controls are enumerated as well.
+  let rackAdds = 0;
+  for (let i = 0; i <= rackFresh.ids.length; i++) {
+    if (!await page.evaluate('document.getElementById("effectRackDialog").open')) {
+      await page.locator('.paneltab[data-panel-tab="look"]').click();
+      await page.locator('#effectRackOpen').click();
+    }
+    const next = page.locator('[data-effect-add]').first();
+    if (await next.count() === 0) break;
+    await next.click();
+    rackAdds++;
+  }
+  if (!await page.evaluate('document.getElementById("effectRackDialog").open')) {
+    await page.locator('.paneltab[data-panel-tab="look"]').click();
+    await page.locator('#effectRackOpen').click();
+  }
+  const rackComplete = await page.evaluate(`(() => {
+    const k = globalThis.__kinect;
+    let stored = [];
+    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    const hidden = k.effectIds().filter((id) => k.effectParamNames(id).some((name) => {
+      const row = document.getElementById(name)?.closest('.row, .checkrow');
+      return !row || row.hidden;
+    }));
+    return {
+      ids: [...k.effectIds()].sort(),
+      stored: [...stored].sort(),
+      hidden,
+      removes: document.querySelectorAll('#effectRackList [data-effect-remove]').length,
+    };
+  })()`);
+  check(JSON.stringify(rackComplete.stored) === JSON.stringify(rackComplete.ids)
+    && rackComplete.hidden.length === 0 && rackComplete.removes === rackComplete.ids.length,
+  'adding the remaining installed effects makes every one available to the sidebar and the control sweep',
+  `${rackAdds} added in the loop, ${rackComplete.hidden.length} hidden, `
+    + `${rackComplete.removes} remove controls for ${rackComplete.ids.length} effects`);
+
   // The sweep is over what the page actually contains rather than over a list kept
   // here, which is the only version of this that survives somebody adding a button.
   //
@@ -3166,6 +3495,7 @@ try {
       groups: ['#appBar', '#panel', '#panelTabs', '#lookPresetGroup', '#cameraGroup', '#navRow',
         '#recordGroup', '#recLookGroup', '#sensorGroup', '#monitorGroup',
         '#programOutGroup', '#presetPick', '#projectDialog', '#exportDialog', '#obsDialog',
+        '#effectRackDialog',
         '#panelDock', '.appmenu']
         .filter((g) => el.closest(g)),
       kf: el.classList.contains('kf'),
@@ -3199,7 +3529,7 @@ try {
   // went on saying "in the panel" about sixty-odd controls in a modal - a diagnostic
   // that names the wrong surface is how a reader stops being able to tell a sweep that
   // grew from one that moved.
-  const DIALOG_GROUPS = ['#presetPick', '#exportDialog', '#obsDialog'];
+  const DIALOG_GROUPS = ['#presetPick', '#exportDialog', '#obsDialog', '#effectRackDialog'];
   const inDialog = sweep.filter((r) => DIALOG_GROUPS.some((group) => r.groups.includes(group))).length;
   const inTbar = sweep.filter((r) => r.inTbar).length;
   note(`${sweep.length} interactive controls on the editor`,
@@ -3273,6 +3603,10 @@ try {
     withControls.length ? `${withControls.join(', ')} has a control` : `${composition.length} checked: ${composition.join(', ')}`);
   check(sweep.some((r) => r.id === 'tPlay') && sweep.some((r) => r.id === 'tSetIn'),
     'the strip is among what was swept', `${sweep.filter((r) => r.inTbar).map((r) => r.id).filter(Boolean).slice(0, 6).join(', ')}...`);
+
+  await page.locator('#effectRackClose').click();
+  check(await page.evaluate('!document.getElementById("effectRackDialog").open'),
+    'the effect search closes from its corner after its generated controls were swept');
 
   // Being in the document is not the same as being reachable, which is the whole of
   // what was wrong with this control before it moved. It sat under thirteen groups of
@@ -3355,7 +3689,7 @@ try {
   // the store it is about to make claims about.
   await page.evaluate(`(() => {
     [...document.querySelectorAll('#panelBody > [data-panel-tab] .grouptoggle')]
-      .filter((b) => b.getAttribute('aria-expanded') === 'true' && b.checkVisibility())
+      .filter((b) => b.getAttribute('aria-expanded') === 'true')
       .forEach((b) => b.click());
     localStorage.removeItem('kinect.panelGroupsOpen');
   })()`);

--- a/tools/effect-check.mjs
+++ b/tools/effect-check.mjs
@@ -246,7 +246,7 @@ const MUTATIONS = {
    */
   'rebuild-keeps-the-paint': {
     file: 'web/main.js',
-    edits: [['\n  groupPainted.clear();\n  panelRowsEmitted = 0;', '\n  panelRowsEmitted = 0;']],
+    edits: [['\n  groupPainted.clear();', '']],
   },
 
   /**
@@ -1419,6 +1419,9 @@ try {
       params: k.params.names().length,
       groups: document.querySelectorAll('#panelBody > [data-group]').length,
       probeRows: document.querySelectorAll('[data-group="probe"] .row').length,
+      probeRowsHidden: [...document.querySelectorAll('[data-group="probe"] .row')]
+        .filter((row) => row.hidden).length,
+      probeRackEmpty: document.querySelector('[data-group="probe"]')?.classList.contains('rackempty') ?? null,
       groupLabel: document.querySelector('[data-group="probe"] .grouphead label')?.textContent ?? null,
       knows: k.params.names().includes('probe.amount') && k.params.names().includes('probe.hue'),
       cell: Object.hasOwn(k.uniforms, 'probeAmount') && Object.hasOwn(k.uniforms, 'probeHue'),
@@ -1431,12 +1434,31 @@ try {
     adopted.params === before.params + 2 && adopted.knows, `${before.params} -> ${adopted.params}`);
   ok('and they are at the end of the look order, which is where the placement rule puts a package nothing has a layout for',
     JSON.stringify(adopted.appended) === JSON.stringify(['probe.amount', 'probe.hue']), JSON.stringify(adopted.appended));
-  ok('the panel grew the package\'s own group, with a row for each parameter',
-    adopted.groups === before.groups + 1 && adopted.probeRows === 2,
-    `${adopted.groups} groups, ${adopted.probeRows} probe rows, heading ${JSON.stringify(adopted.groupLabel)}`);
+  ok('the panel grew the package\'s own group and rows, but keeps a newly installed idle effect out of the sidebar',
+    adopted.groups === before.groups + 1 && adopted.probeRows === 2
+      && adopted.probeRowsHidden === adopted.probeRows && adopted.probeRackEmpty === true,
+    `${adopted.groups} groups, ${adopted.probeRowsHidden} of ${adopted.probeRows} probe rows hidden, `
+    + `rack empty=${adopted.probeRackEmpty}, heading ${JSON.stringify(adopted.groupLabel)}`);
   ok('the uniform cells its bindings need were minted, because no hand-written table holds them',
     adopted.cell === true, `probeAmount and probeHue ${adopted.cell ? 'present' : 'missing'}`);
   ok('and the assembled program carries its chunk text', adopted.inShader === true);
+
+  await page.locator('.paneltab[data-panel-tab="look"]').click();
+  await page.locator('#effectRackOpen').click();
+  await page.locator('[data-effect-add="probe"]').click();
+  const racked = await page.evaluate(() => {
+    const row = document.getElementById('probe.amount')?.closest('.row, .checkrow');
+    let stored = [];
+    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    return { hidden: row?.hidden ?? null, stored, focused: document.activeElement?.id ?? null };
+  });
+  ok('and Add makes that hot-loaded effect available without a reload or a value change',
+    racked.hidden === false && racked.stored.includes('probe'),
+    `hidden=${racked.hidden}, stored=${JSON.stringify(racked.stored)}, focused=${JSON.stringify(racked.focused)}`);
+  await page.locator('#effectRackOpen').click();
+  await page.locator('[data-effect-remove="probe"]').click();
+  await page.locator('#effectRackClose').click();
+  await page.locator('.paneltab[data-panel-tab="record"]').click();
 
   // ---- and now boot-check's own question, on the page that has just been rebuilt
   //

--- a/web/index.html
+++ b/web/index.html
@@ -452,7 +452,10 @@
   .paneltab[aria-selected="true"] { color: var(--accent); }
   .paneltab:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
   #panel .group[hidden] { display: none; }
+  #panel .group.rackempty { display: none; }
   #lookPresetGroup > label { margin-bottom: 6px; }
+  #effectRackGroup { padding-top: 10px; }
+  #effectRackOpen { width: 100%; }
 
   .dialog-head {
     display: flex;
@@ -547,6 +550,25 @@
   #exportDialog { width: min(480px, calc(100vw - 32px)); }
   #obsDialog { width: min(480px, calc(100vw - 32px)); }
   #projectDialog { width: min(480px, calc(100vw - 32px)); }
+  #effectRackDialog { width: min(430px, calc(100vw - 32px)); }
+  .effect-rack-intro {
+    margin: 0 0 14px; color: var(--dim); font-size: 11px; line-height: 1.45;
+  }
+  .effect-rack-list {
+    display: grid; gap: 1px; max-height: min(54vh, 520px); overflow-y: auto;
+    border-top: 1px solid var(--line); border-bottom: 1px solid var(--line);
+  }
+  .effect-rack-row {
+    display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center;
+    gap: 12px; min-height: 48px; padding: 7px 0; border-bottom: 1px solid var(--line);
+  }
+  .effect-rack-row:last-child { border-bottom: 0; }
+  .effect-rack-name { min-width: 0; }
+  .effect-rack-name b { display: block; color: var(--ink); font-size: 12px; font-weight: 500; }
+  .effect-rack-name small { display: block; margin-top: 2px; color: var(--dim); font-size: 9px; }
+  .effect-rack-actions { display: flex; align-items: center; gap: 5px; }
+  .effect-rack-actions .dialog-secondary { min-height: 29px; padding: 0 9px; }
+  .effect-rack-empty { padding: 18px 0; color: var(--dim); font-size: 11px; text-align: center; }
   /* The two readouts inside the export dialog - what the chosen deliverable is, and the
      range the press will take. Both are `<b>` in a field rather than an input, because
      neither is typed into here, and both want the dim monospaced voice the rest of the
@@ -1294,6 +1316,11 @@
          conditioned into, where the points are moved to, how they are drawn, what
          colour they take, what persists between frames, and what the optics do. -->
     <div id="gradeAnchor" hidden></div>
+    <div class="group" id="effectRackGroup" data-panel-tab="look" hidden>
+      <div class="btnrow">
+        <button id="effectRackOpen" type="button">+ add effect</button>
+      </div>
+    </div>
   </div><!-- #panelBody -->
 
   <!-- What the panel becomes when it is collapsed: the three things you press with the
@@ -1482,6 +1509,22 @@
       </div>
     </div>
   </section>
+
+  <dialog id="effectRackDialog" aria-labelledby="effectRackTitle">
+    <div class="dialog-head">
+      <h2 id="effectRackTitle">Effects</h2>
+      <button class="dialog-close" id="effectRackClose" type="button" aria-label="Close">&times;</button>
+    </div>
+    <p class="effect-rack-intro">Add only the effects you want in the sidebar. Removing an
+      effect resets its values and deletes its keyframes.</p>
+    <div class="dialog-field">
+      <label for="effectRackSearch">Find an effect</label>
+      <div class="dialog-input-row">
+        <input id="effectRackSearch" type="search" autocomplete="off" spellcheck="false">
+      </div>
+    </div>
+    <div class="effect-rack-list" id="effectRackList" aria-label="Installed effects"></div>
+  </dialog>
 
   <!-- What the clip *is*, as opposed to what is made from it. Built like `#exportDialog`
        and `#obsDialog` below - the same head, the same `.dialog-field` rows, the same

--- a/web/main.js
+++ b/web/main.js
@@ -2135,11 +2135,12 @@ const presetPickGroups = [];
  *
  * The full argument for it is on `refreshGroups`, which is its only reader. It is declared
  * here rather than there for the boot-order reason its neighbours are: `buildPanel` clears
- * it with the seven maps that find the panel's elements again, because a rebuilt group is
+ * it with the maps that find the panel's elements again, because a rebuilt group is
  * a new element that has never been painted whatever this map remembers - and boot's first
  * `buildPanel` runs well above the line `refreshGroups` sits on.
  */
 const groupPainted = new Map();
+const effectRackPainted = new Map();
 
 // What each parameter is worth in a project nobody has touched, computed once per
 // registry.
@@ -2456,6 +2457,7 @@ function makeResetButton(name) {
   button.setAttribute('aria-label', `${name} reset to default`);
   button.append(resetGlyph());
   button.addEventListener('click', () => {
+    retainEffectFor(name);
     params.set(name, resetTarget(name));
     history.commit();
     // The press removes its own control: writing the default makes the row unmodified,
@@ -2665,6 +2667,8 @@ function panelPlace(group, groupNode) {
 // of one table is exactly the drift this generator exists to remove.
 const panelGroupNodes = new Map();
 const panelGroupParams = new Map();
+const panelGroupElements = new Map();
+const panelEffectRows = new Map();
 
 // One head per group, whether or not the group can be shut, because two shapes of
 // header is two sets of CSS and the one that gets forgotten is the one nobody is
@@ -2717,7 +2721,7 @@ let panelRowsEmitted = 0;
  * taught about none. The cost is a few dozen elements built twice a session, against a
  * page that has just recompiled two shader programs.
  *
- * **Everything the last pass left behind is dropped first, and each of the seven maps is
+ * **Everything the last pass left behind is dropped first, and each lookup map is
  * a name the panel is found again by.** A generated group carries `data-group` and a
  * hand-written one carries an id, which is what makes the selector below able to remove
  * exactly what this function made - the distinction was drawn for a different reason
@@ -2733,6 +2737,8 @@ function buildPanel() {
   resetButtons.clear();
   panelGroupNodes.clear();
   panelGroupParams.clear();
+  panelGroupElements.clear();
+  panelEffectRows.clear();
   panelTail.clear();
   groupDefaults.clear();
   // **The map that says a group has already been painted, cleared with the nodes it is
@@ -2742,10 +2748,11 @@ function buildPanel() {
   // about elements that had been thrown away. A group whose values happened not to change
   // across the install came back with no `shut` class, no `aria-expanded` and an empty
   // mark, showing as open with the panel's own header saying nothing about it, and the
-  // next refresh agreed with itself and left it there. It belongs with the seven maps
+  // next refresh agreed with itself and left it there. It belongs with the lookup maps
   // above rather than beside its own reader, because the thing that invalidates it is
   // exactly what invalidates them: the elements are new.
   groupPainted.clear();
+  effectRackPainted.clear();
   panelRowsEmitted = 0;
   for (const group of PANEL_GROUPS) {
   const groupNode = panelNode('div', group.lookgroup ? 'group lookgroup' : 'group');
@@ -2755,6 +2762,7 @@ function buildPanel() {
   // registry key away from colliding with one of them silently.
   groupNode.dataset.group = group.key;
   groupNode.dataset.panelTab = group.tab;
+  panelGroupElements.set(group.key, groupNode);
   // Named apart from the keyframe button the row loop below declares, which is a
   // different button in a narrower scope: one `button` meaning two things in one loop
   // is how the wrong element ends up registered.
@@ -2801,6 +2809,7 @@ function buildPanel() {
     // `README.md` describes the ↺ under the recorder's *Look* tab, which is where this
     // was found - the page and the page's own documentation disagreeing about a control,
     // with the condition above naming the reason for the other one.
+    let mountedRow = row;
     if (spec.tag === 'look') {
       const keyButton = EDITING ? makeKeyButton(name) : null;
       // After the keyframe control where there is one, which is the order the design
@@ -2814,6 +2823,7 @@ function buildPanel() {
         const checkrow = panelNode('div', 'checkrow');
         checkrow.append(row, ...beside);
         groupNode.append(checkrow);
+        mountedRow = checkrow;
       } else {
         row.append(...beside);
         groupNode.append(row);
@@ -2823,6 +2833,11 @@ function buildPanel() {
     }
     rows++;
     panelRowsEmitted++;
+    const owner = effectOf(name);
+    if (owner) {
+      if (!panelEffectRows.has(owner)) panelEffectRows.set(owner, []);
+      panelEffectRows.get(owner).push(mountedRow);
+    }
     // The evidence set for this group, recorded here because here is where the row was
     // emitted. A group asks whether anybody has touched it by walking exactly the
     // parameters it put on screen, so the header and the rows under it cannot come to
@@ -3928,6 +3943,199 @@ function storeGroupOverride() {
   }
 }
 
+// Which installed effects a person has chosen to keep in the inspector. This is panel
+// state, not project state: values and tracks still decide what the document contains,
+// while this set only keeps an otherwise idle effect within reach. A touched effect is
+// always present whether or not it is named here, so local storage can never hide work.
+const EFFECT_RACKED = 'kinect.rackedEffects';
+const rackedEffects = new Set();
+try {
+  const saved = localStorage.getItem(EFFECT_RACKED);
+  if (saved !== null && saved.trim() !== '') {
+    const parsed = JSON.parse(saved);
+    if (Array.isArray(parsed)) {
+      for (const id of parsed) if (typeof id === 'string' && id) rackedEffects.add(id);
+    }
+  }
+} catch {
+  // The values and tracks remain authoritative when storage is unavailable or damaged.
+}
+
+function storeRackedEffects() {
+  try {
+    localStorage.setItem(EFFECT_RACKED, JSON.stringify([...rackedEffects].sort()));
+  } catch {
+    // The rack still works for this page; only the preference is lost on reload.
+  }
+}
+
+function retainEffectFor(name) {
+  const id = effectOf(name);
+  if (!id || rackedEffects.has(id)) return;
+  rackedEffects.add(id);
+  storeRackedEffects();
+}
+
+function effectTouched(id) {
+  return effectParamNames(id).some(paramTouched);
+}
+
+function effectPresent(id) {
+  return rackedEffects.has(id) || effectTouched(id);
+}
+
+function effectGroups(id) {
+  const keys = new Set(effectParamNames(id).map((name) => PARAMS[name].group));
+  return PANEL_GROUPS.filter((group) => keys.has(group.key));
+}
+
+function refreshEffectRack() {
+  let moved = false;
+  const installed = new Set(effectIds());
+  for (const id of [...effectRackPainted.keys()]) {
+    if (!installed.has(id)) effectRackPainted.delete(id);
+  }
+  for (const id of installed) {
+    const present = effectPresent(id);
+    if (effectRackPainted.get(id) === present) continue;
+    effectRackPainted.set(id, present);
+    for (const row of panelEffectRows.get(id) ?? []) row.hidden = !present;
+    moved = true;
+  }
+  if (!moved) return;
+
+  // A package-owned group leaves with its last visible effect row. Mixed groups remain
+  // because their core rows are basic clip controls and do not belong to the rack.
+  for (const [key, node] of panelGroupElements) {
+    const visible = (panelGroupParams.get(key) ?? []).some((name) => {
+      const id = effectOf(name);
+      return id === null || effectPresent(id);
+    });
+    node.classList.toggle('rackempty', !visible);
+  }
+}
+
+function effectRackEntry(id) {
+  const names = effectParamNames(id);
+  const moved = names.filter((name) => params.get(name) !== groupDefaults.get(name));
+  const keys = names.reduce((count, name) => count + (tracks.get(name)?.keys.length ?? 0), 0);
+  return { names, moved, keys };
+}
+
+let effectRackConfirming = null;
+
+function addEffectToRack(id) {
+  if (!effectInstalled(id)) return false;
+  rackedEffects.add(id);
+  storeRackedEffects();
+  for (const group of effectGroups(id)) {
+    if (!group.collapses) continue;
+    groupOverride.set(group.key, true);
+    groupOverrideDirty = true;
+  }
+  refreshPanel();
+
+  const first = effectParamNames(id)[0];
+  const group = PANEL_GROUPS.find((entry) => entry.key === PARAMS[first]?.group);
+  const dialog = document.getElementById('effectRackDialog');
+  if (dialog.open) dialog.close();
+  if (group) setPanelTab(group.tab);
+  requestAnimationFrame(() => {
+    const control = panelControls.get(first);
+    control?.scrollIntoView({ block: 'center' });
+    control?.focus({ preventScroll: true });
+  });
+  return true;
+}
+
+function removeEffectFromRack(id) {
+  if (!effectInstalled(id)) return false;
+  const { names } = effectRackEntry(id);
+  effectRackConfirming = null;
+  rackedEffects.delete(id);
+  storeRackedEffects();
+
+  // Values and tracks leave as one document edit. The rack choice itself stays outside
+  // undo, so undo restores the work and its touched state makes the effect appear again.
+  withoutRepaint(() => {
+    for (const name of names) params.set(name, resetTarget(name));
+  });
+  for (const name of names) tracks.delete(name);
+  if (selection && names.includes(selection.owner)) selection = null;
+  lanesChanged();
+  requestRepaint();
+  history.commit();
+  paintEffectRackDialog();
+  return true;
+}
+
+function paintEffectRackDialog() {
+  const list = document.getElementById('effectRackList');
+  const search = document.getElementById('effectRackSearch');
+  if (!list || !search) return;
+  const query = search.value.trim().toLocaleLowerCase();
+  const packages = effectPackages
+    .map((entry) => ({ id: entry.id, title: entry.manifest.title || entry.id }))
+    .filter(({ id, title }) => !query
+      || id.toLocaleLowerCase().includes(query)
+      || title.toLocaleLowerCase().includes(query))
+    .sort((a, b) => a.title.localeCompare(b.title) || a.id.localeCompare(b.id));
+
+  list.replaceChildren();
+  if (packages.length === 0) {
+    list.append(panelNode('div', 'effect-rack-empty', 'No installed effects match.'));
+    return;
+  }
+
+  for (const { id, title } of packages) {
+    const entry = effectRackEntry(id);
+    const row = panelNode('div', 'effect-rack-row');
+    row.dataset.effectRack = id;
+    const name = panelNode('div', 'effect-rack-name');
+    const detail = [];
+    if (entry.moved.length) detail.push(`${entry.moved.length} changed`);
+    if (entry.keys) detail.push(`${entry.keys} ${entry.keys === 1 ? 'key' : 'keys'}`);
+    if (!detail.length) detail.push(`${entry.names.length} ${entry.names.length === 1 ? 'control' : 'controls'}`);
+    name.append(panelNode('b', null, title), panelNode('small', null, `${id} · ${detail.join(' · ')}`));
+
+    const actions = panelNode('div', 'effect-rack-actions');
+    if (!effectPresent(id)) {
+      const add = panelNode('button', 'dialog-secondary', 'add');
+      add.type = 'button';
+      add.dataset.effectAdd = id;
+      add.setAttribute('aria-label', `add ${title} to the sidebar`);
+      add.addEventListener('click', () => addEffectToRack(id));
+      actions.append(add);
+    } else if (effectRackConfirming === id) {
+      const cancel = panelNode('button', 'dialog-secondary', 'cancel');
+      cancel.type = 'button';
+      cancel.addEventListener('click', () => { effectRackConfirming = null; paintEffectRackDialog(); });
+      const remove = panelNode('button', 'dialog-secondary', 'reset & remove');
+      remove.type = 'button';
+      remove.dataset.effectConfirmRemove = id;
+      remove.setAttribute('aria-label', `reset and remove ${title}`);
+      remove.addEventListener('click', () => removeEffectFromRack(id));
+      actions.append(cancel, remove);
+    } else {
+      const remove = panelNode('button', 'dialog-secondary', 'remove');
+      remove.type = 'button';
+      remove.dataset.effectRemove = id;
+      remove.setAttribute('aria-label', `remove ${title} from the sidebar`);
+      remove.addEventListener('click', () => {
+        if (entry.moved.length || entry.keys) {
+          effectRackConfirming = id;
+          paintEffectRackDialog();
+        } else {
+          removeEffectFromRack(id);
+        }
+      });
+      actions.append(remove);
+    }
+    row.append(name, actions);
+    list.append(row);
+  }
+}
+
 
 /**
  * Whether one parameter carries evidence that somebody has been here: a keyframe track
@@ -4158,8 +4366,13 @@ function toggleGroup(key) {
 // The no-op declared beside `paramWritten` becomes the real thing here, where both of
 // the stores the predicate reads exist, and the panel is painted once for the state the
 // page booted into.
-groupRevealChanged = refreshGroups;
-refreshGroups();
+function refreshPanel() {
+  refreshEffectRack();
+  refreshGroups();
+}
+
+groupRevealChanged = refreshPanel;
+refreshPanel();
 
 // Every track written through the one door, at one program position. This is the
 // evaluator the note on `evaluating` asked for: it runs inside
@@ -4225,6 +4438,7 @@ const keyTolerance = () => 0.5 / (timeline ? timeline.outputFps : 30);
  * spring back on its own.
  */
 function writeFromControl(name, value) {
+  retainEffectFor(name);
   const applied = params.set(name, value);
   const track = tracks.get(name);
   if (track && track.keys.length > 0) {
@@ -4238,6 +4452,7 @@ function writeFromControl(name, value) {
 
 /** Adds a key at the playhead, or removes the one already there. */
 function toggleKey(name) {
+  retainEffectFor(name);
   const track = trackFor(name);
   const existing = track.keyAt(playheadSec(), keyTolerance());
   if (existing) {
@@ -10772,10 +10987,14 @@ function presetFromCurrentLook(names) {
  */
 
 /** Every look parameter of one effect, in declaration order. */
-const effectParamNames = (id) => params.names('look').filter((n) => effectOf(n) === id);
+function effectParamNames(id) {
+  return params.names('look').filter((n) => effectOf(n) === id);
+}
 
 /** The ids of every effect the registry currently declares. */
-const effectIds = () => effectIdsIn(params.names('look'));
+function effectIds() {
+  return effectIdsIn(params.names('look'));
+}
 
 /**
  * Whether an effect id names a package this build actually has.
@@ -12137,6 +12356,7 @@ function deleteSelectedKey() {
     selection = null;
     timingChanged();
   } else {
+    retainEffectFor(owner);
     tracks.get(owner).removeKey(key);
     // A track with no keys left is not a track. The parameter keeps the value it is
     // holding right now rather than snapping anywhere: `dropTrackIfEmpty` only stops
@@ -14571,6 +14791,11 @@ const shell = shellElements({
   lookImport: 'menuLookImport',
   lookExport: 'menuLookExport',
   state: 'menuState',
+  effectRackOpen: 'effectRackOpen',
+  effectRackDialog: 'effectRackDialog',
+  effectRackClose: 'effectRackClose',
+  effectRackSearch: 'effectRackSearch',
+  effectRackList: 'effectRackList',
   exportClose: 'exportClose',
   projectDialog: 'projectDialog',
   projectClose: 'projectClose',
@@ -14667,6 +14892,17 @@ function openDialog(dialog) {
 // is already current - it would cost nothing today and would hide the day one of those
 // writers stops, which is the wrong direction for something only ever seen inside a modal.
 shell.projectSettings.addEventListener('click', () => openDialog(shell.projectDialog));
+shell.effectRackOpen.addEventListener('click', () => {
+  effectRackConfirming = null;
+  shell.effectRackSearch.value = '';
+  paintEffectRackDialog();
+  openDialog(shell.effectRackDialog);
+  shell.effectRackSearch.focus();
+});
+shell.effectRackSearch.addEventListener('input', () => {
+  effectRackConfirming = null;
+  paintEffectRackDialog();
+});
 // One command for the deliverable, where there were two. `Render` opened this dialog and
 // `Export` jumped past it into `saveExportCopy` when there was something to hand over,
 // which meant one menu item did two unrelated things according to state nothing in the menu
@@ -14962,6 +15198,8 @@ shell.state.addEventListener('click', () => {
 });
 
 shell.exportClose.addEventListener('click', () => ui.exportDialog.close());
+shell.effectRackClose.addEventListener('click', () => shell.effectRackDialog.close());
+shell.effectRackDialog.addEventListener('close', () => { effectRackConfirming = null; });
 shell.projectClose.addEventListener('click', () => shell.projectDialog.close());
 shell.projectDone.addEventListener('click', () => shell.projectDialog.close());
 shell.obsClose.addEventListener('click', () => shell.obsDialog.close());


### PR DESCRIPTION
## Summary

- Keep all installed package effects out of the sidebar until they are explicitly added or carry authored values or keyframes.
- Add a searchable effect rack that preserves basic clip controls and keeps mixed groups visible.
- Make Remove reset every effect value and delete every effect track in one confirmed, undoable document edit.
- Preserve the rack as local panel state while project and preset formats remain unchanged.
- Keep runtime-installed effects hidden until Add or authored state reveals them.

## Verification

- `node tools/syntax-check.mjs`: 77 JavaScript files, 0 failed; 554 anchors matched.
- `npm run test:unit`: 124 passed, 0 failed.
- `node tools/module-check.mjs`: 61 assertions, 0 failed.
- `node tools/boot-check.mjs`: 11 assertions, 0 failed; 49 of 49 package rows hidden and 45 of 45 basic clip rows retained.
- `node tools/boot-check.mjs --mutate effect-rack-shows-every-effect`: 1 intended assertion fired.
- `node tools/boot-check.mjs --mutate reset-before-the-panel-generator`: 1 intended assertion fired.
- `node tools/effect-check.mjs`: 129 assertions, 0 failed.
- `node tools/release-gate-check.mjs`: 0 failed; npm minimum release age remains 48 hours.
- Rendered Playwright flow at 1440x960: fresh sidebar, search, Add, first-control focus, value authoring, key authoring, destructive confirmation, Remove, and one-step undo. The page reported 0 console errors.
- `editor-check --no-render`: 563 assertions with every rack row passing. Four rack mutations added 8, 3, 1, and 1 intended failures.

## Known verification caveat

The unmutated editor check still reports three unrelated gesture failures: paused navigation fell back to one rebuild, double-click removal left three keys, and the crossed-pair timing gesture stopped on the wrong point. The same three rows were stable across both unmutated rack runs. Real export was skipped with `--no-render` because this PR does not touch export.