### PR TITLE
Close the defects the effects stack's reviews found, and three they did not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,12 @@ thing that should be touching capture bytes.
 - **There are three screen-space references and not two, and the third is the newest.** The
   glyph field's legibility band is 8 to 16 pixels of *whichever reading is smaller* — the drawn
   framebuffer sprite, or that sprite back in reference pixels — which the vertex stage writes as
-  `gl_PointSize / max(k, 1.0)` into `vLegiblePx`. Neither half alone is correct and each one
+  `outsideCrop ? 0.0 : gl_PointSize / max(k, 1.0)` into `vLegiblePx`. The crop's half of that is
+  a decision and not a reading: a point outside the box reports no legible pixels at all, so
+  `glyphMix` is exactly 0 and cut-away geometry draws the round mask. Halving the sprite was the
+  whole of what the crop used to contribute here and it was never enough — half of a 64-pixel
+  sprite is 32, still far above the band, so cut geometry drew a *smaller character* where the
+  halving's own paragraph promises dust. Neither half alone is correct and each one
   alone is a shipped defect: in reference pixels the fallback inverts at small buffers, because
   the lower clamp lifts a sub-pixel sprite to one framebuffer pixel and that divides back into
   fifteen reference ones, so the far cloud drew one arbitrary bit of a character each instead of
@@ -263,7 +268,15 @@ thing that should be touching capture bytes.
   arm is above the band on both readings.
 - **1080p is the unit; 600 is bloom's frozen chain; both are correct and do not reconcile them.**
   Every screen-space term is *expressed* against 1080p, which is why the shaders in
-  `web/cloud-shader.js` read `bufferHeight / 1080.0`. Bloom has no parameter to express, because
+  `web/cloud-shader.js` read `bufferHeight / 1080.0`. That sentence was aspirational for one term
+  until recently and is now true of it: the glyph field's point-size ceiling is expressed in
+  reference pixels too, `min(255.0 * k, pointCeiling)`, so the range at which characters stop
+  filling their cells is the same at any output size. The hardware bound stays outside it, because
+  a reference ceiling the GPU will not rasterise is a clamp that does not clamp — measured off the
+  context the tools open, this rig reports `ALIASED_POINT_SIZE_RANGE` as [1, 511] (Apple M2 Max
+  through ANGLE's Metal backend, one read from the page). 255 is the largest number that survives
+  the tallest output `web/export-sizes.js` offers: 2160 is a scale of exactly 2, and 255 × 2 is
+  510. Bloom has no parameter to express, because
   `UnrealBloomPass` bakes its tap count in at construction, so its mip chain is frozen at the
   600-tall buffer the look was graded on: `bloomChainSize` computes
   `refWidth = (bufferWidth / bufferHeight) * 600` and sets the chain at half of it. The mechanism

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ exit code (rule 3).
 | `determinism-check.mjs` | same program time, same image | a capture |
 | `index-check.mjs` | the index, the hash, the frame API | `--url` against a running server |
 | `registry-check.mjs` | one registry, sliders as views of it, every look term live | `--url` |
-| `timeline-check.mjs` | seek equals playback | `--url` |
+| `timeline-check.mjs` | seek equals playback | `--url`, a take of ≥12s |
 | `keyframe-check.mjs` | tracks, the retime curve, undo | `--url`, a take of ≥24s |
 | `export-check.mjs` | resolution, export, the file | `--url`, ffmpeg and ffprobe |
 | `editor-check.mjs` | the editor's controls exist, and pressing them changes something | `--url`, a take of ≥32s |
@@ -214,9 +214,9 @@ than footage** — no depth jitter, no confidence gate chattering on a flat wall
 — so say which sample a number came from. **It refuses to overwrite an existing capture**, because
 the path it runs at is where a machine with a sensor keeps real footage: bare refuses and names
 the size and date of what it declined to destroy, `--force` replaces, `--if-missing` leaves an
-existing one alone and exits 0. `editor-check` and `keyframe-check` exit 2 naming the shortfall on
-a take shorter than they need, because on the short sample they redden rows about a build with
-nothing wrong with it.
+existing one alone and exits 0. `timeline-check`, `editor-check` and `keyframe-check` exit 2 naming
+the shortfall on a take shorter than they need, because on the short sample they redden rows about
+a build with nothing wrong with it.
 
 ## Three things that are easy to get backwards
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,11 @@ GET    /effects/:id          one package: the parsed manifest, the file index, t
 GET    /effects/:id/file/:n  one file's bytes, as text/plain
 PUT    /effects/:id          { manifest, chunks: { <file>: <text> } }  installs into effects/
 DELETE /effects/:id          removes the user's copy only
+POST   /effect-refusals      { ids: [...], reason }  sets aside the user copies of packages a
+                             page could not compile, and answers which it set aside and which
+                             it skipped, with a reason for each. Deliberately not under
+                             /effects/, because a literal segment there outranks :id and an
+                             effect id is a directory name anybody can create
 ```
 
 A revision is a hash of the bytes: `sha256` per file, and the package's own over the sorted
@@ -107,8 +112,11 @@ that pair is identical while the store answered as something else in between. A 
 it passes the comparison by construction, assembles a program out of two revisions, and records
 the revision it opened with, so nothing later ever disagrees either. The counter is the store's
 own history rather than its contents, which is the axis that pair moves along; it is bumped by
-`install` and `remove` and by nothing else, and it is not durable, because a restart makes the
-two listings disagree and the client retries.
+`install`, by `remove` and by a package set aside through `POST /effect-refusals`, and by nothing
+else — the third is the same act as the first two from the store's point of view, a directory
+appearing or leaving under an id, and a page that has just quarantined something it could not
+compile has to be handed the working set on its next poll rather than the one it is blocked on. It
+is not durable, because a restart makes the two listings disagree and the client retries.
 
 **An install is atomic because a package is a directory.** The whole thing is written under
 `<id>.<seq>.tmp`, any existing copy is renamed to `<id>.<seq>.old`, the new one is renamed in and
@@ -226,6 +234,31 @@ restores the document it had, synchronously and without the network, because the
 nothing left to fall back to is the wrong moment to need a fetch. The corner where the rollback
 itself fails says to reload the page and repaints nothing, since a panel painted over a state no
 document describes is a page that looks well and is not.
+
+**The two failures that paragraph names roll back identically and are told apart afterwards,
+which is the one asymmetry in it.** A shader that will not link is a fact about a package: it is
+on disk, it is what the driver rejected, and the rollback leaves it exactly where it was — so the
+next page to open compiles it at boot, where `warmPrograms` runs outside any transaction and takes
+the module down with it, publishing no `__kinect` at all and leaving every tool in the suite
+reporting that it did not run. A document that could not be carried across is a fact about the
+pairing of one clip with one manifest, and the package may be perfectly good. So the throw out of
+`warmPrograms` carries a mark and `setAsideUnlinkable` is called on that mark alone: a build that
+quarantined on the other one would rename somebody's authored fork out of the way because a single
+clip on a single machine could not be opened onto it, and the operator's next move — opening a
+document that names the parameter the fork added — would have worked.
+
+**Which package to name is the hard half, because a link failure is a property of the assembled
+program.** Both programs are one text spliced out of every installed package and the driver's log
+is about a line number in that text, so nothing in it says whose GLSL that was. What the page does
+know is which packages *moved*: it is holding the set it was drawing with, whose programs linked,
+beside the set it just fetched. So the candidates are the ids that arrived and the ids whose
+revision changed — one when one changed, and all of them named in the reason when several did,
+since setting a package aside renames it rather than destroys it and it stays on disk to be
+repaired. An id in the old set and absent from the new one is not a candidate at all: its text is
+not in the program that failed to link. The sequence terminates because the store moves: the page
+is blocked on the signature it failed to adopt, quarantining changes what the next listing says,
+and the rebuild after it links. A store that set nothing aside leaves the signature where it was,
+the block stands, and nothing asks again.
 
 ### A document may name an effect this build has not got
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -3053,6 +3053,34 @@ The tell for this class is a row that fails on a value *near* a boundary — 85%
 window, a value of exactly zero — rather than one that fails by a mile. A build that
 genuinely lost the window would put the marker nowhere near the edge of it.
 
+Three more arrived together in a full replay run. `timeline-check` targeted 12 seconds
+while its documented default opened the 9.43-second sample. The transport clamped correctly
+and the rain-clock row alone failed at 9.43 against 12, which read as a product defect. It now
+refuses a take shorter than `NEEDS_TAKE_SEC` before it opens Chromium, and the documented run
+names `fixture-1g`.
+
+That refusal also closed the door on `sweep-all` before it could enumerate timeline mutations:
+enumeration was a child run too, and still inherited `sample`. Take selection now belongs to the
+common child-command path, so enumeration and the mutation it names cannot use different
+fixtures. With that path disabled, the focused sweep stopped before its first assertion. With it
+enabled, `preroll-constant` ran on `fixture-1g` and reddened 13 rows.
+
+`keyframe-check` compared the transport's source-frame bracket at the page's computed source
+time against a bracket computed at the tool's source time. Those times agreed to 1.1ns, but one
+probe sat exactly on a capture stamp and the rounding put the two readings on opposite sides of
+it. The source-time row already holds the mapping. The bracket row now feeds the page's exact
+source time through an independent walk of the capture index, so it asks only whether the
+transport chose the indexed pair for the value it used. A temporary off-by-one mutation still
+reddened both bracket rows at 25 of 25, plus two downstream refusals.
+
+The trails control in the same tool had the other fixture failure: the wrong closed-form
+pre-roll differed from playback by only 3/255 over 0.021% of pixels under Blackwall, below the
+control's own 16/255 floor. Lowering the floor would have calibrated the row to the failure.
+The same frame under the shipped RGB look differs by 71/255 over 0.336%, while the correct
+window remains byte-identical. `trails-damp-at-target` then reddens exactly the two claim rows.
+**A fixture includes the look as well as the take**; a correct arithmetic difference is not a
+falsification control until the picture makes that difference observable.
+
 ## A probe placed where both builds answer the same thing
 
 Four instruments written for the crop box in one session were each aimed somewhere the

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -2635,9 +2635,47 @@ the timestamp on the line is the cheapest thing that tells those apart; here the
 the section heading above it carry the same second. The repair is a guarded read that leaves the
 timeout reachable and reports "the page never published `__kinect`" apart from "colour never
 arrived", because those are different findings. What it is *not* is a fixed `wait()` after the
-`goto` — the two sections above it in the same tool survive on one, which is the silent-pass
-shape their own comments refuse, and a sleep tuned on this machine is a pass waiting for a
-slower one.
+`goto` — the two sections above it in the same tool survived on one until the entry below, which
+is the silent-pass shape their own comments refuse, and a sleep tuned on this machine is a pass
+waiting for a slower one.
+
+**Then those two sleeps were measured, and the measurement is the entry: a sleep sixty-five
+times longer than what it waits for and a sleep a tenth as long read exactly the same on the
+machine doing the measuring.** `monitor-check` drove the recorder from three places and only
+the third had the guard, so the repair was one wait — `published`, beside `waitFor` in that
+file — which all three call after their own `goto` and which each hands the expression its
+own section reaches through. What the sleeps had been covering, printed by the wait itself
+rather than assumed: 15 to 18ms from `load` to the handle, where one section waited 1200, and
+92 to 94ms to the first depth frame, where the next waited 2000. Six runs, two clean and four
+mutated, on an idle Mac over loopback with a warm page cache and a warm capture sidecar. Both
+margins were real and nothing was reading either, which is the failure rather than a detail
+beside it: the tool passed all 91 rows with the race in it, and would have gone on passing
+until a contended machine turned a margin negative and reddened a decimation row about a
+viewer that had not finished booting.
+
+**The second sleep was covering something a boot probe would not have found**, and that is
+the half worth carrying to the next tool. That section drives the real divisor control, and
+`sendMonitor` in `web/main.js` returns without sending unless the socket is `OPEN` — so a
+page that has published `__kinect` and not yet connected takes the drag, sends nothing, and
+the ÷4 arm becomes a second ÷1 arm read under a ÷4 label, which is the misattribution the
+whole negotiation exists to prevent. A wait on the handle alone is green for that. What it
+waits for instead is a depth texel that is no longer zero: `buildTextures` in
+`web/gpu-textures.js` builds both depth textures zero-filled deliberately, so that every
+point leaves at the empty-sample test until a real frame binds — which means that on a page
+nobody has injected into, the only thing that can write a non-zero texel is a frame off that
+socket, and one clause settles the handle, the socket and the stream together. **Ask a
+readiness wait what its own section reaches, never what publishes first**: the earliest thing
+that happens to be there is a probe whose answer cannot differ from the next probe's.
+
+**A readiness wait earns a falsification control like anything else on this page, and it is
+cheap** — point one at a name that never publishes and read what the run says. The two
+sections whose subject is decimation let the timeout out, so that control ends at 53
+assertions with **none failed** and `DID NOT RUN` naming what never arrived, which is the
+answer that matters under `--mutate`: a red row there would have been counted as the mutation
+being caught. The colour section catches it onto its own row instead, for the reason above,
+and its control reddens exactly that row, leaves the respawn rows green and skips the viewer
+row beneath it. Both were run against the repaired tool, because a wait nobody has watched
+time out is a wait nobody has tested.
 
 **And the same publish race has a second door, where the guard is vacuous rather than
 absent.** `library-check` waited on
@@ -4283,3 +4321,34 @@ that it is the only user package still standing.
 **A refusing gate has this shape wherever it appears**: a section whose rows all read the state
 after a refusal is blind to over-refusal, however many rows it has. Ask what a rule that refused
 everything would fail here, and if the answer is nothing, the missing row is a must-accept.
+
+## A new rule placed ahead of an old one takes that one's fixture away
+
+A hostile fixture reaches the rule it is named after by being the only thing wrong with it.
+Add a rule that fires earlier and the fixture still gets refused, the row still goes green on
+a good build, and nothing anywhere says the probe has stopped arriving where it was aimed.
+
+Three of these landed in one change and they are the same shape read at three distances.
+`effect-check` section 2's `one joint naming one file over and over` probe pushed a thousand
+chunk descriptors, which is a 90,623-byte manifest — so a new 32 KiB manifest bound refused it
+by size, several rules ahead of the assembler's repeat rule, and the row reddened naming the
+manifest on a build where both rules were working. Cut to fifty descriptors it is about 6KB,
+inside every bound and outside none, and it reaches its own rule again. In the same change a
+near-miss fixture built to prove the new `gates` rule does not refuse a legal `degToRad`
+binding was written by repointing the shipped `angle` off `scanAxis`, which left that uniform
+declared and bound to nothing — so it came back refused by the two-ended binding rule two
+hundred lines away, and the row would have been green on a build carrying no gate rule at all.
+It is a new parameter now. And the scan behind the second half of `HOST_DRIVEN_UNIFORMS` read
+declarations without stripping comments, so it walked through the glitch's flare chunk and the
+duotone's tone chunk, which both quote `readRgb, readDepth, readContour` in prose from a
+pinned build, and failed naming `readDepth` on a build with nothing wrong with it. The door's
+own `withoutComments` is the two substitutions that fix it.
+
+**Every hostile fixture is a claim that one rule refuses it, and the claim decays whenever a
+rule is added.** The cheap enforcement is the row `effect-check` already has: every hostile
+package is refused *by the sentence for its own rule*, not merely refused — which is what
+turned the first of these from a silent decay into a red row somebody had to read. A suite
+that only asserted refusal would have carried all three. When a refusal is added ahead of
+others, re-read what the existing probes now trip on rather than only what the new one does,
+and make the new refusal's message name which rule fired, so the next person reads the
+attribution instead of running both arms to work it out.

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -106,15 +106,15 @@ node tools/registry-check.mjs --mutate margins-confined-to-glyphs # ... the same
                                                                   #     wrong fix the character section cannot refuse
 node tools/registry-check.mjs --mutate margins-miss-the-newborn   # ... and narrowed the other way, to the disc's rim and not
                                                                   #     the point that has not faded in yet
-node tools/timeline-check.mjs --url http://localhost:8080 # step 4: seek equals playback
-node tools/timeline-check.mjs --mutate preroll-constant   # ... and must FAIL mutated
-node tools/timeline-check.mjs --mutate draft-always-resets # ... and must FAIL mutated
-node tools/timeline-check.mjs --mutate reading-write-skips-repaint # ... and must FAIL mutated
-node tools/timeline-check.mjs --mutate rain-accumulates   # ... the rain integrated frame to frame, so a seek lands
+node tools/timeline-check.mjs --url http://localhost:8080 --take fixture-1g # step 4: seek equals playback
+node tools/timeline-check.mjs --take fixture-1g --mutate preroll-constant   # ... and must FAIL mutated
+node tools/timeline-check.mjs --take fixture-1g --mutate draft-always-resets # ... and must FAIL mutated
+node tools/timeline-check.mjs --take fixture-1g --mutate reading-write-skips-repaint # ... and must FAIL mutated
+node tools/timeline-check.mjs --take fixture-1g --mutate rain-accumulates   # ... the rain integrated frame to frame, so a seek lands
                                                           #     where playback never would. Its section applies a
                                                           #     rain-raised look of its own, because every other arm
                                                           #     in that file renders the term completely inert
-node tools/timeline-check.mjs --mutate rain-phase-unread  # ... and the same clock written correctly and read by
+node tools/timeline-check.mjs --take fixture-1g --mutate rain-phase-unread  # ... and the same clock written correctly and read by
                                                           #     nothing, which both arms agree about perfectly. It is
                                                           #     the control for the guard rather than for the claim:
                                                           #     what reddens is the row that moves the clock alone
@@ -2756,6 +2756,8 @@ with anything. The names are enumerated and the tools are not. The ten that are 
 need something
 the sweep does not currently arrange - a private server, a GPU browser, a built prefix - so
 wiring them is real work rather than a longer array.
+Replay runs use `fixture-1g`; set `SWEEP_TAKE` when the server names another take that satisfies
+both tools' duration floors.
 
 ## `editor-check` is three rows red at `7cb273d`, and they are not yours
 
@@ -2894,29 +2896,30 @@ than 30.** So size fixtures by *frame count*, not duration: five minutes of its 
 rewritten monotonic stamps — real depth and real JPEGs, only the u64 at payload offset 8 moves.
 Say so whenever a number rests on one.
 
-**And no page can tell you which sample a checkout has, which is why two tools now refuse a
+**And no page can tell you which sample a checkout has, which is why three tools now refuse a
 take instead of assuming one.** `captures/` is gitignored, so every sentence written here about
 "the sample" describes a file the next machine may not hold — and they have already disagreed.
 The paragraph above says 9.3fps; `keyframe-check`'s header said 284 frames over 30.36s and its
 section 6d said 49.79s; the file in this tree is 284 frames over **9.42s at 30.03fps**. One
 frame count, four durations, all of them written down as facts.
 
-The damage is not the prose. `editor-check` seeks to 30s and `keyframe-check` retimes through
-source 20s, and on a 9.42s take every one of those clamps: **ten rows redden in `editor-check`
-and four in `keyframe-check` against a build with nothing wrong with it**, and — the half worth
-fearing — two more `keyframe-check` rows *pass*, because the key they drag has left the ruler
-and a gesture that never happened also never slid a key under its neighbour. Seven of the ten
-and all four of the four go green on a 75.6s fixture with nothing in `web/` changed.
+The damage is not the prose. `timeline-check` targets 12s, `editor-check` seeks to 30s and
+`keyframe-check` retimes through source 20s. On a 9.42s take every one clamps: one row reddens in
+`timeline-check`, ten in `editor-check` and four in `keyframe-check` against a build with nothing
+wrong with it. The quieter half is that two more `keyframe-check` rows *pass*, because the key they
+drag has left the ruler and a gesture that never happened also never slid a key under its
+neighbour. The long fixture makes those fixture failures go away with nothing in `web/` changed.
 
-So both declare a `NEEDS_TAKE_SEC` and exit 2 naming the shortfall, in the same direction and
+So all three declare a `NEEDS_TAKE_SEC` and exit 2 naming the shortfall, in the same direction and
 for the same reason as `requireMutationDelivered`: a red row reads as a catch, so a fixture
 that cannot hold the gesture has to be the harness declining. The declaration is held against
 the file's own literal seek targets by a scan of its own source, so a row added later that
-seeks deeper cannot quietly fall outside it. **The control for both is `--take sample`**: exit
+seeks deeper cannot quietly fall outside it. **The control for all three is `--take sample`**: exit
 2 with nothing asserted, where the same command used to run to the end and report failures.
 
 ```
 node tools/make-fixture.js captures/sample.knct captures/fixture-1g.knct --loops 8
+node tools/timeline-check.mjs --url http://localhost:8080 --take fixture-1g
 node tools/editor-check.mjs   --url http://localhost:8080 --take fixture-1g --no-render
 node tools/keyframe-check.mjs --url http://localhost:8080 --take fixture-1g
 ```

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -663,7 +663,34 @@ node tools/effect-check.mjs --mutate adopt-outside-the-transaction # ... the ado
 node tools/effect-check.mjs --mutate a-broken-shader-is-warm # ... the throw dropped from the end of the warm, leaving a link
                                                           #     failure where three.js puts it: a console line. The install
                                                           #     succeeds, the poll announces success, and the cloud draws
-                                                          #     nothing. Reddens two rows of section 9
+                                                          #     nothing. Reddens **six** rows, measured, all in
+                                                          #     section 9: the two the mutation is about - the rebuild
+                                                          #     reporting success and the broken line reaching the
+                                                          #     assembled program - and the four under them, which are
+                                                          #     the quarantine not happening because there is no longer
+                                                          #     a link failure to mark
+node tools/effect-check.mjs --mutate a-link-failure-is-not-quarantined # ... the throw and its mark left exactly where
+                                                          #     they are and the one call that acts on them dropped,
+                                                          #     which is the build this replaced. The page still
+                                                          #     refuses the package, still rolls back and still says
+                                                          #     which shader did not compile - and the package sits in
+                                                          #     the store afterwards, so the next browser to open
+                                                          #     compiles it at boot, outside any transaction, and dies
+                                                          #     there. Reddens **four** rows, measured, all in section
+                                                          #     9, and the third is the point: the fresh page comes
+                                                          #     back `no __kinect published`
+node tools/effect-check.mjs --mutate any-failure-is-quarantined # ... the mark test dropped and the call kept, so every
+                                                          #     failure the rollback catches reaches the refusal route.
+                                                          #     This is the direction the fix does damage in rather
+                                                          #     than merely fails in, and the page reads correctly
+                                                          #     through all of it - the refusal is right, the sentence
+                                                          #     is right, the rollback is right, and a package nothing
+                                                          #     is wrong with has been renamed out of the way behind
+                                                          #     them. Reddens **three** rows, measured, and only the
+                                                          #     first is a finding: section 6 asks the store whether
+                                                          #     the fork the completeness rule refused is still
+                                                          #     installed, and it answers 404. The two under it are
+                                                          #     section 9's aside count seeing two where it expects one
 node tools/effect-check.mjs --mutate the-sweep-eats-the-last-copy # ... the sweep removing every aside it finds and the recovery
                                                           #     pass removed with it, so a crash between an install's two
                                                           #     renames loses the package to the next install of that id.
@@ -1658,6 +1685,58 @@ about. `Webcam.subscribersCostingTheTake` is written as a filter over `describe(
 and charge every proof tool in this repo for its own localhost connection. Forcing the rule to
 `return this.describe()` reddens three rows — the section 1 one by name, and the two in section
 3 that need a take to start with a loopback webcam attached.
+
+**`monitor-check`** spawns its own server on 8341 and needs none running, but it needs a
+capture at `captures/sample.knct` to stream and a GPU browser for its renderer sections
+(`--no-browser` drops them and says `UNTESTED` rather than passing quietly). Read its three
+`....  waited Nms after load for ...` lines before you read its rows: each is what one
+browser section waited for its page to publish before driving anything, printed rather than
+asserted because there is no threshold here worth gating on, and the number is the headroom
+a slower machine has left. On an idle Mac they run 15 to 18ms, 92 to 94ms and 60 to 68ms.
+**A wait that runs out there is not a row.** The two decimation sections let it throw, so the
+run ends `DID NOT RUN` naming what never arrived — which is what stops a `--mutate` run
+counting a viewer that never came up as the mutation being caught. Only the colour section
+turns it into a failed row, because there "the page never booted" and "colour never arrived"
+are different findings and it is the one place that can tell them apart.
+
+**Its renderer section rebuilds the capture index every run, and that is deliberate**: it
+symlinks the sample into its own staged tree, so the sidecar the first open builds lands
+there and is deleted with it. Warming `captures/sample.idx` therefore does not reach that
+section — it reaches the `--replay` server in the section above, which serves the repo's own
+capture. So a red `the frame API served frame 7 of the sample at every divisor this compares`
+is a server still indexing 138MB rather than a finding about decimation, and it is the row to
+suspect first on a contended machine now that the boot sleep no longer stands between the
+page load and that fetch. Stated rather than measured: that row passed on all six runs behind
+this paragraph, and every one of them was on an idle machine.
+
+**`export-check` has the same shape and a bigger number: 10 of its 66 rows are red on the
+synthetic sample and none of them is about the build.** Nine are the resolution-invariance
+family — `trails`, `rgbsplit`, `scanlines`, `grain`, `bloom`, `nobloom`, `full`, `regionpush`
+and `regionmask` each asking that 1920x1200 is 960x600 at twice the size — and the tenth is the
+crop's cull row. They compare fine structure and coarse means between two renders of the same
+look at two sizes, and `make-sample`'s three surfaces carry no depth jitter and no sensor noise,
+so the structure those rows correlate is aliasing rather than anything in the room. Measured
+against a clean checkout of the merge commit `3b7ab90` and again on the effects branch: **the
+same ten rows, at identical numbers to four figures** — `trails` at a coarse mean of 2.732 on
+both, the crop row at 110 revealed and 314,021 lit against 410,577 released on both. That
+identity is the useful part rather than the count: a change that moved any screen-space term
+would move these numbers, so reading them as equal is a stronger statement than reading them as
+red. Take the baseline before believing this tool has found something, and compare the numbers
+rather than the pass count.
+
+**`registry-check`'s crop and snap rows are placed against a capture, and `make-sample`'s is
+not that capture.** The scrambled set authors `near` 0.35 and `far` 4.2 and places the four
+lateral faces against a cloud running x [-2.31, 2.97] and y [-2.26, 1.63], while
+`tools/make-sample.mjs` builds its back wall at z = 3.2m and its sphere at 1.55m with a 0.28m
+radius — so the whole synthetic cloud sits inside the depth pair and there is nothing for it
+to cut. Run against the synthetic sample the tool therefore comes back **FAIL (3)** on a tree
+with nothing wrong with it: the drop-one sweep reports `unexplained: bottom snapDelta`, the
+count lands at `92 of 97 parameters are proven to reach the pixels`, and the crop's second row
+reports `identical with only near/far authored`. All three are the fixture rather than the
+build, and `snapDelta` at 410 is the same shape — a threshold the synthetic motion never
+crosses. Measured on a clean checkout of the merge commit `3b7ab90`, so a run of this tool
+that reports three reds and these three sentences has found nothing. A machine holding real
+footage sees them pass, and a change that takes the count past three has moved something.
 
 **`guard-check`** spawns its own servers and needs none running. It exits 2 when the machine has
 no non-internal IPv4, because "not listening on the network" is only a claim if there is a

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -173,7 +173,7 @@ draws a cell-sized character at its own unquantised position — that is authori
 defect, and nothing gates one control on the other.
 
 **Three keys decide which character a cell draws, and they add and wrap rather than mixing.**
-`tone key` reads the luminance the cell is about to draw at, `hash key` reads a hash of the
+`tone key` reads where the cell sits between the clip planes, `hash key` reads a hash of the
 cell itself, and `rain key` reads the falling counter passing through it; the three weights
 sum into one index into a table of sixty-four 8x8 bitmasks and wrap. They sum rather than
 blend the way the five readings do because character indices do not average — character 3
@@ -186,9 +186,36 @@ is 0.
 **The table is sorted by ink**, punctuation at the sparse end and dense kana at the other, so
 the tone key reads it as a tone ramp and the hash key reads the same table as noise with
 neither having to choose. What that costs is a latin ramp: a luminance sweep runs through
-kana, so the picture is ASCII art drawn in an alphabet that is not ASCII. There is no depth
-key because the readings already have one — put `readDepth` up and the colour ramp is
-distance, which the tone key then reads as a depth band.
+kana, so the picture is ASCII art drawn in an alphabet that is not ASCII.
+
+**The tone key is a fact about the cell and not about the point, and that is what stops the
+lattice turning it into noise.** It reads a range and not a colour, and the difference only shows
+where a cell holds sources that disagree: collapse a few hundred depth texels onto one cell and a
+key reading each point's own colour picks a different character for each of them, drawn at the
+same snapped position, so the cell paints the union of several characters. On a `cascade`-shaped
+fixture that is 30.65% of the frame inked against 8.66% — three and a half times the ink, and none
+of it the character anybody asked for. There is no cell-constant reading of the drawn colour to
+key on instead: the colour is built per fragment out of five readings and everything the tone
+stage adds, and inside one cell it still varies through the camera texel, through the raw sample
+depth, and through the rain's own lift. So the key reads the range. For `cascade` the two are the
+same thing — it is `readDepth` alone, so its colour *is* the depth ramp read at that range — and
+they part company furthest under `readRgb`, where a white shirt and the black wall behind it sit
+at one depth and take one character.
+
+**It only bites where the characters actually resolve, which bounds the whole thing and is the
+first place a re-measurement goes wrong.** Below the legibility band `glyphMix` is 0, the mark is
+a round splat, and the tone key reaches no pixel at all — so a build with the defect and a build
+without it draw identical frames for a reason that has nothing to do with the key. On a 1080p
+export `cascade`'s 5.5cm cell falls under the band past about four metres; on a 360-tall stage it
+happens at about 1.2m, because at 4.1m that cell rasterises to 4.6 framebuffer pixels against
+17.3 at 1.1m. Measured there, interleaved over three rounds against a build carrying the shipped
+per-point key, every arm repeating its mask and its pixel count identically: a wall ramped ±120mm
+about 2500mm inked 106,282 pixels against 114,537, and a flat wall at the same depth 36,340
+against 40,207. The flat wall is the honest reading of the *meaning* change alone, since a
+homogeneous cell has no occupants that can disagree; the ramped one carries the union defect on
+top of it. Both arms had `fade` and `wake` forced to 0, which changes nothing about the character
+— they scale alpha and never reach the index — and without which a point born on an injected
+frame carries a fade of exactly 0 and the whole frame comes back black.
 
 **The mark crossfades back to the round splat at whichever floor it hits first: the look's own,
 between sixteen and eight reference pixels, or what the buffer can actually resolve**, so the
@@ -196,6 +223,8 @@ near room is text and the far room is texture. At full `glyph.amount` on `cascad
 look's band is 4.0 to 8.0 metres out, the same metres at 1080p and in a 4K export; a buffer
 shorter than 1080 pulls the boundary nearer because eight framebuffer pixels stop existing
 sooner, which is the buffer being honest about what it can draw rather than the look changing.
+Cut-away geometry is outside all of this and falls back to the round mask outright, because a
+piece of scaffolding that is still legible is still reading as surface.
 The reason the floor exists at all is that an 8x8 bitmask sampled
 across eight pixels is a different random set of bits every time the camera moves rather than a
 small character, which bloom then amplifies. Clamping the
@@ -404,7 +433,8 @@ queue to two different machines, and only one of them is about the job.
 
 ### Installing an effect, and taking one away
 
-`PUT /effects/<id>` installs a package and `DELETE /effects/<id>` removes one. The body is
+`PUT /effects/<id>` installs a package, `DELETE /effects/<id>` removes one, and
+`POST /effect-refusals` sets aside a package a page could not compile. The body is
 `{manifest, chunks}` — the manifest as JSON and a map of file name to GLSL text — and the id in
 the path is the namespace its parameters carry, so a manifest declaring a different one is
 refused rather than guessed at. An id is lowercase letters and digits, up to 64 of them: it is a
@@ -420,6 +450,36 @@ forking is refused by name rather than silently doing nothing. Deleting a packag
 in `effects/` uninstalls it, at which point every open document's values under it park exactly as
 they would on a machine that never had it.
 
+**Nothing here compiles GLSL, so the page that discovers a package will not link is what
+quarantines it.** The door refuses a chunk naming something this build has not got and cannot
+refuse one whose GLSL is merely wrong — a missing brace, a `vec3` assigned to a `float` — because
+that is a shader that fails to link, which is a log line inside the driver rather than anything
+the server can see. `warmPrograms` collects those failures and throws, so the page rolls back onto
+the set it was holding; without somewhere to report it the store would go on serving the package
+and every *fresh* page load would compile it at boot and die there. So the page posts to
+`POST /effect-refusals` with the driver's own sentence, and `serveEffectRefusal` renames each user
+copy aside under `<id>.<seq>.incompatible` — the same rename the boot gate makes, so the package
+is still on disk to be repaired and the shipped one answers for that id again. The ids it names
+are the packages that *changed* in that adoption, because a link failure is about the assembled
+program and never says whose GLSL it was: the set the page was drawing with linked, so the culprit
+is among the ones that arrived or moved revision, and all of them are named in the reason when it
+is more than one. Only a link failure may do it. The same rollback catches a document this page
+could not carry onto the new manifest, and `setAsideUnlinkable` is called on a mark the throw
+carries rather than on the rollback having happened, because renaming a fork aside for a fault in
+one clip is a page destroying somebody's work to report its own. The reason is cut to 500
+characters and flattened to one line by both ends, and the flattening is of every control
+character rather than of whitespace alone: this rig's driver answers a `float` assigned to a
+`vec3` with 193 characters carrying two NUL bytes inside the sentence, and a NUL is not
+whitespace, so a collapse of `\s` alone put one into a line somebody reads in a terminal. It grants no
+authority the caller did not have, which is the first thing anybody asks about a route that
+renames a directory on a name off the wire: `PUT` and `DELETE` are on this same server behind this
+same guard and neither asks who is calling, and this does strictly less than either. An id with no
+copy in the user root is skipped rather than refused, per id, because a page that failed to link
+has the ids it was assembling from and no reason to know which root each came out of — the answer
+names what was set aside and what was not, with a reason for each. The store's generation moves
+when anything is set aside, so the page that just called it is handed the working set on its next
+poll.
+
 **A package that this build could not compile is refused at the door, and the refusal names the
 rule it broke.** That matters more than it sounds: a package is GLSL spliced into two shader
 programs and a table of parameters spliced into the registry, and both of those are assembled
@@ -431,16 +491,26 @@ name has to be a bare name in the package's own directory, at most one parameter
 master and its default has to be the value the effect is absent at, the kind and the binding have
 to be ones the registry implements, every uniform a parameter binds has to be declared by some
 program and every uniform the package declares has to be bound by one of its own parameters or
-listed under `hostDriven`, every joint a chunk names has to exist in a spine, and every identifier
-a chunk reaches for has to be something this build has. Four more rules are about the package as a
-whole rather than about one entry in it, because every rule above is satisfied as many times as a
-package repeats a correct entry: a package holds at most 64 files and 256 KiB of chunk text (the
-widest that ships holds eight files and under 17 kilobytes, and every read of the store hashes
-every file of every package), a binding has to be the *shape* of the uniform it writes — `axisDeg`
-needs a `vec2` and everything else a `float` — a step may not be finer than `1e-6`, which is a
-grid neither the rounding nor a 32-bit float can resolve, and a parameter may only name a panel
-group this build holds or one its own package declares, with a package group key that collides
-with either refused by name. A refused package leaves nothing behind.
+listed under `hostDriven`, which is not a list a package writes freely — it names the uniforms
+this build's own render loop drives, which is `rainPhase` and nothing else, because an exemption
+a package issues itself is the rule gone — every joint a chunk names has to exist in a spine, and
+every identifier a chunk reaches for has to be something this build has. Seven more rules are
+about the package as a whole rather than about one entry in it, because every rule above is
+satisfied as many times as a package repeats a correct entry: a package holds at most 64 files and
+256 KiB of chunk text (the widest that ships holds eight files and under 17 kilobytes, and every
+read of the store hashes every file of every package), its manifest holds at most 32 KiB (the
+widest that ships is the glitch's at 2,740 bytes over seven parameters, and a manifest is written
+to disk, hashed on every read and turned into a control per parameter on every open page — so
+twelve thousand correct parameters carrying one small chunk of GLSL passes every rule above it and
+fits inside a request body), a binding has to be the *shape* of the uniform it writes — `axisDeg`
+needs a `vec2` and everything else a `float` — and may not aim at an array at all, since every
+binding writes one cell and three.js takes its uploader off the declaration, a binding that
+declares `gates` has to be something the grade gate can read, so not `axisDeg`, whose
+two-component direction is never zero, and not a table the gate does not collect, a step may not
+be finer than `1e-6`, which is a grid neither the rounding nor a 32-bit float can resolve, and a
+parameter may only name a panel group this build holds or one its own package declares, with a
+package group key that collides with either refused by name. A refused package leaves nothing
+behind.
 
 **A page that is open when an install happens rebuilds itself.** Both shader programs are
 reassembled and swapped, the registry and the panel are rebuilt from the new set, and every value
@@ -609,9 +679,18 @@ on exposure rather than on distance. That is what separates it from the duotone 
 duotone is keyed to depth, replaces the colour outright and runs per point, where this biases
 the colour the assembled frame already has — so a point, the bloom halo around it and the
 halation ringing that halo are toned together, which nothing in the point program can do. It is
-built to leave exposure alone: the tint it applies is divided by its own luminance, so raising
-the master to 1 moves colour and not brightness (measured over three frames, mean luma 124.91 at
-one end of the balance against 125.06 at the other, a spread of 0.12%).
+built to leave exposure alone, and it now does it for every colour rather than for the greys. The
+tinted pixel is scaled back onto the luminance the pixel arrived with, so the outgoing luminance
+is the incoming one by construction whatever the hue. The line that stood here divided the *tint*
+by the tint's own luminance, which cancels only when every channel of the pixel is the same
+number: worked through the shipped poles in double precision — arithmetic over the shader's own
+literals rather than a rendered frame — the tungsten shadow pole took pure red to 0.8599 of its
+luminance and pure blue to 1.2793, with the tungsten highlight pole running the other way at
+1.1139 and 0.8067. Grey came back at exactly 1.0000 at all four poles, which is how a claim that
+wrong survived being looked at, and it is also why the whole-frame reading recorded here (three
+frames, mean luma 124.91 at one end of the balance against 125.06 at the other, 0.12%) could not
+see it: a mean over a frame averages a red that has been pushed down against a blue that has been
+pushed up, and a mostly-desaturated frame has little of either.
 
 `stock balance` is the axis between two stocks and **its two halves are different shapes**. At
 -1 it is a tungsten-balanced stock shot in daylight: shadows cool toward cyan-blue and highlights

--- a/effects-builtin/glyph/cell.vert.glsl
+++ b/effects-builtin/glyph/cell.vert.glsl
@@ -1,1 +1,59 @@
     vCellSeed = hash(dot(wc, vec3(127.1, 311.7, 74.7)));
+    // **Where the cell sits in the clip range, which is the tone key's whole input and is
+    // computed here because it is the only place a per-cell quantity can be computed at
+    // all.** The key used to read `dot(col, w)` down in the fragment stage - the luminance
+    // of the colour the point was about to draw - and the chunk there argued that nothing
+    // was lost by deciding the character beside the colour, because the seed and the rain
+    // coordinate are constant across a sprite. That is true of those two and it was never
+    // true of tone. A sprite is one point, and a *cell* is many: with the lattice collapsing
+    // a few hundred depth texels onto one cell, every occupant computed its own luminance,
+    // chose its own character out of the table, and drew it at the same snapped position as
+    // its neighbours - summed into noise under additive blending and z-fighting at an
+    // identical depth without it. presets-builtin/cascade.json ships in exactly that state:
+    // lattice 1, additive on, glyph.tone 0.3.
+    //
+    // **There is no cell-constant reading of the drawn colour, and that is a fact about the
+    // architecture rather than a thing left undone.** `col` is the five-reading blend plus
+    // the whole f.tone run, and inside one cell it still varies through vUv, through vDepth
+    // - which is the raw sample depth and not the snapped one - and through vEdge, vGhost
+    // and the rain's own lift, which keys on room.y and so moves within a cell. Getting one
+    // number out of that would mean either evaluating the colour a second time on
+    // cell-constant inputs, which is a second implementation of the colour, or a reduction
+    // over each cell's occupants, which is a second pass. Both are refused here for the same
+    // reason everything else in this repo is.
+    //
+    // So the key reads the one cell-constant scalar the picture is actually built on: where
+    // the cell stands between the clip planes. It is a function of wc and the uniforms and
+    // of nothing else, so every occupant of a cell computes the same number by construction
+    // rather than by agreement - which is the property the thinning row in
+    // tools/registry-check.mjs claims and, with tone at 0 in its own fixture, could not see.
+    // **What it costs is that the key is no longer a luminance**, and the two candidates
+    // that are one were measured and are worse: the depth ramp's own luminance is not
+    // monotone in its argument - 0.1086, 0.5564, 0.7874 then back to 0.5051 across the four
+    // stops in web/cloud-shader.js - so a tone ramp built on it would fold over at the top
+    // and never reach the dense end the 63/64 scaling below exists to land on; and the
+    // camera's luminance along the ray through the cell centre goes flat the moment colour
+    // is switched off at the sensor, which is a slider that moves and a keyframe that plays
+    // back against nothing.
+    //
+    // **So the key reads where the cell is and not what colour it draws, and how close those
+    // two are depends on which reading is up.** That limit is named here rather than left to
+    // be discovered, because a parameter whose meaning quietly changes with the look is the
+    // drift this design keeps refusing. It is *exact* for presets-builtin/cascade.json, the
+    // only shipped look carrying this field: cascade is readDepth 1, so its colour is
+    // depthRamp(1 - t) and the argument that ramp is read at is precisely what this key now
+    // carries - the key was already a function of the clip position there, through a lookup
+    // that only bent it. It diverges wherever the colour is built from something else, and
+    // furthest under readRgb, where brightness is the camera's and has nothing to do with
+    // range: a white shirt and the black wall behind it sit at one depth, so they take one
+    // character where the old per-point key gave them two.
+    //
+    // The cell centre carried back out of the levelled frame is the third column of the
+    // rotation dotted with it, rather than a whole transpose whose other two components
+    // would be thrown away - and it is a column rather than a row because that identity
+    // holds only while the cloud's transform is a pure rotation, which is the same premise
+    // the snap in effects-builtin/lattice/ rests on and which registry-check asserts.
+    // Negated because unproject builds the scene looking down -z while vDepth is metres out
+    // in front of the sensor.
+    vCellT = clamp((-dot(modelMatrix[2].xyz, wc * latticeCell) - nearClip)
+      / max(0.001, farClip - nearClip), 0.0, 1.0);

--- a/effects-builtin/glyph/index.frag.glsl
+++ b/effects-builtin/glyph/index.frag.glsl
@@ -1,8 +1,13 @@
-  // **Which character this cell draws.** Decided here rather than in the vertex stage
-  // because one of the three keys does not exist up there: the tone key is the luminance of
-  // the colour the cell is about to draw, which is the line above this one. Nothing is lost
-  // by the move - the cell seed and the rain coordinate are both constant across a sprite,
-  // so the character is too.
+  // **Which character this cell draws.** All three keys are now facts about the cell rather
+  // than about the point, and that is a correction rather than the arrangement this shipped
+  // with. This paragraph used to say the character was decided here because the tone key is
+  // the luminance of the colour the cell is about to draw, and that nothing was lost because
+  // the seed and the rain coordinate are constant across a sprite. The second half is true
+  // and the first half was the defect: constant across a *sprite* is not constant across a
+  // *cell*, and once the lattice collapses a few hundred texels onto one cell its occupants
+  // each read their own colour and each drew a different character in the same place.
+  // effects-builtin/glyph/cell.vert.glsl carries what replaced it and why the drawn colour
+  // could not be the thing replacing it.
   //
   // **The three keys add and wrap rather than mixing the way the five readings do**, and
   // the difference is forced rather than stylistic: character indices do not average.
@@ -13,16 +18,17 @@
   // nothing.
   //
   // **The tone key is scaled by 63/64 where the other two keep the pure wrap**, and that
-  // departs from the design document, which writes all three the same. Luminance is the one
-  // key with a direction: the table is sorted by ink, so a tone ramp is only a ramp if full
-  // luminance lands on the densest character. Unscaled it lands on fract(1.0), which is 0
-  // and therefore the sparsest, so the brightest point in the picture would draw an
-  // apostrophe and the top of the ramp would read as a hole in it. The hash and the rain
-  // are not scaled, because wrapping is exactly what makes them look like noise.
+  // departs from the design document, which writes all three the same. Tone is the one key
+  // with a direction: the table is sorted by ink, so a tone ramp is only a ramp if the top
+  // of the key lands on the densest character. Unscaled it lands on fract(1.0), which is 0
+  // and therefore the sparsest, so the nearest cell in the picture would draw an apostrophe
+  // and the top of the ramp would read as a hole in it. The hash and the rain are not
+  // scaled, because wrapping is exactly what makes them look like noise.
   //
-  // The luminance is clamped for the same reason the scaling exists. col can leave the unit
-  // interval - the readings sum, the flare adds, and a duotone pole is hot - and an
-  // unclamped tone term would carry the top of the ramp round to the sparse end again.
+  // The clamp that used to sit on this line has gone up to the write in the vertex stage,
+  // where it belongs now that the key is a clip-range position rather than a colour - the
+  // reason for it is unchanged and is the scaling's own, that a term reaching past 1 carries
+  // the top of the ramp round to the sparse end again.
   //
   // The rain key reads whole heads gone past rather than the continuous coordinate, because
   // a character index that blends is a character nobody wrote. It is multiplied by the
@@ -32,9 +38,9 @@
   // inert. An irrational step walks the table without repeating, which is what a scramble
   // has to do.
   if (glyphMix > 0.0) {
-    float lum = clamp(dot(col, vec3(0.299, 0.587, 0.114)), 0.0, 1.0);
+    float cellTone = 1.0 - vCellT;
     float rainStep = floor(vRain) * 0.6180339887498949;
-    float f = fract(glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);
+    float f = fract(glyphTone * cellTone * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);
     // Guarded rather than trusted. fract is below 1 by definition, but a value arriving at
     // exactly 1.0 through a rounding would index one past the end of the table, and reading
     // a constant array out of range in GLSL is undefined rather than an error - so the one

--- a/effects-builtin/glyph/manifest.json
+++ b/effects-builtin/glyph/manifest.json
@@ -90,6 +90,12 @@
       "type": "float",
       "init": "0.0",
       "order": 100
+    },
+    {
+      "name": "vCellT",
+      "type": "float",
+      "init": "0.0",
+      "order": 101
     }
   ],
   "consumes": [

--- a/effects-builtin/glyph/mark.frag.glsl
+++ b/effects-builtin/glyph/mark.frag.glsl
@@ -25,6 +25,15 @@
   // reference pixels, because the boundary between text and texture is a property of the
   // look and a 4K export has to draw the same picture the grade was made on. The band is
   // therefore stated once and read against whichever limit is nearer.
+  //
+  // **A cut-away point never draws a character, and it arrives here already saying so.**
+  // The crop writes a legible size of exactly zero for anything outside the box, which is
+  // below the band at every output size, so this collapses to a glyphMix of 0 and the mark
+  // below is the disc. That is asked for in the vertex stage rather than tested again here
+  // because the crop's state is up there and the comment beside that write carries the
+  // argument: halving the sprite was never enough on its own, since half of a sprite well
+  // above the band is still above it, and cut-away geometry drawing a smaller character is
+  // the opposite of the dust the halving's own paragraph promises.
   float glyphMix = glyph * smoothstep(8.0, 16.0, vLegiblePx);
 
   // Additive mode shapes the sprite purely with alpha falloff. Skipping the

--- a/effects-builtin/glyph/size.vert.glsl
+++ b/effects-builtin/glyph/size.vert.glsl
@@ -4,14 +4,48 @@
   // two are nowhere near each other and something had to give; blending rather than
   // switching is what keeps pointSize meaning something at every value in between.
   //
-  // **The ceiling on the glyph branch is the hardware's and not the literal 64**, because a
-  // cell-sized sprite reaches 64 pixels at a metre and that is where a person stands. Past
-  // that the sprite would stop growing while the cell kept growing, so characters would
-  // stop filling their cells, the tiling would open up, and spriteWorld / cell would stop
-  // being 1 at full glyph - which is the property the energy compensation in the fragment
-  // stage rests on. The clamp is in framebuffer pixels, so that failure moves with output
-  // size: the same look that opens gaps at a metre on screen opens them at two metres in a
-  // 4K export, which is exactly the drift the 1080p reference unit exists to stop.
+  // **The ceiling on the glyph branch is 255 reference pixels under the hardware's, and it
+  // is not the literal 64**, because a cell-sized sprite reaches 64 pixels at a metre and
+  // that is where a person stands. Past the ceiling the sprite stops growing while the cell
+  // keeps growing, so characters stop filling their cells, the tiling opens up, and
+  // spriteWorld / cell stops being 1 at full glyph - which is the property the energy
+  // compensation in the fragment stage rests on.
+  //
+  // **The reference scale on the ceiling is the correction, and the hardware bound outside
+  // it is what keeps the correction honest.** This clamp used to be `pointCeiling` alone,
+  // which is framebuffer pixels, so the range at which the tiling opened moved with output
+  // size: the same look that opened gaps at a metre on screen opened them at two metres in
+  // a 4K export, which is exactly the drift the 1080p reference unit exists to stop. Scaling
+  // the look's own number by k puts that range in the unit every other screen-space term
+  // here is expressed in, and the min under pointCeiling is what stops it being a clamp that
+  // does not clamp - a reference ceiling the GPU will not rasterise is a number with no
+  // effect on the picture and a comment claiming one.
+  //
+  // **Which way the picture moves is the opposite of what it looks like, and it is worth
+  // stating rather than being found.** Measured off the context the tools open, this rig
+  // reports ALIASED_POINT_SIZE_RANGE as [1, 511] - Apple M2 Max through ANGLE's Metal
+  // backend - and the tallest output web/export-sizes.js offers is 2160, so the largest
+  // scale an export ever reaches is exactly 2. The old ceiling therefore already sat at
+  // 255.5 reference pixels in a 4K export and at 511 at 1080p, which means 4K was the
+  // tight end all along: the fix pulls 1080p and everything under it down to what 4K can
+  // actually draw, rather than letting 4K reach what 1080p did. 255 is the largest number
+  // that survives that - 255 * 2 is 510, inside the 511 the hardware will take - and above
+  // a scale of 2, which only an interactive window with renderScale wound up reaches, the
+  // min falls back to the hardware and the invariance lapses. That residual is the same one
+  // the lower clamp's comment in web/cloud-shader.js records for the far cloud, and it is
+  // confined the same way: to where the hardware, and not the look, is deciding.
+  //
+  // The number stays a look constant rather than pointCeiling halved, for the reason the
+  // uniform's own comment in web/cloud-shader.js gives about itself - a machine's limit
+  // carried into a document is a document that draws differently on the next machine, and
+  // dividing that limit by two would carry it just as far. 255 is the same number
+  // everywhere, and where a GPU cannot deliver it the hardware bound says so in the picture.
+  //
+  // No shipped look moves. presets-builtin/cascade.json is the only one carrying the glyph
+  // field, its cell is 0.055m, and the projection measures 2.1445 at the shipped field of
+  // view - so its cells are 63.7 reference pixels at a metre and would need a subject at
+  // 0.250m to reach 255, which is nearer than a Kinect v2 ranges and nearer than the 0.15m
+  // floor on dist below.
   //
   // **The old statement survives verbatim on the else branch, and that departs from the
   // design document on purpose.** The document replaces the literal 64 outright. It is kept
@@ -23,7 +57,7 @@
   // branch above.
   if (glyph > 0.0) {
     float base = clamp(pointSize * k / dist, 1.0, 64.0);
-    gl_PointSize = clamp(mix(base, cellPx * k, glyph), 1.0, pointCeiling);
+    gl_PointSize = clamp(mix(base, cellPx * k, glyph), 1.0, min(255.0 * k, pointCeiling));
   } else {
     gl_PointSize = clamp(pointSize * k / max(0.15, -mv.z), 1.0, 64.0);
   }

--- a/effects-builtin/halation/scatter.grade.glsl
+++ b/effects-builtin/halation/scatter.grade.glsl
@@ -8,11 +8,39 @@
       // sits above the threshold - and every bit of the colour comes from the tint.
       //
       // It sits at 150, above the streak at 100 and below everything drawn over the picture,
-      // and the placement is an argument rather than a free slot. The streak's smear is
-      // light that reached the emulsion, so it scatters too, and gathering before it ran
-      // would ring the highlight while leaving the smear it drags across the frame cold. The
-      // raster and the grain are marks made on top of the picture and have nothing to
-      // scatter, which is why they sit below this rather than above it.
+      // and the placement is an argument rather than a free slot. The raster and the grain
+      // are marks made on top of the picture and have nothing to scatter, which is why they
+      // sit below this rather than above it.
+      //
+      // **No gather in this pass can see another effect's output, and that is the rule
+      // rather than a fact about halation.** Every package filling g.body concatenates into
+      // a single fragment shader that runs once per pixel, so a tap reaches a neighbour's
+      // *input* and never a neighbour's *output* - a fragment has no way to read what the
+      // same pass computed at some other pixel. Ordering decides what each effect does to
+      // the pixel it owns, and no ordering can make a gather see work that has not been
+      // written to a texture yet. An effect added here that samples its neighbourhood meets
+      // this the moment it is written, so it is stated before the instance rather than
+      // after it.
+      //
+      // **Halation is one instance and the streak is the other**, which is what says this is
+      // the rule and not a placement somebody got wrong. Every tap below reads tDiffuse, the
+      // immutable input to the whole grade pass, so what halation rings is the highlight as
+      // the frame carried it *into* this pass and never the smear the streak drags across
+      // it - the smear stays cold. The streak meets the same wall from the other side: its
+      // own sixteen taps read tDiffuse too, and only its starting value comes from col.
+      //
+      // The correction is written down rather than made quietly, because this paragraph used
+      // to argue the opposite. It said the streak's smear is light that reached the emulsion
+      // so it scatters too, and that gathering before the streak ran would ring the highlight
+      // while leaving the smear cold. That describes a build which gathers after the streak,
+      // and no build here does.
+      //
+      // **The decision is made rather than pending.** Lifting the limit costs an
+      // intermediate render target - the streak resolved into its own buffer and the grade
+      // split into two passes - bought for a look nobody has reported; recomputing the
+      // streak inside each tap is sixteen sixteen-tap gathers, 256 samples on every pixel of
+      // every frame, for the same thing. Neither is worth ringing a smear, so the claim is
+      // brought down to what ships and the order stays where the paragraph above puts it.
       //
       // Sixteen taps on a golden-angle disc, the distance taken as the square root of the
       // tap's share of the disc so the samples spread evenly over the area instead of

--- a/effects-builtin/stock/curve.grade.glsl
+++ b/effects-builtin/stock/curve.grade.glsl
@@ -34,11 +34,38 @@
       // triples can be checked for neutrality at the two balances and the two ends somebody
       // happened to look at, and every crossover between them is then a guess - so a stock
       // raised to 1 would quietly rebrighten the frame, and the operator would take the
-      // exposure back down and lose the grade they were reaching for. Dividing by the dot
-      // makes every combination of balance and crossover luminance-preserving by
-      // construction under the same weights the reading above uses. The denominator cannot
-      // vanish: all four poles sit within about a fifth of unity in every channel, so the
-      // dot stays near 1 and never near 0.
+      // exposure back down and lose the grade they were reaching for.
+      //
+      // **The pixel is normalised against its own luminance, and the correction is recorded
+      // rather than made quietly, because the line that stood here divided the tint by the
+      // tint's luminance and claimed the same property.** `col * tint / dot(tint, w)` is
+      // luminance-preserving for a neutral grey and for nothing else: the outgoing luminance
+      // is `dot(col * tint, w) / dot(tint, w)`, which collapses to `dot(col, w)` only when
+      // every channel of `col` is the same number and the tint's own dot cancels. For a
+      // saturated pixel it does not cancel at all. Worked through the shipped poles in
+      // double precision - arithmetic over the literals two lines below rather than a
+      // rendered measurement - the tungsten shadow pole took **pure red to 0.8599 of its
+      // luminance and pure blue to 1.2793**, with the tungsten highlight pole running the
+      // other way at 1.1139 and 0.8067; grey came back at exactly 1.0000 at all four poles,
+      // which is how a claim this wrong survived being looked at. A saturated frame at
+      // stock 1 therefore moved a quarter of a stop either side of where it started, which
+      // is exposure wearing a colour control's clothes - the thing this paragraph has always
+      // said the divisor was there to stop.
+      //
+      // So the tinted pixel is scaled back onto the luminance the pixel arrived with, which
+      // is that claim written as arithmetic instead of asserted: `dot(tinted * lum /
+      // dot(tinted, w), w)` is `lum` for every colour, not only for the neutrals.
+      //
+      // **The denominator cannot vanish, and the reason is the poles rather than a clamp.**
+      // Every channel of every pole is strictly positive and sits within about a fifth of
+      // unity, so for a frame whose channels are non-negative the tinted luminance is
+      // bracketed between 0.82 and 1.22 times the original - it reaches zero only where the
+      // original does, and there the factor is multiplying black. The grain a step above can
+      // push a near-black pixel under zero, and it adds the same amount to all three
+      // channels, so both readings cross together and the ratio stays inside that same band.
+      // The guard is therefore on the magnitude rather than on the sign, and what it falls
+      // back to is the unscaled tinted colour - which at a luminance that small is black on
+      // either path.
       //
       // The poles themselves are baked rather than exposed, for the reason
       // effects-builtin/duotone/tone.frag.glsl states about its own two: a look
@@ -68,5 +95,7 @@
         vec3 shadowTint = mix(vec3(0.82, 0.97, 1.22), vec3(1.06, 1.00, 0.93), day);
         vec3 highlightTint = mix(vec3(1.16, 1.02, 0.84), vec3(1.14, 1.02, 0.85), day);
         vec3 tint = mix(shadowTint, highlightTint, e);
-        col = mix(col, col * (tint / dot(tint, vec3(0.299, 0.587, 0.114))), stock);
+        vec3 tinted = col * tint;
+        float tintedLum = dot(tinted, vec3(0.299, 0.587, 0.114));
+        col = mix(col, tinted * (abs(tintedLum) > 1e-5 ? lum / tintedLum : 1.0), stock);
       }

--- a/server/effect-door.js
+++ b/server/effect-door.js
@@ -31,7 +31,7 @@
 
 import {
   MANIFEST_FORMAT, EFFECT_PARAM_KINDS, EFFECT_BIND_TABLES, EFFECT_BIND_TRANSFORMS,
-  CORE_PANEL_GROUP_KEYS,
+  CORE_PANEL_GROUP_KEYS, HOST_DRIVEN_UNIFORMS,
 } from '../web/effect-manifests.js';
 import { assembleShaders } from '../web/shader-assembly.js';
 import { decimalsOf, snapScalar } from '../web/format.js';
@@ -59,6 +59,42 @@ import { decimalsOf, snapScalar } from '../web/format.js';
  */
 const MAX_PACKAGE_FILES = 64;
 const MAX_PACKAGE_BYTES = 256 * 1024;
+
+/**
+ * And how much of the *manifest* this build will take, which the two bounds above leave a
+ * package free to answer with anything at all.
+ *
+ * Both of those count chunk text. A manifest is not chunk text, so a package carrying one
+ * declaration of GLSL and twelve thousand parameters passes every rule in this file: each
+ * parameter is individually correct, each binds a uniform some program really declares, each
+ * names a group that really exists, and the whole thing is comfortably inside the four
+ * megabytes `server/index.js` takes as a request body. Measured, that package is 2.33 MiB on
+ * the wire and the door answers null in 42ms.
+ *
+ * What it costs is paid by everything downstream. The store writes the manifest to disk,
+ * `read` hashes those bytes on every `GET /effects`, and every open page then builds a DOM
+ * control per parameter and a registry entry beside it - so one install lands a permanent
+ * per-poll hashing cost on the server and a panel nothing can scroll on every browser that
+ * adopts it.
+ *
+ * **A bound on the serialised bytes rather than a cap per collection, and the choice is the
+ * one this repo keeps making.** Capping `params` would leave `panelGroups` outside the rule,
+ * capping that too would leave `varyings`, and the field somebody adds next year would be
+ * outside whatever list was written today. The byte count is the whole manifest by
+ * construction: every collection, every label, and every key a later format grows are in it
+ * without being named. It is also the quantity the cost is actually about - what the store
+ * hashes on every poll is bytes, not entries.
+ *
+ * Measured the way the store will write it, `JSON.stringify(manifest, null, 2)` plus the
+ * newline, because that is what lands on disk and what every read hashes rather than what
+ * happened to arrive. The widest manifest that ships is the glitch at 2,740 bytes, seven
+ * parameters and one panel group; 32 KiB is nearly twelve times that, which is the same
+ * multiple the file and byte bounds above sit at. A parameter costs about 280 to 310 bytes in
+ * this spelling depending on how long its label is - the glitch's first one is 283 - so what
+ * the bound leaves room for is a package of around 120 parameters, seventeen times the widest
+ * thing this build ships and rather more rows than a panel can usefully hold.
+ */
+const MAX_MANIFEST_BYTES = 32 * 1024;
 
 /**
  * The finest grid a slider may snap to.
@@ -120,6 +156,71 @@ const VALID_FILE_NAME = /^[a-z0-9][a-z0-9._-]*$/i;
  * encoding step between this count and the one the kernel makes.
  */
 export const MAX_EFFECT_ID = 64;
+
+/**
+ * The ids no package may have, because the HTTP surface has already claimed them.
+ *
+ * **It is empty, and it is here armed rather than deleted.** A literal segment under
+ * `/effects/` outranks the `:id` pattern beside it, so claiming one takes that id away from
+ * every package there will ever be: a package under that name is listed by `GET /effects`,
+ * fetched by the client on the next request and answered `405`, which is `readEffectPackages`
+ * throwing, no `__kinect` published, both surfaces dark and every tool reporting DID NOT RUN.
+ * That shipped once, as `POST /effects/refuse`, and was reproduced against a running server -
+ * the listing carried the package, the read was refused, and `DELETE` was refused too, so it
+ * could not even be uninstalled.
+ *
+ * **The repair was to move the route out of the namespace rather than to reserve the word**, and
+ * the reasoning is worth keeping because it decides what this constant is for. `/jobs/claim`
+ * sits beside `/jobs/:id` on exactly this trade and it is sound there, because a job id is
+ * minted by the queue and nobody can make a job called `claim`. An effect id is a directory
+ * name, so `mkdir` is the whole of what it takes - the collision is not a naming coincidence
+ * here. The refusal route is `POST /effect-refusals` now, at top level, and nothing under
+ * `/effects/` is claimed by anything.
+ *
+ * So this list is empty, the rule below it never fires, and both are kept because the invariant
+ * is still true and still worth enforcing: every literal segment under `/effects/` has to be a
+ * reserved id, and a reserved id has to be refused here. Today that holds trivially. The day
+ * somebody registers `/effects/verify` it stops holding, and what happens then is a server that
+ * will not start with both lists printed - which is the "asked by existing" property that keeps
+ * a rule from being something the next person has to know. A guard deleted for guarding nothing
+ * is a guard nobody reinstates.
+ *
+ * **This is a second spelling of the route table in `server/index.js` and it is held to it
+ * rather than trusted.** The door cannot read that table - `server/index.js` builds a server and
+ * listens when it is imported, and importing it here would be a cycle as well as a side effect -
+ * so the list is stated and the server checks it: the block below `ROUTES` derives every literal
+ * segment under `/effects/` and refuses to boot if the two disagree, in the shape
+ * `withEffectGroups` already uses for `CORE_PANEL_GROUP_KEYS`.
+ *
+ * `test/effect-door.test.mjs` proves the rule on a synthetic id rather than on this list, since
+ * an empty list makes every assertion over it run zero times - which is the vacuity that mutation
+ * found here once already.
+ */
+export const RESERVED_EFFECT_IDS = Object.freeze([]);
+
+/**
+ * Whether one id is a name the HTTP surface has claimed, as a sentence or null.
+ *
+ * **Written as a function taking the list rather than as two lines inside `doorRefusal`, so
+ * that it can be proved on data that exists.** `RESERVED_EFFECT_IDS` is empty today, which makes
+ * every assertion driven through the door over that list run zero times - and that is not a
+ * hypothetical: emptying the list is a mutation that was run here, and it left the row testing
+ * the rule green while the rule was gone. The list is a parameter with a default, so
+ * `test/effect-door.test.mjs` asks the same code the door asks with a reserved id in hand, and
+ * the row goes red when the rule stops working whatever the live list happens to hold.
+ *
+ * The wording names the whole set rather than only the id, because an author who has tripped it
+ * needs to know which names are gone rather than that this one is.
+ */
+export const reservedIdRefusal = (id, reserved = RESERVED_EFFECT_IDS) => {
+  if (!reserved.includes(id)) return null;
+  return `effect ${id} takes an id this build's HTTP surface has already claimed - `
+    + `/effects/${id} is a route rather than a package, so a package under that name is listed by `
+    + 'GET /effects and then refused when the page fetches it, and a page that cannot read a package '
+    + 'the store just listed does not boot at all. '
+    + `${reserved.length === 1 ? 'The reserved name is' : 'The reserved names are'} `
+    + `${reserved.join(', ')}`;
+};
 
 // A GLSL name, which is what a uniform binding, a varying and an identifier all are.
 const GLSL_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -284,17 +385,37 @@ const declaredIn = (text) => {
  * in the shipped set declares one name at two types, which is asserted rather than assumed:
  * `test/effect-door.test.mjs` runs the whole set through this door, and a build that grew
  * such a pair would fail here by refusing a binding it can no longer answer for.
+ *
+ * **The array dimension is part of the type, and dropping it was a hole rather than a
+ * simplification.** `uniform float weights[4];` used to be read as the two words either side
+ * of the space - `weights` declared as `float` - because the name pattern stopped at the
+ * bracket and nothing looked at what followed it. A parameter binding a plain scalar to that
+ * name then satisfied the shape rule below, which asks only for `float` or `vec2`, and three.js
+ * picks its uploader off the *declared* uniform: an array declaration gets the array setter,
+ * handed one number instead of a list. The value never lands, the control still moves, and the
+ * picture does not change - the same silent failure the two ends of a binding exist to refuse,
+ * reached through a reading that threw away the half that said no.
+ *
+ * Both spellings carry the dimension, because GLSL ES 3.00 accepts it on either side of the
+ * name: `float weights[4]` and `float[4] weights` declare the same thing. The second one used
+ * to declare *nothing* here - the name pattern failed against `[4] weights` and the entry was
+ * skipped - so a package could have declared an array under that spelling and had the rule
+ * about a uniform nothing binds unable to see it at all.
  */
 const uniformTypesIn = (text) => {
   const src = withoutComments(text);
   const types = new Map();
-  const decl = /\buniform\s+(?:(?:highp|mediump|lowp)\s+)?([A-Za-z_][A-Za-z0-9_]*)\s+([^;]*);/g;
+  const decl = /\buniform\s+(?:(?:highp|mediump|lowp)\s+)?([A-Za-z_][A-Za-z0-9_]*)((?:\s*\[[^\]]*\])*)\s+([^;]*);/g;
   for (const m of src.matchAll(decl)) {
-    for (const part of m[2].split(',')) {
-      const name = part.trim().match(/^([A-Za-z_][A-Za-z0-9_]*)/);
-      if (!name) continue;
-      if (!types.has(name[1])) types.set(name[1], new Set());
-      types.get(name[1]).add(m[1]);
+    for (const part of m[3].split(',')) {
+      const declared = part.trim().match(/^([A-Za-z_][A-Za-z0-9_]*)((?:\s*\[[^\]]*\])*)/);
+      if (!declared) continue;
+      // The dimension from whichever side of the name carried it, with the whitespace taken
+      // out so `float [4]` and `float[4]` are one string rather than two readings of one
+      // declaration.
+      const type = `${m[1]}${m[2]}${declared[2]}`.replace(/\s+/g, '');
+      if (!types.has(declared[1])) types.set(declared[1], new Set());
+      types.get(declared[1]).add(type);
     }
   }
   return types;
@@ -401,6 +522,15 @@ export function doorRefusal(candidate, { beside = [], spines }) {
       + 'is that name with a suffix on it, so an id with no room for one is a package nothing could set '
       + 'aside once it was in place';
   }
+  // **An id the HTTP surface has already claimed, refused here so it is never a routing
+  // accident.** See `RESERVED_EFFECT_IDS`: a literal segment under `/effects/` outranks the
+  // per-id read beside it, so a package at one of these names is listed by `GET /effects` and
+  // then answered `405` when the client fetches it - which is not a bad install, it is a page
+  // that does not boot. Asked with the shape rules rather than with the rules about a manifest,
+  // because it is a fact about the id and the boot gate has to reach it on a package whose
+  // manifest may be anything at all.
+  const claimed = reservedIdRefusal(id);
+  if (claimed) return claimed;
   if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
     return `effect ${id} arrives with no manifest object - a package is a manifest and its chunks, and half of that is not a package`;
   }
@@ -501,6 +631,22 @@ export function doorRefusal(candidate, { beside = [], spines }) {
   // thousand times passes all of them. What it costs is not the install: it is every
   // `GET /effects` afterwards, which reads and hashes every file of every package, on
   // every poll of every page that is open.
+  //
+  // **The manifest first, because it is the one this section used to be silent about.** The
+  // three bounds under it all count chunk text, and a package can repeat a correct *parameter*
+  // rather than a correct chunk - twelve thousand of them, inside every rule in this file and
+  // inside the request limit, arriving as one small file of GLSL. Asked here rather than after
+  // the parameter walk for the same reason the list-shape rules are asked before anything walks
+  // a list: a bound that only answers once the thing it is bounding has been walked is a bound
+  // the walk has already paid for. See `MAX_MANIFEST_BYTES` for the measurement and for why
+  // this counts bytes rather than capping each collection.
+  const manifestBytes = Buffer.byteLength(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  if (manifestBytes > MAX_MANIFEST_BYTES) {
+    return `effect ${id} carries a manifest of ${manifestBytes} bytes and this build takes ${MAX_MANIFEST_BYTES} - `
+      + 'the widest manifest that ships is under three kilobytes, and this one is written to disk, hashed on '
+      + 'every read of the store and turned into a control per parameter on every page that adopts it, so a '
+      + 'manifest is bounded by what all of those cost rather than by what a request body can hold';
+  }
   const fileCount = new Set([...declaredFiles, ...Object.keys(chunks)]).size;
   if (fileCount > MAX_PACKAGE_FILES) {
     return `effect ${id} carries ${fileCount} files and this build takes ${MAX_PACKAGE_FILES} - `
@@ -685,6 +831,42 @@ export function doorRefusal(candidate, { beside = [], spines }) {
     if (bind.gates !== undefined && typeof bind.gates !== 'boolean') {
       return `${name} declares gates as ${JSON.stringify(bind.gates)} - it says whether this term holds the grade pass open, which is a yes or a no`;
     }
+    // **And a `gates` that nothing can read, which is the same question the array rule asks a
+    // few hundred lines down: does the shape of this binding match what the value has to be.**
+    // `gates` is not a flag on the parameter, it is a promise about the *uniform* - `gradeNeeded`
+    // in `web/main.js` walks the gating bindings, reads the cell each one names, and holds the
+    // grade pass open while any of them is not zero. So a gating binding has to land a number,
+    // on the table that function reads, or the promise is about nothing.
+    //
+    // **Both halves were reachable and the first one is worse than it sounds.** `axisDeg` writes
+    // `.value.set(sin, cos)`, so the cell holds a `Vector2` - a direction rather than an amount,
+    // and never the zero vector. Against the predicate this shipped with, `> 0`, that was always
+    // false and the pass stayed shut for the life of the page; against the `!== 0` it has now,
+    // an object is never strictly equal to zero, so it is always true and the pass runs
+    // full-screen forever. Neither reading of the predicate is wrong - the binding is, and it is
+    // the kind of wrong that changes its symptom when somebody fixes something unrelated, which
+    // is why it is refused here rather than handled there.
+    //
+    // The other half is quieter and is the same claim: `gradeGatesOf` collects only bindings
+    // whose table is `grade`, so `gates` on the point cloud's table is dropped on the floor. The
+    // author has said their term holds the pass open, the pass ignores it, and nothing anywhere
+    // says so. Refused together because they are one rule read from two sides, and neither
+    // refuses anything this build ships: all seven gated parameters are plain grade bindings.
+    if (bind.gates) {
+      if (bind.on !== 'grade') {
+        return `${name} declares gates and binds on ${JSON.stringify(bind.on)} - gates says this term holds `
+          + 'the grade pass open, and the gate reads the grade pass\'s own uniforms, so a gating binding on any '
+          + 'other table is a claim the pass never sees: the control moves, the term is collected by nothing, '
+          + 'and the pass opens and shuts on the parameters that did bind there';
+      }
+      if (bind.transform === 'axisDeg') {
+        return `${name} declares gates beside the axisDeg transform - axisDeg writes a two-component direction `
+          + 'and the gate asks whether the term is zero, which a direction never is. That pair has no reading: '
+          + 'it held the pass shut for the life of the page under the comparison this build used to make, and '
+          + 'holds it open forever under the one it makes now, so it is refused rather than given a meaning '
+          + 'that changes when the comparison does';
+      }
+    }
     if (spec.role !== undefined) {
       if (spec.role !== 'master') {
         return `${name} declares the role ${JSON.stringify(spec.role)} - the only role this build knows is master, `
@@ -865,6 +1047,42 @@ export function doorRefusal(candidate, { beside = [], spines }) {
       return `${id}.${short} binds the uniform ${JSON.stringify(spec.bind.uniform)} and the assembled `
         + `${program} program declares no such uniform - the control would move, the value would be written, and nothing would read it`;
     }
+    // **An array is a place with room for the value and is still not somewhere to put it.**
+    // Every binding this build can make writes one cell - a number, or the two components
+    // `axisDeg` sets - and three.js chooses its uploader from the declaration, so a uniform
+    // declared as an array is handed the array setter and a scalar to fill it with. Nothing
+    // throws: the control moves, the value is written into the cell, and the upload puts it
+    // nowhere the shader reads.
+    //
+    // **What actually closed that is the reading above, and this rule is about the sentence**,
+    // which is worth being exact about rather than letting the refusal take credit for the
+    // repair. Once `uniformTypesIn` keeps the dimension, `float[4]` is not `float` and the
+    // shape rule below refuses the binding on its own - measured, dropping this block leaves
+    // the package refused and never on disk. What it refuses it *for* is then "this binding
+    // needs a float", which sends an author to change their binding when the thing this build
+    // cannot do is the array. So this is asked first, and it says so.
+    //
+    // **Refused rather than given a kind of its own**, because the binding vocabulary is a
+    // closed set stated in `web/effect-manifests.js` and every reader of it - the applier, the
+    // registry, the uniform cell the install mints - implements exactly the two shapes that
+    // are in it. Inventing an array kind here would be a door accepting a manifest three other
+    // places cannot execute, which is the drift this whole file exists to make impossible. An
+    // author who needs one is told so in a sentence rather than by a picture that never moves.
+    //
+    // Read off the *declared* type rather than off the manifest, for the same reason the two
+    // rules around it are: what a package says about its own binding is a claim, and what the
+    // assembled program declares is the fact the driver will act on. Any array reading refuses,
+    // including a name some chunk declares plainly and another declares as an array, because a
+    // build that cannot say which declaration wins cannot say which uploader three.js picks
+    // either.
+    const arrayed = [...declaredAs].filter((t) => t.includes('['));
+    if (arrayed.length) {
+      return `${id}.${short} binds the uniform ${JSON.stringify(spec.bind.uniform)}, which the assembled `
+        + `${program} program declares as ${arrayed.join(' and ')} - this build's binding vocabulary has no `
+        + 'array kind in it, so every parameter writes a single cell and three.js would take the array '
+        + 'uploader off that declaration and hand it one value. The control moves, the write succeeds and '
+        + 'the shader goes on reading whatever the array was initialised with';
+    }
     // **The other half of what a binding promises, and it fails one layer further in.** The
     // rule above asks whether the value has anywhere to go; this asks whether the place is
     // the shape of the value, which nothing else here or downstream ever checks. `axisDeg`
@@ -896,7 +1114,27 @@ export function doorRefusal(candidate, { beside = [], spines }) {
       + 'nothing on this side would ever write it, so the shader reads zero for the life of the page. '
       + 'A uniform this build\'s own render loop drives goes in `hostDriven`';
   }
+  // **And the exception held to what the host actually implements, which it was not.** The
+  // list above excuses a uniform from the rule that something must write it, and while any
+  // name at all could be listed the excuse was self-issued: a package declaring
+  // `uniform float myClock;` and listing it here installed cleanly, and no line anywhere in
+  // this build ever assigned to that cell. So the shader read zero for the life of the page,
+  // no control existed to move it, nothing threw, and the effect was absent from a picture
+  // nobody could see was wrong - the exact failure the two-ended rule stands in front of,
+  // reached through the one door out of it.
+  //
+  // `HOST_DRIVEN_UNIFORMS` is the set the render loop really writes, and it is one name.
+  // Asked before the declaration rule below rather than after it, because it names the cause:
+  // an author who lists a clock this build has not got should be told which clocks it has,
+  // not told that a uniform they can see in their own chunk is missing.
   for (const u of manifest.hostDriven ?? []) {
+    if (!HOST_DRIVEN_UNIFORMS.includes(u)) {
+      return `effect ${id} lists ${JSON.stringify(u)} as host-driven and this build's render loop writes `
+        + `${HOST_DRIVEN_UNIFORMS.map((n) => JSON.stringify(n)).join(' and ')} - the list is an exemption from `
+        + 'the rule that something has to write every uniform a package declares, so a name the host does not '
+        + 'actually drive is that rule excused by a claim nobody checked: the shader reads zero for the life '
+        + 'of the page, and there is no control anywhere that could have moved it';
+    }
     if (!declaredHere.has(u)) {
       return `effect ${id} lists ${JSON.stringify(u)} as host-driven and declares no such uniform - `
         + 'the list says which of this package\'s own declarations the host writes, so a name not among them is a claim about nothing';

--- a/server/effect-store.js
+++ b/server/effect-store.js
@@ -236,9 +236,54 @@ export class EffectStore {
    * unreachable through the install door, which takes them one at a time and would have
    * refused whichever arrived first, so it is hand placement or nothing.
    *
-   * It costs one assembly per *user* package per round, which is a string concatenation
-   * over the shipped set and is paid once at boot; a machine with no forks pays nothing at
-   * all, because the loop walks the user root and that root is where forks are.
+   * **A promotion is only allowed if the set it produces still stands, which is the half
+   * this gate did not ask.** Everything above validates the *candidate*: the door is handed
+   * the packages that would sit beside it and reports what the candidate cannot do. What it
+   * never re-asked is the packages already accepted, and a shadow can invalidate one of them
+   * without being wrong about anything of its own. `doorRefusal` walks the candidate's chunks
+   * for identifiers this build has not got and `forkRefusal` catches a fork that dropped a
+   * parameter - neither looks at a *varying* the fork stopped declaring. So a `rain` fork that
+   * removes `vRain`, with its own two references to it removed as well, is a package with
+   * nothing wrong with it: clean chunks, every parameter kept, the door answers null. It then
+   * shadows the shipped rain, the builtin glyph goes on reading `vRain` out of its
+   * `index.frag.glsl`, and nothing in the assembled pair declares the name. The cloud program
+   * fails to link, `web/main.js` throws while it is still evaluating, and no `__kinect`
+   * publishes - the failure this whole gate exists to move, arriving through the one package
+   * it validated and the two it did not re-ask. Reachable through `PUT /effects/rain` as well
+   * as by hand placement, because the install door has the same shape and the same hole.
+   *
+   * So a candidate is promoted only when every member of the resulting set still passes the
+   * door with the rest of that set beside it, and a candidate that breaks somebody is refused
+   * under a sentence naming both ends: which package it broke and what the door said about it.
+   * The blame lands where the change is, which is the point - the builtins are this build's
+   * own packages and the survivors were standing a moment ago, so the only thing that moved
+   * is the candidate.
+   *
+   * **Except where a builtin was already refused before any fork was in the room**, which is
+   * asked once at the top and is what keeps this from being an over-refusal machine. Without
+   * it, a build that shipped a package its own door refuses would quarantine every fork on
+   * every machine, each under a sentence blaming somebody's authored work for a fault it had
+   * nothing to do with. `test/effect-door.test.mjs` makes that unreachable on a correct build
+   * by running the whole shipped set through this door under bare node; this is what happens
+   * on an incorrect one, and the honest answer there is the log line the paragraph above
+   * declines to be more helpful than.
+   *
+   * The walk over the resulting set is in id order rather than in map order, because the first
+   * refusal found is the sentence the package is set aside under and "whichever the iteration
+   * reached first" is the arbitrariness this method already spent a paragraph removing.
+   *
+   * **Two mutually-dependent forks are still both set aside, and now for the ordinary
+   * reason.** Neither can be promoted first, so neither is ever promoted - unchanged by the
+   * rule above, which only ever refuses more.
+   *
+   * It costs one door pass per builtin once, and then one per candidate plus one per member of
+   * the set that candidate would produce, per round - so with the eighteen packages this build
+   * ships and one fork of one of them in the user root, 36 passes where it used to be one.
+   * Measured on this rig by timing `claimUserRoot` itself, twelve runs of each arm interleaved
+   * rather than one arm after the other, medians: **17.68ms with one fork and 0.057ms with
+   * none.** The second number is the one that matters - a machine with no forks pays nothing
+   * at all, because the walk is over the user root, the baseline pass is skipped when that root
+   * has nothing readable in it, and the user root is where forks are.
    */
   refuseIncompatiblePackages() {
     // **Pass one, and it has no rule of its own about the length of a name.** A directory
@@ -256,11 +301,42 @@ export class EffectStore {
       }
     }
 
+    // Nothing readable in the user root is nothing this gate can set aside, and every pass
+    // below walks a set built out of that root - so the whole of the rest of this method is
+    // about forks, and a machine with none of them stops here having read one directory
+    // listing. Stated as a return rather than left to the loops, because the baseline pass
+    // just below is the one thing here that would otherwise cost something on a machine with
+    // nothing to gate.
+    if (!readable.length) return;
+
     // Read once for the whole gate rather than per candidate, and read from the shipped
     // root by name: `packageOf` resolves through `rootFor`, which answers with the user's
     // copy, so asking it for a builtin a candidate's unvalidated neighbour shadows would
     // hand back the neighbour - the very package this pass is refusing to trust.
     const builtins = new Map(this.idsIn(this.builtinDir).map((id) => [id, this.builtin(id)]));
+
+    // What one member of a standing set is doored against: everything else in it, in the
+    // order `list()` answers and therefore the order the page assembles from.
+    const besideIn = (standing, id) => [...standing.values()]
+      .filter((p) => p.id !== id)
+      .sort((a, b) => (a.id < b.id ? -1 : 1));
+
+    // **The baseline: this build's own packages, asked of each other, with no fork in the
+    // room.** Anything refused here was refused before any user package existed, so it is a
+    // fault in the build rather than something a candidate did - and the rule below has to
+    // know the difference, or the first fork on a machine with a broken builtin is quarantined
+    // for it. Held by identity rather than by id, because a survivor shadowing one of these
+    // ids is a different package and gets asked on its own account.
+    const bornRefused = new Set();
+    for (const [id, pkg] of builtins) {
+      const refusal = doorRefusal(pkg, { beside: besideIn(builtins, id), spines: this.spines });
+      if (!refusal) continue;
+      bornRefused.add(pkg);
+      console.warn(`effect ${id} is shipped with this build and this build's own install door refuses it: `
+        + `${refusal} - nothing here can set a builtin aside, so it goes on being served; what this line `
+        + 'exists for is that a fork standing beside it must not be quarantined in its place');
+    }
+
     const survivors = new Map();
     const refusals = new Map();
     let pending = readable;
@@ -283,8 +359,30 @@ export class EffectStore {
         standing.delete(candidate.id);
         const beside = [...standing.values()].sort((a, b) => (a.id < b.id ? -1 : 1));
         const shadowed = builtins.get(candidate.id) ?? null;
-        const refusal = doorRefusal(candidate, { beside, spines: this.spines })
+        let refusal = doorRefusal(candidate, { beside, spines: this.spines })
           ?? (shadowed ? forkRefusal(candidate, shadowed) : null);
+        // **And the other direction, which is what a shadow can do to the packages it is not
+        // about.** Everything above asks whether the candidate works beside the set; this asks
+        // whether the set still works beside the candidate, and the two are different questions
+        // because the door reads one package's chunks and the whole set's declarations. A fork
+        // that stops declaring a varying its neighbour reads is correct on its own account and
+        // takes the neighbour's program down with it. See this method's own note for the
+        // shipped instance and for why a builtin the baseline already refused is skipped
+        // rather than charged to whoever happens to be standing next to it.
+        if (!refusal) {
+          const resulting = new Map([...builtins, ...survivors]);
+          resulting.set(candidate.id, candidate);
+          for (const id of [...resulting.keys()].sort()) {
+            const member = resulting.get(id);
+            if (member === candidate || bornRefused.has(member)) continue;
+            const broke = doorRefusal(member, { beside: besideIn(resulting, id), spines: this.spines });
+            if (!broke) continue;
+            refusal = `with it installed this build can no longer assemble ${id}: ${broke}. Nothing is `
+              + `wrong with ${id} on its own - it stood a moment ago and stands again once ${candidate.id} `
+              + 'is out of the way, so the package being set aside is the one that changed';
+            break;
+          }
+        }
         if (refusal) {
           refusals.set(candidate.id, refusal);
           stillPending.push(candidate);
@@ -324,6 +422,41 @@ export class EffectStore {
    * announced it cannot use is a page that fails with a sentence in the log naming exactly
    * why; a build that will not start is a machine with nothing to read at all.
    */
+  /**
+   * One package set aside on a client's word, with the generation moved to match - which is the
+   * whole of what this adds over `setAside` and is why it exists rather than the route reaching
+   * in to do both.
+   *
+   * **The counter is the store's own history and the store is the only thing that may move it.**
+   * `install` and `remove` bump it and each carries the argument for where in the operation the
+   * bump sits; a route doing `EFFECTS.generation += 1` after calling `setAside` made a third
+   * writer of a field two methods here already own, and the next one would have been written the
+   * same way. So the composite is a method: ask whether there is a user copy, rename it, move
+   * the number.
+   *
+   * **The boot gate deliberately does not come through here.** It calls `setAside` directly and
+   * moves nothing, because it runs before the socket has dispatched a request and there is no
+   * earlier number for any reader to be holding - see `claimUserRoot`. This is the other case:
+   * pages are open, one of them has just failed to compile a package and rolled back, and what
+   * it needs is for the next poll to disagree with the listing it is holding so it is handed the
+   * set without the broken package in it.
+   *
+   * Three outcomes rather than a boolean, because the caller answers per id and "there was
+   * nothing of yours here" and "it would not move" are different sentences: `absent` is an id
+   * with no copy in the user root, which is what a builtin looks like from here, `stuck` is a
+   * rename that would not go, and `aside` is the one that moved.
+   *
+   * The user root is read per call rather than snapshotted by the caller, which is what makes an
+   * id named twice answer honestly: the second one finds the first already renamed and comes
+   * back `absent` rather than being sent into a rename of a directory that is no longer there.
+   */
+  setAsideForClient(id, reason) {
+    if (!this.idsIn(this.dir).includes(id)) return 'absent';
+    if (!this.setAside(id, reason)) return 'stuck';
+    this.generation += 1;
+    return 'aside';
+  }
+
   setAside(id, refusal) {
     const stem = id.slice(0, MAX_EFFECT_ID);
     const seq = `${process.pid}.${Date.now().toString(36)}`;

--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,7 @@ import { EffectStore } from './effect-store.js';
 // this process at all: it answers whether the page *would* boot with this package
 // installed, and the only way to ask that honestly is with the same assembler the page
 // runs.
-import { doorRefusal, forkRefusal } from './effect-door.js';
+import { RESERVED_EFFECT_IDS, doorRefusal, forkRefusal } from './effect-door.js';
 import { cloudSpine } from '../web/cloud-shader.js';
 import { gradeSpine } from '../web/grade-shader.js';
 import { Recorder } from './recorder.js';
@@ -627,6 +627,13 @@ const sendJson = (res, body, status = 200) => {
 // is a request nobody meant.
 const MAX_BODY_BYTES = 4 * 1024 * 1024;
 
+// How much of a page's own sentence about a package it could not compile goes into the log
+// line beside it. A driver's link log is whatever the driver felt like emitting, which on a
+// bad day is the whole shader source - and this ends up in `console.warn` on a server nobody
+// is watching, above the store's own sentence, which is the one that says what happened. See
+// `serveEffectRefusal`.
+const MAX_REFUSAL_REASON = 400;
+
 function readBody(req) {
   return new Promise((done, fail) => {
     const chunks = [];
@@ -1151,6 +1158,105 @@ async function serveEffectWrite(req, res, [id]) {
     // fine and retrying it is the right next move.
     return sendJson(res, { error: `effect ${id} could not be written: ${err.message}` }, 500);
   }
+}
+
+/**
+ * The packages a page could not compile, set aside on that page's word.
+ *
+ * **This build has no GLSL compiler and is not getting one.** The door refuses a package
+ * whose chunks name something this build has not got, and it cannot refuse one whose GLSL is
+ * merely wrong: a missing brace, a `vec3` assigned to a `float`, a function called with two
+ * arguments where it takes three. Those are syntactically reachable, they name only
+ * identifiers that exist, and what they produce is a shader that will not link - which is a
+ * log line inside the driver rather than an exception anywhere the server can see. So the
+ * only thing in this program that ever *learns* a package cannot be compiled is a page that
+ * tried, and until this route existed it had nowhere to say so: `warmPrograms` collects the
+ * link failures and throws, the hotload transaction rolls the page back onto the set it was
+ * holding, the store never hears, and the package sits there. The page that discovered it
+ * carries on, and every *fresh* page load compiles that package at boot and dies on it - no
+ * `__kinect`, both surfaces dark, and the machine is one reload away from being unusable by
+ * anybody who was not already looking at it.
+ *
+ * **It grants the caller no authority it did not already have, which is worth writing down
+ * because it is the first question a reviewer asks about a route that takes an id off the
+ * wire and renames a directory.** `PUT /effects/:id` and `DELETE /effects/:id` are on this
+ * same server behind this same guard and neither asks who is calling - anything that can
+ * reach this route can already install a package over that id or remove it outright. And
+ * this does strictly less than either: `setAside` renames within the user directory, so the
+ * package is still on disk under `<id>.<seq>.incompatible`, still complete, and still there
+ * to be repaired and moved back. The one thing it cannot do at all is touch a builtin, which
+ * is not a rule written here - it is `setAside` renaming inside `this.dir` and nothing else.
+ *
+ * **An id with no copy in the user root is skipped rather than refused**, and the answer says
+ * so per id. A builtin is the case that matters: a page that failed to link a program has the
+ * ids it was assembling from and no reason to know which root each of them came out of, and
+ * the honest answer to "set aside the builtin glyph" is that there is nothing here to set
+ * aside, not a 4xx that leaves the caller unable to tell which of the ids it named went
+ * through. A partial answer is the useful one - the packages that could be quarantined were,
+ * and the rest are named with why.
+ */
+async function serveEffectRefusal(req, res) {
+  let body;
+  try {
+    body = await readBody(req);
+  } catch (err) {
+    return sendJson(res, { error: err.message }, 400);
+  }
+  if (!Array.isArray(body.ids)) {
+    return sendJson(res, {
+      error: 'this route takes { ids: [...], reason } - a page that could not compile the installed set '
+        + 'names which packages it was compiling, and a body without that list is a request about nothing',
+    }, 400);
+  }
+  // **Bounded against the store rather than against a number somebody picked.** The ids a page
+  // can honestly name are the ids it was assembling from, and that set is exactly what this
+  // store answered its listing with - so a list longer than the store has packages is a list
+  // that is not about this store, and the bound moves by itself as packages are installed. The
+  // alternative is a constant here that a machine with a lot of effects eventually trips over.
+  //
+  // Counted off the two directory listings rather than through `list()`, which reads and hashes
+  // every file of every package to build an answer this line takes the length of. That is the
+  // work `GET /effects` exists to do and it is the wrong thing to make a bad request pay for.
+  const installed = new Set([...EFFECTS.idsIn(EFFECTS.builtinDir), ...EFFECTS.idsIn(EFFECTS.dir)]).size;
+  if (body.ids.length > installed) {
+    return sendJson(res, {
+      error: `this names ${body.ids.length} packages and the store holds ${installed} - `
+        + 'the ids a page can have failed to compile are the ids it was handed, so a longer list is not about this store',
+    }, 400);
+  }
+  // The reason is the page's own sentence and arrives over the network, so it is treated the
+  // way every other string off the wire is: it goes into a `console.warn` line the operator
+  // reads after the fact, and a link log is whatever a driver felt like emitting - three
+  // hundred lines of shader source in the bad case. Collapsed to one line so it cannot forge
+  // log lines around itself, and cut, because the sentence that matters is the store's own and
+  // it is printed after this one.
+  const reason = typeof body.reason === 'string' && body.reason.trim().length
+    ? body.reason.replace(/\s+/g, ' ').trim().slice(0, MAX_REFUSAL_REASON)
+    : 'a page that adopted it could not compile the programs it assembles into, and said no more than that';
+  const setAside = [];
+  const skipped = [];
+  // **The rename and the generation bump are one call into the store, rather than the two this
+  // route used to make.** The counter is the store's own history and `install` and `remove`
+  // already own it; a route reaching in with `EFFECTS.generation += 1` was a third writer of a
+  // field nothing outside that file should be assigning to, and the next route would have
+  // copied it. `setAsideForClient` carries the argument for why this case moves the number and
+  // the boot gate's does not, and answers which of the three things happened so the reasons
+  // below stay where a caller can read them.
+  const WHY = {
+    absent: 'there is no copy of it in the user root - a builtin is what this build ships with and what an '
+      + 'install falls back to, so there is nothing here that could be set aside',
+    stuck: 'it could not be renamed out of the way - the server log says what the rename answered',
+  };
+  for (const id of body.ids) {
+    if (typeof id !== 'string') {
+      skipped.push({ id: String(id), why: WHY.absent });
+      continue;
+    }
+    const outcome = EFFECTS.setAsideForClient(id, `a page that adopted it reports that it does not compile: ${reason}`);
+    if (outcome === 'aside') setAside.push(id);
+    else skipped.push({ id, why: WHY[outcome] });
+  }
+  return sendJson(res, { setAside, skipped });
 }
 
 async function writeDocument(req, res, store, name) {
@@ -1757,6 +1863,29 @@ const ROUTES = [
       return res.end(bytes);
     },
   },
+
+  // ---- the packages a page could not compile
+  //
+  // **A namespace of its own, and being outside `/effects/` is the whole reason it is here
+  // rather than there.** This route was `POST /effects/refuse` first, and that is one segment
+  // and a table walked in order: a literal under `/effects/` outranks the `:id` read beside it,
+  // so a package directory called `refuse` was listed by `GET /effects` and then answered 405
+  // when the page fetched it - no `__kinect`, both surfaces dark. Reproduced against a running
+  // server, and the `DELETE` was 405 too, so it could not even be uninstalled.
+  //
+  // The first repair reserved the word at the install door. What that missed is that the
+  // collision is not a property of the word: `/jobs/claim` sits beside `/jobs/:id` on the same
+  // trade, and it holds there because a job id is *minted by the queue*, so nobody can make a
+  // job called `claim`. An effect id is a directory name and `mkdir` is all it takes. So the
+  // namespace is the fix and the reservation is the guard: at top level nothing under
+  // `/effects/` is claimed, an existing package called `refuse` keeps working and needs no
+  // quarantine, and no reader has to learn why one word is forbidden.
+  //
+  // Plural resource noun at top level, posted to, which is the shape `/deliverables`, `/jobs`
+  // and `/library` already have. It joins `OWNED_NAMESPACES` by existing, so a path under it
+  // that matches no entry gets the API's 404 rather than a file lookup.
+  { path: '/effect-refusals', pattern: /^\/effect-refusals\/?$/, write: { methods: ['POST'], run: serveEffectRefusal } },
+
   {
     path: '/projects/:name',
     pattern: /^\/projects\/([^/]+)$/,
@@ -1836,6 +1965,45 @@ export const OWNED_NAMESPACES = new Set(ROUTES.map((r) => {
   }
   return first;
 }));
+
+/**
+ * The ids this table takes away from the effect store, derived from the table and held against
+ * the door's copy.
+ *
+ * **It is empty today, and the check is here for the day it is not.** A literal segment under
+ * `/effects/` outranks the `:id` pattern beside it, because the dispatcher walks this array in
+ * order - so registering one would take that id away from every package there will ever be. A
+ * package at that name is listed by `GET /effects` and then answered 405 when the client fetches
+ * it, which is `readEffectPackages` throwing, no `__kinect`, and both surfaces dark. That is not
+ * hypothetical: the refusal route was `POST /effects/refuse` first and did exactly this, which
+ * is why it is `POST /effect-refusals` now.
+ *
+ * So nothing under `/effects/` is claimed, `RESERVED_EFFECT_IDS` is empty, and the two agree
+ * trivially. What this block buys is that they go on agreeing: register `/effects/verify`
+ * tomorrow and this server refuses to start with both lists printed, rather than shipping a
+ * build where one package id is quietly unreadable. The table is the authority and the door's
+ * constant is checked against it, so the door is never reserving a word somebody typed once.
+ *
+ * **Held equal here rather than imported**, on the same argument `withEffectGroups` makes about
+ * `CORE_PANEL_GROUP_KEYS`: the door is a pure module that `test/effect-door.test.mjs` runs under
+ * bare node, and importing this file to read a list would import a server that binds a port. So
+ * two statements, and a start that refuses to come up with both printed if they have come apart
+ * - which is the loud direction, where a door reserving the wrong word is silent until somebody
+ * loses a page over it.
+ *
+ * The pattern matches one literal segment and nothing else: `:id` carries a colon, and
+ * `/effects/:id/file/:name` has a segment past it, so neither is a claim on an id.
+ */
+const RESERVED_BY_ROUTES = [...new Set(
+  ROUTES.map((r) => r.path.match(/^\/effects\/([^/:]+)$/)?.[1]).filter((seg) => seg !== undefined),
+)].sort();
+if (RESERVED_BY_ROUTES.join(',') !== [...RESERVED_EFFECT_IDS].sort().join(',')) {
+  throw new Error(`the route table claims the effect ids ${RESERVED_BY_ROUTES.join(', ') || '(none)'} and `
+    + `RESERVED_EFFECT_IDS names ${[...RESERVED_EFFECT_IDS].sort().join(', ') || '(none)'} - the install door reads `
+    + 'the second one, so the two disagreeing is a door reserving a name this table has not claimed or, worse, '
+    + 'leaving one it has: a package under a claimed id is listed by GET /effects and refused when the page '
+    + 'fetches it, which is a page that does not boot');
+}
 
 /**
  * The pages, and the only URLs they answer at.

--- a/server/index.js
+++ b/server/index.js
@@ -2946,7 +2946,7 @@ function startLive() {
       // At the top with the two nullings below, because every exit path matters and the
       // restart branch returns before the rest of the handler runs.
       if (child === proc) child = null;
-      // **The hello goes with the grabber that sent it.** `/record/start` stamps the
+      // The hello goes with the grabber that sent it. `/record/start` stamps the
       // take it opens with whatever is in here, and between a grabber exiting and the
       // next one handshaking that is the *previous* grabber's - so a take started
       // during a USB drop or a colour toggle carried a hello describing a moment

--- a/test/effect-door.test.mjs
+++ b/test/effect-door.test.mjs
@@ -25,7 +25,10 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { MAX_EFFECT_ID, doorRefusal, forkRefusal } from '../server/effect-door.js';
+import {
+  MAX_EFFECT_ID, RESERVED_EFFECT_IDS, doorRefusal, forkRefusal, reservedIdRefusal,
+} from '../server/effect-door.js';
+import { HOST_DRIVEN_UNIFORMS } from '../web/effect-manifests.js';
 import { snapScalar } from '../web/format.js';
 import { cloudSpine } from '../web/cloud-shader.js';
 import { gradeSpine } from '../web/grade-shader.js';
@@ -360,6 +363,307 @@ test('a package may only put its rows in a group that exists, and may not claim 
     c.manifest.panelGroups[0].key = 'glitch';
     for (const p of Object.values(c.manifest.params)) p.panel.group = 'glitch';
   }), /effect glitch already declares/, 'a package group colliding with another package\'s is refused, naming the other package');
+});
+
+// **An array is a uniform with room for the value and is still not somewhere to put it.** The
+// shape rule above reads the declared type, and the reading it was built on threw away the
+// dimension: `uniform float weights[4]` came back as `weights` declared `float`, which is
+// exactly what a plain binding asks for. Three.js takes its uploader off the declaration, so
+// the array setter is handed one number, the write succeeds, and the shader goes on reading
+// whatever the array was initialised with - a control that moves and a picture that does not,
+// which is the failure both halves of the binding rule exist to refuse.
+//
+// Both spellings, because GLSL ES 3.00 takes the dimension on either side of the name and only
+// one of them used to be read at all: `float[4] weights` declared nothing here, so the rule
+// about a uniform nothing binds could not see it either.
+test('a binding may not aim at an array, whichever side the dimension is written on', () => {
+  const arrayed = (declaration) => brokenBy('thermal', (c) => {
+    c.manifest.chunks.push({ stage: 'f.decl', order: 700, file: 'weights.frag.glsl' });
+    c.chunks['weights.frag.glsl'] = `${declaration}\n`;
+    c.manifest.params.weights = {
+      kind: 'scalar', label: 'Weights', def: 0, min: 0, max: 1, step: 0.05,
+      panel: { group: 'colour' }, bind: { on: 'points', uniform: 'thermalWeights' },
+    };
+  });
+  assert.match(arrayed('uniform float thermalWeights[4];'), /declares as float\[4\].*no array kind/s,
+    'a scalar bound to an array declared after the name is refused, naming the dimension it found');
+  assert.match(arrayed('uniform float[4] thermalWeights;'), /declares as float\[4\].*no array kind/s,
+    'and the type-level spelling of the same declaration is refused identically, which is the half that used to declare nothing at all');
+  // The must-accept control for the reading rather than for the rule: the same package with
+  // the same new uniform and no dimension on it goes through, so the refusal above is about
+  // the brackets and not about anything else the fixture does.
+  assert.equal(arrayed('uniform float thermalWeights;'), null,
+    'and the same declaration without a dimension is not refused, which is what says this rule is about the array');
+});
+
+// **An id the HTTP surface has already claimed, which is a rule about the id rather than about
+// the package.** A literal segment under `/effects/` outranks the `:id` pattern beside it, so a
+// package called `refuse` is listed by `GET /effects` and then answered 405 when the client
+// fetches it — `readEffectPackages` throws, the top-level await fails, no `__kinect` publishes.
+// Reproduced against a real server before this rule existed: the listing carried it, `GET
+// /effects/refuse` answered `405 it takes POST`, `DELETE` answered 405 as well so it could not
+// even be removed, and the boot gate said nothing at all because nothing in this door had an
+// opinion about the id beyond its shape and its length.
+test('an id the route table has claimed is not an id a package may have', () => {
+  const all = shipped();
+  const donor = all.find((p) => p.id === 'thermal');
+  // The donor is dropped from `beside` for the same reason the id-length rows drop it: leaving
+  // the original standing beside its own copy collides on every slot and varying it declares,
+  // and the candidate would be refused for something that has nothing to do with its name.
+  const named = (id) => doorRefusal(
+    { id, manifest: { ...JSON.parse(JSON.stringify(donor.manifest)), id }, chunks: { ...donor.chunks } },
+    { beside: beside(all, 'thermal'), spines: SPINES },
+  );
+  // **The live list is empty, so every assertion driven through the door over it runs zero
+  // times.** That is not a hypothetical worry: emptying the list is a mutation that was run
+  // against the previous version of this row, and it left the row green while the rule it tests
+  // was gone. The rule is asked directly instead, with a reserved id in hand, so it is proved on
+  // data that exists — `reservedIdRefusal` is the same code path `doorRefusal` calls.
+  assert.match(reservedIdRefusal('verify', ['verify']),
+    /effect verify takes an id this build's HTTP surface has already claimed/,
+    'the reserved-id rule does not refuse an id on the list it was handed, so nothing here proves it works');
+  assert.match(reservedIdRefusal('verify', ['verify', 'check']), /The reserved names are verify, check/,
+    'and it names the whole set, because an author who trips it needs to know which names are gone');
+  // The must-accept half, one character off in each direction: a rule matching by prefix would
+  // pass the rows above and take ids away from packages that never collided with anything.
+  assert.equal(reservedIdRefusal('verifier', ['verify']), null, 'an id that merely starts with a reserved one is not reserved');
+  assert.equal(reservedIdRefusal('verif', ['verify']), null, 'and neither is one a reserved name starts with');
+
+  // And the live list, driven through the whole door. Today it is empty and this loop is a
+  // no-op, which is exactly why the four rows above exist — but it is what would fire if the
+  // list ever grew, and it is where a real reserved id would be proved refused end to end.
+  for (const id of RESERVED_EFFECT_IDS) {
+    assert.match(named(id), new RegExp(`effect ${id} takes an id this build's HTTP surface has already claimed`),
+      `a package at the reserved id ${id} is accepted, so the store will list one the page cannot read`);
+  }
+  // The shipped set, which is the control that says the list has not grown into a name a real
+  // package uses. Live data, and it does not depend on the list being non-empty.
+  for (const pkg of all) {
+    assert.equal(named(pkg.id) && reservedIdRefusal(pkg.id), null,
+      `the shipped ${pkg.id} sits on a reserved id, so this build refuses its own package`);
+  }
+});
+
+// **The reserved list held to the table it is a second spelling of.** `server/index.js` derives
+// the same set off `ROUTES` at module load and refuses to boot if the two disagree, which is the
+// authority; this asks it again where no server starts, so a route added under `/effects/` fails
+// the unit suite rather than waiting for somebody to run one. Read as text rather than imported,
+// because importing that module builds a server and binds a port.
+test('RESERVED_EFFECT_IDS is what the route table actually claims', () => {
+  const claimedIn = (paths) => [...new Set(
+    paths.map((p) => p.match(/^\/effects\/([^/:]+)$/)?.[1]).filter((s) => s !== undefined),
+  )].sort();
+
+  const server = readFileSync(join(ROOT, 'server/index.js'), 'utf8');
+  const paths = [...server.matchAll(/path:\s*'(\/effects\/[^']*)'/g)].map((m) => m[1]);
+  // Non-vacuous by construction: the scan has to have found the per-id route, or it is reading
+  // nothing and the comparison below is between two empty lists for the wrong reason.
+  assert.ok(paths.includes('/effects/:id'),
+    `the scan found ${paths.length} effect route paths and none of them is the per-id read, so it is not reading the table`);
+  assert.deepEqual(claimedIn(paths), [...RESERVED_EFFECT_IDS].sort(),
+    'the route table claims a different set of effect ids than the door reserves - a package under a claimed id '
+    + 'is listed by GET /effects and refused when the page fetches it, which is a page that does not boot');
+
+  // **And the extraction shown to find something, because today it correctly finds nothing.**
+  // Both sides of the comparison above are empty, so it passes on a build where the route table
+  // claims nothing — which is the state this build is in and the state it should stay in. What
+  // it must not do is pass because the extraction is broken. The same function is handed a path
+  // list with a literal segment in it, which is what the table would look like the day somebody
+  // registers one.
+  assert.deepEqual(claimedIn(['/effects', '/effects/:id', '/effects/verify', '/effects/:id/file/:name']),
+    ['verify'],
+    'the extraction does not pick a literal segment out of the route paths, so the comparison above '
+    + 'is between two empty lists whatever the table holds');
+});
+
+// **A `gates` the gate cannot read, which is the array rule's question asked one field over.**
+// `gates` is a promise about the uniform rather than a flag on the parameter: `gradeNeeded` in
+// `web/main.js` walks the gating bindings, reads the cell each names, and holds the grade pass
+// open while any is not zero. So the binding has to land a number, on the table that function
+// reads.
+//
+// The axisDeg half is the one that bites twice. It lands a `Vector2`, which is never the zero
+// vector, so under the `> 0` this shipped with the pass stayed shut forever and under the
+// `!== 0` it has now an object is never strictly equal to zero and it runs full-screen forever.
+// The symptom flipped when somebody fixed something unrelated, which is the argument for
+// refusing the binding rather than teaching the predicate about it.
+test('a gating binding has to be something the gate can read', () => {
+  // The raster's angle is the shipped axisDeg, on the grade table, with no gate on it.
+  assert.match(brokenBy('raster', (c) => { c.manifest.params.angle.bind.gates = true; }),
+    /declares gates beside the axisDeg transform/,
+    'a gate on a two-component direction is refused, because there is no zero for it to be at');
+  // The other side of the same rule: the gate collects only grade-table bindings, so a gate on
+  // the point cloud's table is a claim the pass never sees.
+  assert.match(brokenBy('rain', (c) => { c.manifest.params.amount.bind.gates = true; }),
+    /declares gates and binds on "points"/,
+    'a gate on the point cloud\'s table is refused, because nothing collects it');
+
+  // **Three near-misses, and without them the two rows above pass on a door that refuses every
+  // `gates` there is.** A plain grade binding with a gate is what all seven shipped gated
+  // parameters are; `degToRad` lands a number and zero radians is zero degrees, so it gates
+  // perfectly well; and `axisDeg` with no gate is the shipped raster untouched.
+  assert.equal(brokenBy('raster', (c) => { c.manifest.params.amount.bind.gates = true; }), null,
+    'a plain grade binding that gates is what the shipped set already does');
+  // Added as a parameter of its own rather than by repointing the shipped `angle`, which was
+  // the first attempt and proved nothing: moving `angle` off `scanAxis` leaves that uniform
+  // declared with nothing binding it, so the fixture came back refused by a rule two hundred
+  // lines away and the row would have been green on a build with no gate rule at all.
+  assert.equal(brokenBy('raster', (c) => {
+    c.manifest.params.tilt = {
+      def: 0, min: 0, max: 1, step: 0.05, kind: 'scalar', label: 'raster tilt',
+      panel: { group: 'raster', tab: 'look' },
+      bind: { on: 'grade', uniform: 'scanTilt', transform: 'degToRad', gates: true },
+      under: 'amount',
+    };
+    c.chunks['decl.grade.glsl'] = `${c.chunks['decl.grade.glsl']}uniform float scanTilt;\n`;
+  }), null, 'and degToRad lands a number, so it gates like any other scalar');
+  assert.equal(brokenBy('raster', () => {}), null,
+    'and the shipped raster, whose angle is axisDeg with no gate on it, is untouched by this rule');
+
+  // The must-accept control for the set: every gated parameter that ships is a plain grade
+  // binding, so a rule that had crept wider would fail here rather than in a browser.
+  for (const pkg of shipped()) {
+    for (const [short, spec] of Object.entries(pkg.manifest.params)) {
+      if (!spec.bind?.gates) continue;
+      assert.equal(spec.bind.on, 'grade', `the shipped ${pkg.id}.${short} gates on ${spec.bind.on}`);
+      assert.equal(spec.bind.transform, undefined,
+        `the shipped ${pkg.id}.${short} gates through the ${spec.bind.transform} transform`);
+    }
+  }
+});
+
+// **The exemption from the rule that something has to write every uniform, held to what this
+// build actually writes.** `hostDriven` excuses a uniform from having a parameter behind it,
+// and while any name at all could go in the list the excuse was self-issued: a package could
+// declare a clock of its own, list it, install cleanly, and read zero from it for the life of
+// the page with no control anywhere that could have moved it. That is the exact failure the
+// two-ended rule stands in front of, reached through the sentence that lets a package out of
+// it.
+test('hostDriven names a uniform this build really drives, not any uniform at all', () => {
+  assert.equal(brokenBy('rain', () => {}), null, 'the shipped rain is accepted before this row changes anything');
+  assert.match(brokenBy('rain', (c) => {
+    c.chunks['decl.vert.glsl'] += 'uniform float rainOwnClock;\n';
+    c.manifest.hostDriven.push('rainOwnClock');
+  }), /lists "rainOwnClock" as host-driven and this build's render loop writes "rainPhase"/,
+  'a package inventing its own host-driven uniform is refused, naming what the host does write');
+  // The must-accept half: the shipped list is one name and it has to keep going through, or
+  // the row above is passing on a door that refuses every `hostDriven` entry there is.
+  assert.deepEqual([...HOST_DRIVEN_UNIFORMS], ['rainPhase'],
+    'the host-driven set is the one name the rain needs - a set that had grown would need this row read again');
+
+  // **The other end of the constant, which no import can hold, and it is asked in both
+  // directions.** The render loop writes one named cell rather than iterating a list, so the
+  // two statements are held together here rather than by a shared symbol.
+  const main = readFileSync(join(ROOT, 'web/main.js'), 'utf8');
+  const written = new Set(
+    [...main.matchAll(/\buniforms\.([A-Za-z_][A-Za-z0-9_]*)\.value\s*(?:=[^=]|\.set\b)/g)].map((m) => m[1]),
+  );
+
+  // Direction one: a name on the list that the page never assigns to. That is the door going on
+  // excusing a uniform nothing writes, which is the whole hole the constant closes.
+  for (const name of HOST_DRIVEN_UNIFORMS) {
+    assert.ok(written.has(name),
+      `${name} is listed as host-driven and nothing in web/main.js writes it, so the door is excusing a uniform that reads zero`);
+  }
+
+  // **Direction two, and it is asked against the packages rather than against the writes**,
+  // because "is this a host clock" is not a question a scan of `web/main.js` can answer: the
+  // page assigns to dozens of cells and almost all of them are the spine's own - `mixT`,
+  // `spanSec`, `time`. What makes a write host-driven is the *other* end, that the uniform is
+  // declared by a package rather than by a spine, and that is knowable off disk. So the rule is:
+  // a uniform some shipped package declares, that `web/main.js` writes, has to be on the list.
+  // A name that appears on both sides and not in the constant is a host clock somebody wired up
+  // without saying so, and the door would then refuse the package that declares it - which is
+  // the loud direction, and is still the two statements disagreeing.
+  // **Comments stripped first, which this row did not do and which produced a false finding.**
+  // The chunks in this repo carry more comment than code, and two of them name the spine's own
+  // read uniforms in prose - the glitch's flare chunk and the duotone's tone chunk each quote a
+  // pinned build's `readRgb, readDepth, readContour` reading. A declaration pattern whose tail
+  // runs to the next semicolon walks straight through a paragraph, so both came back as
+  // package-declared, both are written by `web/main.js`, and the row failed naming `readDepth`
+  // on a build with nothing wrong with it. `withoutComments` in `server/effect-door.js` is the
+  // same two substitutions and exists for the same reason.
+  const withoutComments = (text) => text
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+  const declaredByPackages = new Set();
+  for (const pkg of shipped()) {
+    for (const raw of Object.values(pkg.chunks)) {
+      const text = withoutComments(raw);
+      for (const m of text.matchAll(/\buniform\s+(?:(?:highp|mediump|lowp)\s+)?[A-Za-z_][A-Za-z0-9_]*\s+([^;]*);/g)) {
+        for (const part of m[1].split(',')) {
+          const nm = part.trim().match(/^([A-Za-z_][A-Za-z0-9_]*)/);
+          if (nm) declaredByPackages.add(nm[1]);
+        }
+      }
+    }
+  }
+  const unlisted = (writes, declared, listed) => [...writes]
+    .filter((n) => declared.has(n) && !listed.includes(n));
+  assert.deepEqual(unlisted(written, declaredByPackages, HOST_DRIVEN_UNIFORMS), [],
+    'web/main.js writes a uniform a shipped package declares that HOST_DRIVEN_UNIFORMS does not name - '
+    + 'that is a host clock wired up without the door being told, and the door will refuse the package that declares it');
+
+  // **And the same predicate shown to fire, because on this build it cannot.** The only name in
+  // both scans is `rainPhase` and it is on the list, so the assertion above is green on the
+  // corpus that exists whatever the rule says - taking the name off the list does not reach it
+  // either, because the shipped rain is then refused and the identity row at the top of this
+  // test fails first. A conjunct that no input can redden is the vacuous one
+  // `docs/instruments.md` keeps recording, so the rule is asked once more against a triple built
+  // to trip it.
+  assert.deepEqual(
+    unlisted(new Set(['rainPhase', 'someClock']), new Set(['someClock']), ['rainPhase']),
+    ['someClock'],
+    'the direction-two rule does not flag a name that is written, package-declared and unlisted, so the row above proves nothing');
+
+  // **What neither direction reaches, said out loud rather than left to be assumed.** Both read
+  // `web/main.js` as text through one spelling of the write, so a build that started assigning
+  // through a computed key would pass direction one while writing nothing this row can see and
+  // fail direction two by finding nothing at all. And direction two is over the *shipped*
+  // packages only, because a package installed at runtime is not on disk when this runs - a
+  // fork declaring a uniform the host happens to write is outside this rule and is caught by
+  // the door instead, which refuses it for having no parameter behind it.
+  assert.ok(declaredByPackages.size > 0 && written.size > 0,
+    `this row read ${declaredByPackages.size} package-declared uniforms and ${written.size} writes in web/main.js - `
+    + 'either being empty means the scan found nothing and both directions above were vacuous');
+});
+
+// **How big the manifest may be, which every bound above it is silent about.** The three that
+// were here count chunk text, and a package can repeat a correct *parameter* rather than a
+// correct chunk: twelve thousand of them, each individually valid, arriving with one small
+// file of GLSL and inside the four megabytes the server takes as a body. What it costs is the
+// store writing and hashing those bytes on every poll, and a DOM control per parameter on
+// every page that adopts it.
+test('the door bounds the manifest as well as the chunks it names', () => {
+  const withParams = (n) => brokenBy('thermal', (c) => {
+    for (let i = 0; i < n; i++) {
+      c.manifest.params[`k${i}`] = {
+        kind: 'scalar', label: `Knob number ${i} of a manifest nobody wrote by hand`,
+        def: 0, min: 0, max: 1, step: 0.05,
+        panel: { group: 'colour' }, bind: { on: 'points', uniform: 'thermal' },
+      };
+    }
+  });
+  // Sized around the bound rather than far past it, so a build whose bound had drifted anywhere
+  // at all fails one of these two rows. Measured, a parameter of this shape costs 309 bytes in
+  // the spelling the store writes: 95 of them is 29,857 bytes and 115 is 36,067, which straddles
+  // the 32,768 this build takes with about ten per cent either side.
+  assert.equal(withParams(95), null, 'a manifest inside the bound is not refused by it');
+  assert.match(withParams(115), /carries a manifest of \d+ bytes/,
+    'and one past it is refused by name, counting the bytes the store would write');
+  // The reported shape, so the row is about the thing that was found rather than about a
+  // fixture built to trip a number: none of the bounds that count chunk text can see it, and
+  // it is comfortably inside the request limit.
+  assert.match(withParams(12000), /carries a manifest of \d+ bytes/,
+    'the twelve thousand parameters that fit in a request body are refused');
+
+  // The must-accept control, which is what says the bound is not merely low: every manifest
+  // this build ships is inside it, measured the way the store writes them.
+  for (const pkg of shipped()) {
+    const bytes = Buffer.byteLength(`${JSON.stringify(pkg.manifest, null, 2)}\n`, 'utf8');
+    assert.ok(bytes <= 32 * 1024,
+      `the shipped ${pkg.id} carries a ${bytes}-byte manifest, which this build's own door would refuse`);
+  }
 });
 
 test('a fork may add and retune, and may not drop', () => {

--- a/test/effect-store-gate.test.mjs
+++ b/test/effect-store-gate.test.mjs
@@ -1,0 +1,274 @@
+// The boot gate against a user root somebody has put packages into, under bare node.
+//
+// **`test/effect-door.test.mjs` cannot ask this and it is worth saying why rather than
+// leaving two files that look like one.** That one is about `doorRefusal`, which is a pure
+// function of an envelope and the two spines - no filesystem, no store, no roots. What this
+// file is about is the thing the door cannot see from inside itself: a package that is
+// perfectly correct on its own account and takes one of its neighbours down, which is a
+// property of the *set* the store settles on and only exists once there are two roots and a
+// rename to make. So the fixtures here are directories, the subject is
+// `EffectStore.refuseIncompatiblePackages`, and the assertions are about what is left standing
+// afterwards.
+//
+// The user root is a fresh temporary directory each time. The builtin root is the repo's own
+// `effects-builtin/`, which is read and never written - the store only ever renames inside its
+// user root, and a test that pointed both at the same place would be one bug away from moving
+// a shipped package.
+//
+// Still bare node: no server, no port, no browser. What a browser adds is the last row of
+// `effect-check` section 12, which is the same gate asked of a page that has to come up.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { EffectStore } from '../server/effect-store.js';
+import { cloudSpine } from '../web/cloud-shader.js';
+import { gradeSpine } from '../web/grade-shader.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILTIN = join(ROOT, 'effects-builtin');
+const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+
+const builtinManifest = (id) => JSON.parse(readFileSync(join(BUILTIN, id, 'manifest.json'), 'utf8'));
+
+/**
+ * One package written into a user root the way an install would have left it: the manifest
+ * pretty-printed, and every chunk the manifest names beside it.
+ *
+ * Chunk text defaults to the builtin's, so a fixture states only what it changed - which is
+ * what makes these forks rather than fresh packages, and what makes a row about the one field
+ * the fork moved.
+ */
+const stageFork = (dir, id, manifest, chunkEdits = {}) => {
+  const at = join(dir, id);
+  rmSync(at, { recursive: true, force: true });
+  mkdirSync(at, { recursive: true });
+  writeFileSync(join(at, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  for (const c of manifest.chunks ?? []) {
+    const shipped = readFileSync(join(BUILTIN, id, c.file), 'utf8');
+    writeFileSync(join(at, c.file), chunkEdits[c.file] ? chunkEdits[c.file](shipped) : shipped);
+  }
+  return at;
+};
+
+/** The ids a user root is actually serving: directories, minus every aside, which carries a dot. */
+const standing = (dir) => readdirSync(dir, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && !e.name.includes('.'))
+  .map((e) => e.name)
+  .sort();
+
+const asides = (dir) => readdirSync(dir, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && e.name.endsWith('.incompatible'))
+  .map((e) => e.name)
+  .sort();
+
+/**
+ * A verbatim fork of a shipped package at a new version, which every row here needs as its
+ * control: it changes nothing but the version string, so a gate that set it aside is refusing
+ * a package rather than validating one.
+ */
+const verbatim = (id) => ({ ...builtinManifest(id), version: '2.0.0' });
+
+/**
+ * The `rain` fork this whole file is about: the `vRain` varying dropped, and the two places
+ * the rain's own chunks read it edited out so that nothing about the package itself is wrong.
+ *
+ * That is what makes it the shape the gate could not see. `doorRefusal` walks the *candidate's*
+ * chunks for identifiers this build has not got, and there is nothing left in these to find;
+ * `forkRefusal` catches a fork that dropped a parameter, and every parameter is here. So the
+ * door answers null, the fork shadows the shipped rain, and the builtin glyph goes on reading
+ * `vRain` out of its own `index.frag.glsl` with nothing anywhere declaring it. The cloud
+ * program does not link, `web/main.js` throws while it is still evaluating, and no `__kinect`
+ * publishes - on a machine where every package passed the door it was held to.
+ */
+const rainWithoutTheVarying = () => {
+  const manifest = verbatim('rain');
+  manifest.varyings = [];
+  return { manifest, chunkEdits: {
+    'cell.vert.glsl': (text) => text.replace(/^.*\bvRain\b.*$/gm, '  // the varying this fork dropped'),
+    'lift.frag.glsl': (text) => text.replace(/fract\(vRain\)/g, '0.5'),
+  } };
+};
+
+const withStore = (stage, assertions) => {
+  const dir = mkdtempSync(join(tmpdir(), 'effect-store-gate-'));
+  try {
+    stage(dir);
+    const store = new EffectStore(dir, BUILTIN, SPINES);
+    store.claimUserRoot();
+    assertions(store, dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+// **The finding.** Before this, the gate validated each candidate against the standing set and
+// never re-asked the standing set afterwards - so a shadow that removed something a neighbour
+// reads was promoted, and the neighbour it broke was a builtin nobody looked at again.
+test('a fork that takes a neighbour down with it is set aside, and the neighbour is not', () => {
+  const { manifest, chunkEdits } = rainWithoutTheVarying();
+  withStore((dir) => stageFork(dir, 'rain', manifest, chunkEdits), (store, dir) => {
+    assert.deepEqual(standing(dir), [],
+      'the fork is set aside: nothing is left serving out of the user root');
+    assert.equal(asides(dir).length, 1, `one aside, and the user root holds ${asides(dir).join(', ')}`);
+    assert.match(asides(dir)[0], /^rain\./, 'and the aside is the fork rather than anything else');
+    // Renamed and never deleted, which is the promise a fork is authored work rests on.
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(dir, asides(dir)[0], 'manifest.json'), 'utf8')).version, '2.0.0',
+      'the fork is still on disk under its aside, whole, to be repaired and moved back');
+    // And the id answers from the shipped package again, which is the reading that says the
+    // gate did something rather than nothing.
+    assert.equal(store.read('rain').builtin, true, 'the id is handed back to the package this build ships');
+    assert.equal(store.list().length, readdirSync(BUILTIN).length,
+      'and every shipped package is still listed - the gate refused one package, not everything near it');
+  });
+});
+
+// **The must-accept control, and without it the row above passes on a gate that quarantines
+// every fork there is.** The same package, forked verbatim at a new version: nothing is dropped,
+// nothing is renamed, and it has to be standing when the gate is done.
+test('a fork that changes nothing is left exactly where it is', () => {
+  withStore((dir) => stageFork(dir, 'rain', verbatim('rain')), (store, dir) => {
+    assert.deepEqual(standing(dir), ['rain'], 'the healthy fork is still serving out of the user root');
+    assert.deepEqual(asides(dir), [], 'and nothing was renamed aside');
+    assert.equal(store.read('rain').builtin, false, 'the store answers for it as the user\'s copy');
+    assert.equal(store.read('rain').manifest.version, '2.0.0', 'at the version the fork declares');
+  });
+});
+
+// **Which of two forks loses, asked where the answer is not arbitrary.** The gate blames the
+// package that changed, so a healthy fork standing beside a destructive one has to survive it -
+// and this is the row that separates "sets aside the one that broke something" from "sets aside
+// whatever it was walking when the set stopped assembling".
+//
+// `glyph` is the neighbour the rain fork actually breaks, so a verbatim glyph fork is the
+// package with the most reason to be blamed by a gate that got the attribution wrong: it is the
+// one whose chunks the door would report the missing name against.
+test('the fork that changed is the one set aside, not the one it broke', () => {
+  const { manifest, chunkEdits } = rainWithoutTheVarying();
+  withStore((dir) => {
+    stageFork(dir, 'glyph', verbatim('glyph'));
+    stageFork(dir, 'rain', manifest, chunkEdits);
+  }, (store, dir) => {
+    assert.deepEqual(standing(dir), ['glyph'], 'the glyph fork survives and the rain fork does not');
+    assert.equal(asides(dir).length, 1, `one aside, and the user root holds ${asides(dir).join(', ')}`);
+    assert.match(asides(dir)[0], /^rain\./, 'and it is the rain, which is the package that changed');
+    assert.equal(store.read('glyph').manifest.version, '2.0.0', 'the glyph fork is what the store answers with');
+    assert.equal(store.read('rain').builtin, true, 'and the rain answers from the shipped package');
+  });
+});
+
+// **A package called `refuse`, which this build once could not serve and now simply serves.**
+// The refusal route was `POST /effects/refuse` first, and a literal segment under `/effects/`
+// outranks the `:id` read beside it — so this package was listed by `GET /effects` and then
+// answered 405 when the page fetched it, which is `readEffectPackages` throwing, no `__kinect`,
+// both surfaces dark. Reproduced against a running server, `DELETE` refused too, and the boot
+// gate silent because nothing in the door had an opinion about the id.
+//
+// The first repair reserved the word at the door and quarantined this package. The repair that
+// landed moved the route to `POST /effect-refusals`, so nothing under `/effects/` is claimed and
+// there is no word to reserve — and `refuse` is an ordinary effect id again. This row is the
+// regression test for that: the package stands, the store serves it, and nobody's work is
+// quarantined over a routing collision that no longer exists.
+//
+// It is the id `refuse` specifically rather than an arbitrary name, because that is the one the
+// collision was about. A row using some other id would pass on the build that had the defect.
+test('a package called refuse is an ordinary package again', () => {
+  const named = { ...builtinManifest('thermal'), id: 'refuse', title: 'A package named for what was once a route' };
+  withStore((dir) => {
+    const at = join(dir, 'refuse');
+    mkdirSync(at, { recursive: true });
+    writeFileSync(join(at, 'manifest.json'), `${JSON.stringify(named, null, 2)}\n`);
+    for (const c of named.chunks ?? []) {
+      writeFileSync(join(at, c.file), readFileSync(join(BUILTIN, 'thermal', c.file), 'utf8'));
+    }
+    writeFileSync(join(at, 'witness.marker'), 'somebody\'s package, under a name this build once took\n');
+    stageFork(dir, 'rain', verbatim('rain'));
+  }, (store, dir) => {
+    assert.deepEqual(standing(dir), ['rain', 'refuse'], 'both packages stand: nothing about either id is refused');
+    assert.deepEqual(asides(dir), [], 'and nothing was renamed aside, because there is no reserved name any more');
+    assert.equal(store.read('refuse')?.manifest.title, named.title, 'the store answers for it as an ordinary package');
+    assert.ok(store.list().some((e) => e.id === 'refuse'),
+      'and the listing carries it, which is what the page fetches next — the request that used to be answered 405');
+    assert.ok(existsSync(join(dir, 'refuse', 'witness.marker')), 'with its files exactly where they were');
+  });
+});
+
+// **A build whose own shipped package this build's door refuses, which is the one condition
+// under which the whole-set pass would be an over-refusal machine.** Every member of the
+// settled set is asked, and a builtin that was already refused before any fork existed would
+// come back refused for every candidate in turn - so the first fork on such a machine would be
+// quarantined under a sentence blaming somebody's authored work for a fault in the build. The
+// gate takes a baseline with no fork in the room and excuses what it finds there.
+//
+// **Staged against a copied builtin root, because there is no other way to ask.** On a correct
+// build this condition is unreachable - `test/effect-door.test.mjs` runs the whole shipped set
+// through the same door - so a row that used the repo's own `effects-builtin/` could not go red
+// whatever the code did, which is the vacuous conjunct `docs/instruments.md` keeps recording.
+// The copy is a temporary directory and the repo's own root is only ever read.
+test('a fork is not quarantined for a builtin this build was already refusing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'effect-store-gate-'));
+  const brokenBuiltins = mkdtempSync(join(tmpdir(), 'effect-store-builtin-'));
+  try {
+    cpSync(BUILTIN, brokenBuiltins, { recursive: true });
+    // An identifier that is nowhere in this build, which is a rule the door already has and
+    // is the cheapest way to make one shipped package fail its own door without making it
+    // unreadable - the store still parses it, lists it and serves it.
+    const heat = join(brokenBuiltins, 'thermal/heat.frag.glsl');
+    writeFileSync(heat, `${readFileSync(heat, 'utf8')}  col = vec3(qqNotHere);\n`);
+
+    const at = join(dir, 'rain');
+    mkdirSync(at, { recursive: true });
+    const manifest = verbatim('rain');
+    writeFileSync(join(at, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+    for (const c of manifest.chunks ?? []) {
+      writeFileSync(join(at, c.file), readFileSync(join(BUILTIN, 'rain', c.file), 'utf8'));
+    }
+
+    const store = new EffectStore(dir, brokenBuiltins, SPINES);
+    store.claimUserRoot();
+    assert.deepEqual(standing(dir), ['rain'],
+      'the fork is standing, because the fault was in the build rather than in the fork');
+    assert.deepEqual(asides(dir), [], 'and nothing was renamed aside');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(brokenBuiltins, { recursive: true, force: true });
+  }
+});
+
+// **A fork that reads a name only another fork declares, which is the property the promotion
+// loop repeats to convergence for and the one a stricter rule is most likely to undo.** The
+// install door offers a candidate every other installed package's varyings, so installing a
+// rain fork with a new varying and then a glyph fork that reads it is a pair this build's own
+// door takes one at a time - and a gate that swept once would meet glyph first, find the name
+// nowhere, and quarantine a package that has been working since the day it landed.
+//
+// **The varying has to be one the shipped set has not got, and this row said `vRain` first.**
+// That proved nothing: the builtin rain declares `vRain`, so a glyph fork doored while the
+// rain fork was still pending found the name on the shipped package standing in its place and
+// passed on the first sweep. The row stayed green under a mutation that reduced the loop to
+// one pass, which is the vacuous conjunct `docs/instruments.md` keeps recording. `vDrizzle`
+// exists nowhere but in the fork that declares it, so the second sweep is the only thing that
+// can promote the fork that reads it.
+test('a fork reading a name only another fork declares is promoted on the second pass', () => {
+  const rain = verbatim('rain');
+  rain.varyings = [...rain.varyings, { name: 'vDrizzle', type: 'float', init: '0.0', order: 210 }];
+  const glyph = verbatim('glyph');
+  withStore((dir) => {
+    stageFork(dir, 'glyph', glyph, {
+      // Multiplied by zero, so the fork reads the name and draws exactly what the shipped
+      // glyph draws - the row is about which packages are standing, and a fixture that also
+      // changed the picture would be two claims in one.
+      'index.frag.glsl': (text) => `${text}  falloff *= 1.0 - 0.0 * vDrizzle;\n`,
+    });
+    stageFork(dir, 'rain', rain);
+  }, (store, dir) => {
+    assert.deepEqual(standing(dir), ['glyph', 'rain'], 'both forks are standing');
+    assert.deepEqual(asides(dir), [], 'and neither was renamed aside');
+    assert.equal(store.list().filter((e) => !e.builtin).length, 2,
+      'and the store is serving both of them as user packages');
+  });
+});

--- a/test/glyph-ceiling.test.mjs
+++ b/test/glyph-ceiling.test.mjs
@@ -1,0 +1,147 @@
+// The unit the glyph field's point-size ceiling is expressed in, held as arithmetic.
+//
+// **This is the same shape as `test/bloom-chain.test.mjs` and it is here for the same
+// reason.** The property is a relation between a screen-space term and the buffer it is
+// drawn into, no rendered comparison can see it cheaply, and it is a pure function - so it
+// is pinned under bare node instead of through a GPU. The glyph branch clamps the grown
+// sprite to `min(255.0 * k, pointCeiling)` framebuffer pixels, where `k` is
+// `bufferHeight / 1080.0`, so the *reference-pixel* distance at which a cell-sized sprite
+// stops growing is that clamp divided by `k` again. Under the shipped form that comes back
+// as the same number at every output size; under the form this replaced - the hardware
+// ceiling alone, in framebuffer pixels - it comes back as `pointCeiling / k`, which is not
+// constant in `k` by construction. That difference is the whole of what item 15 changed and
+// it is one line of arithmetic to state.
+//
+// **What this cannot see**, stated rather than left to be discovered, because the residual
+// is the honest counterpart of the claim: it proves the ceiling is *expressed* in the right
+// unit and proves nothing at all about whether a sprite actually stops growing there on a
+// GPU. A driver that ignored the clamp, a clamp applied to the wrong branch, or a
+// `gl_PointSize` the rasteriser rounds differently are all green here. What closes that end
+// is that the clamp is one `clamp()` in one statement in
+// `effects-builtin/glyph/size.vert.glsl`, and `registry-check`'s glyph sections draw
+// through it on every run - so a clamp that stopped clamping at all takes the tiling with
+// it. The narrow gap that stays open is a ceiling that clamps at the wrong *distance* while
+// still being written in reference pixels, and no arm in this repo holds that.
+//
+// The 255 is written out here rather than read out of the shader, for the reason the bloom
+// chain's oracle gives about its own 300: a test that asked the implementation what number
+// it used would agree with it by construction and could never see the number move. The row
+// at the foot of this file is what stops that being a second copy - it requires the GLSL to
+// carry this exact literal in this exact expression, which is the mechanism `syntax-check`
+// already runs over the constants that cross into `native/grabber.cpp`.
+//
+// **Which means the last row is the only one that can see the shader at all, and that is
+// worth saying rather than leaving somebody to find it in a mutation run.** The four rows
+// above it are arithmetic over a rule; they are about this build only because the last one
+// binds the rule to the shipped statement. Measured rather than reasoned, by editing
+// `effects-builtin/glyph/size.vert.glsl` and running this file: putting the ceiling back to
+// `pointCeiling` alone - the regression this arm exists for - fails the binding row and
+// leaves the other four green, and retuning the shader's literal to 300 while this file
+// still says 255 does exactly the same. Both are caught, neither is caught twice, and a
+// reader who deletes the binding row as redundant has deleted the whole instrument.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { EXPORT_SIZES } from '../web/export-sizes.js';
+
+/** The look's own ceiling, in pixels at 1080p. */
+const GLYPH_CEILING_REF = 255;
+
+/**
+ * What this rig's context reports for the top of `ALIASED_POINT_SIZE_RANGE`, which is what
+ * `pointCeiling` is written out of at boot. Measured off the WebGL context on the page the
+ * proof tools open - Apple M2 Max through ANGLE's Metal backend - and a parameter here
+ * rather than a constant, because it is a property of a machine and the rows below have to
+ * be able to ask what happens on a different one.
+ */
+const MEASURED_POINT_CEILING = 511;
+
+/** Every buffer height an export can ask for, which is what the invariance ranges over. */
+const EXPORT_HEIGHTS = [...new Set(EXPORT_SIZES.flatMap(({ sizes }) => sizes.map(([, h]) => h)))];
+
+/** The shipped clamp, and then the distance it puts the ceiling at in the look's own unit. */
+const shipped = (bufferHeight, pointCeiling) => {
+  const k = bufferHeight / 1080;
+  return Math.min(GLYPH_CEILING_REF * k, pointCeiling) / k;
+};
+
+/** What the same reading gives for the form this replaced: the hardware bound, alone. */
+const hardwareAlone = (bufferHeight, pointCeiling) => {
+  const k = bufferHeight / 1080;
+  return pointCeiling / k;
+};
+
+test('the ceiling is the same reference-pixel distance at every size an export offers', () => {
+  const read = EXPORT_HEIGHTS.map((h) => [h, shipped(h, MEASURED_POINT_CEILING)]);
+  for (const [h, ref] of read) {
+    assert.equal(ref, GLYPH_CEILING_REF, `a ${h}-tall buffer put the ceiling at ${ref}`);
+  }
+  // And the table is not one entry, which is what makes the row above range over something.
+  assert.ok(EXPORT_HEIGHTS.length >= 4, `only ${EXPORT_HEIGHTS.length} distinct export heights`);
+});
+
+test('while the hardware bound alone is a different distance at every size, which is the defect', () => {
+  // The falsification row, and the mutation it stands against is putting the ceiling back
+  // into framebuffer pixels. Without this every assertion above is satisfied by a build
+  // that happens to agree at one height.
+  //
+  // The direction is the half worth writing down, because it is the opposite of what it
+  // looks like. 4K was the *tight* end all along: at 2160 the old ceiling already sat at
+  // 255.5 reference pixels where at 1080 it sat at 511, so a look opened gaps at twice the
+  // range in a 4K export. The fix pulls every smaller output down to what the tallest one
+  // can actually draw rather than lifting 4K, which it cannot - 1022 framebuffer pixels is
+  // past what the rasteriser will take.
+  const distances = EXPORT_HEIGHTS.map((h) => hardwareAlone(h, MEASURED_POINT_CEILING));
+  assert.ok(new Set(distances).size > 1,
+    `the hardware bound gave one distance at every height: ${distances.join(', ')}`);
+  assert.equal(hardwareAlone(1080, MEASURED_POINT_CEILING), 511);
+  assert.equal(hardwareAlone(2160, MEASURED_POINT_CEILING), 255.5);
+});
+
+test('255 is the largest ceiling the tallest offered output can actually rasterise', () => {
+  // Why the number is that number, held rather than asserted in prose. The clamp cannot ask
+  // for more framebuffer pixels than the hardware will draw, so the reference ceiling is
+  // bounded by `pointCeiling` divided by the largest scale an export reaches - and the
+  // tallest entry in the table is what decides it.
+  const tallest = Math.max(...EXPORT_HEIGHTS);
+  const largestScale = tallest / 1080;
+  assert.equal(largestScale, 2, `the tallest export is ${tallest}, a scale of ${largestScale}`);
+  assert.ok(GLYPH_CEILING_REF * largestScale <= MEASURED_POINT_CEILING,
+    `${GLYPH_CEILING_REF} * ${largestScale} is past the ${MEASURED_POINT_CEILING} this rig draws`);
+  assert.ok((GLYPH_CEILING_REF + 1) * largestScale > MEASURED_POINT_CEILING,
+    `${GLYPH_CEILING_REF + 1} would also have fitted, so this is not the largest`);
+});
+
+test('and on a GPU that cannot draw it the hardware wins, which is the bound doing its job', () => {
+  // Not a defect and not hidden: a machine whose rasteriser stops below the look's ceiling
+  // clamps tighter than the document asked, and the invariance lapses there rather than the
+  // clamp quietly asking for a sprite that will not be drawn. The same lapse is what an
+  // interactive window reaches past a scale of 2, which only `renderScale` wound up gets to.
+  const small = 128;
+  assert.equal(shipped(2160, small), small / 2);
+  assert.equal(shipped(1080, small), small);
+  assert.notEqual(shipped(2160, small), shipped(1080, small));
+  // While a machine with headroom to spare holds the look's number rather than reaching for
+  // the headroom, which is what keeps a document portable between the two.
+  assert.equal(shipped(2160, 8192), GLYPH_CEILING_REF);
+  assert.equal(shipped(1080, 8192), GLYPH_CEILING_REF);
+});
+
+test('the shader carries this exact ceiling, so the number above is not a second copy', () => {
+  // The cross-language half. `GLYPH_CEILING_REF` is stated once, in JavaScript, and the GLSL
+  // is required to agree with it - so retuning the ceiling in the shader without retuning it
+  // here fails under bare node rather than drifting. The whole statement is matched rather
+  // than the literal alone, because `255.0` appearing somewhere in the file is not the same
+  // fact as the clamp being written against the buffer scale.
+  const src = readFileSync(new URL('../effects-builtin/glyph/size.vert.glsl', import.meta.url), 'utf8');
+  const clamp = `min(${GLYPH_CEILING_REF}.0 * k, pointCeiling)`;
+  assert.ok(src.includes(clamp), `the glyph branch does not clamp to ${clamp}`);
+  // And it is the grown sprite that is bounded by it, not the fallback beside it - the else
+  // branch keeps the literal 64 it always had, which `export-check`'s `pointsize-absolute`
+  // anchors on.
+  assert.ok(src.includes(`gl_PointSize = clamp(mix(base, cellPx * k, glyph), 1.0, ${clamp});`),
+    'the reference ceiling is not on the glyph branch');
+  assert.ok(src.includes('gl_PointSize = clamp(pointSize * k / max(0.15, -mv.z), 1.0, 64.0);'),
+    'the fallback branch no longer carries the statement export-check anchors on');
+});

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -1102,23 +1102,14 @@ const MUTATIONS = {
   'fit-lands-after-history-begins': {
     file: 'web/main.js',
     edits: [
-      // Lifted out of its place above the marks...
       ['  await fitCropToTake(id, params.get(\'near\'), params.get(\'far\'))\n'
-        + '    .catch((err) => { say(`the crop box could not be fitted to this take: ${err.message}`); });\n'
-        + '  // Awaited, so the first paint of the ruler already has the ticks on it. A take',
-      '  // Awaited, so the first paint of the ruler already has the ticks on it. A take'],
-      // ...and put back on the far side of the baseline, committing like any other edit,
-      // which is exactly what it must not be. The comment above `begin` is part of the
-      // anchor because `history.begin()` alone appears twice in this file.
-      ['  // The stack starts from whatever the clip already is, so the first undo has\n'
-        + '  // somewhere honest to land rather than an empty document.\n'
-        + '  history.begin();',
-      '  // The stack starts from whatever the clip already is, so the first undo has\n'
-        + '  // somewhere honest to land rather than an empty document.\n'
-        + '  history.begin();\n'
+        + '    .catch((err) => { say(`the crop box could not be fitted to this take: ${err.message}`); });\n',
+      ''],
+      ['\n  history.begin();\n',
+      '\n  history.begin();\n'
         + '  await fitCropToTake(id, params.get(\'near\'), params.get(\'far\'))\n'
         + '    .catch((err) => { say(`the crop box could not be fitted to this take: ${err.message}`); });\n'
-        + '  history.commit();'],
+        + '  history.commit();\n'],
     ],
   },
   // **The shape is written and the stage is not letterboxed to it.** `setProjectAspect`
@@ -2178,12 +2169,9 @@ const MUTATIONS = {
   'space-unbound': {
     file: 'web/main.js',
     edits: [[
-      '      // Or the page scrolls under the strip.\n      e.preventDefault();\n'
-      + '      // `pendingPlay` beside `playing` for the reason the play button\'s comment gives\n'
-      + '      // at length: a play warming up from a draft is a play this press means to stop.\n'
-      + '      if (timeline.playing || timeline.pendingPlay) pauseTransport();\n'
+      '      if (timeline.playing || timeline.pendingPlay) pauseTransport();\n'
       + '      else timeline.play().catch(showTimelineError);\n      return;',
-      '      // Or the page scrolls under the strip.\n      e.preventDefault();\n      return;',
+      '      return;',
     ]],
   },
 
@@ -2207,17 +2195,8 @@ const MUTATIONS = {
   'ease-handles-on-flat': {
     file: 'web/main.js',
     edits: [
-      [
-        '    // A flat segment gets none, for the reason `segmentHasShape` gives.\n'
-        + '    if (!segmentHasShape(keys, seg, row.kind)) continue;\n',
-        '',
-      ],
-      [
-        '      // A segment that went flat under the drag has no shape left to edit, so its\n'
-        + '      // handle has to go rather than be moved - which is a rebuild, not a move.\n'
-        + '      if (!segmentHasShape(keys, seg, row.kind)) return false;\n',
-        '',
-      ],
+      ['    if (!segmentHasShape(keys, seg, row.kind)) continue;\n', ''],
+      ['      if (!segmentHasShape(keys, seg, row.kind)) return false;\n', ''],
     ],
   },
 

--- a/tools/effect-check.mjs
+++ b/tools/effect-check.mjs
@@ -249,7 +249,7 @@ const MUTATIONS = {
    */
   'rebuild-forgets-the-tab': {
     file: 'web/main.js',
-    edits: [['\n  hideOffTab();\n\n  // And the dialog', '\n\n  // And the dialog']],
+    edits: [['\n  hideOffTab();\n\n', '\n\n']],
   },
 
   /**

--- a/tools/effect-check.mjs
+++ b/tools/effect-check.mjs
@@ -61,10 +61,18 @@
 //     accumulators mid-playback; a package that did change GLSL must release the program it
 //     replaced; and a rebuild must stand down when a gesture starts while it is reading
 //     rather than when it started reading.
-//  9. **A package this build cannot compile is a rollback and a sentence, not a black
-//     frame.** The door checks vocabulary and cannot compile GLSL, so identifier-valid text
-//     that is syntactically broken reaches the driver - where a link failure is a log line
-//     and not an exception. `a-broken-shader-is-warm` is the control.
+//  9. **A package this build cannot compile is a rollback, a sentence, and a package the
+//     store stops serving.** The door checks vocabulary and cannot compile GLSL, so
+//     identifier-valid text that is syntactically broken reaches the driver - where a link
+//     failure is a log line and not an exception. Rolling back is only half of it: the
+//     package survives the rollback, and the next page to open compiles it at boot, outside
+//     any transaction, and publishes no `__kinect` at all. The only process in this program
+//     with a GL context is the page, so the page is what tells the store, and the row that
+//     matters is the fresh load booting afterwards rather than the store's answer.
+//     `a-broken-shader-is-warm` and `a-link-failure-is-not-quarantined` are the controls for
+//     the two halves, and `any-failure-is-quarantined` is the control for the direction that
+//     does damage - a refusal about a *document* must never set a package aside, which is
+//     what section 6 asks of the store after the completeness rule has refused a fork.
 // 10. **A fork the door passed years ago is asked again at every start.** A package outlives
 //     the build it was installed on, and an upgrade that drops or renames a joint leaves a
 //     valid fork shadowing an upgraded builtin with nothing re-validating it - which is a
@@ -112,6 +120,14 @@
 //   node tools/effect-check.mjs --mutate the-gate-runs-before-the-bind   # must FAIL
 //   node tools/effect-check.mjs --mutate the-aside-keeps-the-whole-name  # must FAIL
 //   node tools/effect-check.mjs --mutate a-refused-body-is-a-failed-read # must FAIL
+//   node tools/effect-check.mjs --mutate the-gate-never-re-asks-the-set  # must FAIL
+//   node tools/effect-check.mjs --mutate door-takes-an-array-binding     # must FAIL
+//   node tools/effect-check.mjs --mutate hostdriven-takes-any-name       # must FAIL
+//   node tools/effect-check.mjs --mutate door-takes-any-manifest         # must FAIL
+//   node tools/effect-check.mjs --mutate a-refusal-moves-no-generation   # must FAIL
+//   node tools/effect-check.mjs --mutate door-takes-a-gates-nothing-reads # must FAIL
+//   node tools/effect-check.mjs --mutate a-link-failure-is-not-quarantined # must FAIL
+//   node tools/effect-check.mjs --mutate any-failure-is-quarantined      # must FAIL
 //
 // It spawns its own server on a port nothing else in the suite uses and needs none
 // running. A GPU browser, a free port 8281, no capture, no sensor and no ffmpeg.
@@ -321,12 +337,106 @@ const MUTATIONS = {
    * failure where three.js puts it: a line in a console nobody has open. The install
    * succeeds, the document is carried across, the poll announces that the page has been
    * rebuilt from the new effects, and the cloud renders nothing at all.
+   *
+   * **The whole statement is anchored rather than its first line**, which is worth a
+   * sentence because the anchor had to move once already. It used to quote a bare
+   * `throw new Error(...)`, and the throw is a marked one now - `reloadEffects` reads
+   * `shaderLinkFailure` to decide which failures may reach the refusal route, and a
+   * classification that matched words in the sentence is what `effectRefusal`'s own comment
+   * rejects by name, so the mark had to be minted here where the difference is known. Taking
+   * the statement whole is what leaves nothing of it behind: a replacement that swapped only
+   * the first line would leave a live call to the minter standing under a `void`, which
+   * builds an error and does nothing with it and reads to the next person like code that
+   * still matters.
    */
   'a-broken-shader-is-warm': {
     file: 'web/main.js',
     edits: [[
-      "    throw new Error(`this build's shaders did not compile after the effects changed - ${linkFailures[0]}`);",
-      "    console.warn(`shaders did not compile: ${linkFailures[0]}`);",
+      "    throw shaderLinkFailure(\n"
+      + "      `this build's shaders did not compile after the effects changed - ${linkFailures[0]}`,\n"
+      + '      linkFailures[0],\n'
+      + '    );',
+      '    console.warn(`shaders did not compile: ${linkFailures[0]}`);',
+    ]],
+  },
+
+  /**
+   * `door-takes-a-gates-nothing-reads` drops the pair of rules that ask whether a `gates`
+   * binding lands something the gate can actually read, which is how the door shipped. Both
+   * shapes then install cleanly and the promise the author made is about nothing: a gating
+   * binding on the point cloud is collected by no walk, and a gating binding through `axisDeg`
+   * puts a `Vector2` where a number belongs, which held the grade pass shut for the life of the
+   * page under the comparison `gradeNeeded` used to make and holds it open forever under the one
+   * it makes now.
+   *
+   * Written from `server/effect-door.js`'s side because that is where the refusal is, and aimed
+   * at the `if (bind.gates)` that guards both halves rather than at either sentence, so one
+   * mutation takes the whole rule away. Reddens **one** row, measured - section 2's hostile
+   * sweep - and the row now names both fixtures rather than the first of them, which is what
+   * makes a single mutation over two rules readable at all.
+   */
+  'door-takes-a-gates-nothing-reads': {
+    file: 'server/effect-door.js',
+    edits: [[
+      '    if (bind.gates) {\n      if (bind.on',
+      '    if (false) {\n      if (bind.on',
+    ]],
+  },
+
+  /**
+   * `a-link-failure-is-not-quarantined` leaves the throw and the mark exactly where they are
+   * and drops the one call that acts on them, which is the build this fix was written to
+   * replace and is the state every green run before it was in. The page still refuses the
+   * package, still rolls back, still says which shader did not compile - and the package sits
+   * in the store afterwards, so the next browser to open compiles it at boot, where
+   * `warmPrograms` runs outside any transaction and takes the module down with it.
+   *
+   * **Reddens four rows, measured, all of them in section 9, and the third is the point.** The
+   * store still lists the package and there is no aside beside it, which is the mechanism; the
+   * fresh page comes back `no __kinect published: this build's shaders did not compile`, which
+   * is the damage; and the delete that follows answers 200 rather than 404, because the live
+   * copy is still there to remove. Without the fresh-page row a build that called the route
+   * and achieved nothing would pass everything above it.
+   */
+  'a-link-failure-is-not-quarantined': {
+    file: 'web/main.js',
+    edits: [[
+      '  const setAside = failure?.shaderLinkFailure\n'
+      + '    ? await setAsideUnlinkable(heldPackages, fetched, failure.linkLog)\n'
+      + '    : null;',
+      '  const setAside = null;',
+    ]],
+  },
+
+  /**
+   * `any-failure-is-quarantined` keeps the call and drops the mark test, so every failure the
+   * rollback catches reaches the refusal route. That is the direction this fix does damage in
+   * rather than merely fails in, and it is the harder half to notice: the page behaves
+   * correctly in every reading a person takes of it - the refusal is right, the sentence is
+   * right, the rollback is right - and a package nothing is wrong with has been renamed out of
+   * the way behind all of it.
+   *
+   * The failure it turns loose is the one section 6 provokes on purpose: install a fork that
+   * *adds* a parameter while a document holds that effect, and the per-effect completeness
+   * rule refuses the subset. Nothing about the package is wrong there; what could not be done
+   * is carrying *this document* onto it, and the operator's next move - opening a document
+   * that names the new parameter - would have worked.
+   *
+   * **Reddens three rows, measured, and only the first is the finding.** Section 6's asks the
+   * store whether the fork is still installed and comes back `GET /effects/probe answered 404,
+   * user root holds probe.<seq>.incompatible` - a package renamed out of the way for a fault
+   * in a clip, which is the whole of what this mutation is about. The two under it are section
+   * 9's and are the fixture carrying forward rather than a second finding: both of them key on
+   * there being exactly one `probe.*.incompatible` in the user root, and section 6's innocent
+   * aside is sitting beside section 9's real one. Everything else in section 9 stays green -
+   * the store still drops the package and the generation still moves by one - which is what
+   * makes those two a count going wrong rather than a second thing being found.
+   */
+  'any-failure-is-quarantined': {
+    file: 'web/main.js',
+    edits: [[
+      '  const setAside = failure?.shaderLinkFailure\n',
+      '  const setAside = failure\n',
     ]],
   },
 
@@ -647,6 +757,112 @@ const MUTATIONS = {
    * the pair of rows still sees a number move, on a store that has stopped counting half of
    * what it does.
    */
+  /**
+   * `the-gate-never-re-asks-the-set` puts the boot gate back to validating each candidate and
+   * never re-asking the packages it has already accepted, which is how it shipped. That reads
+   * as sufficient and is not: `doorRefusal` walks the *candidate's* chunks for names this build
+   * has not got and `forkRefusal` catches a dropped parameter, so a fork that stops declaring a
+   * varying its neighbour reads is correct about everything the gate asks it. It is promoted,
+   * it shadows the shipped package, and the neighbour's program stops linking.
+   *
+   * Reddens **five** rows, measured. Four of them are section 15 and are what this is about:
+   * the fork stands, the aside is not there, the log says nothing, and the page opened on that
+   * store publishes no `__kinect` at all - the last of those is the finding and the three above
+   * it are how it got there. The must-accept row beside them stays green, because a gate that
+   * quarantines nothing leaves the healthy glyph fork alone too, and that is exactly what makes
+   * it a control for over-refusal rather than for this.
+   *
+   * **The fifth is a cascade into section 16 and this comment said four until it was counted.**
+   * That section drives the refusal route against a store section 15 was supposed to have
+   * cleaned up, so with the rain fork still standing its row about the shipped set being all
+   * that is left sees a user package and reddens. It is a consequence of the fixture surviving
+   * rather than a second finding, and it is written down because a comment naming which rows
+   * catch a mutation is a claim like any other.
+   */
+  'the-gate-never-re-asks-the-set': {
+    file: 'server/effect-store.js',
+    edits: [[
+      '        if (!refusal) {\n          const resulting = new Map([...builtins, ...survivors]);',
+      '        if (false) {\n          const resulting = new Map([...builtins, ...survivors]);',
+    ]],
+  },
+
+  /**
+   * `door-takes-an-array-binding` drops the rule that a binding may not aim at an array,
+   * leaving the shape rule beside it. The two are not the same question: three.js takes its
+   * uploader off the declaration, so an array uniform is handed the array setter and one
+   * number, and the write succeeds into a cell no shader reads.
+   *
+   * Aimed at the refusal rather than at the reading that finds the dimension, because those
+   * two fail differently and `test/effect-door.test.mjs` separates them: with the reading
+   * undone the door accepts the package outright, and with only the refusal gone it refuses
+   * under the shape sentence instead.
+   *
+   * So this reddens **one** row, measured - the refusal row, on the sentence rather than on the
+   * acceptance - and the residue row beside it stays green, because the shape rule catches the
+   * package a few lines later and it never reaches disk. This comment said two until it was
+   * counted, on the assumption that a mutation of a refusal means a package lands. The one that
+   * would land is the reading, and the reading has no mutation here because
+   * `door-takes-any-manifest` and the bare-node rows already carry that shape.
+   */
+  'door-takes-an-array-binding': {
+    file: 'server/effect-door.js',
+    edits: [['    if (arrayed.length) {', '    if (false) {']],
+  },
+
+  /**
+   * `hostdriven-takes-any-name` puts back the door that let a package list any uniform at all
+   * as host-driven. `hostDriven` is the one exemption from the rule that something has to write
+   * every uniform a package declares, and an exemption a package issues itself is the rule
+   * gone: the shader reads zero for the life of the page and no control exists that could
+   * have moved it.
+   *
+   * Reddens **two** rows of section 2, measured - the refusal and the residue, because nothing
+   * else in this door has anything to say about the package and it lands on disk. The sweep
+   * after them is what keeps it to two rather than carrying an installed fixture into section 3.
+   */
+  'hostdriven-takes-any-name': {
+    file: 'server/effect-door.js',
+    edits: [['    if (!HOST_DRIVEN_UNIFORMS.includes(u)) {', '    if (false) {']],
+  },
+
+  /**
+   * `door-takes-any-manifest` drops the bound on the manifest, leaving the three that count
+   * chunk text. A package can repeat a correct *parameter* rather than a correct chunk, so
+   * those three see a small package while the store writes and hashes megabytes on every read
+   * and every open page builds a control per parameter. Reddens **two** rows of section 2,
+   * measured - the refusal and the residue, because the package lands on disk - on the same
+   * argument `door-takes-any-expansion` does, and the sweep after them keeps it to two.
+   */
+  'door-takes-any-manifest': {
+    file: 'server/effect-door.js',
+    edits: [['  if (manifestBytes > MAX_MANIFEST_BYTES) {', '  if (false) {']],
+  },
+
+  /**
+   * `a-refusal-moves-no-generation` stops the refusal route counting itself as a change of the
+   * store. A set-aside id stops resolving from the user root and starts answering from the
+   * builtin, and the page that just called the route is sitting on a rolled-back set waiting
+   * for the next poll to hand it a working one - so a store that does not move the number is
+   * a page whose recovery depends on the revisions happening to differ. Reddens one row of
+   * section 16 and leaves the three beside it green, because the rename still happens.
+   *
+   * **Re-anchored once, and where it moved to is the mutation reading better than it did.** It
+   * used to quote `EFFECTS.generation += 1` in the route, and the bump has since moved into
+   * `setAsideForClient` so that the store's own history has one writer rather than a route
+   * reaching into a field it does not own. Anchored on the assignment beside the rename it
+   * belongs to, which is also what keeps it distinct from the two `store-generation-never-moves`
+   * edits: three assignments of that field now exist in one file and each is quoted with the
+   * line above it.
+   */
+  'a-refusal-moves-no-generation': {
+    file: 'server/effect-store.js',
+    edits: [[
+      "    if (!this.setAside(id, reason)) return 'stuck';\n    this.generation += 1;",
+      "    if (!this.setAside(id, reason)) return 'stuck';",
+    ]],
+  },
+
   'store-generation-never-moves': {
     file: 'server/effect-store.js',
     edits: [
@@ -1300,10 +1516,18 @@ try {
     // must-accept control; what these rows add is that the refusal happens on disk, through
     // the route, and leaves nothing behind.
     ['one joint naming one file over and over', 'probe', bent((p) => {
-      // The reported shape: a thousand descriptors over one 493-byte chunk, which carries
+      // The reported shape was a thousand descriptors over one 493-byte chunk, which carries
       // 493 bytes and asks a driver to compile half a megabyte. It is refused for being a
-      // repeat rather than for being large, so the count here is about reaching the rule.
-      for (let i = 0; i < 1000; i++) p.manifest.chunks.push({ stage: 'f.tone', order: 500 + i, file: 'tone.frag.glsl' });
+      // repeat rather than for being large, so the count here is only about reaching the rule.
+      //
+      // **Fifty rather than a thousand, and the reduction is a measured finding rather than
+      // tidying.** A descriptor costs about ninety bytes in the manifest, so the thousand-entry
+      // fixture arrived as a 90,623-byte manifest - past the bound this door now puts on that,
+      // which fires several rules earlier. The row went red naming the manifest size, on a
+      // build where both rules were working: the fixture had stopped reaching the rule it is
+      // named after. Fifty descriptors is about 6KB of manifest, comfortably inside every bound
+      // here and outside none, so what refuses it is the repeat and nothing else.
+      for (let i = 0; i < 50; i++) p.manifest.chunks.push({ stage: 'f.tone', order: 500 + i, file: 'tone.frag.glsl' });
     }), /spliced into "f\.tone" twice/],
     ['a manifest asking for more assembled text than it carries', 'probe', bent((p) => {
       // Sixty distinct files of three kilobytes on two stages each: 62 files and about 180KB
@@ -1324,23 +1548,106 @@ try {
     ['a bound finer than this build\'s own rounding can write', 'probe', bent((p) => {
       p.manifest.params.hue.min = 1e-101;
     }), /declares min as 1e-101, which needs 100 decimal places/],
+    // **A binding aimed at an array, which passed the shape rule by being read without its
+    // dimension.** `uniform float probeWeights[4]` came back as `probeWeights` declared
+    // `float`, which is exactly what a plain binding asks for - and three.js takes its
+    // uploader off the declaration, so the array setter is handed one number. The write
+    // succeeds and the shader goes on reading whatever the array held.
+    ['a parameter bound to an array uniform', 'probe', bent((p) => {
+      p.chunks['decl.frag.glsl'] = 'uniform float probeAmount, probeHue;\nuniform float probeWeights[4];\n';
+      p.manifest.params.weights = {
+        def: 0, min: 0, max: 1, step: 0.01, kind: 'scalar', label: 'probe weights',
+        panel: { group: 'probe', tab: 'look' },
+        bind: { on: 'points', uniform: 'probeWeights' },
+        under: 'amount',
+      };
+    }), /no array kind/],
+    // **A package excusing itself from the rule that something has to write every uniform.**
+    // `hostDriven` is the one exception to it, and while the door took any name at all the
+    // exception was self-issued: nothing in this build writes `probeClock`, so the shader
+    // reads zero for the life of the page with no control anywhere that could move it.
+    ['a host-driven uniform this build\'s render loop does not write', 'probe', bent((p) => {
+      p.chunks['decl.frag.glsl'] = 'uniform float probeAmount, probeHue, probeClock;\n';
+      p.manifest.hostDriven = ['probeClock'];
+    }), /this build's render loop writes "rainPhase"/],
+    // **And the size of the manifest itself, which the three bounds above cannot see.** They
+    // count chunk text; this package repeats a correct *parameter* rather than a correct
+    // chunk. Two hundred of them is about 60KB of manifest arriving with the same two small
+    // files of GLSL, inside every rule in this door and inside the four megabytes the server
+    // takes as a body - and the store then writes it, hashes it on every read, and every open
+    // page builds a control per parameter out of it.
+    ['a manifest that is enormous and carries almost no GLSL', 'probe', bent((p) => {
+      for (let i = 0; i < 200; i++) {
+        p.manifest.params[`k${i}`] = {
+          def: 0, min: 0, max: 1, step: 0.01, kind: 'scalar', label: `probe knob number ${i}`,
+          panel: { group: 'probe', tab: 'look' },
+          bind: { on: 'points', uniform: 'probeHue' },
+          under: 'amount',
+        };
+      }
+    }), /carries a manifest of \d+ bytes/],
+    // **A `gates` the gate can never read, in both of the shapes that reach it.** `gates` is a
+    // promise about the *uniform* rather than a flag on the parameter: `gradeNeeded` in
+    // `web/main.js` walks the gating bindings, reads the cell each names and holds the grade
+    // pass open while any is not zero. So the promise is about nothing unless the binding lands
+    // a number on the table that walk reads.
+    //
+    // The first fixture binds on the point cloud, whose uniforms `gradeGatesOf` never collects,
+    // so the author has said their term holds the pass open and the pass has never heard of it.
+    // The second lands a `Vector2` - `axisDeg` writes a sine and a cosine, which is a direction
+    // and never the zero vector - and it is the one whose *symptom moved under an unrelated
+    // fix*: against `> 0` the pass stayed shut for the life of the page, and against the
+    // `!== 0` that predicate is now, an object is never strictly equal to zero, so the pass
+    // runs full-screen forever. Neither reading of the comparison is wrong, which is exactly
+    // why the pair is refused at the door rather than given a meaning in the page.
+    //
+    // `scanAxis` because it is a `vec2` some installed program declares, which is what gets
+    // this fixture past the uniform rule and down to the one it is named after; a package
+    // binding a neighbour's uniform is legal here and most of what ships does it.
+    ['a gating binding on a table the gate never reads', 'probe', bent((p) => {
+      p.manifest.params.hue.bind.gates = true;
+    }), /declares gates and binds on "points"/],
+    ['a gating binding whose value is a direction rather than an amount', 'probe', bent((p) => {
+      p.manifest.params.hue.bind = {
+        on: 'grade', uniform: 'scanAxis', transform: 'axisDeg', gates: true,
+      };
+      p.chunks['decl.frag.glsl'] = 'uniform float probeAmount;\n';
+    }), /declares gates beside the axisDeg transform/],
   ];
 
   let refusedCount = 0;
-  let wrongReason = null;
+  // **Every fixture that answered with the wrong rule, and this used to keep only the first.**
+  // The row makes one claim per hostile package - each is refused *by the rule it is named
+  // after* - so a row that can report one violation of N is a row that cannot say which of its
+  // claims failed. What that costs is not tidiness: a refusal added to the door can fire ahead
+  // of several existing fixtures at once, and with only the first reported the loop is see one,
+  // fix it, re-run, see the next. It happened here - a new bound on manifest size caught a
+  // thousand-descriptor fixture before it reached the repeat rule it is named after - and
+  // recovering the attribution cost a two-arm experiment that the list below would have
+  // answered outright.
+  const wrongReasons = [];
   let residue = null;
   for (const [what, id, body, matches] of hostile) {
     const answer = await put(id, body);
     if (answer.status === 409 && matches.test(answer.body.error ?? '')) refusedCount++;
-    // Truncated, because a door that accepted one of these answers with the whole package it
-    // just stored - and one of the fixtures here carries sixty files, so an un-cut detail
-    // line buries the row name that says which rule stopped firing under a wall of revisions.
-    else wrongReason ??= `${what}: ${answer.status} ${(answer.body.error ?? JSON.stringify(answer.body)).slice(0, 200)}`;
+    // Truncated per entry, because a door that accepted one of these answers with the whole
+    // package it just stored - and one of the fixtures here carries sixty files, so an un-cut
+    // detail line buries the row name that says which rule stopped firing under a wall of
+    // revisions. Cut harder now that several can be printed at once, since the useful part of
+    // a door's sentence is its opening clause and the row has to stay one line.
+    else wrongReasons.push(`${what}: ${answer.status} ${(answer.body.error ?? JSON.stringify(answer.body)).slice(0, 120)}`);
     const held = userRootHolds();
     if (held.length !== 0) residue ??= `${what} left ${held.join(', ')}`;
   }
+  // The count stays in the row's name rather than only in its detail, because it is what
+  // separates a tool that has gone stale from a build that has broken: a run naming 22 rules
+  // against a tree carrying 25 is a fixture list nobody updated, and that reading is available
+  // before anybody looks at which of them failed.
   ok(`every hostile package is refused with the sentence for its own rule - ${hostile.length} rules`,
-    refusedCount === hostile.length, wrongReason ?? `${refusedCount} of ${hostile.length}`);
+    refusedCount === hostile.length,
+    wrongReasons.length
+      ? `${wrongReasons.length} of ${hostile.length} answered with the wrong rule - ${wrongReasons.join(' | ')}`
+      : `${refusedCount} of ${hostile.length}`);
   ok('and none of them reaches the filesystem: no package, no .tmp, no .old left behind',
     residue === null, residue ?? `user root ${userRootHolds().join(', ') || 'empty'}`);
   // **Swept after the row that measures it, so a caught mutation cannot become a crash five
@@ -1765,6 +2072,21 @@ try {
   ok('and the signature with it, so nothing is left claiming to be assembled from a set it refused',
     afterFork.signature === beforeFork.signature,
     afterFork.signature === beforeFork.signature ? 'unchanged' : 'the page moved to the new set');
+  // **And the fork is still installed, which is the one thing in this rollback that is about
+  // the store rather than about this page.** Section 9 has the page ask the store to set a
+  // package aside when a program will not link, and this is the refusal that must never reach
+  // that route: what failed here is the completeness rule, which is a fact about the pairing
+  // of *this document* with that manifest and says nothing whatever about the package. A
+  // build that quarantined on it would rename somebody's authored fork out of the way because
+  // one clip on one machine could not be carried onto it - and the operator's next move,
+  // opening a document that does not name `probe.glow`, would have worked. The mark on the
+  // throw is what separates the two and `any-failure-is-quarantined` is the mutation that
+  // takes it away.
+  const forkStanding = await getJson('/effects/probe');
+  ok('and the fork is still installed, because a page that could not carry its document across has said nothing about the package',
+    forkStanding.status === 200 && forkStanding.body.builtin === false
+      && !userRootHolds().some((name) => /^probe\..+\.incompatible$/.test(name)),
+    `GET /effects/probe answered ${forkStanding.status}, user root holds ${userRootHolds().join(', ') || 'nothing'}`);
   ok('the parked pool is exactly what it was: the same values, the same track, the same entry',
     JSON.stringify(afterFork.pool) === JSON.stringify(beforeFork.pool),
     `${Object.keys(afterFork.pool.params).length} values, ${Object.keys(afterFork.pool.tracks).length} tracks`);
@@ -2455,6 +2777,10 @@ try {
   const broken = await put('probe', brokenProbe());
   ok('the server takes it: every name in it is one this build has, which is all the door can ask',
     broken.status === 200, `${broken.status}: ${broken.body.error ?? 'installed'}`);
+  // The store as it stands with the package in it, read before the page is asked to adopt it,
+  // because the quarantine below is a change to *this* and the only honest way to say a
+  // counter moved is to have read it on the other side of the thing that moves it.
+  const stored = await getJson('/effects');
 
   const refused = await page.evaluate(async () => {
     const k = globalThis.__kinect;
@@ -2481,6 +2807,63 @@ try {
     `${refused.names.length} parameters, the signature ${refused.signatureHeld ? 'held' : 'moved'}, `
     + `the broken line ${refused.shader ? 'reached the assembled program' : 'did not'}`);
 
+  // **And then the half of this that is not about this page at all.** Rolling back puts this
+  // browser right and leaves the package exactly where it was, so the next browser to open
+  // compiles it at boot - where `warmPrograms` runs outside any transaction and takes the
+  // module down with it, publishing no `__kinect` and leaving every tool in this suite
+  // reporting that it did not run. Nothing on the server can see that coming, because the
+  // door assembles and binds and is not a compiler: the only process in this program holding
+  // a GL context is the page that just failed, which is why quarantining is something the
+  // page does rather than something done to it. `setAsideUnlinkable` in `web/main.js` is the
+  // caller and `serveEffectRefusal` in `server/index.js` is the route.
+  //
+  // **Only a link failure may do this, which is the constraint the row in section 6 holds.**
+  // The same rollback catches a document this page could not carry across, and setting a
+  // package aside for one of those would rename authored work out of the way for a fault in a
+  // clip - so the throw carries a mark and the caller reads it. `any-failure-is-quarantined`
+  // is the mutation for that direction and it reddens there rather than here.
+  const afterRefusal = await getJson('/effects');
+  const asides = userRootHolds().filter((name) => /^probe\..+\.incompatible$/.test(name));
+  ok('the page has the store set the package aside, so the id stops answering with something that will not compile',
+    (afterRefusal.body.effects ?? []).every((e) => e.id !== 'probe')
+      && afterRefusal.body.generation === stored.body.generation + 1
+      && asides.length === 1,
+    `${(afterRefusal.body.effects ?? []).length} packages, generation ${stored.body.generation} -> `
+    + `${afterRefusal.body.generation}, user root holds ${userRootHolds().join(', ') || 'nothing'}`);
+  // Renamed and never deleted, for the reason the boot gate's aside is: a package that will
+  // not compile on this build is somebody's authored work and a fork is repairable. The files
+  // are counted rather than trusted, because a rename that dropped one would leave a
+  // directory nobody can move back and every reading above would still be green.
+  ok('and renamed rather than deleted, with every file it arrived with still in it',
+    asides.length === 1
+      && readdirSync(join(USER_ROOT, asides[0])).sort().join(', ') === 'decl.frag.glsl, manifest.json, tone.frag.glsl',
+    asides.length === 1
+      ? `${asides[0]} holds ${readdirSync(join(USER_ROOT, asides[0])).sort().join(', ')}`
+      : `${asides.length} asides in the user root`);
+  // **The row the two above exist for, and the one thing neither of them can say.** A store
+  // that answered perfectly would still be beside the point if the surface it feeds did not
+  // come up, and coming up is exactly what the quarantine is for: this is the fresh load that
+  // was dying, asked of a browser rather than of a route. Without it a build that called the
+  // route and achieved nothing would pass both rows above.
+  const freshPage = await browser.newPage({ viewport: { width: 800, height: 600 } });
+  const freshErrors = [];
+  freshPage.on('pageerror', (e) => freshErrors.push(String(e)));
+  await freshPage.goto(`${BASE}/record`, { waitUntil: 'load' }).catch(() => {});
+  const freshBooted = await freshPage.waitForFunction('Boolean(globalThis.__kinect)', null, { timeout: 20000 })
+    .then(() => freshPage.evaluate(() => !globalThis.__kinect.params.names().includes('probe.amount')))
+    .catch(() => null);
+  ok('and a page opened fresh on that store boots, which is what the package surviving the rollback used to stop',
+    freshBooted === true,
+    freshBooted === null
+      ? `no __kinect published: ${freshErrors[0]?.slice(0, 130) ?? 'nothing arrived on the page error channel'}`
+      : `__kinect published, probe.amount ${freshBooted ? 'absent from' : 'in'} the registry`);
+  await freshPage.close();
+
+  // And the page that discovered it, converging on the store it just changed. The delete this
+  // row used to open with has gone: the quarantine has already taken the live copy out of the
+  // user root, so there is nothing left to remove and `DELETE /effects/probe` answers 404 -
+  // which is the state being *left* rather than a failure, and is asked for here so a build
+  // that quarantined nothing cannot reach this row's green through the old route.
   const mended = await del('probe');
   const mendedPage = await page.evaluate(async () => {
     const k = globalThis.__kinect;
@@ -2488,9 +2871,13 @@ try {
     try { await k.effects.reload(); } catch (err) { threw = String(err.message); }
     return { threw, knows: k.params.names().includes('probe.amount') };
   });
-  ok('and taking the package back off restores the page, so a build that cannot compile is a state to leave rather than one to be stuck in',
-    mended.status === 200 && mendedPage.threw === null && mendedPage.knows === false,
-    mendedPage.threw ?? 'the page rebuilt without it');
+  ok('and the page rebuilds from what is left, so a build that cannot compile is a state to leave rather than one to be stuck in',
+    mended.status === 404 && mendedPage.threw === null && mendedPage.knows === false,
+    `DELETE answered ${mended.status}, ${mendedPage.threw ?? 'the page rebuilt without it'}`);
+  // The aside swept, so the sections below stage their fixtures into the user root this one
+  // found rather than into one carrying a leftover from section 9. The rows above are the
+  // proof that it was there; keeping it would be a coupling nothing states.
+  if (asides.length === 1) rmSync(join(USER_ROOT, asides[0]), { recursive: true, force: true });
 
   // ---- and a package that never went through the door at all
   //
@@ -3221,6 +3608,205 @@ try {
     afterShapeless.status === 200 && adoptedAfter === true,
     `${afterShapeless.status}: ${afterShapeless.body.error ?? 'installed'}, and the page `
     + `${adoptedAfter ? 'adopted it' : 'never adopted it'}`);
+
+  await browser.close();
+  browser = null;
+
+  // ============ 15. a fork that is correct about itself and wrong about the set
+  //
+  // **Section 12 asks whether the gate refuses a package this build cannot assemble. This
+  // asks the half that is not about the package at all.** The gate validated each candidate
+  // against the packages standing beside it and never re-asked those packages afterwards, so
+  // a shadow could be promoted and take one of them down: `doorRefusal` walks the
+  // *candidate's* chunks for names this build has not got, and `forkRefusal` catches a fork
+  // that dropped a parameter, and neither of them looks at a varying the fork stopped
+  // declaring.
+  //
+  // So the fixture is a `rain` fork with `vRain` gone and its own two references to it edited
+  // out. Nothing about the package is wrong - clean chunks, every parameter kept, the door
+  // answers null - and the builtin glyph goes on reading `vRain` out of its
+  // `index.frag.glsl` with nothing anywhere declaring it. The cloud program does not link,
+  // `web/main.js` throws while it is still evaluating, and no `__kinect` publishes.
+  //
+  // **`test/effect-store-gate.test.mjs` holds the same property under bare node and this is
+  // not that row twice.** That one reads directories; this one is the failure itself - a page
+  // that has to come up on the store the gate settled, which is the only reading that says
+  // the quarantine was for the right reason. And it is reached through the real server, with
+  // the real restart, on the tree this tool staged.
+  console.log('\n[effect] 15. a fork that is correct about itself and takes its neighbour down');
+
+  await stopAll();
+  for (const held of userRootHolds()) rmSync(join(USER_ROOT, held), { recursive: true, force: true });
+
+  // The healthy fork is `glyph` and it is the package the rain fork actually breaks, which
+  // makes it the one a gate with the attribution backwards would blame: it is the package
+  // whose chunk the door reports the missing name against. It has to be standing at the end.
+  const healthyGlyph = JSON.parse(readFileSync(join(BUILTIN_ROOT, 'glyph/manifest.json'), 'utf8'));
+  healthyGlyph.version = '2.0.0';
+  const glyphFork = join(USER_ROOT, 'glyph');
+  mkdirSync(glyphFork, { recursive: true });
+  writeFileSync(join(glyphFork, 'manifest.json'), `${JSON.stringify(healthyGlyph, null, 2)}\n`);
+  for (const c of healthyGlyph.chunks ?? []) {
+    writeFileSync(join(glyphFork, c.file), readFileSync(join(BUILTIN_ROOT, 'glyph', c.file), 'utf8'));
+  }
+
+  const strippedRain = JSON.parse(readFileSync(join(BUILTIN_ROOT, 'rain/manifest.json'), 'utf8'));
+  strippedRain.version = '2.0.0';
+  strippedRain.varyings = [];
+  const rainFork = join(USER_ROOT, 'rain');
+  mkdirSync(rainFork, { recursive: true });
+  writeFileSync(join(rainFork, 'manifest.json'), `${JSON.stringify(strippedRain, null, 2)}\n`);
+  for (const c of strippedRain.chunks ?? []) {
+    const shipped = readFileSync(join(BUILTIN_ROOT, 'rain', c.file), 'utf8');
+    writeFileSync(join(rainFork, c.file), c.file === 'cell.vert.glsl'
+      ? shipped.replace(/^.*\bvRain\b.*$/gm, '  // the varying this fork dropped')
+      : shipped.replace(/fract\(vRain\)/g, '0.5'));
+  }
+  writeFileSync(join(rainFork, 'witness.marker'), 'the author\'s own copy of a fork this build cannot keep\n');
+
+  ok('a fork with nothing wrong with it and a fork that drops a varying its neighbour reads are both staged',
+    existsSync(join(rainFork, 'manifest.json')) && existsSync(join(glyphFork, 'manifest.json'))
+      && !/vRain/.test(readFileSync(join(rainFork, 'cell.vert.glsl'), 'utf8')),
+    `user root holds ${userRootHolds().join(', ')}`);
+
+  await start();
+
+  const settledRain = await getJson('/effects/rain');
+  ok('the fork that broke its neighbour is the one set aside, and the id answers from the shipped package again',
+    settledRain.status === 200 && settledRain.body.builtin === true,
+    `answered ${settledRain.status}, builtin=${settledRain.body.builtin}, `
+    + `version ${JSON.stringify(settledRain.body.manifest?.version)}`);
+  // **The must-accept row, and it is the one the row above is silent about.** A gate that
+  // quarantined both would satisfy it: rain would answer from the builtin, and a page would
+  // come up.
+  const settledGlyph = await getJson('/effects/glyph');
+  ok('and the fork it broke is left exactly where it was, because the package that changed is the package that goes',
+    settledGlyph.status === 200 && settledGlyph.body.builtin === false
+      && settledGlyph.body.manifest?.version === '2.0.0',
+    `answered ${settledGlyph.status}, builtin=${settledGlyph.body.builtin}, `
+    + `version ${JSON.stringify(settledGlyph.body.manifest?.version)}`);
+  const rainAsides = userRootHolds().filter((n) => /^rain\..*\.incompatible$/.test(n));
+  ok('the fork is renamed aside rather than deleted, with the author\'s own file still in it',
+    rainAsides.length === 1 && existsSync(join(USER_ROOT, rainAsides[0], 'witness.marker')),
+    `user root holds ${userRootHolds().join(', ') || 'empty'}`);
+  ok('and the start said which package it could no longer assemble, rather than only which one it moved',
+    /effect rain was installed by an earlier build/.test(serverLog)
+      && /can no longer assemble glyph/.test(serverLog) && /vRain/.test(serverLog),
+    (serverLog.split('\n').find((l) => /^effect rain/.test(l))
+      ?? `nothing about rain in ${serverLog.length} bytes of server log`).slice(0, 170));
+
+  // **The row the four above exist for**, on the same argument section 12 makes: everything
+  // so far is HTTP against a store, and the failure this gate is about is the assembler
+  // throwing while `web/main.js` is still evaluating. A store that answered perfectly and a
+  // page that never published `__kinect` is the build this whole surface is arranged to
+  // prevent.
+  browser = await chromium.launch();
+  const settledPage = await browser.newPage({ viewport: { width: 800, height: 600 } });
+  const settledErrors = [];
+  settledPage.on('pageerror', (e) => settledErrors.push(String(e)));
+  await settledPage.goto(`${BASE}/record`, { waitUntil: 'load' }).catch(() => {});
+  const settledBoot = await settledPage.waitForFunction('Boolean(globalThis.__kinect)', null, { timeout: 20000 })
+    .then(() => settledPage.evaluate(() => globalThis.__kinect.params.names().includes('rain.speed')))
+    .catch(() => null);
+  ok('and a page opened on the store the gate settled boots, which is the failure the whole pass is about',
+    settledBoot === true,
+    settledBoot === null
+      ? `no __kinect published: ${settledErrors[0]?.slice(0, 130) ?? 'nothing arrived on the page error channel'}`
+      : `__kinect published, rain.speed ${settledBoot ? 'in' : 'missing from'} the registry`);
+
+  // ============ 16. the route a page uses to say what it could not compile
+  //
+  // **This build has no GLSL compiler and the door is not one.** A package whose chunks name
+  // only identifiers this build has can still be GLSL that will not link - a missing brace, a
+  // `vec3` assigned to a `float` - and what that produces is a log line inside the driver.
+  // So the only thing in this program that ever learns a package cannot be compiled is a page
+  // that tried, and `POST /effect-refusals` is where it says so. Section 9 is the page half of
+  // this; these rows are the route's own contract, driven over HTTP, because a route that is
+  // only ever exercised through its one caller is a route whose skipped and refused answers
+  // nobody has read.
+  console.log('\n[effect] 16. the route a page uses to say a package would not compile');
+
+  const beforeRefuse = await getJson('/effects');
+  const quarantined = await fetch(`${BASE}/effect-refusals`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids: ['glyph', 'thermal', 'nosuchpackage'], reason: 'link failed:\n  not a compiler' }),
+  }).then(async (r) => ({ status: r.status, body: await r.json() }));
+  ok('a page naming a package it could not compile has the user copy set aside, and the id answers from the builtin again',
+    quarantined.status === 200 && quarantined.body.setAside?.join(',') === 'glyph'
+      && (await getJson('/effects/glyph')).body.builtin === true,
+    `${quarantined.status}: set aside ${JSON.stringify(quarantined.body.setAside)}`);
+  // **An id with no user copy is skipped rather than quarantined, per id.** A page that failed to
+  // link has the ids it was assembling from and no reason to know which root each came out
+  // of, so a 4xx over the builtin in the list would leave it unable to tell which of the
+  // three went through. `setAside` renames inside the user root and nothing else, so a
+  // builtin is not a rule written into the route - it is the one thing the rename cannot
+  // reach.
+  ok('and a builtin and a name that is nowhere are each skipped with a reason rather than refusing the whole call',
+    quarantined.body.skipped?.length === 2
+      && quarantined.body.skipped.every((s) => /no copy of it in the user root/.test(s.why))
+      && quarantined.body.skipped.map((s) => s.id).sort().join(',') === 'nosuchpackage,thermal',
+    `skipped ${JSON.stringify(quarantined.body.skipped?.map((s) => s.id))}`);
+  const afterRefuse = await getJson('/effects');
+  ok('the store counts it as a change of its own, because what every open page is holding a listing of has moved',
+    afterRefuse.body.generation === beforeRefuse.body.generation + 1,
+    `generation ${beforeRefuse.body.generation} -> ${afterRefuse.body.generation}`);
+  ok('and the shipped set is all still there, so a route that renames one directory renamed one directory',
+    afterRefuse.body.effects?.length === beforeRefuse.body.effects.length
+      && (afterRefuse.body.effects ?? []).every((e) => e.builtin),
+    `${afterRefuse.body.effects?.length ?? 'no'} packages, `
+    + `${(afterRefuse.body.effects ?? []).filter((e) => !e.builtin).length} of them from the user root`);
+  // The reason is a page's own sentence off the network, so it is cut and flattened before it
+  // reaches a log line - a driver's link log is whatever the driver felt like emitting, and a
+  // newline in it is a forged line in somebody's terminal.
+  ok('the page\'s reason reaches the log as one line rather than as whatever a driver emitted',
+    /a page that adopted it reports that it does not compile: link failed: not a compiler/.test(serverLog),
+    (serverLog.split('\n').find((l) => /does not compile/.test(l)) ?? 'nothing in the log about it').slice(0, 150));
+
+  const noList = await fetch(`${BASE}/effect-refusals`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ reason: 'x' }),
+  }).then(async (r) => ({ status: r.status, body: await r.json() }));
+  const tooMany = await fetch(`${BASE}/effect-refusals`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids: new Array(afterRefuse.body.effects.length + 1).fill('glyph') }),
+  }).then(async (r) => ({ status: r.status, body: await r.json() }));
+  ok('a body with no list and a list longer than the store has packages are both refused by name',
+    noList.status === 400 && tooMany.status === 400 && /not about this store/.test(tooMany.body.error ?? ''),
+    `${noList.status} and ${tooMany.status}: ${(tooMany.body.error ?? '').slice(0, 80)}`);
+  // **The route is a `write`, so it stands behind the same gate every other consequence does**,
+  // and a GET has to say what it takes rather than report itself as something that is not there.
+  const getRefuse = await fetch(`${BASE}/effect-refusals`);
+  const getRefuseSaid = (await getRefuse.json()).error ?? '';
+  const putRefuse = await fetch(`${BASE}/effect-refusals`, {
+    method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(probePackage()),
+  });
+  ok('the namespace answers for itself: a GET says what it takes, and a PUT does not install a package into it',
+    getRefuse.status === 405 && /takes POST/.test(getRefuseSaid)
+      && putRefuse.status === 405 && !userRootHolds().includes('effect-refusals'),
+    `GET ${getRefuse.status} "${getRefuseSaid.slice(0, 70)}", PUT ${putRefuse.status}, `
+    + `user root holds ${userRootHolds().join(', ') || 'nothing'}`);
+  // **And the id this route used to steal is an id like any other, which is the row the move
+  // out of `/effects/` exists for.** The route was `POST /effects/refuse` first, and the table
+  // is walked in order, so that literal outranked the `:id` entry beside it: a package
+  // genuinely called `refuse` was listed by `GET /effects` and then answered 405 when a page
+  // fetched it - `readEffectPackages` throwing, no `__kinect`, both surfaces dark - and it
+  // could not be uninstalled either, because the `DELETE` was 405 too. That is not the shape
+  // `/jobs/claim` gets away with beside `/jobs/:id`: a job id is minted by the queue and nobody
+  // can make a job called `claim`, while an effect id is a directory name and `mkdir` is the
+  // whole of what it takes. Reserving the word at the door was the first repair and it is the
+  // guard rather than the fix, so this asks the question the guard is about: install the
+  // package, read it back, see it listed, take it away again.
+  const asRefuse = await put('refuse', bent((p) => { p.manifest.id = 'refuse'; }));
+  const readRefuse = await getJson('/effects/refuse');
+  const listsRefuse = ((await getJson('/effects')).body.effects ?? []).some((e) => e.id === 'refuse');
+  const dropRefuse = await del('refuse');
+  ok('and a package genuinely called refuse installs, serves, lists and uninstalls, because nothing under /effects/ is claimed',
+    asRefuse.status === 200 && readRefuse.status === 200 && readRefuse.body.manifest?.id === 'refuse'
+      && listsRefuse === true && dropRefuse.status === 200 && !userRootHolds().includes('refuse'),
+    `PUT ${asRefuse.status}, GET ${readRefuse.status} for id ${JSON.stringify(readRefuse.body.manifest?.id)}, `
+    + `${listsRefuse ? 'listed' : 'not listed'}, DELETE ${dropRefuse.status}, `
+    + `user root holds ${userRootHolds().join(', ') || 'nothing'}`);
 
   await browser.close();
   browser = null;

--- a/tools/keyframe-check.mjs
+++ b/tools/keyframe-check.mjs
@@ -227,18 +227,8 @@ const MUTATIONS = {
   // slider mutates `retime.rate` outside the transport's exclusive queue, so a
   // committed step 4 could hit it too - it is only far harder to reach without a
   // drag rewriting the curve on every pointer move.
-  'seek-plans-once': { file: 'web/main.js', edits: [[
-    `    let planned = this.planSeek(programSec, options.frames);
-    for (let attempt = 0; !this.source.resident(planned.from, planned.to); attempt++) {
-      if (attempt >= SEEK_REPLANS) {
-        // Overtaken, not broken. The hand that moved the curve has already queued a
-        // repaint, so this operation is stale before it finishes and the useful
-        // thing to do is stand down quietly rather than shout - a drag rewrites the
-        // curve on every pointer move, and an error per move is an instrument
-        // crying wolf at its own user. Asking for a repaint here is what makes the
-        // quiet safe: it guarantees a successor, so standing down costs a frame
-        // rather than leaving a stale image nobody could attribute to anything.
-        this.overtaken++;
+  'seek-plans-once': { file: 'web/main.js', edits: [
+    [`        this.overtaken++;
         if (this.overtaken > SEEK_OVERTAKEN_LIMIT) {
           this.overtaken = 0;
           throw new Error(
@@ -251,10 +241,16 @@ const MUTATIONS = {
       }
       await this.source.ensure(planned.from, planned.to);
       planned = this.planSeek(programSec, options.frames);
-    }`,
+    }
+`, ''],
+    [`    let planned = this.planSeek(programSec, options.frames);
+    for (let attempt = 0; !this.source.resident(planned.from, planned.to); attempt++) {
+      if (attempt >= SEEK_REPLANS) {
+`,
     `    const planned = this.planSeek(programSec, options.frames);
-    await this.source.ensure(planned.from, planned.to);`,
-  ]] },
+    await this.source.ensure(planned.from, planned.to);
+`],
+  ] },
   // The pre-roll goes back to reading the uniforms, which hold the look at wherever
   // the playhead was parked rather than the look at the target.
   // The surface half alone. It used to carry the trails half too, which made it two

--- a/tools/keyframe-check.mjs
+++ b/tools/keyframe-check.mjs
@@ -1815,11 +1815,12 @@ console.log('\n== 3b. a seek that jumps from a cheap look to an expensive one ==
 console.log('\n== 3c. a pre-roll whose window is dearer than its target ==');
 {
   await setRetime(FLAT);
-  await applyLook(BLACKWALL_LOOK);
+  await applyLook(RGB_LOOK);
   // Fade and wake at zero and unkeyed, so the surface half computes 0 and cannot
   // mask the trails half by being the larger of the two.
   await page.evaluate(`globalThis.__kinect.params.apply(${src({ fade: 0, wake: 0 })})`);
-  await setTracks({ trails: [{ t: 0, value: 0.95 }, { t: 7.8, value: 0.95 }, { t: 8.0, value: 0.5 }] });
+  const dampTrack = [{ t: 0, value: 0.95 }, { t: 7.8, value: 0.95 }, { t: 8.0, value: 0.5 }];
+  await setTracks({ trails: dampTrack });
   await settle();
 
   const TARGET = 8.0;
@@ -1841,7 +1842,7 @@ console.log('\n== 3c. a pre-roll whose window is dearer than its target ==');
   let needed = 0;
   for (let n = 1; n <= 400; n += 1) {
     product *= scalarAt(
-      [{ t: 0, value: 0.95 }, { t: 7.8, value: 0.95 }, { t: 8.0, value: 0.5 }],
+      dampTrack,
       TARGET - (n - 1) / seen.fps,
     );
     needed = n;
@@ -1900,7 +1901,7 @@ console.log('\n== 4. program time maps to source time through the curve ==');
 
     const wantSource = probes.map((p) => retimeAt(curve, p));
     const sourceErr = worst(read.source.map((v, i) => Math.abs(v - wantSource[i])));
-    const wantBracket = wantSource.map((s) => bracketOf(s));
+    const wantBracket = read.source.map((s) => bracketOf(s));
     const bracketBad = read.bracket.filter((b, i) => b !== wantBracket[i]).length;
     // The program length is the point at which the curve first reaches the end of
     // the take, computed here from the tool's own curve by bisection.

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -577,9 +577,9 @@ const MUTATIONS = {
     edits: [
       ["  { path: '/sensor/health', pattern: /^\\/sensor\\/health$/, read: serveSensorHealth },\n", ''],
       [
-        '  // The table first, the file tree second. `serveRoute` answers false only for a',
-        '  if (urlPath === \'/sensor/health\') { serveSensorHealth(req, res); return; }\n\n'
-        + '  // The table first, the file tree second. `serveRoute` answers false only for a',
+        '  let handledByTable = true;',
+        '  if (urlPath === \'/sensor/health\') { serveSensorHealth(req, res); return; }\n'
+        + '  let handledByTable = true;',
       ],
     ],
   },
@@ -1130,11 +1130,8 @@ const MUTATIONS = {
   // drain that finally runs is quadratic in it. The stall is synchronous, so the
   // grabber sees backpressure and drops depth packets at the device.
   'settle-drains-on-poll-only': { file: 'server/recorder.js', edits: [[
-    `    // Drained on the frame path rather than only when something asks for state, and
-    // that placement is what makes the queue bounded by the ceiling below instead of
-    // by the length of the take. \`settle\` carries the measurement and the mechanism.
-    settle(take);`,
-    '    /* mutation: the queue is drained only when something asks for state */',
+    '\n    settle(take);\n',
+    '\n    /* mutation: the queue is drained only when something asks for state */\n',
   ]] },
   // The head advances and the array is never compacted, which leaves the depth
   // correct and the allocation growing with the take - and puts every operation over
@@ -1150,9 +1147,8 @@ const MUTATIONS = {
   // carrying it is the panel's five-second poll - and after the queue drains on
   // every write, no monitor has to be open for the drop to happen at all.
   'drop-transition-silent': { file: 'server/recorder.js', edits: [[
-    `        // stays green costs the take.
-        this.onChange(this.state);`,
-    '        /* mutation: the drop is left to the five-second poll */',
+    '        this.onChange(this.state);\n      }\n      return;',
+    '        /* mutation: the drop is left to the five-second poll */\n      }\n      return;',
   ]] },
   // The push moves out from behind the transition flag and fires per dropped frame,
   // which is a socket write in the frame path on the one machine that cannot afford
@@ -1622,8 +1618,8 @@ const MUTATIONS = {
   // the identity test it copies appears verbatim in the spawn-`error` handler thirty
   // lines up and a bare anchor would match twice.
   'exit-keeps-the-child-reference': { file: 'server/index.js', edits: [[
-    '      // restart branch returns before the rest of the handler runs.\n      if (child === proc) child = null;',
-    '      // restart branch returns before the rest of the handler runs.',
+    '      if (child === proc) child = null;\n      // The hello goes with',
+    '      // The hello goes with',
   ]] },
 
   // ---- a shipped look and the definition it is written against

--- a/tools/monitor-check.mjs
+++ b/tools/monitor-check.mjs
@@ -354,6 +354,62 @@ const waitFor = async (cond, ms, what = 'condition') => {
   throw new Error(`timed out after ${ms}ms waiting for ${what}`);
 };
 
+/**
+ * Waits until the page has published what the section about to run reaches through,
+ * and throws naming what never arrived.
+ *
+ * **`waitUntil: 'load'` stopped meaning the page is up when the effect packages moved
+ * onto the wire.** Boot fetches every one of them over HTTP behind the module's own
+ * top-level await, so `globalThis.__kinect` publishes tens of milliseconds *after* the
+ * event `goto` resolves on - measured at 366ms to `load` against 398ms to the handle,
+ * on loopback with a warm page cache. Every driver reaching straight through that
+ * handle on the line after a `goto` is racing that gap, and the race does not arrive
+ * looking like one: a predicate raising `TypeError: Cannot read properties of
+ * undefined` inside `waitFor` is not caught by it, so the seconds the wait was given
+ * are never spent and the row reddens in the same second the heading above it printed.
+ *
+ * So every clause a caller hands this is written to be **false** on a page that has not
+ * booted rather than to throw on one, and `Boolean` is what reads `?.`'s `undefined` as
+ * false. `docs/instruments.md` carries the other half of that rule, which cost two
+ * tools a section each: a guard written with `?.` and compared against `null` is not a
+ * guard, because `undefined !== null` is true before anything exists - the wait then
+ * resolves on its first tick having proved nothing, and the timeout is a comment.
+ *
+ * **A caller asks for what its own section reaches rather than for the earliest thing
+ * that happens to be there.** `__kinect` existing says the module finished evaluating;
+ * it does not say the socket has connected or that a frame has landed, and a probe
+ * whose answer cannot differ from the next probe's is not a probe.
+ *
+ * The two sections whose subject is decimation let the throw out, and that is the
+ * honest verdict rather than a shortcut: the catch at the bottom of this file records
+ * a run that threw as `DID NOT RUN` and nothing in it as a finding, which is what
+ * stops a `--mutate` run reading a viewer that never came up as the mutation being
+ * caught. The colour section catches it and puts it on a row instead, because it is
+ * the one place where "the page never booted" and "colour never arrived" are two
+ * different findings and something can tell them apart.
+ *
+ * **What it waited out is printed rather than left to be assumed**, because the
+ * failure this closes is invisible on the machine that closes it: on an idle Mac the
+ * gap is a few hundred milliseconds and the sleep this replaced covered it by luck,
+ * so a run that says nothing cannot be told from one where the wait does nothing. The
+ * number is the evidence, and it is the same number that says how much headroom a
+ * slower machine has left. Not an assertion, because there is no threshold here worth
+ * gating on: a page is up when it is up.
+ */
+const published = async (page, reaches, what, ms = 20000) => {
+  const began = Date.now();
+  await waitFor(
+    // Caught rather than let out: an evaluate landing while the page is still navigating
+    // rejects with a destroyed execution context, which is a page that is not up yet
+    // rather than an answer about one, and letting it past the predicate would end the
+    // run with the timeout unspent for the second reason rather than the first.
+    () => page.evaluate(`Boolean(${reaches})`).catch(() => false),
+    ms,
+    what,
+  );
+  console.log(`  ....  waited ${Date.now() - began}ms after load for ${what}`);
+};
+
 // The full chromium build rather than the bundled headless shell, for `export-check`'s
 // reason: the shell has no GPU and falls back to SwiftShader, and a renderer nothing
 // else in this repo reproduces is not the renderer the claim is about.
@@ -764,7 +820,18 @@ try {
       const pageErrors = [];
       page.on('pageerror', (e) => pageErrors.push(e.message));
       await page.goto(RECORDER_URL, { waitUntil: 'load' });
-      await wait(1200);
+      // The door and the texture every row below reads back through, rather than the
+      // handle they hang off: what this section does is inject a block and read
+      // `depthCurr` for where its samples landed, so the probe goes on the two objects
+      // whose absence would be the reason it could not. Nothing waits out a duration
+      // beside it, because this server was started with no grabber at all - nothing
+      // arrives on its own, and an injected block is the only thing that ever touches
+      // these textures. A timeout here is a page that never booted rather than a frame
+      // that landed in the wrong place, which is why it is left to throw.
+      await published(page,
+        'typeof globalThis.__kinect?.drive?.injectDepth === "function"'
+        + ' && Boolean(globalThis.__kinect?.uniforms?.depthCurr?.value?.image?.data)',
+        'the viewer to publish the depth door and the texture it writes into');
 
       // Values are generated inside the page from an index, and the expectation is
       // computed from the same index by the reader rather than from anything the door
@@ -930,7 +997,23 @@ try {
       await start([...streamer(), '--captures', join(WORK, 'caps-5b'), '--name', 'renderlive',
         '--projects', join(WORK, 'p5b'), '--presets', join(WORK, 'q5b')]);
       await page.goto(RECORDER_URL, { waitUntil: 'load' });
-      await wait(2000);
+      // **Two clauses, and the second is the one a boot probe would miss.** `setDivisor`
+      // below drives the real control, and `sendMonitor` in `web/main.js` returns
+      // silently unless the socket is OPEN - so a page whose handle has published but
+      // whose socket has not connected takes the drag, sends nothing, and turns the ÷4
+      // arm into a second ÷1 arm read under a ÷4 label, which is the misattribution the
+      // whole negotiation exists to avoid. A depth texel that is no longer zero settles
+      // both halves at once: `web/gpu-textures.js` builds both depth textures zero-filled
+      // deliberately, so that every point leaves at the empty-sample test until a real
+      // frame binds, and on a page nobody has injected into the only thing that writes
+      // one is a frame off that socket. So the wait ends when the stream this section
+      // measures is actually running, rather than when a clock says it probably is, and
+      // a timeout is a stream that never started rather than a divisor that was not
+      // applied - which is why it is left to throw.
+      await published(page,
+        'typeof globalThis.__kinect?.drive?.injectDepth === "function"'
+        + ' && Boolean(globalThis.__kinect?.uniforms?.depthCurr?.value?.image?.data?.some((v) => v !== 0))',
+        'the live socket to land a depth frame in the viewer');
 
       const setDivisor = (d) => page.evaluate(`(${`(d) => {
         const el = document.getElementById('monDivisor');
@@ -1081,30 +1164,40 @@ try {
       // and has to say so. A fixed wait here would turn "no colour ever decoded" into a
       // silent pass on the row that matters most.
       //
-      // **It reads through a published `__kinect` rather than off one, and that is the
-      // difference between a wait and a throw.** `load` stopped meaning the page is up
-      // when the effect packages moved onto the wire: boot now fetches them over HTTP, so
-      // `__kinect` publishes tens of milliseconds *after* the event `goto` waits for -
-      // measured at 366ms to `load` against 398ms to the handle. Reaching straight through
-      // the handle raises a TypeError inside the predicate, `waitFor` does not catch one,
-      // and the twenty seconds are never spent: the row reddened in the same second it was
+      // **Boot is waited for apart from colour, and that is the difference between a wait
+      // and a throw.** `published` above carries why `load` no longer means the page is
+      // up; what is particular here is that reaching for the value before the object
+      // exists raises a TypeError inside the predicate, `waitFor` does not catch one, and
+      // the twenty seconds are never spent - the row reddened in the same second it was
       // printed, saying no colour ever bound about a build whose colour binds in 451ms.
-      // The two sections above survive on a fixed `wait()` after their own `goto`, which is
-      // the silent-pass shape this comment already refuses, so the guard belongs here rather
-      // than a third sleep. `-1` for an unpublished handle keeps the timeout reachable, and
-      // the two states are reported apart below because "the page never booted" and "colour
-      // never arrived" are different findings.
+      // The two sections above come through the same helper rather than a sleep each,
+      // which is the reason it is a helper at all: three copies of a readiness rule drift,
+      // and the copy that drifts is the one nobody re-reads.
+      //
+      // It is caught rather than let out here alone, because this is the one section that
+      // can tell the two states apart and they are different findings: everything below
+      // measures a toggle, so a page that never booted has to say so rather than be
+      // reported as a colour that never arrived. `-1` from the read below keeps the same
+      // distinction available after the colour wait, for a page that booted and then died
+      // inside it.
+      let up = true;
+      try {
+        await published(page, 'globalThis.__kinect?.uniforms?.hasColor',
+          'the viewer to publish the colour uniform the toggle is measured against');
+      } catch { up = false; }
       const hasColor = () => page.evaluate('globalThis.__kinect ? globalThis.__kinect.uniforms.hasColor.value : -1');
       let bound = false;
-      try {
-        await waitFor(async () => (await hasColor()) === 1, 20000, 'a colour frame to decode and bind');
-        bound = true;
-      } catch { /* the row below is the report, and the rows after it are skipped */ }
+      if (up) {
+        try {
+          await waitFor(async () => (await hasColor()) === 1, 20000, 'a colour frame to decode and bind');
+          bound = true;
+        } catch { /* the row below is the report, and the rows after it are skipped */ }
+      }
       // Short-circuited and caught, because this read runs on the path where the wait has
       // already failed: a page that died during those twenty seconds would throw here and
       // turn a red row into a crash with the count still short, which is the shape that
       // reads as a catch to anything checking exit codes.
-      const booted = bound || (await hasColor().catch(() => -1)) !== -1;
+      const booted = up && (bound || (await hasColor().catch(() => -1)) !== -1);
       ok('a colour-on grabber paints the cloud with a real decoded JPEG, which is what the toggle is measured against',
         bound, bound ? '' : (booted
           ? 'hasColor never reached 1, so no colour ever bound and nothing below would have measured the toggle'

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -790,6 +790,26 @@ const MUTATIONS = {
       + 'stay green, correctly - they run with the ripple and the push at zero, where this '
       + 'mutation is the shipped arithmetic',
   },
+  // **The tone key read off the point instead of the cell, which is the line that shipped.**
+  // It is the whole of the old expression, clamp and weights and all, so a build under this
+  // mutation is the build the repo drew with before the fix rather than an invented defect.
+  //
+  // Nothing that renders a flat wall can see it, and that is the point rather than a caveat:
+  // with one depth behind every cell each occupant reads the same colour and chooses the same
+  // character, so every glyph arm in this file except the heterogeneous one stays green. It
+  // takes a cell whose occupants disagree, and then the cell paints the union of the
+  // characters they each chose.
+  'glyph-tone-per-point': {
+    file: 'effects-builtin/glyph/index.frag.glsl',
+    edits: [[
+      '    float cellTone = 1.0 - vCellT;',
+      '    float cellTone = clamp(dot(col, vec3(0.299, 0.587, 0.114)), 0.0, 1.0);',
+    ]],
+    fails: 'the thinning row of the heterogeneous section, alone. All three of its guards stay '
+      + 'green - the occupants still land in one cell, they still paint many colours as '
+      + 'splats, and the mask still moves when the key does - which is what says this is the '
+      + 'character following the point rather than the fixture collapsing',
+  },
   // The three keys mixed rather than summed, which draws a completely plausible wrong
   // character in every cell. Nothing asking whether the frame changed can tell the two
   // apart, and the discriminator the design document proposes cannot either: at two keys
@@ -803,13 +823,38 @@ const MUTATIONS = {
   'glyph-index-averages': {
     file: 'effects-builtin/glyph/index.frag.glsl',
     edits: [[
-      '    float f = fract(glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
-      '    float f = (glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep) '
+      '    float f = fract(glyphTone * cellTone * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
+      '    float f = (glyphTone * cellTone * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep) '
         + '/ max(1e-4, glyphTone + glyphHash + glyphRain);',
     ]],
-    fails: 'the row that says doubling two keys renders a different frame, alone - the guard '
-      + 'and the solo-key control beside it stay green, because a mix still draws characters '
-      + 'and still draws different ones for each key',
+    fails: 'two rows: the one that says doubling two keys renders a different frame, and the '
+      + 'fitted index row beneath it, where a normalising mix with the other two keys down '
+      + 'draws one character at every tone and the painted count sits at 20104px across the '
+      + 'whole sweep. The guard and the solo-key control stay green, because a mix still draws '
+      + 'characters and still draws different ones for each key',
+  },
+  // **A composition that is scale-sensitive and monotone out of the sparse end and is still
+  // not a sum**, which is the shape the section's own comment used to name as the thing
+  // nothing here could refuse. Squaring the argument leaves the doubling row green - four
+  // times a number is not the same number - and leaves the hash sweep climbing, because the
+  // square of a rising quantity rises. It draws a different character in every cell.
+  //
+  // What refuses it is the fitted row: the ink a cell paints is read back out of the
+  // framebuffer and held against the popcount of the character a wrapped sum names, and a
+  // square lands its indices somewhere else in a table sorted by ink. Measured, the worst
+  // arm of the sweep comes back 41.2% off the fit where the clean run's worst is 3.1%.
+  'glyph-index-squares': {
+    file: 'effects-builtin/glyph/index.frag.glsl',
+    edits: [[
+      '    float f = fract(glyphTone * cellTone * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
+      '    float s = glyphTone * cellTone * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep;\n'
+        + '    float f = fract(s * s);',
+    ]],
+    fails: 'the fitted index row of the index section, alone. Its guard stays green - the '
+      + 'cloud is still unrotated and the predicted sweep still walks the table - and so do '
+      + 'the doubling row and the hash sweep above it, which is the whole reason this control '
+      + 'exists: a square is scale-sensitive and it is monotone, so every row that stood here '
+      + 'before this one passes it',
   },
   // The tonal key promoted to the zero it defaults to, so a cell's character stops knowing
   // how bright the cell is. The drop-one sweep sees this the plain way. The row it exists
@@ -820,12 +865,15 @@ const MUTATIONS = {
   'glyph-tone-ignored': {
     file: 'effects-builtin/glyph/index.frag.glsl',
     edits: [[
-      '    float f = fract(glyphTone * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
-      '    float f = fract(0.0 * lum * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
+      '    float f = fract(glyphTone * cellTone * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
+      '    float f = fract(0.0 * cellTone * (63.0 / 64.0) + glyphHash * vCellSeed + glyphRain * rainStep);',
     ]],
-    fails: 'three rows: glyph.tone unexplained in the drop-one sweep, the count at 85 of 89, '
-      + 'and the ink ramp\'s strict row at 1.55% to 1.55%. The non-decreasing row above it '
-      + 'stays green and that is why the strict one exists - four equal readings satisfy '
+    fails: 'four rows: glyph.tone unexplained in the drop-one sweep, the count beneath it one '
+      + 'lower than the clean run\'s, the ink ramp\'s strict row at 1.55% to 1.55%, and the '
+      + 'fitted index row, where every arm of the sweep draws index 0 and paints the same '
+      + '2852px. The count is quoted as a delta rather than as a figure because the clean run '
+      + 'moves with the parameter table. The non-decreasing row above the strict one stays '
+      + 'green and that is why the strict one exists - four equal readings satisfy '
       + '"non-decreasing" perfectly. Both source rows stay green too, correctly: this '
       + 'mutation does not touch the table',
   },
@@ -913,10 +961,13 @@ const MUTATIONS = {
     ]],
     fails: 'four rows, on a tree that is otherwise green. **Two carry the claim** and they '
       + 'are the two halves of it: the in-band '
-      + 'cell coming back a hard bit at one colour, and the cut-away cell doing the same - '
-      + 'vSize is taken before the halving as well as in the wrong unit, so this mutation is '
-      + 'wrong about both. The hard-bit reference row above them stays green, which is what '
-      + 'says the statistic still reads a one where it should. **Two are the two-surface '
+      + 'cell coming back a hard bit at one colour, and the cut-away pair parting company - '
+      + 'vSize is the un-halved reference size and carries no crop state at all, so a cut-away '
+      + 'cell measures 72 reference pixels, sits well above the band, and draws the characters '
+      + 'the crop asked it not to. That second half used to read as a colour count and reads as '
+      + 'the keys reaching a pixel inside the crop now, which is the same mutation caught by a '
+      + 'row a blend cannot satisfy. The hard-bit reference row above them stays green, which '
+      + 'is what says the statistic still reads a one where it should. **Two are the two-surface '
       + 'section losing its fixture**, both guards: that section wants a far surface under '
       + 'the band drawing splats, and the reference reading puts it above at 30 pixels, so '
       + 'the far surface inks 1.71% of the frame instead of 41.42% and the at-risk '
@@ -942,8 +993,8 @@ const MUTATIONS = {
   'crossfade-ignores-the-buffer-scale': {
     file: 'web/cloud-shader.js',
     edits: [[
-      '  vLegiblePx = gl_PointSize / max(k, 1.0);',
-      '  vLegiblePx = gl_PointSize;',
+      '  vLegiblePx = outsideCrop ? 0.0 : gl_PointSize / max(k, 1.0);',
+      '  vLegiblePx = outsideCrop ? 0.0 : gl_PointSize;',
     ]],
     fails: 'the claim row of the above-1080 section, alone: the two key settings parting '
       + 'company at a cell the look asked to draw as a splat. Its guard row stays green - the '
@@ -953,21 +1004,29 @@ const MUTATIONS = {
       + 'is the coverage statement rather than luck: every other arm here renders at a third '
       + 'of the reference height, where the divisor this deletes is 1',
   },
-  // The same reading taken one line too early, which is the half of it the crop owns. The
-  // size is right and the unit is right; what is missing is the cut-away halving, so a
-  // point drawn at half its pixels is crossfaded as though it still had all of them.
-  // Written at the assignment rather than by moving it, so the anchor is one line and the
-  // arithmetic is exactly the pre-halving value.
-  'crossfade-before-the-halving': {
+  // **The crop left to the size crossfade to handle, which is the build that shipped and is
+  // what this replaces `crossfade-before-the-halving` with.** That control planted the
+  // reading one line too early, so a cut-away point was crossfaded as though the halving had
+  // not happened - a distinction that had a subject only while a halved sprite was still
+  // being asked whether it was legible. It is not, now: a cut-away point reports no legible
+  // pixels at all, so the halving cannot reach the crossfade by any route and a mutation
+  // about where the reading is taken relative to it has nothing left to move.
+  //
+  // The defect worth a control is the older one underneath it. Halving a 64-pixel sprite
+  // leaves 32, which is above the band's top, so cut-away geometry went on drawing
+  // characters - smaller ones - where the halving's own paragraph in web/cloud-shader.js
+  // promises dust. This mutation is that build exactly: the reading with the crop taken out
+  // of it and nothing else touched.
+  'crop-still-draws-characters': {
     file: 'web/cloud-shader.js',
     edits: [[
+      '  vLegiblePx = outsideCrop ? 0.0 : gl_PointSize / max(k, 1.0);',
       '  vLegiblePx = gl_PointSize / max(k, 1.0);',
-      '  vLegiblePx = (outsideCrop ? gl_PointSize * 2.0 : gl_PointSize) / max(k, 1.0);',
     ]],
-    fails: 'the cut-away row of the unit section, alone. The in-band row beside it stays '
-      + 'green, because nothing there is cropped and the two expressions are the same '
-      + 'number - which is the split that says the crop half is its own claim rather than a '
-      + 'second reading of the unit',
+    fails: 'the cut-away row of the unit section, alone: the three keys parting company on a '
+      + 'frame every point of which the crop has cut away. Its guard stays green, because the '
+      + 'cut-away wall still paints, and so does the uncropped control beside it - that arm is '
+      + 'inside no crop, so this mutation is the shipped expression there',
   },
   // **The rain key's counter used raw, which is inert at exactly the weight where it should
   // be loudest.** The key reads whole drops gone past, an integer, and the fraction of an
@@ -4834,6 +4893,42 @@ const FIELD_HELPERS = `
     return a;
   };
   const oneTexel = (mm) => { const a = new Uint16Array(512 * 424); a[212 * 512 + 256] = mm; return a; };
+  // **A wall whose texels sit at different depths inside one cell**, which is the fixture
+  // every other glyph section here deliberately is not. A flat wall hands every occupant of
+  // a cell the same colour, so a character keyed on the point and a character keyed on the
+  // cell draw the same picture and no thinning can tell them apart - which is exactly why
+  // the tone key shipped broken. The spread is bounded under half a cell so the occupants
+  // stay inside one cell rather than becoming several: what this fixture is about is many
+  // *different* sources in one cell, not more cells.
+  const hetero = (baseMm, ampMm) => {
+    const a = new Uint16Array(512 * 424);
+    const span = 2 * ampMm + 1;
+    for (let r = 0; r < 424; r++) {
+      for (let c = 0; c < 512; c++) a[r * 512 + c] = baseMm - ampMm + ((r * 7 + c * 11) % span);
+    }
+    return a;
+  };
+  // Every second texel in each axis dropped out of whatever was planted, which the thinned
+  // helper above does for a constant plane and this does for a fixture that varies.
+  const thin = (src) => {
+    const a = new Uint16Array(512 * 424);
+    for (let r = 0; r < 424; r += 2) for (let c = 0; c < 512; c += 2) a[r * 512 + c] = src[r * 512 + c];
+    return a;
+  };
+  // Which pixels a frame painted at all, as one hash, and it is the only comparison a
+  // heterogeneous cell admits. The *colour* of a painted pixel is the colour of whichever
+  // occupant won the depth test, and at full lattice every occupant of a cell is at the same
+  // snapped depth - so which one that is depends on attribute order and changes when the
+  // sources are thinned, on a build with nothing wrong with it. Which pixels got painted is
+  // a different quantity: a set bit of the character paints and a clear bit discards, so the
+  // mask is the bitmask the cell chose and nothing else.
+  const maskHash = (px, bg) => {
+    const m = new Uint8Array(px.length / 4);
+    for (let i = 0, j = 0; i < px.length; i += 4, j++) {
+      m[j] = (px[i] !== bg[i] || px[i + 1] !== bg[i + 1] || px[i + 2] !== bg[i + 2]) ? 1 : 0;
+    }
+    return sha256(m);
+  };
   // A near surface standing in front of a far one, which one depth image cannot hold
   // twice over: a texel is one range, so the two surfaces have to be cut out of the same
   // grid rather than stacked along one ray. Every step-th texel in each axis is the near
@@ -5008,6 +5103,104 @@ console.log('\n[registry] one cell, one character: the mark is a fact about the 
       ? 'identical as round splats too - the thinning reached nothing'
       : `${(100 * shots.wholeDots.lit).toFixed(2)}% inked, ${shots.wholeDots.hash.slice(0, 12)} `
         + `against ${shots.thinnedDots.hash.slice(0, 12)}`);
+}
+
+// **The same claim asked of a cell whose occupants disagree, which is the fixture the
+// section above cannot be and the reason the tone key shipped broken.** That section holds
+// `glyph.tone` at 0, and its own comment gives the reason - the colour planted two sections
+// up is a 2x2 image, so points inside one cell would draw different colours and the equality
+// would fail on a build with nothing wrong with it. A deliberate exclusion carrying a good
+// justification is exactly where CLAUDE.md's fifth rule says to look, and what it was
+// excluding was the only condition in which a per-point tone key differs from a per-cell one
+// at all. On a flat wall the two builds are the same picture.
+//
+// **So the wall is a fine depth ramp bounded under half a cell.** Every texel snaps into the
+// same cell its neighbours do - the row below asserts that rather than assuming it - and
+// every texel arrives with its own depth, so a key reading the colour the point is about to
+// draw reads a different number for each occupant and a key reading the cell reads one.
+// Bounding the spread is what keeps this a statement about occupants rather than about
+// cells: let it past half a cell and the occupied set changes, which is a different claim
+// that the turbulence section below already makes.
+//
+// **The comparison is the painted mask and not the pixels**, for the reason `maskHash`
+// carries: at full lattice every occupant of a cell is at one snapped depth, so which one
+// wins the depth test is attribute order and thinning moves it on any build. Which pixels
+// were painted is the character. A per-point key paints the *union* of the characters its
+// occupants chose - which is what "they composite into noise" is, said as a set - and
+// dropping three quarters of those occupants changes the union.
+//
+// The clip range is tightened to 2.0/3.0 rather than left at the section's 0.5/4, and that
+// is sensitivity rather than decoration: the tone key reads a position in that range, so a
+// 0.24m spread of occupants is 24% of a metre-wide range against 6.9% of a 3.5m one, and the
+// characters an old build would disagree about go from about three apart to about ten.
+console.log('\n[registry] and a cell whose occupants disagree still draws one character');
+{
+  const hetero = await page.evaluate(`(async () => {
+    ${PAGE_HELPERS}
+    ${FIELD_HELPERS}
+    const look = { ...${JSON.stringify(GLYPH_LOOK)}, cell: 0.25, 'glyph.tone': 1,
+      'glyph.hash': 0, 'glyph.rain': 0, near: 2, far: 3 };
+    const wall = hetero(2500, 120);
+    const bg = field({ look, depth: empty() }).slice();
+    const at = async (over, depth) => {
+      const px = field({ look: { ...look, ...over }, depth });
+      return { mask: await maskHash(px, bg), levels: levels(px, bg), ...above(px, bg) };
+    };
+    return {
+      whole: await at({}, wall),
+      thinned: await at({}, thin(wall)),
+      // The same wall drawn as round splats, which is what says the occupants really do
+      // differ: a flat wall at one depth paints one colour and this paints many.
+      dots: await at({ 'glyph.amount': 0 }, wall),
+      flatDots: await at({ 'glyph.amount': 0 }, plane(2500)),
+      // The key moved on the same geometry, so the mask is shown to be able to see a
+      // character before it is asked to prove one did not change.
+      toneDown: await at({ 'glyph.tone': 0 }, wall),
+      cell: k.uniforms.latticeCell.value,
+    };
+  })()`);
+
+  // The first guard, and it is the fixture's whole premise: the planted depths have to land
+  // in one cell. Written out here rather than asked of the page, the same way the fitted row
+  // further down reimplements the snap it is testing.
+  const cellOf = (mm) => Math.floor(-(mm / 1000) / hetero.cell + 0.5);
+  const oneCell = cellOf(2380) === cellOf(2620);
+  check(oneCell && hetero.whole.lit > 0.005,
+    'the planted occupants span 0.24m and all of it falls in one cell, and the wall draws '
+    + 'characters - so the rows below are about disagreeing occupants rather than about '
+    + 'more cells',
+    `2.380m and 2.620m both snap to cell ${cellOf(2380)} at a ${hetero.cell}m grid, `
+    + `${(100 * hetero.whole.lit).toFixed(2)}% inked`);
+
+  // The second guard, and the one the section above could not satisfy. A build whose tone key
+  // reads the point rather than the cell can only differ where the points differ, so an arm
+  // that cannot show its occupants differing is an arm that proves nothing.
+  check(hetero.dots.levels > hetero.flatDots.levels * 4,
+    'and as round splats those occupants paint many colours where a flat wall paints few, so '
+    + 'the cell genuinely holds sources a per-point key would read differently',
+    `${hetero.dots.levels} distinct colours on the ramped wall against `
+    + `${hetero.flatDots.levels} on a flat one at the same depth`);
+
+  // The third guard: the mask can see a character at all. Without it the claim below is
+  // satisfied by any two frames whose painted sets happen not to move.
+  check(hetero.whole.mask !== hetero.toneDown.mask,
+    'and dropping the tone key repaints the frame, so the mask is an observable that reads '
+    + 'which character was chosen',
+    `${hetero.whole.mask.slice(0, 12)} at a tone of 1 against `
+    + `${hetero.toneDown.mask.slice(0, 12)} at 0`);
+
+  // **The claim.** Which character a cell draws cannot depend on which of its occupants
+  // arrived, so dropping three quarters of them paints exactly the same pixels. A build
+  // keying the tone on the colour each point is about to draw paints the union of several
+  // characters per cell, and the union changes when the sources are thinned.
+  check(hetero.whole.mask === hetero.thinned.mask,
+    'thinning a cell whose occupants sit at different depths paints the identical pixels, so '
+    + 'the tone key is a fact about the cell rather than about whichever point got there',
+    hetero.whole.mask === hetero.thinned.mask
+      ? `both ${hetero.whole.mask.slice(0, 12)} over ${hetero.whole.painted}px painted`
+      : `${hetero.whole.mask.slice(0, 12)} against ${hetero.thinned.mask.slice(0, 12)} - the `
+        + `cell is painting the union of its occupants' characters, `
+        + `${hetero.whole.painted}px against ${hetero.thinned.painted}px`);
 }
 
 // The defect the probe this design came out of actually shipped, and the one the spec says
@@ -5240,8 +5433,10 @@ console.log('\n[registry] the three keys add and wrap, so doubling two of them i
   // that is neither a sum nor a difference can still climb monotonically out of the sparse
   // end. A squared sum is the clearest of them - it is scale-sensitive, so the doubling row
   // passes it, and it is monotone in each key with the other down, so this row passes it
-  // too. Nothing in this suite separates a sum from a squared sum, and the two draw
-  // different characters in every cell.
+  // too. That gap stood open for a while and this comment used to end by naming it; what
+  // closes it is the fitted row at the foot of this section, which predicts the index from
+  // the keys and reads the drawn ink back against the compiled alphabet, and
+  // `glyph-index-squares` is the control that must redden it and nothing else here.
   const ramp = keys.ramp;
   const inks = ramp.map((r) => r.lit);
   const descents = ramp.filter((r, i) => i > 0 && r.lit < ramp[i - 1].lit);
@@ -5277,6 +5472,113 @@ console.log('\n[registry] the three keys add and wrap, so doubling two of them i
         + 'whole-number counter is inert at this weight'
       : `${keys.rainAlone.hash.slice(0, 12)} against ${keys.neither.hash.slice(0, 12)} with `
         + 'every key down');
+
+  // **An oracle for the composition rather than another property of it**, and the comment
+  // above the sweep names why one was needed: a squared sum is scale-sensitive, so the
+  // doubling row passes it, and it is monotone in each key with the others down, so the ink
+  // sweep passes it too - and it draws a different character in every cell. Every row above
+  // this one asks whether two pictures differ. None of them can say which character was
+  // chosen, and that is what "the three keys add and wrap" is a claim about.
+  //
+  // **The observable is ink, and the arithmetic that turns ink into an index is the
+  // alphabet's own sorted table read out of the compiled shader.** At full glyph on a flat
+  // wall with lattice 1 the sprite is exactly the cell, so the marks tile the covered region
+  // with no gaps and no overlap and the painted fraction of that region is the character's
+  // popcount over 64. Coverage is identical across the arms below - same wall, same cell,
+  // same pose, same sprite - so the painted counts across a sweep are one unknown constant
+  // times a sequence of popcounts this file predicts without asking the shader anything.
+  // Fitting that constant by least squares leaves seven measurements against one free
+  // parameter, and a build composing its keys any other way lands its indices somewhere
+  // else in a table sorted by ink.
+  //
+  // **The prediction reimplements the snap rather than reading it**, which is the whole
+  // point of an oracle, and the guard under it enforces the one premise that
+  // reimplementation rests on: with the cloud carrying no rotation, room space is sensor
+  // space, so the wall's cell centre is `floor(-2.4 / cell + 0.5) * cell` and the tone key
+  // reads that depth's place in the clip range. The far plane is moved out to 8 so the
+  // sweep walks two thirds of the table instead of the third the shipped range reaches -
+  // seven distinct popcounts from 5 to 15, where at far 4 the top three arms land on 10,
+  // 10 and 11 and the fit stops being able to tell them apart.
+  const oracle = await page.evaluate(`(async () => {
+    ${PAGE_HELPERS}
+    ${FIELD_HELPERS}
+    const look = { ...${JSON.stringify(GLYPH_LOOK)}, cell: 0.25, 'glyph.hash': 0,
+      'glyph.rain': 0, near: 0.5, far: 8 };
+    const wall = plane(2400);
+    const bg = field({ look: { ...look, 'glyph.tone': 0 }, depth: empty() }).slice();
+    // Exact rather than thresholded: at full glyph the mark is a hard bit at one colour, so
+    // a pixel was either painted by a set bit or left as the empty frame.
+    const painted = (px) => {
+      let n = 0;
+      for (let i = 0; i < px.length; i += 4) {
+        if (px[i] !== bg[i] || px[i + 1] !== bg[i + 1] || px[i + 2] !== bg[i + 2]) n++;
+      }
+      return n;
+    };
+    let cloud = null;
+    k.scene.traverse((o) => { if (o.geometry === k.geometry) cloud = o; });
+    cloud.updateMatrixWorld(true);
+    const rows = [];
+    for (const tone of [0.1, 0.25, 0.4, 0.55, 0.7, 0.85, 1]) {
+      rows.push({ tone, painted: painted(field({ look: { ...look, 'glyph.tone': tone }, depth: wall })) });
+    }
+    return {
+      rows,
+      cloudMatrix: Array.from(cloud.matrixWorld.elements).map((v) => Number(v.toFixed(9))),
+      near: k.uniforms.nearClip.value,
+      far: k.uniforms.farClip.value,
+      cell: k.uniforms.latticeCell.value,
+      shader: k.material.fragmentShader,
+    };
+  })()`);
+
+  {
+    const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    const levelled = oracle.cloudMatrix.every((v, i) => v === IDENTITY[i]);
+    const table = oracle.shader.match(/const uvec2 GLYPHS\[64\] = uvec2\[64\]\(([\s\S]*?)\n\);/);
+    const popcount = (n) => { let c = 0; for (let x = n >>> 0; x; x >>>= 1) c += x & 1; return c; };
+    const inks = table
+      ? [...table[1].matchAll(/uvec2\(0x([0-9a-fA-F]{8})u,\s*0x([0-9a-fA-F]{8})u\)/g)]
+        .map(([, a, b]) => popcount(parseInt(a, 16)) + popcount(parseInt(b, 16)))
+      : [];
+    // The snap, the clip position and the index, written out here rather than asked of the
+    // page. -2.4 is the planted wall in metres of scene, which unproject puts down -z.
+    const cellZ = Math.floor(-2.4 / oracle.cell + 0.5) * oracle.cell;
+    const cellTone = 1 - Math.min(1, Math.max(0,
+      (-cellZ - oracle.near) / Math.max(0.001, oracle.far - oracle.near)));
+    const predicted = oracle.rows.map((r) => {
+      const f = (r.tone * cellTone * (63 / 64)) % 1;
+      const idx = Math.min(Math.floor(f * 64), 63);
+      return { ...r, idx, ink: inks[idx] ?? 0 };
+    });
+
+    // The two guards, and they are separate questions. The first is the premise the
+    // prediction rests on - a rotated cloud would put the cell somewhere else and the whole
+    // sequence below would be about a different wall. The second is that the sweep reaches
+    // characters of genuinely different density, because a fit against seven equal popcounts
+    // is satisfied by any build that draws one character everywhere.
+    const spread = Math.max(...predicted.map((p) => p.ink)) / Math.min(...predicted.map((p) => p.ink));
+    check(levelled && inks.length === 64 && spread > 2,
+      'the cloud is unrotated and the predicted sweep walks the table from sparse to dense, '
+      + 'so the fit below has a premise and something to fit',
+      `${levelled ? 'identity' : 'rotated'} cloud, ${inks.length} characters read off the `
+      + `compiled shader, cell centre at ${(-cellZ).toFixed(3)}m giving a tone of `
+      + `${cellTone.toFixed(4)}, predicted ink ${predicted.map((p) => p.ink).join('/')}`);
+
+    // The claim. One free constant - how many pixels the tiling covers - against seven
+    // painted counts, fitted by least squares so no arm is privileged as the reference.
+    const num = predicted.reduce((s, p) => s + p.painted * p.ink, 0);
+    const den = predicted.reduce((s, p) => s + p.ink * p.ink, 0);
+    const perBit = den > 0 ? num / den : 0;
+    const residuals = predicted.map((p) => Math.abs(p.painted - perBit * p.ink) / Math.max(1, perBit * p.ink));
+    const worst = Math.max(...residuals);
+    check(worst < 0.08,
+      'the ink a cell paints is the popcount of the character the wrapped sum names, at every '
+      + 'step of the sweep - so the three keys add into an index rather than into anything '
+      + 'else that rises with them',
+      predicted.map((p, i) => `tone ${p.tone}: index ${p.idx}, ink ${p.ink}, ${p.painted}px `
+        + `against ${Math.round(perBit * p.ink)} (${(100 * residuals[i]).toFixed(1)}%)`).join('; '));
+  }
 }
 
 // The alphabet is sorted by ink so that one table can be read as tone by one key and as
@@ -5408,6 +5710,14 @@ console.log('\n[registry] the alphabet is sorted by ink, and the tone key reads 
 // 0.125m cell at the pinned pose's four metres rasterises into about 12 pixels and measures
 // 36 reference pixels: inside the band on the reading the shipped build takes, and well
 // above it on the reading it must not take.
+//
+// **The crop's pair at the foot of the section is a different claim wearing this one's
+// fixture**, and it is worth saying so rather than letting the heading cover it. The crop
+// used to reach the crossfade by halving the sprite, and this section asked whether the
+// halved size was the size being read; a cut-away point now reports no legible pixels at
+// all, so the question is no longer about a unit but about whether a character is drawn.
+// The two rows there are an equality over the keys and its uncropped control, and they stay
+// in this section because they need exactly this section's stage and cell to stand up.
 console.log('\n[registry] and the band is counted in the pixels the buffer actually has');
 {
   const unit = await page.evaluate(`(async () => {
@@ -5416,34 +5726,46 @@ console.log('\n[registry] and the band is counted in the pixels the buffer actua
     const base = { ...${JSON.stringify(GLYPH_LOOK)}, 'glyph.hash': 0, 'glyph.tone': 0, 'glyph.rain': 0 };
     const wall = plane(2400);
     const bg = field({ look: base, depth: empty() }).slice();
-    const at = (over, cropOutside = null) => {
+    const at = async (over, cropOutside = null) => {
       const px = field({ look: { ...base, ...over }, depth: wall, cropOutside });
-      return { levels: levels(px, bg), ...above(px, bg) };
+      return { hash: await sha256(px), levels: levels(px, bg), ...above(px, bg) };
     };
+    // The three keys raised together, for the two rows that ask whether a key can reach a
+    // pixel at all. Which characters they choose does not matter to either row - only that
+    // the answer is a different picture where the mark is a character and the same picture
+    // where it is a splat.
+    const LOUD = { 'glyph.hash': 1, 'glyph.tone': 0.7 };
+    // Every point outside the box, by the depth pair rather than by a lateral face: the wall
+    // is at 2.4m and the far face is at 1.0, so the whole frame is cut away and the faint
+    // pass is what keeps it on screen to be measured.
+    const CUT = { cell: 0.25, crop: true, near: 0.5, far: 1.0 };
     return {
       // 0.25m: 24 framebuffer pixels, 72 reference. Above the band on both readings, so
       // the mark is a hard bit whichever one the shader takes - this is the arm that says
       // the statistic can read a one.
-      above: at({ cell: 0.25 }),
+      above: await at({ cell: 0.25 }),
       // 0.125m: 12 framebuffer pixels, 36 reference. The two readings disagree here.
-      inside: at({ cell: 0.125 }),
-      // The crop's own half, which is the same disagreement produced by the halving rather
-      // than by the cell. A cut-away point draws at half its size, so a 0.25m cell that is
-      // above the band whole is inside it cut - and the sprite is then smaller than the
-      // cell pitch, so the marks stand apart and nothing overlaps into a second value.
-      // The depth range is what puts every point outside the box: the wall is at 2.4m and
-      // the far face is at 1.0, so the whole frame is cut away and the faint pass keeps it.
-      cropped: at({ cell: 0.25, crop: true, near: 0.5, far: 1.0 }, 0.6),
+      inside: await at({ cell: 0.125 }),
+      // The crop's own half, and it is a different claim from the two above rather than a
+      // third reading of theirs: a cut-away point is scaffolding, so it draws the round mask
+      // whatever size it came out at. Both arms are the same geometry at the same cell with
+      // the keys down and up.
+      croppedQuiet: await at(CUT, 0.6),
+      croppedLoud: await at({ ...CUT, ...LOUD }, 0.6),
+      // The control, which is that same pair with nothing cut away. Without it the equality
+      // above would pass on a page where the keys reach nothing anywhere.
+      wholeQuiet: await at({ cell: 0.25 }),
+      wholeLoud: await at({ cell: 0.25, ...LOUD }),
     };
   })()`);
 
   // The floor is 0.5% and not the 3% the two-surface guard uses, for that section's own
   // reason: every key is down here so every cell draws index 0, the sparsest character in a
   // table sorted by ink, and it reads 1.55% on a build doing exactly what it should.
-  check(unit.above.lit > 0.005 && unit.inside.lit > 0.005 && unit.cropped.painted > 500,
+  check(unit.above.lit > 0.005 && unit.inside.lit > 0.005 && unit.croppedQuiet.painted > 500,
     'all three arms draw their marks, so the counts below are taken on pictures',
     `above ${(100 * unit.above.lit).toFixed(2)}% inked, inside `
-    + `${(100 * unit.inside.lit).toFixed(2)}%, cut away ${unit.cropped.painted}px painted`);
+    + `${(100 * unit.inside.lit).toFixed(2)}%, cut away ${unit.croppedQuiet.painted}px painted`);
 
   // The reference the other two are read against. A hard bit is one colour, and if this
   // arm ever stops reading one the statistic has stopped meaning what the rows below take
@@ -5462,12 +5784,33 @@ console.log('\n[registry] and the band is counted in the pixels the buffer actua
     `${unit.inside.levels} distinct colours at 12 framebuffer pixels against `
     + `${unit.above.levels} at 24`);
 
-  // The crop half of the same claim, which had never executed: the halving is the last
-  // thing that moves the sprite and the reading is taken after it.
-  check(unit.cropped.levels > 1,
-    'and a cut-away cell is read at the half size it is actually drawn at, so the crop edge '
-    + 'crossfades rather than staying a hard mark at half the pixels',
-    `${unit.cropped.levels} distinct colours over ${unit.cropped.painted}px`);
+  // **The crop's own claim, and it is an equality over the keys rather than a statistic
+  // about the mark.** A cut-away point draws no character at all, so the three keys are
+  // choosing a symbol nothing draws and cannot reach a pixel - which is bit-identity with
+  // no threshold anywhere in it. The row this replaces counted distinct colours and asked
+  // that a cut-away cell be a blend rather than a hard bit, which was the halving's own
+  // claim; a build that falls back to the round mask satisfies that count for a reason the
+  // row was not testing, and would have gone on reading green while the picture changed
+  // completely. Counting colours cannot separate "crossfaded halfway" from "not a character
+  // at all", and the keys can.
+  check(unit.croppedQuiet.hash === unit.croppedLoud.hash,
+    'a cut-away cell draws the round mask, so the three keys reach no pixel inside the crop '
+    + 'and cut geometry reads as dust rather than as smaller text',
+    unit.croppedQuiet.hash === unit.croppedLoud.hash
+      ? `both ${unit.croppedQuiet.hash.slice(0, 12)} with the keys down and up, over `
+        + `${unit.croppedQuiet.painted}px painted`
+      : `${unit.croppedQuiet.hash.slice(0, 12)} against ${unit.croppedLoud.hash.slice(0, 12)} - `
+        + 'the crop is still drawing characters');
+
+  // And its control: the identical geometry and the identical two key settings with nothing
+  // cut away, where the marks are characters and the keys have to move the picture. Without
+  // it the equality above passes on any page where the keys reach nothing at all.
+  check(unit.wholeQuiet.hash !== unit.wholeLoud.hash,
+    'while the same two key settings on the same cell outside no crop do draw different '
+    + 'characters, so the equality above is not a fixture the keys cannot move',
+    unit.wholeQuiet.hash === unit.wholeLoud.hash
+      ? `identical uncropped too, ${unit.wholeQuiet.hash.slice(0, 12)} - the keys reached nothing`
+      : `${unit.wholeQuiet.hash.slice(0, 12)} against ${unit.wholeLoud.hash.slice(0, 12)}`);
 }
 
 // **And the other half of the invariant, which needs a buffer this file does not otherwise

--- a/tools/sensor-view-check.mjs
+++ b/tools/sensor-view-check.mjs
@@ -1426,6 +1426,33 @@ try {
       hidden: seen.hidden.map((t) => t.tab),
     };
   };
+  // A package group is built only for an effect somebody has added, so both arms add every
+  // installed effect through the rack dialog first: the rows below ask about reachability, not
+  // rack membership.
+  const rackEveryEffect = async (page) => {
+    const racked = [];
+    for (let guard = 0; guard <= 40; guard += 1) {
+      await page.click('#panelTabs [role="tab"][data-panel-tab="look"]');
+      const door = await page.evaluate(`(() => {
+        const b = document.getElementById('effectRackOpen');
+        return b !== null && b.checkVisibility({ checkVisibilityCSS: true });
+      })()`);
+      if (!door) throw new Error('the rack door is not on this surface, so no package group can be added');
+      await page.click('#effectRackOpen');
+      const next = await page.evaluate(`(() => {
+        const add = document.querySelector('#effectRackList button[data-effect-add]');
+        return add === null ? null : add.dataset.effectAdd;
+      })()`);
+      if (next === null) {
+        await page.evaluate(`document.getElementById('effectRackDialog').close()`);
+        return racked;
+      }
+      // Adding closes the dialog and moves to the group's own tab, so each one is a fresh open.
+      await page.click(`#effectRackList button[data-effect-add="${next}"]`);
+      racked.push(next);
+    }
+    throw new Error(`the rack still offered an effect after ${racked.length} were added: ${racked.join(' ')}`);
+  };
   const panelRun = await onFreshPage('the panel arms', { }, async ({ page }) => {
     // **The collapse rule needs a document with something in it, and this arm was giving
     // it one with nothing.** Which groups the panel leaves open derives from the clip, so
@@ -1447,12 +1474,13 @@ try {
       __kinect.params.set(name, was === 0 ? 1 : was * 1.7);
       return { name, was, now: __kinect.params.get(name) };
     })()`);
+    const racked = await rackEveryEffect(page);
     const walked = await walkTabs(page);
     await page.evaluate(`__kinect.params.reset([${JSON.stringify(nudge.name)}])`);
-    return { ...walked, nudge };
+    return { ...walked, nudge, racked };
   });
   const recPanelRun = await onFreshPage('the recorder panel arm', { path: RECORDER_PATH },
-    async ({ page }) => walkTabs(page));
+    async ({ page }) => { await rackEveryEffect(page); return walkTabs(page); });
   if (!panelRun.ok) throw new Error(`the editor panel arm did not run: ${panelRun.error}`);
   if (!recPanelRun.ok) throw new Error(`the recorder panel arm did not run: ${recPanelRun.error}`);
   {

--- a/tools/sweep-all.mjs
+++ b/tools/sweep-all.mjs
@@ -36,6 +36,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const argv = process.argv.slice(2);
 const OUT = resolvePath(argv.includes('--out') ? argv[argv.indexOf('--out') + 1] : join(ROOT, '.sweep-all'));
 const URL = process.env.SWEEP_URL ?? 'http://localhost:8080';
+const TAKE = process.env.SWEEP_TAKE ?? 'fixture-1g';
 const CRASH = 'Execution context was destroyed';
 const TOOLS = ['library', 'timeline', 'keyframe', 'export'];
 
@@ -50,7 +51,11 @@ rmSync(join(OUT, 'SUMMARY.txt'), { force: true });
 
 function run(tool, args, timeoutMs = 900_000) {
   return new Promise((resolve) => {
-    const child = spawn('node', [`tools/${tool}-check.mjs`, ...args], { cwd: ROOT });
+    const toolArgs = [...args];
+    if ((tool === 'timeline' || tool === 'keyframe') && !toolArgs.includes('--take')) {
+      toolArgs.push('--take', TAKE);
+    }
+    const child = spawn('node', [`tools/${tool}-check.mjs`, ...toolArgs], { cwd: ROOT });
     // Decoded through a StringDecoder rather than by concatenating Buffers. `out += c`
     // calls toString() per chunk, so a multi-byte sequence straddling a chunk boundary
     // becomes two replacement characters and the line it was on is corrupted - which

--- a/tools/timeline-check.mjs
+++ b/tools/timeline-check.mjs
@@ -378,6 +378,14 @@ const index = await (await fetch(`${URL_BASE}/capture/${TAKE}/index`)).json();
 const stamps = index.frames.stampMs;
 const TIMES = stamps.map((s) => (s - stamps[0]) / 1000);
 const DURATION = TIMES[TIMES.length - 1];
+const NEEDS_TAKE_SEC = 12;
+
+if (!(DURATION >= NEEDS_TAKE_SEC)) {
+  console.log(`\n[timeline] DID NOT RUN - the take "${TAKE}" holds ${DURATION.toFixed(2)}s of source and `
+    + `these rows need ${NEEDS_TAKE_SEC}s. Point --take at a longer capture `
+    + '(tools/make-fixture.js loops a short one).');
+  process.exit(2);
+}
 
 function bracketOf(sourceSec) {
   let lo = 0;
@@ -763,7 +771,7 @@ console.log('\n== 1. the same program position, reached two ways ==');
 // Well inside the take on purpose. A target close enough to the head that the
 // pre-roll is clipped by it would prove the equality against a shorter warm-up
 // than the one under test, which is an easier claim wearing this one's name.
-const TARGET_SEC = 12.0;
+const TARGET_SEC = NEEDS_TAKE_SEC;
 {
   const config = { ...BLACKWALL, rate: 1, fps: 30, targetSec: TARGET_SEC, frames: null };
   const played = await arm({ ...config, kind: 'playback', label: 'played' });

--- a/web/cloud-shader.js
+++ b/web/cloud-shader.js
@@ -631,14 +631,32 @@ void main() {
   // the divisor is 1 and this is the drawn sprite, at 1080 the two units coincide exactly,
   // and above it this is the drawn sprite back in reference pixels.
   //
-  // Taken here because this is the last line in the file that can move gl_PointSize, and
-  // the halving above it is inside the reading on purpose - a cut-away cell drawn at half
-  // its pixels has half the texels to resolve on, whatever the look asked for.
+  // Taken here because this is the last line in the file that can move gl_PointSize, so
+  // whatever the halving above it did is already in the number.
+  //
+  // **A cut-away point reports no legible pixels at all, which is the crop's own half of
+  // this and is a decision rather than a reading.** The halving used to be the whole of what
+  // the crop contributed here, and it was not enough: a 64-pixel sprite halved to 32 is
+  // still far above the band, so cut-away geometry drew a *smaller character* where the
+  // paragraph above the halving promises dust. The two claims are not the same claim - "a
+  // quarter of the footprint is a quarter of the occlusion" is about how much room the
+  // scaffolding takes up, and it says nothing about whether the scaffolding is still
+  // reading as text. So the fallback to the round mask is asked for here rather than left
+  // to the size crossfade to arrive at, and it is exact rather than nearly: zero is below
+  // the band's lower end at every output size, so glyphMix is exactly 0 and the mark is
+  // the disc the look draws with no glyph field at all, discard and all.
+  //
+  // **What this varying is therefore has to be said out loud, because the name reads like
+  // the other thing.** It is not the sprite's size; it is how many pixels this mark has to
+  // be legible in, and a point the crop has cut away has been asked not to read as surface,
+  // so it has none. Every other point's answer is still the lesser of the two readings
+  // above. The halving stays where it is because the occlusion argument it was written for
+  // is untouched - it is simply no longer carrying a second job it was never able to do.
   //
   // vSize is a different quantity and stays one: it is what the additive normalisation
   // divides by, it is taken before the halving, and it is in reference pixels always,
   // because brightness has to be invariant to output size where legibility cannot be.
-  vLegiblePx = gl_PointSize / max(k, 1.0);
+  vLegiblePx = outsideCrop ? 0.0 : gl_PointSize / max(k, 1.0);
 }
 ` },
   ]),

--- a/web/effect-manifests.js
+++ b/web/effect-manifests.js
@@ -52,6 +52,37 @@ export const EFFECT_BIND_TABLES = Object.freeze(['points', 'grade']);
 export const EFFECT_BIND_TRANSFORMS = Object.freeze(['axisDeg', 'degToRad']);
 
 /**
+ * The uniforms this build's own render loop writes, which is the one exception to the rule
+ * that a package's uniform has to be bound by one of that package's parameters.
+ *
+ * **The exception is what the rule is for, so it has to be as closed as the rule is.** A
+ * uniform nothing writes reads zero for the life of the page - the control that should have
+ * moved it does not exist, nothing throws, and the effect is simply absent from a picture that
+ * looks fine. `hostDriven` is a manifest saying "this one is written from outside", and while
+ * the door took any name at all it was a way of asserting that about a uniform nothing in this
+ * build has ever written: valid GLSL, a clean install, and the exact failure the two-ended
+ * binding rule refuses, reached through the sentence that excuses a package from it.
+ *
+ * `rainPhase` is the whole set and the rain is why it exists. `renderProgramFrame` in
+ * `web/main.js` writes it once a frame from program time, deliberately as a second cell beside
+ * `uniforms.time` so that `timeline-check --mutate rain-accumulates` has one line to integrate;
+ * a package that wants a clock of its own gets a parameter, not an entry here.
+ *
+ * **Stated here rather than in the render loop, and the two ends are held together by a test
+ * rather than by an import.** The loop writes one named cell - `uniforms.rainPhase.value = t` -
+ * because that is what a hand-written render step looks like, and threading a list through it
+ * would be a loop iterating a constant to write the one assignment it already has. So the door
+ * reads this and `test/effect-door.test.mjs` reads `web/main.js`, refusing a name here that the
+ * page does not actually write. That catches the drift the constant is about: a name kept on
+ * this list after the host stopped writing it is a package the door goes on excusing and the
+ * shader goes on reading zero from.
+ *
+ * Frozen for the reason the vocabularies above it are: a closed set anybody could push onto is
+ * not a closed set, and this one is the door's own exception list.
+ */
+export const HOST_DRIVEN_UNIFORMS = Object.freeze(['rainPhase']);
+
+/**
  * The panel groups the client's own spine holds, as a set, sorted so it reads as one.
  *
  * **The install door needs this and cannot reach the thing that declares it.**

--- a/web/main.js
+++ b/web/main.js
@@ -222,6 +222,34 @@ const tornRead = (why) => Object.assign(new Error(why), { tornRead: true });
 const effectRefusal = (why) => Object.assign(new Error(why), { effectRefusal: true });
 
 /**
+ * A rebuild that failed because a shader program *would not link*, marked so the one caller
+ * entitled to act on that can tell it from every other way an adoption fails.
+ *
+ * **The mark is what keeps a quarantine off the innocent.** A link failure is the one
+ * failure this page can attribute to a package rather than to itself: the door assembles and
+ * binds and cannot compile, so identifier-valid GLSL that the driver rejects installs
+ * cleanly, and every fresh page load then compiles it at boot - where `warmPrograms` runs
+ * outside any transaction and takes the module down with it, publishing no `__kinect` and
+ * leaving every tool in the suite reporting that it did not run. So the page that discovers
+ * it asks the store to set the package aside. What must not reach that route is any of the
+ * *other* throws the same rollback catches - `buildPanel` refusing a group key, the
+ * completeness rule refusing a document that names a subset of a fork's parameters - because
+ * "this page could not carry its open document across" says nothing whatever about the
+ * package, and setting one aside on it would rename a perfectly good fork out of the way for
+ * a fault in a clip.
+ *
+ * A property beside `effectRefusal`'s rather than a subclass or a phrase in the sentence, for
+ * the reason written out there: the sentences are read by a person and a classification that
+ * matched words in them would be re-decided by every edit to the prose. It carries the
+ * driver's own log beside the mark, because the sentence a person reads is framed on the way
+ * out and the far side's log wants the compiler's words rather than this page's.
+ */
+const shaderLinkFailure = (why, log) => Object.assign(new Error(why), {
+  shaderLinkFailure: true,
+  linkLog: log,
+});
+
+/**
  * `GET /effects`, with the shape of the answer held to what every reader of it assumes.
  *
  * **A 200 carrying a body this build cannot read used to escape every guard there was.**
@@ -1166,9 +1194,9 @@ function updateDrawRange() {
  * The grade terms whose being up is what makes the pass worth running, read off the
  * packages rather than listed here.
  *
- * A binding declares `gates` when a non-zero value has to switch the pass on, and five of
- * the shipped effects do. That used to be five lines of `grade.uniforms.X.value > 0` in the
- * function below, which was true of the shipped set and true by transcription: a package
+ * A binding declares `gates` when a non-zero value has to switch the pass on, and seven of
+ * the shipped effects do. That used to be a line of `grade.uniforms.X.value > 0` per gating
+ * effect in the function below, true of the shipped set and true by transcription: a package
  * installed next year would have written its term into the pass and left the pass shut, so
  * its slider would have moved a uniform nothing ran and the effect would have been silently
  * absent - the shape this repo keeps case files about. Derived, a package is counted by
@@ -1189,6 +1217,32 @@ function updateDrawRange() {
  * end. The mirror case is worse in the other direction: uninstall the last gating effect
  * and the pass stayed open forever on a term nothing could reach any more. It is the same
  * walk over the same packages, one line inside `adoptEffectPackages`.
+ *
+ * **The question a gate asks is whether the term is at zero, and it used to ask whether the
+ * term was above it.** `gates` means a *non-zero* value switches the pass on - the door says
+ * so in its own refusal sentence, the paragraph above says so, and every reading of the
+ * binding says so - but the test below was `> 0`, which is the same answer only for a
+ * parameter whose range starts at zero. All seven shipped gated masters run 0..N, so the
+ * transcription was true of the set that exists and false of the contract, and the gate
+ * matrix could not see the difference because it has no negative range to drive. What that
+ * cost was the same silent absence the derivation above exists to end, arriving from the
+ * other side: install a package whose gated master runs -1..1, drag it below zero, and the
+ * slider moves, the uniform takes the value, `gradeNeeded` says no, and the pass stays shut
+ * across the whole negative half of a range the package author declared.
+ *
+ * **It reads the uniform, so it reads whatever the binding writes there, and this line takes
+ * that for a number.** A scalar write and `degToRad` both land one, and zero means the same
+ * thing in each. `axisDeg` lands a `Vector2` of a sine and a cosine, which is a direction
+ * rather than an amount and is never the zero vector - so a package declaring `gates` beside
+ * `transform: 'axisDeg'` has no term to be up or down at all, and the comparison below would
+ * hold the pass open on it forever where the one it replaced held it shut forever. Neither
+ * reading is the wrong one; the binding is, which is why `doorRefusal` refuses that pair
+ * outright rather than this function being taught a second shape. It refuses `gates` on any
+ * table but `grade` in the same breath and for the same reason read from the other side:
+ * `gradeGatesOf` collects grade bindings only, so a gating binding anywhere else is a promise
+ * this walk never sees. What is left here is therefore a number by construction, and the
+ * assumption is written down rather than defended, because a door is a thing that can be
+ * edited and a comparison against a `Vector2` is silent in whichever direction it fails.
  */
 let GRADE_GATES;
 const gradeGatesOf = (packages) => packages.flatMap((pkg) => Object.values(pkg.manifest.params ?? {})
@@ -1196,7 +1250,7 @@ const gradeGatesOf = (packages) => packages.flatMap((pkg) => Object.values(pkg.m
   .map((p) => p.bind.uniform));
 
 function gradeNeeded() {
-  return GRADE_GATES.some((name) => grade.uniforms[name].value > 0);
+  return GRADE_GATES.some((name) => grade.uniforms[name].value !== 0);
 }
 
 // ------------------------------------------------- fitting the box to the footage
@@ -1495,11 +1549,11 @@ let PANEL_GROUPS;
  * three places this could fail. The throw stays anyway, because the door is not the only
  * way a binding reaches here.
  *
- * The gate is composed on top rather than spelled into each of the five writes. Each post
+ * The gate is composed on top rather than spelled into each of the gating writes. Each post
  * pass costs a full-screen read and write whether or not it changes anything, so a term of
  * the grade at zero has to shut its pass rather than run it as a no-op - and `gradeNeeded`
- * asks the five uniforms rather than the five parameters, so it goes on being right when a
- * project writes them in any order.
+ * asks the uniforms rather than the parameters, so it goes on being right when a project
+ * writes them in any order.
  */
 function effectApply(bind) {
   const table = () => (bind.on === 'grade' ? grade.uniforms : uniforms);
@@ -3138,6 +3192,127 @@ function adoptEffectPackages(packages, programs, held = {}) {
 adoptEffectPackages(effectPackages, shaderPrograms);
 
 /**
+ * How much of the driver's log travels to the store, in characters.
+ *
+ * The reason is written into the server's own log, and a link log is whatever the driver
+ * felt like emitting - some of them quote the offending line, some quote the whole
+ * translated program, and a Metal shader compiler will hand back kilobytes for one missing
+ * semicolon. Bounded on this side rather than trusted to be bounded on the other, for the
+ * reason every other length in this program is: the far side is defending a disk file
+ * against whatever a browser sends it, and a caller that leans on that defence is a caller
+ * that stops working the day the defence is written differently.
+ *
+ * **Four hundred because that is where the store cuts, and the two numbers agreeing is the
+ * point rather than a coincidence.** `serveEffectRefusal` slices the reason at
+ * `MAX_REFUSAL_REASON`, so a longer one is not refused, it is silently shortened - and the
+ * sentence a person then reads in the log is not the sentence this page composed, with
+ * nothing anywhere saying where it was cut. This is still this side's own bound and not a
+ * lean on that one; what matching buys is that what is sent is what is written. The pair is
+ * held together by nothing but this paragraph, which is the honest state of it.
+ *
+ * It is about twice what this rig's own driver emits for a type error - measured, a `float`
+ * assigned to a `vec3` comes back as 193 characters carrying the line number and both halves
+ * of the mismatch - which leaves room for a longer one without letting a shader's whole
+ * source through.
+ */
+const REFUSE_REASON_MAX = 400;
+
+/**
+ * Asks the store to set aside the packages this adoption's link failure can be attributed
+ * to, so the next page to load is not the one that dies compiling them.
+ *
+ * **The whole of why this exists is that the install door cannot compile.** It assembles the
+ * set, binds every uniform and refuses an identifier this build has not got - and a shader
+ * that is syntactically broken while naming only familiar identifiers passes all of that and
+ * is refused by the driver, which reports a log rather than throwing. So a package can be
+ * installed cleanly, roll this page back, and then take down every fresh page load at boot,
+ * where `warmPrograms` runs outside any transaction: no `__kinect`, neither surface opening,
+ * and every tool in the suite reporting that it did not run. The page that discovers the
+ * failure is the only thing in this program with a GL context to discover it in, so it is
+ * what tells the store.
+ *
+ * **A link failure is a property of the assembled program and does not name a package**,
+ * which is the hard half. Both programs are one text spliced out of every installed package,
+ * and the driver's log is about a line number in that text. What this page does know is
+ * which packages *moved*: it is holding the set it was running a moment ago and the set it
+ * just fetched, and the programs assembled from the first one linked. So the candidates are
+ * the ids whose revision changed and the ids that arrived - one of which is the culprit, and
+ * all of which are named when there is more than one, because a set-aside package is renamed
+ * rather than deleted and stays on disk to be repaired. An id present in the set before and
+ * absent from the set after is deliberately not a candidate: its text is not in the program
+ * that failed to link, so it cannot be what the driver rejected.
+ *
+ * **Every way this can fail is swallowed**, and that is not laziness about errors. The
+ * caller is on its way to throwing a refusal that carries the mark the poll reads to stop
+ * asking, so a throw from here would replace that sentence with a network error, lose the
+ * mark, and put the page back on a six-second loop against a store it has already refused.
+ * A server without the route is one of those ways and it is a deployment fact rather than a
+ * fault to report on a chip. Nothing here branches on a status to detect one, and that is
+ * deliberate rather than unfinished: every non-2xx is the same outcome, which is that the store
+ * did not hear and the page says what it always says. A status branch would also have been
+ * wrong twice already - an older server answers 405 rather than 404, because this route was
+ * `POST /effects/refuse` before it was `POST /effect-refusals` and a path under `/effects/`
+ * falls through to the `:id` entry, whose writes are `PUT` and `DELETE`.
+ *
+ * **The address is outside `/effects/` and that is load-bearing rather than tidy.** The route
+ * table is walked in order and a literal segment outranks the `:id` pattern beside it, so a
+ * package genuinely called `refuse` was listed by `GET /effects`, answered 405 when this page
+ * fetched it, and took `readEffectPackages` down with it - no `__kinect`, both surfaces dark,
+ * and no way to uninstall the thing either, since the `DELETE` was 405 too. An effect id is a
+ * directory name and `mkdir` is all it takes to make one, so the namespace is the fix.
+ */
+async function setAsideUnlinkable(before, after, log) {
+  const held = new Map(before.map((p) => [p.id, p.rev]));
+  const ids = after.filter((p) => held.get(p.id) !== p.rev).map((p) => p.id);
+  // **No candidates is unreachable rather than merely unlikely, and it returns rather than
+  // asking.** The programs are assembled out of the packages alone, so a set where nothing
+  // changed assembles to identical text, and identical text is what `sameProgram` compares -
+  // the warm that produced this failure would not have run. A request naming no ids would be
+  // this page asking the store to act on nothing, which the store would have to have an
+  // answer for.
+  if (ids.length === 0) return null;
+  // The compiler's words on one line, because they land in a log where a newline is a new
+  // record, and named with the candidates when the culprit is one of several rather than
+  // known - a person reading the store's log needs to know the set was ambiguous, since it
+  // decides how many packages they go and look at.
+  //
+  // **Every control character and not only whitespace, because a collapse of `\s` alone
+  // leaves the rest behind.** A driver's log is bytes it chose, and the one measured for
+  // `REFUSE_REASON_MAX` above puts two NULs in the middle of its sentence. A NUL is not
+  // whitespace, so it came through the collapse untouched and travelled into a line somebody
+  // reads in a terminal - the same class of forgery the newline collapse is here to stop, and
+  // one an escape sequence would reach through in the same way. Sanitised on this side rather
+  // than left to the far side, for the reason the length cap is.
+  const line = String(log ?? '').replace(/[\s\p{Cc}\p{Cf}]+/gu, ' ').trim();
+  const named = ids.length > 1 ? `one of ${ids.join(', ')}: ` : '';
+  const reason = `${named}${line}`.slice(0, REFUSE_REASON_MAX);
+  try {
+    const res = await fetch('/effect-refusals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids, reason }),
+    });
+    if (!res.ok) {
+      console.warn(`could not set aside ${ids.join(', ')}: POST /effect-refusals answered ${res.status}`);
+      return null;
+    }
+    const body = await res.json();
+    const setAside = Array.isArray(body?.setAside) ? body.setAside : [];
+    // The store declining an id is information rather than a failure: a builtin nothing forks
+    // cannot be set aside, and an id already aside is the answer this page wanted. Logged
+    // because a run where everything was skipped is a run after which the store is exactly
+    // where it was, and that is the case where nothing converges and somebody has to know why.
+    for (const skip of Array.isArray(body?.skipped) ? body.skipped : []) {
+      console.warn(`the store kept ${skip?.id}: ${skip?.why}`);
+    }
+    return setAside.length ? setAside : null;
+  } catch (err) {
+    console.warn(`could not set aside ${ids.join(', ')}: ${err.message}`);
+    return null;
+  }
+}
+
+/**
  * The store read again, and everything on this page rebuilt from what it says.
  *
  * **The document goes out through the serialiser and comes back through the loader, and
@@ -3186,6 +3361,15 @@ adoptEffectPackages(effectPackages, shaderPrograms);
  * network, and because staying synchronous is what keeps the half-swapped state
  * unobservable: from any other task the page is either the old set or the old set, never
  * the pair mid-swap.
+ *
+ * **One of the failures it rolls back is also told to the store, and exactly one.** A shader
+ * that will not link is the only thing that can go wrong in here which is a fact about a
+ * package rather than about this page - and rolling back is not enough for it, because the
+ * package stays installed and the next fresh page load compiles it at boot, outside any
+ * transaction, and dies. So a link failure and nothing else asks the store to set the
+ * changed packages aside; every other throw the rollback catches is this page failing to
+ * carry its own document, which says nothing about the package and must never rename one.
+ * `shaderLinkFailure` is the mark that separates them and `setAsideUnlinkable` is the call.
  *
  * **The completeness refusal stays a refusal**, and that is the decision this rollback is
  * built around rather than a limitation of it. Filling the parameter the fork added from
@@ -3301,6 +3485,16 @@ async function reloadEffects() {
       // A refusal, so the poll asks once: the document and the set are both exactly what
       // they were, and a retry is the same two failures at the cost of a second refetch on
       // a page whose next honest instruction is to reload.
+      //
+      // **Nothing is set aside from here even when the failure that started it was a link
+      // failure**, and the reason is the state this page is in rather than the state the
+      // store is in. Everything else on the way out of this function runs against a page
+      // that came back whole; here the document could not be restored onto either set, so
+      // the honest instruction is to reload - and a route call placed in front of that
+      // instruction is one more thing between the operator and the only action left. The
+      // corner is also barely reachable from a link failure: the throw happens before the
+      // forward `restoreProject`, so the document the rollback is putting back is one the
+      // old registry serialised a few lines earlier.
       throw effectRefusal(
         'the installed effects changed, this page could not carry the open document across to them, '
         + `and it could not put itself back either - reload the page: ${stuck.message}`,
@@ -3309,15 +3503,47 @@ async function reloadEffects() {
   }
   refreshGroups();
   requestRepaint();
+  // **The store told, after the page is whole and before the sentence goes out.** A shader
+  // that would not link is the one failure here that is about a package rather than about
+  // this page, and the package survives the rollback: this page goes back to the programs it
+  // was drawing with, and the next fresh load compiles the broken one at boot, where
+  // `warmPrograms` runs outside any transaction and takes the module down. So the page that
+  // discovered it asks the store to set it aside - see `setAsideUnlinkable` for how the
+  // candidates are chosen and why every failure of that call is swallowed.
+  //
+  // **And this terminates rather than looping, which is the interaction with
+  // `refusedEffectSignature` worth walking.** The block goes up on the signature the page
+  // failed on, which is the signature of the set that would not link. Setting a package
+  // aside changes the store, so the next listing carries a different signature - one this
+  // page has never refused - and the block correctly does not cover it, so the next tick
+  // rebuilds against the set with the culprit removed and that set links. If the store sets
+  // nothing aside, the signature has not moved, the block stands, and nothing asks again:
+  // both directions end.
+  //
+  // Awaited here and nowhere earlier, because the rollback above is synchronous on purpose -
+  // from any other task the page is either the old set or the old set, never the pair
+  // mid-swap - and an `await` placed inside it would be exactly the window that promises to
+  // be unobservable.
+  const setAside = failure?.shaderLinkFailure
+    ? await setAsideUnlinkable(heldPackages, fetched, failure.linkLog)
+    : null;
   // Thrown after the repaint rather than before it, so the page the operator is looking at
   // is the rolled-back one by the time the sentence describing it arrives.
   if (failure) {
     // A refusal for the reason the adoption's own failures are: the rollback landed, so the
     // page is whole and the set on the server is still the one it cannot use. Asking again
     // in six seconds refetches every package to reach this same sentence.
+    //
+    // The clause about what was set aside is appended rather than put in front, because the
+    // chip this lands on ellipsises and the compiler's own words are what somebody debugging
+    // a package needs first. `say` writes the whole sentence into the element's `title`, so
+    // the tail is a hover away rather than gone.
     throw effectRefusal(
       'the server installed the effects it was asked for, but this page could not carry the open '
-      + `document across to them, so it is still running the effects it had: ${failure.message}`,
+      + `document across to them, so it is still running the effects it had: ${failure.message}`
+      + (setAside
+        ? ` (${setAside.join(', ')} set aside, so the next rebuild is without ${setAside.length > 1 ? 'them' : 'it'})`
+        : ''),
     );
   }
   // A set this page has carried a document onto is a set it is not blocked on, whichever door
@@ -4121,8 +4347,30 @@ function paintEffectRackDialog() {
       remove.type = 'button';
       remove.dataset.effectRemove = id;
       remove.setAttribute('aria-label', `remove ${title} from the sidebar`);
+      // **The document is asked again here, and the row's own reading of it is not what
+      // decides.** This press either opens a confirmation or resets every value and deletes
+      // every track the effect owns, and the entry a few lines above was read when the list
+      // was painted - which nothing repaints when the document moves underneath it. The
+      // dialog is modal, so no slider can move behind it, and the page's own Cmd-Z handler
+      // fires straight through a modal: paint the rack while an effect sits at its defaults,
+      // tab to its remove button, undo the edit that reset it, and the closure still says
+      // nothing is there to lose while the document holds the work the undo just brought
+      // back. Pressed, that skipped the confirmation and reset the restored values in the
+      // same gesture, which is the one outcome in this dialog nobody can get back.
+      //
+      // **The row's detail text goes stale the same way and is deliberately left that way**,
+      // which is the choice between recomputing at the press and repainting the list whenever
+      // the document moves. There is no single writer to hang a repaint on - values, tracks, the
+      // undo stack and a hotload all move this state, and this file's own rule is that a
+      // repaint belongs where the state is written rather than in a second reader beside it -
+      // so the repaint would have to be a poll or a hook on `history`, and either one rebuilds
+      // the list under whatever the operator is pointing at. `N changed` reading one edit out
+      // of date is a count somebody can see and re-open the dialog to correct; the press is a
+      // decision, and a decision has to be taken against the document as it is at the moment
+      // it is taken. The confirmation this now opens paints the true counts on its way up.
       remove.addEventListener('click', () => {
-        if (entry.moved.length || entry.keys) {
+        const now = effectRackEntry(id);
+        if (now.moved.length || now.keys) {
           effectRackConfirming = id;
           paintEffectRackDialog();
         } else {
@@ -4535,8 +4783,25 @@ let parkedLook = { params: {}, tracks: {}, requires: [] };
  * `refuseRequires` would then be reading a list that no longer describes the values
  * beside it.
  *
+ * **That sentence was a description of what the serialiser does and it needed a line to be
+ * true of what the badge says.** The commit rewrites the document and nothing was dropping
+ * the notice beside it, so the chip went on quoting a version pair the open document no
+ * longer named - which is the shape of stale reading this repo is least able to afford
+ * here, because the argument for surfacing a skew instead of parking the effect is that the
+ * notice is the only thing that says so. `history.commit` is where the clear is, beside the
+ * write that makes it necessary.
+ *
  * Replaced whole by `restoreProject` for the reason `parkedLook` is: it is a property of
- * the open document, not an accumulation across the ones a session has seen.
+ * the open document, not an accumulation across the ones a session has seen. Two of that
+ * door's four callers land where they should - a load recomputes from the file, and an undo
+ * recomputes from a stack snapshot that already carries the derived list - and the other
+ * two are a known gap rather than a decision: a hotload and its rollback hand
+ * `restoreProject` the output of `serialiseProjectBody`, whose `requires` has already been
+ * derived by the time the loader reads it, so an install landing while a skewed document is
+ * open and uncommitted clears the notice without anything having been written to disk at
+ * all. Recovering it would mean carrying
+ * the authored version across a serialisation that exists to replace it, and the value it
+ * would recover is one line of prose about a document nobody has saved.
  */
 let effectVersionSkew = [];
 
@@ -5424,6 +5689,40 @@ const history = {
     this.stack.push(this.baseline);
     if (this.stack.length > UNDO_LIMIT) this.stack.shift();
     this.baseline = now;
+    // **The version notice, dropped here because this is the line that makes it false.**
+    // The badge says the open document was authored against a version other than the one
+    // installed, and `requires` is derived from the installed set by every serialisation -
+    // so the snapshot two lines above and the auto-save two lines below both already claim
+    // the version that is actually here. The declaration of `effectVersionSkew` has always
+    // said the notice does not survive the next commit and nothing made it stop, which left
+    // a chip quoting a pair the document no longer names, for the rest of the session, over
+    // a picture that was by then exactly what the document asked for. That matters more than
+    // a stale line usually would: the decision *not* to park an effect that is here at
+    // another version rests on this notice being the one thing that says so, and a notice
+    // that is wrong is worse than none.
+    //
+    // Cleared rather than recomputed, and the two are the same answer. A recomputation would
+    // read `requires` back off the snapshot and compare each entry against `versionOf`, and
+    // `requiresFor` writes `versionOf` into every entry it derives - so the comparison is
+    // between a value and itself and the list is empty by construction. Written out, the
+    // clear is that derivation with the arithmetic done.
+    //
+    // **Guarded on there being a notice, and the guard is load-bearing rather than thrift.**
+    // `paintMissingEffects` rebuilds the chip with `replaceChildren`, and the chip carries
+    // the suppress button for every effect this build has not got - so painting it on every
+    // slider release would replace, under the pointer, the one control an operator with a
+    // parked effect is reaching for.
+    //
+    // The other four doors onto this state are `restoreProject`'s, and they answer for
+    // themselves rather than needing anything here: a load recomputes from the file's own
+    // `requires`, which is the one place the authored version still exists; an undo
+    // recomputes from a stack snapshot, which carries the derived list, so a notice cleared
+    // here stays cleared through the undo of the edit that cleared it - which is right,
+    // since undo is about what the clip is and this machine has built it either way.
+    if (effectVersionSkew.length) {
+      effectVersionSkew = [];
+      paintMissingEffects();
+    }
     // Auto-save the project after every change. Fire-and-forget: a failed save is
     // logged in the UI but it must not block the interaction that caused it.
     const workingBody = { ...serialiseProject(), take: { id: openTakeId, hash: openTakeHash } };
@@ -15802,8 +16101,21 @@ function warmPrograms() {
   }
   // After the restore rather than inside the try, so the enabled flags and the
   // accumulators are back where they belong before the caller starts unwinding.
+  //
+  // **Marked, because this is the one failure in the whole adoption that names a package
+  // rather than this page.** Everything else the rollback catches is a document that could
+  // not be carried across or a registry that would not build, and a store asked to set a
+  // package aside for one of those would be renaming somebody's fork out of the way for a
+  // fault in a clip. See `shaderLinkFailure`, and `setAsideUnlinkable` for what the one
+  // caller entitled to read the mark does with it. The first failure is the one carried:
+  // the two programs are warmed in one composed frame, so a second entry is the same
+  // package's other stage or the other program built from the same set, and a person
+  // reading a chip needs the compiler's first sentence rather than all of them.
   if (linkFailures.length) {
-    throw new Error(`this build's shaders did not compile after the effects changed - ${linkFailures[0]}`);
+    throw shaderLinkFailure(
+      `this build's shaders did not compile after the effects changed - ${linkFailures[0]}`,
+      linkFailures[0],
+    );
   }
 }
 warmPrograms();


### PR DESCRIPTION
Follow-up to the effects stack (#75–#83). Those nine PRs carried forty review comments and not one thread was resolved before merge.

Each comment was verified against the merged tree rather than against the commit it was filed on, because #81 was five rounds of hardening and several flags had already been closed later in the same stack. **Thirteen were still live, three were judgement calls, and the remaining twenty-four had been fixed in-stack or were deliberate design.** Three more defects were found while doing the work — one of them in the fix for another.

## The three nobody had reported

**A package called `refuse` could brick the page.** The quarantine route was `POST /effects/refuse`, and a literal segment there outranks `/effects/:id`. Nothing reserved that id, so a directory anyone could create became legal, unreadable and un-deletable — 405 to both `GET` and `DELETE` — and the page died at boot with no `__kinect`. That is exactly the failure the route exists to prevent, reached through the route. The route moved off the namespace entirely rather than reserving a word.

**`gates` beside `transform: 'axisDeg'` was never refused,** and two independently correct changes were about to make it worse. The transform writes a two-component value and the gate reads a scalar, so under the old `> 0` predicate it was permanently false; the `!== 0` fix in this same PR would have made it permanently true and held a full-screen grade pass open forever.

**A driver's link log carries NUL bytes.** The refusal reason collapsed `\s+`, a NUL is not whitespace, and a control character travelled into a line an operator reads in a terminal — the same forgery class the newline collapse exists to stop, through the gap it left.

## What changed

| area | items |
|---|---|
| **door / store** | boot gate revalidates after promoting a fork · array uniforms refused as scalar targets · `hostDriven` restricted to names the host drives · manifest bytes in the package bound · `gates` shape rules · effects root locked rather than the port |
| **compile gate** | `POST /effect-refusals` — the page that discovers a package will not link is what quarantines it, on a mark the throw carries rather than on the rollback |
| **client** | `gradeNeeded` tests nonzero · version-skew notice clears on commit · rack Remove recomputes at the press |
| **looks** | glyph tone is a fact about the cell · ceiling in reference pixels · cut-away geometry falls back to dots · film stock preserves per-pixel luminance · halation's placement claim corrected to what ships |
| **instruments** | `monitor-check` readiness waits · `registry-check` index rows · three new `effect-check` mutations |

## Measurements

`effect-check` 147/0 · `effect-conformance` 111/0 · `monitor-check` 91/0 · `library-check` 506/0 · `guard-check` 24/0 · `boot-check` 11/0 · `level-check` 32/0 · `vcam-check` 41/0 · `module-check` 61/0 · unit 141/0 · `syntax-check` 79 files 0 failed · `determinism` PASS.

`registry-check` reports 3 failed and `export-check` 10. **Both are the synthetic fixture, not the build, and both are unchanged from a clean checkout of `3b7ab90`** — export-check's ten come back at identical numbers to four figures on both sides, which reads as a stronger result than the count: a change that moved any screen-space term would have moved them. `docs/proof-tools.md` now records what each fixture cannot reach.

Two behaviour changes are deliberate and visible. `cascade` moves, because it ships drawing summed mismatched characters — 106,282 pixels inked against 114,537 on a heterogeneous fixture. And the 4K picture moves, because expressing the glyph ceiling in reference pixels is the point of that item rather than a side effect.

**Not run:** `index-check` wants a 1.1GB fixture, `editor-check` and `keyframe-check` want 32s and 24s takes against a 9.43s sample, and `jobs-check`, `sensor-view-check`, `cpp-check` and `release-gate-check` cover surfaces nothing here touches.

## Left open, on purpose

- The version-skew notice is still dropped by the hotload/rollback pair without a commit. Recovering it means carrying a second copy of `requires` for one badge.
- `test/glyph-ceiling.test.mjs` proves the ceiling is *expressed* in the right unit and not that a sprite stops growing there on a GPU.
- The `registry-check` and `export-check` fixture gaps are documented rather than closed; closing them means widening `make-sample`, whose geometry several other tools' numbers are placed against.


## Before-merge replay proof

A full no-Kinect replay run drove the real editor against a 75.69s take: it opened the take, authored two camera keys and one look key, set an out marker, and exported a verified 960x540 H.264 file with 116 decoded frames. The automated editor check ran 569/0. Timeline ran 75/0, keyframe ran 139/0, and sensor-view ran 132/0.

That run found two defects in the proof fixtures, not in the editor: timeline targeted 12s while its documented default take ended at 9.43s, and keyframe's trails control hid the wrong pre-roll under a look whose pixels moved only 3/255. The fixes refuse a short timeline take before Chromium starts, route one explicit long take through sweep enumeration and execution, compare the page's exact source time to the independent index walk, and use a look where the trails mutation moves 71/255. The focused sweep control fired 13 rows; the trails mutation fired exactly its two claim rows.

The merge gates are syntax 79 files/0 failed with all 565 anchors matching once, unit 141/0, module 61/0, C++ 5/0, jobs 91/0, and release-gate 0 failed. The documented synthetic-fixture baselines remain registry 3 failed and export 10 failed. Registration remained unproven because the local corpus lacks params.bin; vendor source passed 290 assertions with one link proof unproven because no built vendor prefix was present.