### PR TITLE
Add a datamosh pass that drags the picture into vertical needles

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ blackwall, ghost rim, ghost fill, bands, thickness, wall sweep, scan, rim, therm
 edges — each carry a slider and a value.](media/look.png)
 
 `blackwall`, `contour`, `depth`, `ghost` and `rgb` ship in `presets-builtin/` and cannot be
-overwritten, and beside them ship five graded looks — `ember`, `grille`, `voxel`, `tearline`
-and `cascade` — which are one reading with somebody's grade already on it rather than a place
-to start. **save** writes yours to `presets/`, and **export** and **import** move them
+overwritten, and beside them ship seven graded looks — `ember`, `grille`, `voxel`, `tearline`,
+`cascade`, `updraft` and `rift` — which are one reading with somebody's grade already on it
+rather than a place to start. The last two are `ember` under a datamosh and differ only in
+`datamosh.splay`: `updraft` streams the whole frame upward, `rift` pulls it apart from the line
+outward. **save** writes yours to `presets/`, and **export** and **import** move them
 between machines as JSON. Every scalar underneath is still yours to move, and a row you have
 changed grows a **↺** that puts just that one back.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ rest.
 
 The look is not one program. Every effect is a package — a manifest and the GLSL chunks it
 splices into the shaders — and the page assembles both point-cloud programs, the grade pass, the
-parameter registry and the panel out of whatever the store holds. `server/effect-store.js` serves
+mosh pass, the parameter registry and the panel out of whatever the store holds. `server/effect-store.js` serves
 them and `web/shader-assembly.js` joins them.
 
 **Two roots, and the user's copy wins.** `effects-builtin/` is what the build ships with and
@@ -184,9 +184,9 @@ would refuse a pair this build's own install door accepts.
 
 ### Assembly: a spine with joints, and the chunks that fill them
 
-`web/cloud-shader.js` and `web/grade-shader.js` each export a **spine** — verbatim GLSL segments
-with named joints between them — and `web/shader-assembly.js` concatenates a spine with whatever
-the installed packages bring. Neither module imports anything and neither interpolates: a chunk's
+`web/cloud-shader.js`, `web/grade-shader.js` and `web/mosh-shader.js` each export a **spine** —
+verbatim GLSL segments with named joints between them — and `web/shader-assembly.js` concatenates
+a spine with whatever the installed packages bring. Neither module imports anything and neither interpolates: a chunk's
 text is spliced between two segments exactly as it arrived, because every transformation on the
 way is a byte that could move without breaking a compile or showing in a picture anybody would
 look twice at.
@@ -209,6 +209,52 @@ offering one name is a refusal rather than a chunk quietly spliced into both. A 
 joint nothing holds is refused by name, for the same reason the alternative design was rejected:
 tagging each chunk with its program's name means a tag nobody spelled right lands the chunk in no
 program at all, the page boots, and the effect is simply gone.
+
+### A pass that reads the frame it drew last time
+
+The mosh pass in `web/mosh-pass.js` is the third spine and the third bind table, and it is the
+only pass in the chain with memory: it draws into one target while reading the one it drew into
+last time, then swaps. That is what lets a chunk hold pixels back rather than only transform the
+ones in front of it, which is the whole of what a datamosh is. It sits between the trails and the
+bloom, feed-side, because a compression artifact happened to the picture on the way here rather
+than to the display.
+
+**Memory is what makes a pass unseekable, so the memory has a stated ceiling.** A frame that
+depends on every frame before it cannot be reproduced by any length of pre-roll — the failure
+`MAX_AGE` in `web/surface-memory.js` exists to prevent one surface over. So a package binding on
+this table declares exactly one parameter as its `bounds`, in seconds, and the render loop raises
+`moshIFrame` for one frame whenever that much program time has gone by. On that frame the pass
+draws exactly what it was handed and reads no history at all.
+
+That is a GOP, and seeking works the way seeking to a keyframe works: `moshFramesBack` walks back
+to the nearest frame the pass refreshed on and the seek decodes forward from there. Three kinds of
+frame end the walk — the refresh itself, the pass's first live frame (whose history is black), and
+the head of the take — and the walk is in frames rather than in seconds because that is what the
+loop renders. A walk subtracting `1 / outputFps` off a float lands a whisker under a boundary and
+reports a refresh one frame early.
+
+**The memory is bounded twice over and the pre-roll only reads one of the two.** A shipped
+datamosh also fades what it holds by a decay each frame, so at 0.88 a frame the trail is down to
+0.05% after sixty and the refresh has nothing left to bound. A decay-aware walk would stop sooner
+and make every scrub cheaper — the shape `trailsFramesBack` already has — and it is deliberately
+not built: it would need a second role marker in the manifest naming which term is the decay, for
+a saving that only shows while somebody is dragging the playhead. The refresh is the stated bound
+and the pre-roll is measured against it, so the answer is sometimes longer than it strictly needs
+to be and never shorter.
+
+**A seek with no pre-roll at all does not isolate this pass**, which cost one green mutation run
+before it was noticed. `resetAccumulators` clears the surface memory too, and its state texture
+reads differently on its first frame whatever the fade and wake say, so an arm rendered with
+nothing before it parts from a playback on a build whose mosh reads no history whatsoever.
+`timeline-check` section 7 isolates it with a *short* pre-roll instead — long enough for every
+other accumulator to converge, short of the refresh by enough that only the smear's own history
+is missing.
+
+**A camera move does not clear it, and that is the opposite of the trails.** Screen-space history
+belongs to the pose that produced it, so `renderProgramFrame` clears the afterimage when the
+camera moves; dragging stale pixels through a camera move is what this pass is *for*, so its
+history survives navigation. `timeline-check` asserts the camera path is identical across its
+playback, seek and control arms, which is where a divergence would show.
 
 ### Hotload is boot, run a second time
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -282,6 +282,52 @@ never checked against the predicate — is admitted silently. Where the reading 
 than an extent, measure the baseline and subtract it, because a position has no tolerance to hide
 a passenger in.
 
+### A control that clears three accumulators cannot say which one it was about
+
+`timeline-check` section 7 asks whether the mosh pass really reads the frame it drew last time,
+and the obvious control is the one every section above it uses: render the target with no
+pre-roll at all and require the picture to differ. It does differ — and it differs on a build
+whose mosh reads no history whatsoever. `--mutate mosh-no-history` points the pass's fetch at
+the incoming frame instead of its own last output, and the run came back **87 passed, 0 failed**.
+
+The reason is that a pre-roll is not one accumulator's. `resetAccumulators` clears the surface
+memory's state texture too, and that texture reads differently on its first frame whatever the
+fade and wake say, so the arm parts from a playback for a reason that has nothing to do with the
+pass under test. Putting fade, wake and trails to zero was not enough: the state texture is
+written on every arriving frame regardless of what the look does with it.
+
+What isolates the pass is a **short** pre-roll rather than no pre-roll — long enough for every
+other accumulator to have converged, short of the refresh by enough that the only thing missing
+is the smear's own history. Measured: 35 frames short of a 60-frame pre-roll parts from the
+playback by 20/255 across 57.9% of the frame with the pass intact, and by **exactly zero** under
+the same mutation. The separation is total, so the floor only has to sit between them.
+
+Beside it, the same section had a second arm that could not fail. `--mutate mosh-never-refreshes`
+removes the periodic I-frame, which should leave a playback carrying unbounded history against a
+seek that starts from a reset — and it reddened nothing, because the look under the section used
+the shipped decay of 0.88 a frame. 0.88^60 is 0.05%: the decay had already bounded the memory the
+refresh was supposed to bound, so removing the refresh changed no pixel. The section now names
+0.99, where the refresh is what binds.
+
+**Both are the same shape: a probe placed where its answer is the same either way.** Ask what the
+arm would read on a build with the defect, not what it reads on the build in front of you.
+
+### A search across two named programs cannot find a third program's text
+
+`effect-conformance-check` hollows each installed package in turn, checks that its GLSL has left
+the assembled shaders, puts it back and checks that it returns. The search was written as
+
+```js
+`${p.cloud.vertexShader}${p.cloud.fragmentShader}${p.grade.vertexShader}${p.grade.fragmentShader}`
+```
+
+which is every program this build had when the tool was written. A pass with its own spine
+arrived, and the row for the package that fills it read `while hollow: gone; after: missing` —
+the text was never in the string being searched, so its absence proved nothing and its return
+could not be seen. The fix is `Object.values(programs)`: the page already answers with every
+program it compiled, and reading them all means a fourth spine is asked by existing rather than
+by somebody remembering to add it here.
+
 ## Mutation-test the instrument, don't just reason about it
 
 Deliberately break the thing under test, run the check, and confirm it fails on the assertions it

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -48,6 +48,24 @@ same A/B the frame rate moved with whatever else the machine was doing, while th
 for a 40-move drag came back 1818, 1818 and 1869 — the amplification is deterministic and the
 rate is not, so the count is what carries an argument and the rate is what makes it legible.
 
+## `gl.finish()` does not fence on ANGLE's Metal backend
+
+A timing loop needs the GPU to have finished before the clock is read, and `gl.finish()` is the
+call that is supposed to say so. On this rig it does not. Fifty renders of a 434,176-point cloud
+into a 1052x592 buffer, with `gl.finish()` after the loop, timed **0.022 ms per render** - about
+forty times faster than the 0.83 ms the same pass measures under the paced harness in
+`docs/performance.md`. What was being timed is the JavaScript that queues the work.
+
+The renderer string is not the tell here either: `WEBGL_debug_renderer_info` reported
+`ANGLE (Apple, ANGLE Metal Renderer: Apple M2 Max)`, so this is the real GPU submitting real
+commands and answering the clock before it has drawn any of them. `gl.getParameter(gl.RENDERER)`
+without the extension answers `WebKit WebGL`, which reads like a software fallback and is not one.
+
+**So a wall clock around a render loop measures nothing on this machine.** The numbers in
+`docs/performance.md` come from renders paced by the animation loop, where the compositor forces
+the frame to complete, and a new timing harness has to do the same rather than reaching for a
+fence.
+
 ## A tight loop cannot measure an allocation
 
 Two arms that both hit the allocator back to back are not an A/B of allocation cost.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -523,6 +523,24 @@ crop-box measurement above had to move to the editor to escape. That half is
 `grabber --profile` on the sensor with `prof-summary` reading the contention, and it is
 deferred. Until both are run the honest statement is the one at the top of this subsection.
 
+## The mosh pass: what it allocates, and the number that is not here
+
+The feedback pass in `web/mosh-pass.js` costs, per rendered frame it is enabled for, **two
+full-screen draws** — the mosh program into one target and a copy out of it — against the grade's
+one and the bloom's thirteen. That is its shape rather than its price, and the price is not in
+this file: the paired A/B that every number in [What each effect costs](#what-each-effect-costs)
+comes from was attempted and thrown away, because the harness written for it read a wall clock
+around a render loop and `gl.finish()` does not fence on this machine. `docs/measurement.md`
+carries what that measured instead. The number wants the animation-loop pacing the older table
+used, and nobody has re-run it that way.
+
+**What is measured is the memory, because it is arithmetic rather than a timing.** Two
+`HalfFloatType` RGBA targets at the drawing buffer's size, so eight bytes a pixel each: **33.2 MB
+at 1920x1080 and 132.7 MB at 3840x2160**. Both are allocated whenever the chain exists rather
+than when the pass is switched on — three's own `AfterimagePass` behaves the same way and this
+pass follows it rather than inventing a second policy — so a build nobody has raised the smear on
+still holds them.
+
 ## The effect extraction cost nothing in pixels, and that is a measurement
 
 Moving every effect's GLSL out of two shader files and into sixteen packages is a refactor

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -89,11 +89,11 @@ node tools/registry-check.mjs --mutate rain-span-in-frames        # ... its head
 node tools/registry-check.mjs --mutate normalisation-floor-restored # ... the pile-up fix, planted because no shipped look reaches
                                                                   #     the band - a sprite grown to a cell moves the floor from
                                                                   #     19cm out to where a person stands
-node tools/registry-check.mjs --mutate glyph-leaks-at-zero        # ... and the master exactly absent at 0, which is what nine of
-                                                                  #     the ten shipped looks rest on - cascade is the tenth and
-                                                                  #     the only one that draws a character at all. The eight-of-ten
-                                                                  #     population next door is a different set: that one is the
-                                                                  #     lattice-zero looks the compensation has to leave alone
+node tools/registry-check.mjs --mutate glyph-leaks-at-zero        # ... and the master exactly absent at 0, which is what eleven of
+                                                                  #     the twelve shipped looks rest on - cascade is the exception
+                                                                  #     and the only one that draws a character at all. The ten-of-
+                                                                  #     twelve population next door is a different set: that one is
+                                                                  #     the lattice-zero looks the compensation has to leave alone
 node tools/registry-check.mjs --mutate rain-leaks-at-zero         # ... the other master, on the same terms
 node tools/registry-check.mjs --mutate compensation-leaks-at-lattice-zero # ... and the energy correction, which rides no master at
                                                                   #     all and so is excused by neither

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -353,7 +353,8 @@ and the dark between the needles stays dark; a mix feeds the whole frame back in
 greys it over in about a second.
 
 `splay` is which of the two readings of "vertically" you want. At 0 the whole frame drags one way,
-which is the picture melting; at 1 it is pulled *away* from `line`, so everything above that
+and that way is up rather than down — the pass fills a fragment from below it, so there is no
+setting that streams the picture downward as a sheet. At 1 it is pulled *away* from `line`, so everything above that
 height streaks upward and everything below it streaks down, and the frame comes apart from the
 middle out. `line` is where that split sits, as a fraction of frame height from the bottom.
 `grain px` is how wide a column of the picture pulling by one amount is: at 1 the frame is a field
@@ -758,21 +759,23 @@ and the keys it names in `values` are its scope. A parameter's key is dotted by 
 belongs to — `glyph.tone`, `raster.pitch` — and a core value that belongs to no effect stays
 bare, like `pointSize` or `readDepth`. `requires` is `[{ id, version }]`, one entry per effect
 the values touch, derived from them rather than typed: a look that never raises the rain
-carries no entry for it. Ten ship read-only from `presets-builtin/` and are marked `·` in the
+carries no entry for it. Twelve ship read-only from `presets-builtin/` and are marked `·` in the
 picker. Five of them — `rgb`, `depth`,
 `ghost`, `contour` and `blackwall` — are one per reading and differ in little else, so they
 are where a grade starts, with `blackwall.json` carrying the twelve values the old mode
-wrote. The other five — `ember`, `grille`, `voxel`, `tearline` and `cascade` — are graded
-looks in their own right: the first four read Blackwall and `cascade` reads depth, and each
-spends a duotone, a raster and a toe on top of that reading, so applying one takes a finished
-grade rather than clearing the desk.
+wrote. The other seven — `ember`, `grille`, `voxel`, `tearline`, `cascade`, `updraft` and
+`rift` — are graded looks in their own right: all of them read Blackwall except `cascade`,
+which reads depth, and each spends a duotone, a raster and a toe on top of that reading, so
+applying one takes a finished grade rather than clearing the desk. `updraft` and `rift` are
+`ember`'s grade with the datamosh over it and differ only in `datamosh.splay` — 0 streams the
+whole frame upward, 1 pulls it apart from `datamosh.line` outward.
 Nothing in the format marks the difference and nothing should — they are all documents, and
 the split is editorial. A preset naming two values is equally valid, and applying it leaves
 everything else where the grade left it.
 
-**All ten name the whole look**: the 27 bare core values every look owes, plus every parameter
+**All twelve name the whole look**: the 27 bare core values every look owes, plus every parameter
 of each effect the document itself touches — so picking one gives you that look whatever was
-on screen before it. The all-or-none reading rule means all ten also name the three reading
+on screen before it. The all-or-none reading rule means all twelve also name the three reading
 packages, Ghost, Contour and Blackwall, with all nine of their parameters. A shipped whole look
 therefore names at least 36 values. `blackwall.json` claims five more effects whose fourteen
 parameters bring it to 50. Applying a whole look resets every effect the document does not
@@ -781,8 +784,8 @@ and writing it in at its defaults describe the same look. Framing — levelling,
 the crop box — is the shot rather
 than the look, so no shipped document names it and picking one never reframes what you
 framed. `none` is the one entry that does reach the framing, because it is the way back to
-the defaults rather than an eleventh look. `library-check` holds the rule against the
-registry: a new core value fails all ten until each names it, and a new parameter added to an
+the defaults rather than a thirteenth look. `library-check` holds the rule against the
+registry: a new core value fails all twelve until each names it, and a new parameter added to an
 effect fails only the documents whose `requires` already claims that effect — an effect
 nothing has reached yet fails nothing, because nothing claims it.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -336,9 +336,35 @@ frames and not a duration: at 0.9 the trail is down to 12% after twenty of them,
 0.83s of a 24fps deliverable and 0.33s of a 60fps one. `fade` and `wake` are in milliseconds
 for the reason [surface memory](architecture.md#surface-memory) gives, and this term is the
 exception to that rather than a second expression of it — so a look graded at one output rate
-does not keep its trail at another. It is the only term this applies to, because
-`AfterimagePass` in `web/post-chain.js` is the only pass in the chain that carries anything
-from one render to the next.
+does not keep its trail at another. It applies to `reach` and `decay` under Datamosh as well and
+to nothing else: those two passes are the only ones in the chain that carry anything from one
+render to the next, and both count what they carry in renders.
+
+**`datamosh.amount`** is the picture dissolving into vertical needles, and it is the one pass in
+the chain that reads the frame it drew last time. Every frame the picture is pulled a little way
+along Y and what it leaves behind does not clear, so a highlight stretches into a streak that
+grows for as long as the pass remembers. `amount` is the master and the one worth keyframing: at
+zero the pass is switched off and costs nothing, so the dissolve arrives and clears on one track.
+
+`reach px` is how far the picture is pulled each rendered frame, in pixels at the 1080p reference,
+and `decay` is what fraction of the trail survives a frame — the two together set how long a
+needle is. The blend is a per-channel maximum rather than a mix, so a highlight leaves a needle
+and the dark between the needles stays dark; a mix feeds the whole frame back into itself and
+greys it over in about a second.
+
+`splay` is which of the two readings of "vertically" you want. At 0 the whole frame drags one way,
+which is the picture melting; at 1 it is pulled *away* from `line`, so everything above that
+height streaks upward and everything below it streaks down, and the frame comes apart from the
+middle out. `line` is where that split sits, as a fraction of frame height from the bottom.
+`grain px` is how wide a column of the picture pulling by one amount is: at 1 the frame is a field
+of separate needles, and at 16 it comes apart in ribbons. Ragged rather than a clean stretch is
+the whole difference between this and a vertical zoom.
+
+`refresh s` is the one control that is not only a look: it is how long the pass is allowed to
+remember, and every that many seconds of program time the picture snaps back to the frame it was
+handed. That snap is the pulse the look wants and it is also what makes the timeline work — a seek
+decodes forward from the last one, the way seeking to a keyframe does — so a long refresh is a
+long dissolve *and* a long pre-roll on every scrub.
 
 ## The edit, and what comes out of it
 

--- a/effects-builtin/datamosh/decl.mosh.glsl
+++ b/effects-builtin/datamosh/decl.mosh.glsl
@@ -1,1 +1,1 @@
-uniform float mosh, moshReach, moshDecay, moshSplay, moshLine, moshGrain, moshCycleRefresh, moshRefresh;
+uniform float mosh, moshReach, moshDecay, moshSplay, moshLine, moshGrain, moshDrift, moshSpeed, moshCycleRefresh, moshRefresh;

--- a/effects-builtin/datamosh/decl.mosh.glsl
+++ b/effects-builtin/datamosh/decl.mosh.glsl
@@ -1,1 +1,1 @@
-uniform float mosh, moshReach, moshDecay, moshSplay, moshLine, moshGrain, moshRefresh;
+uniform float mosh, moshReach, moshDecay, moshSplay, moshLine, moshGrain, moshCycleRefresh, moshRefresh;

--- a/effects-builtin/datamosh/decl.mosh.glsl
+++ b/effects-builtin/datamosh/decl.mosh.glsl
@@ -1,0 +1,1 @@
+uniform float mosh, moshReach, moshDecay, moshSplay, moshLine, moshGrain, moshRefresh;

--- a/effects-builtin/datamosh/manifest.json
+++ b/effects-builtin/datamosh/manifest.json
@@ -1,0 +1,152 @@
+{
+  "format": 1,
+  "id": "datamosh",
+  "version": "1.0.0",
+  "title": "Datamosh",
+  "params": {
+    "amount": {
+      "def": 0,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "datamosh",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "mosh",
+        "gates": true
+      },
+      "role": "master"
+    },
+    "reach": {
+      "def": 14,
+      "min": 0,
+      "max": 64,
+      "step": 0.5,
+      "kind": "scalar",
+      "label": "reach px",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshReach"
+      },
+      "under": "amount"
+    },
+    "decay": {
+      "def": 0.88,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "decay",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshDecay"
+      },
+      "under": "amount"
+    },
+    "splay": {
+      "def": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "splay",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshSplay"
+      },
+      "under": "amount"
+    },
+    "line": {
+      "def": 0.55,
+      "min": 0,
+      "max": 1,
+      "step": 0.01,
+      "kind": "scalar",
+      "label": "line",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshLine"
+      },
+      "under": "amount"
+    },
+    "grain": {
+      "def": 3,
+      "min": 1,
+      "max": 64,
+      "step": 1,
+      "kind": "scalar",
+      "label": "grain px",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshGrain"
+      },
+      "under": "amount"
+    },
+    "refresh": {
+      "def": 1.2,
+      "min": 0.1,
+      "max": 4,
+      "step": 0.05,
+      "kind": "scalar",
+      "label": "refresh s",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshRefresh",
+        "bounds": true
+      },
+      "under": "amount"
+    }
+  },
+  "panelGroups": [
+    {
+      "key": "datamosh",
+      "label": "Datamosh",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "post",
+      "order": 100
+    }
+  ],
+  "chunks": [
+    {
+      "stage": "m.decl",
+      "order": 100,
+      "file": "decl.mosh.glsl"
+    },
+    {
+      "stage": "m.body",
+      "order": 100,
+      "file": "mosh.mosh.glsl"
+    }
+  ]
+}

--- a/effects-builtin/datamosh/manifest.json
+++ b/effects-builtin/datamosh/manifest.json
@@ -107,6 +107,40 @@
       },
       "under": "amount"
     },
+    "drift": {
+      "def": 0,
+      "min": 0,
+      "max": 10,
+      "step": 0.1,
+      "kind": "scalar",
+      "label": "drift",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshDrift"
+      },
+      "under": "amount"
+    },
+    "speed": {
+      "def": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1,
+      "kind": "scalar",
+      "label": "speed",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshSpeed"
+      },
+      "under": "amount"
+    },
     "cycleRefresh": {
       "def": false,
       "kind": "step",

--- a/effects-builtin/datamosh/manifest.json
+++ b/effects-builtin/datamosh/manifest.json
@@ -107,6 +107,20 @@
       },
       "under": "amount"
     },
+    "cycleRefresh": {
+      "def": false,
+      "kind": "step",
+      "label": "cycle",
+      "panel": {
+        "group": "datamosh",
+        "tab": "look"
+      },
+      "bind": {
+        "on": "mosh",
+        "uniform": "moshCycleRefresh"
+      },
+      "under": "amount"
+    },
     "refresh": {
       "def": 1.2,
       "min": 0.1,
@@ -123,7 +137,7 @@
         "uniform": "moshRefresh",
         "bounds": true
       },
-      "under": "amount"
+      "under": "cycleRefresh"
     }
   },
   "panelGroups": [

--- a/effects-builtin/datamosh/mosh.mosh.glsl
+++ b/effects-builtin/datamosh/mosh.mosh.glsl
@@ -12,7 +12,26 @@
           // which is the difference between a vertical zoom and a field of needles. A column is
           // a few reference pixels wide, so the raggedness is the same at any output size.
           float column = floor(vUv.x * ref.x / max(moshGrain, 1.0));
-          float reach = moshReach * pull * (0.55 + 0.9 * hash(vec2(column, 3.7)));
+
+          // Static: original per-column randomness
+          float staticVal = hash(vec2(column, 3.7));
+
+          // When drift > 0, animate: time-varying hash, undulation, and noise field combined.
+          // Speed controls animation rate, drift controls intensity/blend.
+          float t = time * moshSpeed;
+          // Time-varying hash: columns re-roll their reach periodically
+          float timeHash = hash(vec2(column, 3.7 + floor(t)));
+          // Smooth undulation: sine wave adds breathing motion, phase offset per column
+          float wave = 0.5 + 0.5 * sin(column * 0.2 + t * 3.14);
+          // Noise field: spatiotemporal variation across the frame
+          float noise = hash(vec2(column * 0.1 + t, floor(vUv.y * 30.0 + t * 0.5)));
+          float dynamicVal = timeHash * (0.6 + 0.4 * wave) * (0.7 + 0.6 * noise);
+
+          // Blend: drift controls how much dynamic vs static
+          float blend = clamp(moshDrift, 0.0, 1.0);
+          float variation = mix(staticVal, dynamicVal, blend);
+
+          float reach = moshReach * pull * (0.55 + 0.9 * clamp(variation, 0.0, 1.0));
           vec3 held = texture2D(tOld, vUv - vec2(0.0, reach * texel.y)).rgb * moshDecay;
           // Brightest wins rather than a blend, so a highlight leaves a needle and the dark
           // between the needles stays dark. A blend feeds the whole frame back into itself and

--- a/effects-builtin/datamosh/mosh.mosh.glsl
+++ b/effects-builtin/datamosh/mosh.mosh.glsl
@@ -1,0 +1,21 @@
+        // The picture is pulled away from a line and what it leaves behind does not clear, so
+        // every bright thing stretches into a vertical needle and the frame dissolves upward
+        // and downward at once.
+        if (mosh > 0.0) {
+          // Which way this fragment is pulled. At splay 0 the whole frame drags one way; at 1 it
+          // is pulled away from the line, which is what makes the picture streak up above it and
+          // down below rather than sliding as one sheet. The ramp is smooth across the line
+          // rather than a sign, or the two halves meet at a seam a pixel wide.
+          float away = clamp((vUv.y - moshLine) * 8.0, -1.0, 1.0);
+          float pull = mix(1.0, away, moshSplay);
+          // Ragged rather than a clean stretch: neighbouring columns pull by different amounts,
+          // which is the difference between a vertical zoom and a field of needles. A column is
+          // a few reference pixels wide, so the raggedness is the same at any output size.
+          float column = floor(vUv.x * ref.x / max(moshGrain, 1.0));
+          float reach = moshReach * pull * (0.55 + 0.9 * hash(vec2(column, 3.7)));
+          vec3 held = texture2D(tOld, vUv - vec2(0.0, reach * texel.y)).rgb * moshDecay;
+          // Brightest wins rather than a blend, so a highlight leaves a needle and the dark
+          // between the needles stays dark. A blend feeds the whole frame back into itself and
+          // greys it over in about a second.
+          col = mix(col, max(fresh, held), mosh);
+        }

--- a/presets-builtin/README.md
+++ b/presets-builtin/README.md
@@ -126,9 +126,11 @@ none of them names the thing it is referencing.
 
 **`updraft.json` and `rift.json` are `ember`'s grade with the datamosh raised over it, and
 `datamosh.splay` is the whole of what separates them.** `updraft` sits at 0, where every column
-drags the same way and the whole picture streams upward — measured rather than assumed, because
-the name went out backwards once: over `captures/fixture-long.knct` at 1.100s the light the pass
-adds sits 33.2 rows above the centroid of the frame it was added to. `rift` sits at 1, where the
+drags the same way and the whole picture streams upward — upward is the only direction the pass
+has rather than a setting, since it fills a fragment from below it, and the name went out
+backwards once before anybody checked. Measured over `captures/fixture-long.knct`: the light the
+pass adds aligns with the frame it was added to at a displacement of 32 rows of 360 toward the
+top, and every downward displacement correlates worse. `rift` sits at 1, where the
 picture is pulled away from `datamosh.line` and comes apart from the middle outward. They are
 built on `ember` rather than on a reading because the smear is nearly invisible over a light
 grade, and each carries the reach, decay and grain its own reading wanted: 14 pixels at 0.92 over

--- a/presets-builtin/README.md
+++ b/presets-builtin/README.md
@@ -1,21 +1,21 @@
 # The looks that ship
 
-Ten preset documents in exactly the shape `PUT /presets/:name` writes and
+Twelve preset documents in exactly the shape `PUT /presets/:name` writes and
 `applyStoredPreset` reads: `{ version, values }`, plus a `requires` list — one entry per
 effect the values touch — whenever the look raises any. They are the same kind of file a
 user's own preset is, and they are read-only only in the sense that the store serves them
 from here and writes go to the user's directory — saving over one forks it rather than
 overwriting it.
 
-**Five of them are readings and five are looks, and nothing but this paragraph tells the
+**Five of them are readings and seven are looks, and nothing but this paragraph tells the
 two kinds apart.** `rgb`, `depth`, `ghost`, `contour` and `blackwall` are one per reading
 and are where a grade starts: the first four differ from each other in nothing but the
 reading, `blackwall` adds the post chain its mode always wrote, and what goes on top of any
-of them is yours. `ember`, `grille`, `voxel`, `tearline` and `cascade` are graded looks in
-their own right — each of them takes one reading and then spends a duotone, a raster, a toe
-and whatever else its picture wanted, so applying one is taking somebody else's grade rather
-than clearing the desk to begin your own. No field in the format says which kind a file is,
-and none should: a kind field would be a mechanism carrying a sentence, and every preset a
+of them is yours. `ember`, `grille`, `voxel`, `tearline`, `cascade`, `updraft` and `rift` are
+graded looks in their own right — each of them takes one reading and then spends a duotone, a
+raster, a toe and whatever else its picture wanted, so applying one is taking somebody else's
+grade rather than clearing the desk to begin your own. No field in the format says which kind a
+file is, and none should: a kind field would be a mechanism carrying a sentence, and every preset a
 user saves would have to answer it too, where the question has no answer.
 
 They exist as files rather than as constants in `web/main.js`, and that is the whole point
@@ -29,9 +29,9 @@ name.
 
 Naming the whole look means the 36 core values every look owes regardless of which effects it
 uses, plus every parameter of each effect the document itself touches, with a `requires` entry
-claiming that effect — and **that is the rule an eleventh one has to meet**, enforced by
+claiming that effect — and **that is the rule a thirteenth one has to meet**, enforced by
 `library-check` against the registry rather than against a list. A new core value fails all
-ten until each names it; a new parameter on an effect a document already touches fails that
+twelve until each names it; a new parameter on an effect a document already touches fails that
 document alone, because completeness is a function of what each document's own `requires`
 claims rather than a single count every file owes. Picking a shipped look therefore gives you
 that look and nothing else, whatever was on screen before it.
@@ -44,8 +44,9 @@ reading the value back out of the registry with that look on screen rather than 
 eight numbers into nine files. That took the look tag less its framing from 69 to 77 — and 69
 rather than the 68 this paragraph carried until now, because a look value was added after the
 sentence was written and nobody re-ran the count. A number in prose beside a registry that
-grows rots exactly the way the section below says a number in a document does; 77 is what a
-run reports. Measured after the padding, over `captures/sample.knct` at 15 pinned program
+grows rots exactly the way the section below says a number in a document does, and this one
+rotted again: 92 is what a run reports now, seven of the fifteen between them being the
+datamosh's. Measured after the padding, over `captures/sample.knct` at 15 pinned program
 positions running 0 to 0.9933s, drawn into a 572x322 buffer inside a 640x360 viewport at
 device scale 1: eight of the nine render byte-identical frames to the pre-implementation build
 at every one of those positions, three passes agreeing, two of them in one page and the third
@@ -59,7 +60,7 @@ also what a project saves and what step 5 can keyframe — a crop you could not 
 be a worse program — but they are measured in metres in the room, so a look that named them
 would reframe your shot when you picked it. `none` is the control that does reach them: it
 resets every look value including the framing, which is why it is the way back to nothing
-rather than an eleventh look.
+rather than a thirteenth look.
 
 **This reverses what this file used to say, and the reversal is the interesting part.** The
 nine were each sparse in a *different* set of keys, and the argument written here for that
@@ -89,9 +90,10 @@ where they always claimed to be.
 That line is the one `wholeLookTag` already drew, and moving the shipped nine across it gets
 the provenance stamp back for free: picking `voxel` says `applied voxel · <rev>` rather than
 `applied 43 of 86 values from voxel`, because the document now answers the question the stamp
-asks. That 86 is the whole look tag, framing included, and it is the number the picker prints
-rather than the 77 the rule above counts — the two differ by the nine framing values and are
-not a spelling of each other.
+asks. That 86 is the whole look tag as the registry stood then, framing included, and it is the
+number the picker prints rather than the 77 the rule above counts — the two differ by the nine
+framing values and are not a spelling of each other. A run reports 101 against 92 now, for the
+reason the paragraph above gives.
 
 **A look that switches a term on names all of that term's parameters** was the narrower rule
 this file carried before, learned from `tearline` shipping a duotone with a depth and a split
@@ -108,11 +110,11 @@ where picking `contour` after somebody had pulled the band count to 60 gave them
 the five readings are the rebased ones — `pointSize` is pixels at 1080p, and the buffer those
 looks were graded against was 600 tall, so 4.5 and 5 pixels there are 8.1 and 9 here. That
 rebase happened once, when the screen-space terms went resolution-relative; nothing else in
-either look was in pixels. The five graded looks came after it and are in 1080p pixels
-throughout: four of them sit on Blackwall's 8.1, and `voxel` names 6.5 because its lattice
+either look was in pixels. The seven graded looks came after it and are in 1080p pixels
+throughout: six of them sit on Blackwall's 8.1, and `voxel` names 6.5 because its lattice
 wanted a smaller point, which is a value somebody chose rather than a rebase of one.
 
-**`cascade.json` is the tenth document and the only one that draws the glyph field**, which
+**`cascade.json` is the only document that draws the glyph field**, which
 is why it exists at all: the feature draws one picture, and without a document holding it
 that picture has to be rebuilt from eight sliders plus a lattice nobody would connect to
 them. It reads depth rather than Blackwall, sits at `lattice.amount` 1.0 on a 5.5cm cell with
@@ -121,6 +123,36 @@ falling 0.55 m/s with heads 1.3m apart and 0.45m of trail, under a green duotone
 raster at a low weight and a little bloom. It is named in the house style rather than after the film the
 look references — `ember`, `grille`, `voxel` and `tearline` are single evocative nouns and
 none of them names the thing it is referencing.
+
+**`updraft.json` and `rift.json` are `ember`'s grade with the datamosh raised over it, and
+`datamosh.splay` is the whole of what separates them.** `updraft` sits at 0, where every column
+drags the same way and the whole picture streams upward — measured rather than assumed, because
+the name went out backwards once: over `captures/fixture-long.knct` at 1.100s the light the pass
+adds sits 33.2 rows above the centroid of the frame it was added to. `rift` sits at 1, where the
+picture is pulled away from `datamosh.line` and comes apart from the middle outward. They are
+built on `ember` rather than on a reading because the smear is nearly invisible over a light
+grade, and each carries the reach, decay and grain its own reading wanted: 14 pixels at 0.92 over
+6-pixel columns for the updraft, 20 at 0.9 over 2-pixel ones for the rift, which is ragged where
+the updraft is broad. They are the two documents raising every accumulator this program has —
+`trails` and the surface memory from `ember`, and the mosh over them — which is why
+`determinism-check` reads `rift` rather than spelling a smear out.
+
+**Those six numbers are the one part of these two documents nobody graded against footage**,
+and they are here as a starting point rather than as a finished look. `ember`'s grade underneath
+them was graded; the reach, decay and grain over it were chosen from what the pass does and then
+checked over `captures/fixture-long.knct`, which is `make-sample` looped and therefore a flat wall
+with no depth jitter, no dropped frames and none of the sparse bright glints a smear is really
+for. A pass over a real take is owed, and re-grading these six is the expected outcome of it
+rather than a sign anything regressed.
+
+**`rift`'s line at 0.55 needs a subject that straddles it, and that is a property of the shot
+rather than of the document.** The pass ramps `away` over `(vUv.y - line) * 8`, so it pulls a half
+at full strength only past 0.125 of frame height either side, and a line the picture sits wholly
+above renders the frame `updraft` renders — measured, at line 0.10, byte-identical to splay 0 in
+every band. Over `captures/fixture-long.knct` with the camera at (0, 0.1, 1.6) the light spans
+0.171 to 0.901 of frame height, and 0.55 divides it 41.7% above against 58.3% below at mean pulls
+of +0.83 and −0.88, which is a split at both halves' saturation. Anything from about 0.30 to 0.70
+splits that framing; 0.25 and below leaves too little underneath to tear.
 
 **`voxel`'s exposure moved 1.15 to 5.65 in the same change, and that is a re-grade rather
 than a padding.** The glyph field's energy compensation cancels the pile-up a lattice creates
@@ -154,4 +186,4 @@ weights in the panel are for; picking a document is going somewhere.
 **The reading weights are all or none**, which is a format rule rather than a convention here
 and is enforced by `refusePresetBody`: a file naming two of the five leaves the other three at
 whatever the clip was wearing, which renders as a mixture nobody authored. Naming none of them
-is a legal look that is not about the reading. All ten name all five.
+is a legal look that is not about the reading. All twelve name all five.

--- a/presets-builtin/rift.json
+++ b/presets-builtin/rift.json
@@ -1,0 +1,115 @@
+{
+  "version": 6,
+  "requires": [
+    {
+      "id": "ghost",
+      "version": "1.0.0"
+    },
+    {
+      "id": "contour",
+      "version": "1.0.0"
+    },
+    {
+      "id": "blackwall",
+      "version": "1.0.0"
+    },
+    {
+      "id": "glitch",
+      "version": "1.0.0"
+    },
+    {
+      "id": "duotone",
+      "version": "1.0.0"
+    },
+    {
+      "id": "rgbsplit",
+      "version": "1.0.0"
+    },
+    {
+      "id": "raster",
+      "version": "1.0.0"
+    },
+    {
+      "id": "grain",
+      "version": "1.0.0"
+    },
+    {
+      "id": "streak",
+      "version": "1.0.0"
+    },
+    {
+      "id": "vignette",
+      "version": "1.0.0"
+    },
+    {
+      "id": "datamosh",
+      "version": "1.0.0"
+    }
+  ],
+  "values": {
+    "pointSize": 8.1,
+    "opacity": 1,
+    "exposure": 1.15,
+    "additive": true,
+    "interpolate": true,
+    "snapDelta": 250,
+    "fade": 120,
+    "wake": 550,
+    "cell": 0.05,
+    "regionX": 0,
+    "regionY": 0,
+    "regionZ": -2,
+    "regionW": 0,
+    "regionH": 0,
+    "regionD": 0,
+    "regionRound": 0.5,
+    "regionSoft": 0.2,
+    "readRgb": 0,
+    "readDepth": 0,
+    "rgbSaturation": 1,
+    "depthGamma": 1,
+    "rim": 0.5,
+    "bloom": 0.8,
+    "trails": 0.45,
+    "crush": 0.06,
+    "denoise": true,
+    "edgeTol": 120,
+    "ghost.amount": 0,
+    "ghost.rim": 0.7,
+    "ghost.fill": 0.35,
+    "contour.amount": 0,
+    "contour.bands": 12,
+    "contour.width": 0.08,
+    "blackwall.amount": 1,
+    "blackwall.sweep": 0.28,
+    "blackwall.scan": 0.35,
+    "glitch.amount": 0.1,
+    "glitch.density": 0.45,
+    "glitch.shove": 0.45,
+    "glitch.tint": 1.8,
+    "glitch.bands": 12,
+    "glitch.axis": 0,
+    "glitch.rate": 7,
+    "duotone.amount": 0.92,
+    "duotone.hue": 28,
+    "duotone.split": 0.48,
+    "duotone.span": 5.95,
+    "duotone.motion": 0.35,
+    "rgbsplit.amount": 1.2,
+    "raster.amount": 0.34,
+    "raster.angle": 0,
+    "raster.pitch": 0.4,
+    "raster.hard": 0.85,
+    "grain.amount": 0.2,
+    "streak.amount": 0.2,
+    "streak.angle": 0,
+    "vignette.amount": 0.62,
+    "datamosh.amount": 1,
+    "datamosh.reach": 20,
+    "datamosh.decay": 0.9,
+    "datamosh.splay": 1,
+    "datamosh.line": 0.55,
+    "datamosh.grain": 2,
+    "datamosh.refresh": 1.2
+  }
+}

--- a/presets-builtin/updraft.json
+++ b/presets-builtin/updraft.json
@@ -1,0 +1,115 @@
+{
+  "version": 6,
+  "requires": [
+    {
+      "id": "ghost",
+      "version": "1.0.0"
+    },
+    {
+      "id": "contour",
+      "version": "1.0.0"
+    },
+    {
+      "id": "blackwall",
+      "version": "1.0.0"
+    },
+    {
+      "id": "glitch",
+      "version": "1.0.0"
+    },
+    {
+      "id": "duotone",
+      "version": "1.0.0"
+    },
+    {
+      "id": "rgbsplit",
+      "version": "1.0.0"
+    },
+    {
+      "id": "raster",
+      "version": "1.0.0"
+    },
+    {
+      "id": "grain",
+      "version": "1.0.0"
+    },
+    {
+      "id": "streak",
+      "version": "1.0.0"
+    },
+    {
+      "id": "vignette",
+      "version": "1.0.0"
+    },
+    {
+      "id": "datamosh",
+      "version": "1.0.0"
+    }
+  ],
+  "values": {
+    "pointSize": 8.1,
+    "opacity": 1,
+    "exposure": 1.15,
+    "additive": true,
+    "interpolate": true,
+    "snapDelta": 250,
+    "fade": 120,
+    "wake": 550,
+    "cell": 0.05,
+    "regionX": 0,
+    "regionY": 0,
+    "regionZ": -2,
+    "regionW": 0,
+    "regionH": 0,
+    "regionD": 0,
+    "regionRound": 0.5,
+    "regionSoft": 0.2,
+    "readRgb": 0,
+    "readDepth": 0,
+    "rgbSaturation": 1,
+    "depthGamma": 1,
+    "rim": 0.5,
+    "bloom": 0.8,
+    "trails": 0.45,
+    "crush": 0.06,
+    "denoise": true,
+    "edgeTol": 120,
+    "ghost.amount": 0,
+    "ghost.rim": 0.7,
+    "ghost.fill": 0.35,
+    "contour.amount": 0,
+    "contour.bands": 12,
+    "contour.width": 0.08,
+    "blackwall.amount": 1,
+    "blackwall.sweep": 0.28,
+    "blackwall.scan": 0.35,
+    "glitch.amount": 0.1,
+    "glitch.density": 0.45,
+    "glitch.shove": 0.45,
+    "glitch.tint": 1.8,
+    "glitch.bands": 12,
+    "glitch.axis": 0,
+    "glitch.rate": 7,
+    "duotone.amount": 0.92,
+    "duotone.hue": 28,
+    "duotone.split": 0.48,
+    "duotone.span": 5.95,
+    "duotone.motion": 0.35,
+    "rgbsplit.amount": 1.2,
+    "raster.amount": 0.34,
+    "raster.angle": 0,
+    "raster.pitch": 0.4,
+    "raster.hard": 0.85,
+    "grain.amount": 0.2,
+    "streak.amount": 0.2,
+    "streak.angle": 0,
+    "vignette.amount": 0.62,
+    "datamosh.amount": 1,
+    "datamosh.reach": 14,
+    "datamosh.decay": 0.92,
+    "datamosh.splay": 0,
+    "datamosh.line": 0.55,
+    "datamosh.grain": 6,
+    "datamosh.refresh": 1.6
+  }
+}

--- a/server/effect-door.js
+++ b/server/effect-door.js
@@ -521,9 +521,12 @@ export function doorRefusal(candidate, { beside = [], spines }) {
         return `${name} declares under as ${JSON.stringify(spec.under)} - it names another parameter key in the same package`;
       }
       const parent = manifest.params[spec.under];
-      if (!parent || parent === spec || parent.role !== 'master') {
-        return `${name} declares itself under ${JSON.stringify(spec.under)}, which is not another master in ${id} - `
-          + 'the parent is the term whose non-zero value reveals this row';
+      // A step defaulting to false is absent at false, so its children hide when it is unchecked.
+      const validParent = parent && parent !== spec
+        && (parent.role === 'master' || (parent.kind === 'step' && parent.def === false));
+      if (!validParent) {
+        return `${name} declares itself under ${JSON.stringify(spec.under)}, which is not a valid parent in ${id} - `
+          + 'the parent is a master or a step defaulting to false, whose non-zero value reveals this row';
       }
     }
   }

--- a/server/effect-door.js
+++ b/server/effect-door.js
@@ -7,6 +7,7 @@
 
 import {
   MANIFEST_FORMAT, EFFECT_PARAM_KINDS, EFFECT_BIND_TABLES, EFFECT_BIND_TRANSFORMS,
+  EFFECT_GATED_TABLES, EFFECT_BOUNDED_TABLES,
   CORE_PANEL_GROUP_KEYS, HOST_DRIVEN_UNIFORMS, effectBindUniformType,
 } from '../web/effect-manifests.js';
 import { assembleShaders } from '../web/shader-assembly.js';
@@ -187,7 +188,7 @@ const spineTextByProgram = (spines) => Object.fromEntries(
 );
 
 // Which assembled program a binding's table writes into - the one place the two vocabularies meet.
-const PROGRAM_OF_TABLE = { points: 'cloud', grade: 'grade' };
+const PROGRAM_OF_TABLE = { points: 'cloud', grade: 'grade', mosh: 'mosh' };
 
 // Read off the spines rather than decided here: a chunk names a joint and never a program, so the
 // spine holding the joint is what says where it lands.
@@ -357,6 +358,8 @@ export function doorRefusal(candidate, { beside = [], spines }) {
       + 'would assemble no control from, and the panel group it asks for would be a heading with nothing under it';
   }
   let masters = 0;
+  let bounds = 0;
+  let onBounded = 0;
   for (const [short, spec] of Object.entries(manifest.params)) {
     const name = `${id}.${short}`;
     if (!VALID_PARAM_KEY.test(short)) {
@@ -454,17 +457,17 @@ export function doorRefusal(candidate, { beside = [], spines }) {
         + 'landing the value unconverted, so this is the same refusal one door earlier';
     }
     if (bind.gates !== undefined && typeof bind.gates !== 'boolean') {
-      return `${name} declares gates as ${JSON.stringify(bind.gates)} - it says whether this term holds the grade pass open, which is a yes or a no`;
+      return `${name} declares gates as ${JSON.stringify(bind.gates)} - it says whether this term holds its pass open, which is a yes or a no`;
     }
     // `gates` is a promise about the *uniform*: `gradeNeeded` walks the gating bindings and reads
     // the cell each names, so one on another table is collected by nothing, and one beside a
     // vector transform asks whether a direction or pair of edges is zero.
     if (bind.gates) {
-      if (bind.on !== 'grade') {
+      if (!EFFECT_GATED_TABLES.includes(bind.on)) {
         return `${name} declares gates and binds on ${JSON.stringify(bind.on)} - gates says this term holds `
-          + 'the grade pass open, and the gate reads the grade pass\'s own uniforms, so a gating binding on any '
-          + 'other table is a claim the pass never sees: the control moves, the term is collected by nothing, '
-          + 'and the pass opens and shuts on the parameters that did bind there';
+          + `its pass open, and the tables with a pass to hold are ${EFFECT_GATED_TABLES.join(' and ')}, so a `
+          + 'gating binding anywhere else is a claim no pass ever sees: the control moves, the term is '
+          + 'collected by nothing, and the passes open and shut on the parameters that did bind there';
       }
       if (effectBindUniformType(bind.transform) !== 'float') {
         return `${name} declares gates beside the ${bind.transform} transform - that transform writes a two-component value `
@@ -472,6 +475,25 @@ export function doorRefusal(candidate, { beside = [], spines }) {
           + 'it held the pass shut for the life of the page under the comparison this build used to make, and '
           + 'holds it open forever under the one it makes now, so it is refused rather than given a meaning '
           + 'that changes when the comparison does';
+      }
+    }
+    if (bind.bounds !== undefined && typeof bind.bounds !== 'boolean') {
+      return `${name} declares bounds as ${JSON.stringify(bind.bounds)} - it says whether this term is how `
+        + 'long its pass remembers, which is a yes or a no';
+    }
+    if (EFFECT_BOUNDED_TABLES.includes(bind.on)) onBounded += 1;
+    if (bind.bounds) {
+      bounds += 1;
+      if (!EFFECT_BOUNDED_TABLES.includes(bind.on)) {
+        return `${name} declares bounds and binds on ${JSON.stringify(bind.on)} - bounds says this term is the `
+          + `seconds its pass remembers for, and the passes with memory are ${EFFECT_BOUNDED_TABLES.join(' and ')}. `
+          + 'On any other table it bounds nothing: the render loop would read it for a refresh that never has to '
+          + 'happen, and the seek would compute a pre-roll for a pass that never needed one';
+      }
+      if (spec.kind !== 'scalar' || effectBindUniformType(bind.transform) !== 'float') {
+        return `${name} declares bounds and is a ${spec.kind} binding writing `
+          + `${effectBindUniformType(bind.transform)} - a memory is a length of time, which is one number of `
+          + 'seconds. A step or a two-component value has no reading the pre-roll could divide by';
       }
     }
     if (spec.role !== undefined) {
@@ -508,6 +530,18 @@ export function doorRefusal(candidate, { beside = [], spines }) {
   if (masters > 1) {
     return `effect ${id} declares ${masters} parameters with the role master - one package is absent at one term, `
       + 'and two of them is two answers to whether this effect is contributing';
+  }
+  // A pass with memory has to say how long it remembers, once. Nothing else in this program can
+  // supply that number: a seek reproduces a feedback pass by decoding from the last frame that
+  // refreshed it, so a package that binds there and names no period is a pass no seek can land
+  // in, and two periods is two answers to where the last refresh was.
+  if (onBounded > 0 && bounds !== 1) {
+    return `effect ${id} binds ${onBounded} parameter${onBounded === 1 ? '' : 's'} on a pass that carries a `
+      + `frame of memory and declares ${bounds} of them as its bounds - it declares exactly one, in seconds. `
+      + `${bounds === 0
+        ? 'With none, the memory has no ceiling and no length of pre-roll reproduces it, so every seek into '
+        + 'this look lands somewhere playback never was'
+        : 'With two, the refresh the pre-roll decodes from is whichever one the page happened to collect first'}`;
   }
 
   // ---- where the rows would land, which nothing before the swap asks

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ import { EffectStore } from './effect-store.js';
 import { RESERVED_EFFECT_IDS, doorRefusal, forkRefusal } from './effect-door.js';
 import { cloudSpine } from '../web/cloud-shader.js';
 import { gradeSpine } from '../web/grade-shader.js';
+import { moshSpine } from '../web/mosh-shader.js';
 import { Recorder } from './recorder.js';
 import { JobStore } from './jobs.js';
 import { Webcam } from './webcam.js';
@@ -119,9 +120,9 @@ const PRESETS = new DocumentStore(
   PROJECT_VERSION,
   resolve(flag('--builtin-presets', join(ROOT, 'presets-builtin'))),
 );
-// The two spines every program is assembled from, named once because the install door and the
+// The spines every program is assembled from, named once because the install door and the
 // store's own boot gate both read them.
-const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+const SPINES = { cloud: cloudSpine, grade: gradeSpine, mosh: moshSpine };
 // Constructed here and *settled* in `listen`'s callback: the process that loses the bind must
 // exit before it renames anything of the winner's.
 const EFFECTS = new EffectStore(

--- a/test/cloud-shader.test.mjs
+++ b/test/cloud-shader.test.mjs
@@ -10,6 +10,7 @@ import { dirname, join } from 'node:path';
 
 import { cloudSpine } from '../web/cloud-shader.js';
 import { gradeSpine } from '../web/grade-shader.js';
+import { moshSpine } from '../web/mosh-shader.js';
 import { assembleShaders } from '../web/shader-assembly.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -21,6 +22,7 @@ const BUILTIN = join(ROOT, 'effects-builtin');
 const TABLES = {
   cloud: { file: 'point-cloud.js', open: '\n  uniforms = {\n', close: '\n  };\n', key: /^ {4}([A-Za-z_]\w*):/gm, floor: 60 },
   grade: { file: 'post-chain.js', open: '\nconst GRADE_UNIFORMS = {\n', close: '\n};\n', key: /^ {2}([A-Za-z_]\w*):/gm, floor: 8 },
+  mosh: { file: 'post-chain.js', open: '\nconst MOSH_UNIFORMS = {\n', close: '\n};\n', key: /^ {2}([A-Za-z_]\w*):/gm, floor: 4 },
 };
 
 const shippedPackages = () => readdirSync(BUILTIN, { withFileTypes: true })
@@ -34,7 +36,9 @@ const shippedPackages = () => readdirSync(BUILTIN, { withFileTypes: true })
     return { id, manifest, chunks };
   });
 
-const PROGRAMS = assembleShaders({ cloud: cloudSpine, grade: gradeSpine }, shippedPackages());
+const PROGRAMS = assembleShaders(
+  { cloud: cloudSpine, grade: gradeSpine, mosh: moshSpine }, shippedPackages(),
+);
 
 /** Every name a `uniform` line declares, split on commas because one line carries several. */
 const declaredInGlsl = (program) => {

--- a/test/effect-door.test.mjs
+++ b/test/effect-door.test.mjs
@@ -10,14 +10,17 @@ import { fileURLToPath } from 'node:url';
 import {
   MAX_EFFECT_ID, RESERVED_EFFECT_IDS, doorRefusal, forkRefusal, reservedIdRefusal,
 } from '../server/effect-door.js';
-import { HOST_DRIVEN_UNIFORMS } from '../web/effect-manifests.js';
+import {
+  HOST_DRIVEN_UNIFORMS, EFFECT_GATED_TABLES, EFFECT_BOUNDED_TABLES,
+} from '../web/effect-manifests.js';
 import { snapScalar } from '../web/format.js';
 import { cloudSpine } from '../web/cloud-shader.js';
 import { gradeSpine } from '../web/grade-shader.js';
+import { moshSpine } from '../web/mosh-shader.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const BUILTIN = join(ROOT, 'effects-builtin');
-const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+const SPINES = { cloud: cloudSpine, grade: gradeSpine, mosh: moshSpine };
 
 const load = (id) => {
   const dir = join(BUILTIN, id);
@@ -339,10 +342,41 @@ test('a gating binding has to be something the gate can read', () => {
   for (const pkg of shipped()) {
     for (const [short, spec] of Object.entries(pkg.manifest.params)) {
       if (!spec.bind?.gates) continue;
-      assert.equal(spec.bind.on, 'grade', `the shipped ${pkg.id}.${short} gates on ${spec.bind.on}`);
+      assert.ok(EFFECT_GATED_TABLES.includes(spec.bind.on),
+        `the shipped ${pkg.id}.${short} gates on ${spec.bind.on}, which holds no pass open`);
       assert.equal(spec.bind.transform, undefined,
         `the shipped ${pkg.id}.${short} gates through the ${spec.bind.transform} transform`);
     }
+  }
+});
+
+test('a pass that remembers is told how long for, exactly once', () => {
+  assert.match(brokenBy('datamosh', (c) => { delete c.manifest.params.refresh.bind.bounds; }),
+    /declares 0 of them as its bounds/,
+    'a mosh package with no period is a feedback pass no seek could reproduce');
+  assert.match(brokenBy('datamosh', (c) => { c.manifest.params.grain.bind.bounds = true; }),
+    /declares 2 of them as its bounds/,
+    'and two periods is two answers to where the last refresh was');
+  assert.match(brokenBy('raster', (c) => { c.manifest.params.pitch.bind.bounds = true; }),
+    /declares bounds and binds on "grade"/,
+    'a period on a pass with no memory bounds nothing');
+  assert.match(brokenBy('datamosh', (c) => {
+    c.manifest.params.refresh.kind = 'step';
+    c.manifest.params.refresh.def = false;
+    delete c.manifest.params.refresh.min;
+    delete c.manifest.params.refresh.max;
+    delete c.manifest.params.refresh.step;
+  }), /declares bounds and is a step binding/,
+  'and a period that is a switch is not a length of time');
+  assert.equal(brokenBy('datamosh', () => {}), null, 'the shipped datamosh passes the rule');
+
+  // The census, so a second package binding on a pass with memory is asked by existing.
+  for (const pkg of shipped()) {
+    const onBounded = Object.values(pkg.manifest.params)
+      .filter((spec) => EFFECT_BOUNDED_TABLES.includes(spec.bind?.on));
+    if (onBounded.length === 0) continue;
+    assert.equal(onBounded.filter((spec) => spec.bind.bounds).length, 1,
+      `the shipped ${pkg.id} binds on a pass with memory and does not name exactly one period`);
   }
 });
 

--- a/test/effect-door.test.mjs
+++ b/test/effect-door.test.mjs
@@ -70,7 +70,7 @@ test('the door names what it refuses, one rule at a time', () => {
     ['a second master', 'rain', (c) => { Object.assign(c.manifest.params.speed, { role: 'master', def: 0, min: 0 }); }, /2 parameters with the role master/],
     ['a reading flag that is not boolean', 'ghost', (c) => { c.manifest.params.amount.reading = 'yes'; }, /declares reading as "yes"/],
     ['a reading that is not the inert master', 'ghost', (c) => { c.manifest.params.rim.reading = true; }, /declares itself a reading/],
-    ['a dependent row naming no master', 'ghost', (c) => { c.manifest.params.rim.under = 'missing'; }, /not another master in ghost/],
+    ['a dependent row naming no valid parent', 'ghost', (c) => { c.manifest.params.rim.under = 'missing'; }, /not a valid parent in ghost/],
     ['a binding no program declares', 'thermal', (c) => { c.manifest.params.amount.bind.uniform = 'thermalll'; }, /declares no such uniform/],
     ['a uniform no parameter writes', 'rain', (c) => { c.chunks['decl.frag.glsl'] += 'uniform float rainStray;\n'; }, /"rainStray" and binds no parameter/],
     ['a chunk file naming a path', 'thermal', (c) => { c.manifest.chunks[0].file = '../out.glsl'; c.chunks['../out.glsl'] = ''; }, /"\.\.\/out\.glsl"/],

--- a/test/effect-store-gate.test.mjs
+++ b/test/effect-store-gate.test.mjs
@@ -11,10 +11,11 @@ import { fileURLToPath } from 'node:url';
 import { EffectStore } from '../server/effect-store.js';
 import { cloudSpine } from '../web/cloud-shader.js';
 import { gradeSpine } from '../web/grade-shader.js';
+import { moshSpine } from '../web/mosh-shader.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const BUILTIN = join(ROOT, 'effects-builtin');
-const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+const SPINES = { cloud: cloudSpine, grade: gradeSpine, mosh: moshSpine };
 
 const builtinManifest = (id) => JSON.parse(readFileSync(join(BUILTIN, id, 'manifest.json'), 'utf8'));
 

--- a/test/mosh-preroll.test.mjs
+++ b/test/mosh-preroll.test.mjs
@@ -1,0 +1,72 @@
+// How far back a seek has to start for the mosh pass to land where playback did. The walk is
+// the one thing standing between a feedback pass and a timeline that cannot reproduce itself,
+// and it is arithmetic over two functions of program time - so it is asked here, under bare
+// node, where every input can be moved one at a time.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { moshFramesBack, moshRefreshes } from '../web/mosh-pass.js';
+
+const FPS = 30;
+const CEILING = 600;
+
+// A look that is up for the whole take, refreshing every 1.2s.
+const live = () => 1;
+const dead = () => 0;
+const period = (seconds) => () => seconds;
+
+test('the walk stops at the nearest frame the pass refreshes on', () => {
+  // 1.2s at 30fps is frame 36. A target at frame 40 decodes from frame 36, four back.
+  const at = (frame) => moshFramesBack(frame / FPS, FPS, live, period(1.2), CEILING);
+  assert.equal(at(40).frames, 4);
+  assert.equal(at(40).covered, true);
+  // A target that is itself a refresh needs no pre-roll: the pass draws what it was handed.
+  assert.equal(at(36).frames, 0);
+  assert.equal(at(37).frames, 1);
+});
+
+test('a pass that is not up needs no pre-roll at all', () => {
+  assert.deepEqual(moshFramesBack(4, FPS, dead, period(1.2), CEILING), { frames: 0, covered: true });
+});
+
+test('the frame where the pass came up is a refresh, because its history is black', () => {
+  // Up from 3s. A target at 3.4s decodes from the first live frame and no further, whatever the
+  // period says - twelve frames rather than the thirty-six a 1.2s period would ask for.
+  const upAtThree = (t) => (t >= 3 ? 1 : 0);
+  assert.deepEqual(moshFramesBack(3.4, FPS, upAtThree, period(1.2), CEILING),
+    { frames: 12, covered: true });
+});
+
+test('the head of the take stops the walk rather than running it off the front', () => {
+  const back = moshFramesBack(0.2, FPS, live, period(1.2), CEILING);
+  assert.equal(back.frames, 6);
+  assert.equal(back.covered, true);
+});
+
+test('a ceiling the walk runs out of is reported rather than rounded off', () => {
+  const back = moshFramesBack(10, FPS, live, period(4), 8);
+  assert.deepEqual(back, { frames: 8, covered: false });
+});
+
+test('the period keyframes, so the boundary is asked with the value each end had', () => {
+  // The same two program positions, under a period that moves between them. Under 1.2s both
+  // sides floor to 4; stretched to 2.0 at the near end, the near side floors to 2 and the step
+  // is a refresh - which is the whole reason the two values are asked separately.
+  assert.equal(moshRefreshes(4.9, 1.2, 5.0, 1.2), false);
+  assert.equal(moshRefreshes(4.9, 1.2, 5.0, 2.0), true);
+  // A period of zero is not a period: it refreshes every frame rather than dividing by nothing.
+  assert.equal(moshRefreshes(4.9, 1.2, 5.0, 0), true);
+  assert.equal(moshRefreshes(4.9, 0, 5.0, 1.2), true);
+});
+
+test('the walk and the loop ask the same question, so a moved period moves both', () => {
+  // A period that steps from 1.2 to 2.0 at 5s. The walk has to find the refresh the loop would
+  // have fired, and the loop fires it on the first frame whose own period disagrees with the
+  // one before it - here the frame at 5s.
+  const stepped = (t) => (t >= 5 ? 2.0 : 1.2);
+  const back = moshFramesBack(5.2, FPS, live, stepped, CEILING);
+  assert.equal(back.frames, 6, 'six frames back from 5.2s is 5.0s, where the period changed');
+  const at = 5.2 - back.frames / FPS;
+  assert.ok(moshRefreshes(at - 1 / FPS, stepped(at - 1 / FPS), at, stepped(at)),
+    'and that frame is one the loop would have refreshed on');
+});

--- a/test/shader-assembly.test.mjs
+++ b/test/shader-assembly.test.mjs
@@ -11,12 +11,13 @@ import { dirname, join } from 'node:path';
 
 import { cloudSpine } from '../web/cloud-shader.js';
 import { gradeSpine } from '../web/grade-shader.js';
+import { moshSpine } from '../web/mosh-shader.js';
 import { assembleShaders } from '../web/shader-assembly.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const BUILTIN = join(ROOT, 'effects-builtin');
 
-const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+const SPINES = { cloud: cloudSpine, grade: gradeSpine, mosh: moshSpine };
 
 // A claim rather than a convention: the flip control below requires the program a chunk's
 // name promises to be the only one that moves.
@@ -24,6 +25,7 @@ const NAMES = {
   '.vert.glsl': ['cloud', 'vertexShader'],
   '.frag.glsl': ['cloud', 'fragmentShader'],
   '.grade.glsl': ['grade', 'fragmentShader'],
+  '.mosh.glsl': ['mosh', 'fragmentShader'],
 };
 
 const shippedPackages = () => readdirSync(BUILTIN, { withFileTypes: true })

--- a/tools/determinism-check.mjs
+++ b/tools/determinism-check.mjs
@@ -1,6 +1,6 @@
 // Proves that the same program time produces the same image. Every input is pinned - a fixed
-// run of real capture frames, a fixed camera pose, colour off - with both feedback paths left
-// switched on, since they are the only things that could carry state between two runs. The
+// run of real capture frames, a fixed camera pose, colour off - with all three feedback paths
+// left switched on, since they are the only things that could carry state between two runs. The
 // frames are sampled every fourth frame, because a static scene makes the afterimage converge
 // to its own input and return the same hash whether the accumulator ran or not.
 //
@@ -34,23 +34,11 @@ const STRIDE = Number(flag('--stride', '4'));
 // from display frames.
 const SUBSTEPS = Number(flag('--substeps', '4'));
 
-// The shipped Blackwall document, read rather than restated: a copy of these values typed in
-// here would be a second source of truth for a look.
-const NETRUN_MOSH = {
-  'datamosh.amount': 1,
-  'datamosh.reach': 16,
-  'datamosh.decay': 0.92,
-  'datamosh.splay': 1,
-  'datamosh.line': 0.55,
-  'datamosh.grain': 3,
-  'datamosh.refresh': 1.2,
-};
-const BLACKWALL_LOOK = JSON.parse(
-  readFileSync(new URL('../presets-builtin/blackwall.json', import.meta.url), 'utf8'),
+// The shipped `rift` document, read rather than restated: a copy of these values typed in
+// here would be a second source of truth for a look. It is the look every section here runs.
+const RIFT_LOOK = JSON.parse(
+  readFileSync(new URL('../presets-builtin/rift.json', import.meta.url), 'utf8'),
 ).values;
-
-// Blackwall with the smear over it, which is the look every section here runs.
-const NETRUN_LOOK = { ...BLACKWALL_LOOK, ...NETRUN_MOSH };
 
 // Playwright is a tool the proofs reach for rather than a dependency, so it is resolved
 // wherever it sits.
@@ -290,12 +278,11 @@ async function openPage() {
   }
   if (!gpu.colorBufferFloat) throw new Error('no EXT_color_buffer_float: the surface memory is not running at float');
 
-  // Blackwall, read out of the document that ships it rather than typed in here, with the
-  // datamosh raised over it. Blackwall was chosen because it is the one preset that switches on
-  // both of the accumulators it knew about; the mosh pass is a third, and a third accumulator no
-  // named look enables is the object every observation here would skip. The terms are spelled
-  // out rather than read off a preset because no shipped document carries them yet.
-  await page.evaluate(`globalThis.__kinect.applyPreset(${JSON.stringify(NETRUN_LOOK)})`);
+  // `rift`, read out of the document that ships it rather than typed in here. It was chosen
+  // because it switches on all three of the passes that carry state from one render to the
+  // next - the afterimage, the surface memory and the mosh - and an accumulator no named look
+  // enables is the object every observation here would skip.
+  await page.evaluate(`globalThis.__kinect.applyPreset(${JSON.stringify(RIFT_LOOK)})`);
 
   await page.evaluate(async () => {
     const buffer = await (await fetch('/__pinned.bin')).arrayBuffer();

--- a/tools/determinism-check.mjs
+++ b/tools/determinism-check.mjs
@@ -36,9 +36,21 @@ const SUBSTEPS = Number(flag('--substeps', '4'));
 
 // The shipped Blackwall document, read rather than restated: a copy of these values typed in
 // here would be a second source of truth for a look.
+const NETRUN_MOSH = {
+  'datamosh.amount': 1,
+  'datamosh.reach': 16,
+  'datamosh.decay': 0.92,
+  'datamosh.splay': 1,
+  'datamosh.line': 0.55,
+  'datamosh.grain': 3,
+  'datamosh.refresh': 1.2,
+};
 const BLACKWALL_LOOK = JSON.parse(
   readFileSync(new URL('../presets-builtin/blackwall.json', import.meta.url), 'utf8'),
 ).values;
+
+// Blackwall with the smear over it, which is the look every section here runs.
+const NETRUN_LOOK = { ...BLACKWALL_LOOK, ...NETRUN_MOSH };
 
 // Playwright is a tool the proofs reach for rather than a dependency, so it is resolved
 // wherever it sits.
@@ -148,7 +160,10 @@ const runAfter = `async ({ substeps, tailOnly }) => {
     out,
     drawRange: k.geometry.drawRange.count,
     damp: k.afterimage.uniforms.damp.value,
-    passes: { afterimage: k.afterimage.enabled, bloom: k.bloom.enabled, grade: k.grade.enabled },
+    passes: {
+      afterimage: k.afterimage.enabled, mosh: k.mosh.enabled,
+      bloom: k.bloom.enabled, grade: k.grade.enabled,
+    },
     ghosts: k.stateStats().ghostsDrawn,
   };
 }`;
@@ -275,9 +290,12 @@ async function openPage() {
   }
   if (!gpu.colorBufferFloat) throw new Error('no EXT_color_buffer_float: the surface memory is not running at float');
 
-  // Blackwall, read out of the document that ships it rather than typed in here. It is the one
-  // preset that switches on both accumulators at once, which is why this section names a look.
-  await page.evaluate(`globalThis.__kinect.applyPreset(${JSON.stringify(BLACKWALL_LOOK)})`);
+  // Blackwall, read out of the document that ships it rather than typed in here, with the
+  // datamosh raised over it. Blackwall was chosen because it is the one preset that switches on
+  // both of the accumulators it knew about; the mosh pass is a third, and a third accumulator no
+  // named look enables is the object every observation here would skip. The terms are spelled
+  // out rather than read off a preset because no shipped document carries them yet.
+  await page.evaluate(`globalThis.__kinect.applyPreset(${JSON.stringify(NETRUN_LOOK)})`);
 
   await page.evaluate(async () => {
     const buffer = await (await fetch('/__pinned.bin')).arrayBuffer();
@@ -338,6 +356,7 @@ console.log(`\n[determinism] ${runA.out.length} images per run, `
   + `drawRange=${runA.drawRange} (ghost half ${runA.drawRange > 512 * 424 ? 'drawn' : 'OFF'})`);
 console.log(`[determinism] surface memory ${runA.ghosts}% of pixels ghosting at the end of the run, `
   + `afterimage ${p.afterimage ? `on damp=${runA.damp}` : 'OFF'}, `
+  + `mosh ${p.mosh ? 'on' : 'OFF'}, `
   + `bloom ${p.bloom ? 'on' : 'OFF'}, grade ${p.grade ? 'on' : 'OFF'}`);
 console.log(`[determinism] distinct images within run 1: ${varied}/${runA.out.length}`
   + `${varied < runA.out.length / 2 ? '  <-- input barely moves, the run proves little' : ''}`);
@@ -378,6 +397,6 @@ if (pageErrors.length) console.log(`\n[determinism] page errors:\n  ${pageErrors
 
 const pass = ab.same && ac.same && !ad.same
   && varied > runA.out.length / 2
-  && p.afterimage && p.bloom && p.grade && runA.ghosts > 0;
+  && p.afterimage && p.mosh && p.bloom && p.grade && runA.ghosts > 0;
 console.log(`\n[determinism] ${pass ? 'PASS' : 'FAIL'}`);
 process.exit(pass ? 0 : 1);

--- a/tools/effect-check.mjs
+++ b/tools/effect-check.mjs
@@ -98,7 +98,7 @@ const MUTATIONS = {
 
   'gates-are-frozen-at-boot': {
     file: 'web/main.js',
-    edits: [['  GRADE_GATES = gradeGatesOf(packages);\n', '  GRADE_GATES ??= gradeGatesOf(packages);\n']],
+    edits: [['  PASS_GATES = passGatesOf(packages);\n', '  PASS_GATES ??= passGatesOf(packages);\n']],
   },
 
   'every-reload-warms': {
@@ -143,8 +143,8 @@ const MUTATIONS = {
   'door-takes-a-gates-nothing-reads': {
     file: 'server/effect-door.js',
     edits: [[
-      '    if (bind.gates) {\n      if (bind.on',
-      '    if (false) {\n      if (bind.on',
+      '    if (bind.gates) {\n      if (!EFFECT_GATED_TABLES',
+      '    if (false) {\n      if (!EFFECT_GATED_TABLES',
     ]],
   },
 

--- a/tools/effect-conformance-check.mjs
+++ b/tools/effect-conformance-check.mjs
@@ -212,9 +212,13 @@ try {
   await page.waitForFunction('Boolean(globalThis.__kinect)', null, { timeout: 20000 });
 
   /** All four assembled shader strings, as one, for the marker rows. */
+  // Every program the page reports rather than the two it used to have. A chunk belongs to one
+  // spine and the spines are a set this build can grow: naming them here meant the mosh pass's
+  // text was searched for in the two programs it can never be in, and the row asking whether a
+  // hollowed package's text comes back said it never did.
   const assembled = () => page.evaluate(() => {
     const p = globalThis.__kinect.effects.programs();
-    return `${p.cloud.vertexShader}${p.cloud.fragmentShader}${p.grade.vertexShader}${p.grade.fragmentShader}`;
+    return Object.values(p).map((x) => `${x.vertexShader}${x.fragmentShader}`).join('');
   });
 
   if (MUTATE) {

--- a/tools/export-check.mjs
+++ b/tools/export-check.mjs
@@ -113,9 +113,25 @@ const MUTATIONS = {
   // Grain and scanlines go back to being sized in framebuffer pixels.
   'grade-absolute': { file: 'web/grade-shader.js', edits: [[
     `      float k = resolution.y / 1080.0;
-      vec2 ref = resolution / k;`,
+      vec2 ref = resolution / k;
+      vec2 texel = 1.0 / ref;
+      vec3 col;`,
     `      float k = 1.0;
-      vec2 ref = resolution;`,
+      vec2 ref = resolution;
+      vec2 texel = 1.0 / ref;
+      vec3 col;`,
+  ]] },
+  // The smear's reach and its column width go back to framebuffer pixels, so a needle covers
+  // half as much of the frame every time the buffer doubles.
+  'mosh-buffer-sized': { file: 'web/mosh-shader.js', edits: [[
+    `      float k = resolution.y / 1080.0;
+      vec2 ref = resolution / k;
+      vec2 texel = 1.0 / ref;
+      vec3 fresh = texture2D(tNew, vUv).rgb;`,
+    `      float k = 1.0;
+      vec2 ref = resolution;
+      vec2 texel = 1.0 / ref;
+      vec3 fresh = texture2D(tNew, vUv).rgb;`,
   ]] },
   // The bloom chain sized against the drawing buffer again, where its halo halves in width every
   // time the buffer doubles.
@@ -271,8 +287,14 @@ const MUTATIONS = {
       '  uniforms.bufferHeight.value = buf.x * (1080 / 1728);',
     ],
     [
-      '      float k = resolution.y / 1080.0;',
-      '      float k = resolution.x / 1728.0;',
+      `      float k = resolution.y / 1080.0;
+      vec2 ref = resolution / k;
+      vec2 texel = 1.0 / ref;
+      vec3 col;`,
+      `      float k = resolution.x / 1728.0;
+      vec2 ref = resolution / k;
+      vec2 texel = 1.0 / ref;
+      vec3 col;`,
       'web/grade-shader.js',
     ],
   ] },
@@ -689,7 +711,16 @@ const RES_ARM = `async ({ label, look, at, resLook, camera }) => {
   // a worst tile of 48.7/255, which reads as the rebase having broken and was a mask
   // still fading the cloud. Zero is the default for all four, so this changes nothing
   // for any row that was here before.
-  const REGION_BASE = { 'noise.amount': 0, 'push.amount': 0, 'noise.region': 0, 'mask.amount': 0 };
+  //
+  // **The smear is here for the same reason and it is the sharper case**, because the rows that
+  // inherit it are the rebase ones, whose whole job is to keep Blackwall's own values rather than
+  // spreading an OFF. The row that raises the smear runs last in each size's pass, so without
+  // this line every arm after it rendered through a MoshPass nobody asked for: measured the first
+  // time as eighteen rows red at a luminance ratio of 1.87, and nine more after putting it in the
+  // pipeline looks alone, where the rebase arms never see it.
+  const REGION_BASE = {
+    'noise.amount': 0, 'push.amount': 0, 'noise.region': 0, 'mask.amount': 0, 'datamosh.amount': 0,
+  };
   const merged = { ...REGION_BASE, ...resLook, ...look };
   const dropped = Object.keys(merged).filter((n) => !known.has(n));
   k.params.apply(Object.fromEntries(Object.entries(merged).filter(([n]) => known.has(n))));
@@ -977,6 +1008,18 @@ const PIPELINES = [
   ['regionpush', { look: { ...OFF, ...REGION_AT_SUBJECT, 'push.amount': 0.35 } }],
   ['regionmask', { look: { ...OFF, ...REGION_AT_SUBJECT, 'mask.amount': 0.5 } }],
   ['crop', { look: { ...OFF, ...REGION_OFF, left: -0.8, right: 0.8, bottom: -0.8, top: 0.8 } }],
+  // The one row whose pass carries a frame of memory. `RES_ARM` reaches its position through a
+  // real seek, so the pre-roll has run and the smear it measures has history behind it; the
+  // refresh puts the last decode point a second before the arm's own position at 1.5s.
+  ['datamosh', { look: { ...OFF,
+    'datamosh.amount': 1,
+    'datamosh.reach': 18,
+    'datamosh.decay': 0.9,
+    'datamosh.splay': 1,
+    'datamosh.line': 0.55,
+    'datamosh.grain': 4,
+    'datamosh.refresh': 1.5,
+  } }],
 ];
 
 // Which measurement each row is judged on, per row because the terms live at different spatial
@@ -997,6 +1040,10 @@ const RES_TOLERANCE = {
   regionpush: { on: 'coarse', mean: 1.8, ratio: 0.005 },
   regionmask: { on: 'coarse', mean: 1.5, ratio: 0.005 },
   crop: { on: 'coarse', mean: 0.9, ratio: 0.005 },
+  // Measured on this rig: 3.088 clean against 5.791 under `--mutate mosh-buffer-sized`, so the
+  // floor sits between the two rather than above both. The mutation also moves the luminance
+  // ratio to 0.938, and either half alone catches it.
+  datamosh: { on: 'coarse', mean: 4.0, ratio: 0.03 },
 };
 
 const ARMS = [];

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -881,7 +881,7 @@ const pageMutation = mutation && mutation.file.startsWith('web/') ? mutation : n
 const PAGE_URLS = { 'library.html': '/gallery', 'menu.html': '/' };
 const urlForPageFile = (file) => PAGE_URLS[file] ?? `/${file}`;
 const serverMutation = mutation && mutation.file.startsWith('server/') ? mutation : null;
-// A mutation of one of the nine documents the picker offers, which is the third kind of file
+// A mutation of one of the twelve documents the picker offers, which is the third kind of file
 // this tree stages and the only one that is data rather than code.
 const documentMutation = mutation && mutation.file.startsWith('presets-builtin/') ? mutation : null;
 

--- a/tools/module-check.mjs
+++ b/tools/module-check.mjs
@@ -829,7 +829,7 @@ const EXEMPTIONS = [
     binding: 'TOP_CENTRE',
     why: 'The world x/z the plan view is centred on. Read by the two directions of the same coordinate change and by nothing else, and a pair of numbers rather than a point because it is not a place in three dimensions.',
   },
-  // Four entries rather than one, because an exemption follows a binding rather than a kind.
+  // One entry per binding, because an exemption follows a binding rather than a kind.
   {
     module: 'web/post-chain.js',
     binding: 'renderPass',
@@ -840,6 +840,12 @@ const EXEMPTIONS = [
     binding: 'afterimage',
     why: 'The trails pass. `enabled` and `uniforms.damp` are written by the trails parameter\'s apply, together and in one line, because a damp of zero is a pass not worth running.',
   },
+  {
+    module: 'web/post-chain.js',
+    binding: 'mosh',
+    why: 'The feedback pass. `enabled` is written by the datamosh master the way the trails\' is, `uniforms.time` and `uniforms.moshIFrame` by the render loop once a frame, and `uniforms.resolution` by the resize - and its two history targets are read out by name where the accumulator reset clears them.',
+  },
+  // Four entries rather than three, because the fourth pass arrived with the same interface.
   {
     module: 'web/post-chain.js',
     binding: 'bloom',

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -4127,7 +4127,7 @@ console.log('\n[registry] the two masters are exactly absent at zero, and so is 
     'while raised, those same three keys do move the picture', 'the keys reach nothing at all');
 
   pair('flatFine', 'flatCoarse',
-    'at a lattice of 0 the cell size reaches no pixel, so the eight shipped looks that never '
+    'at a lattice of 0 the cell size reaches no pixel, so the ten shipped looks that never '
     + 'snap are untouched by the energy compensation', 'the compensation is not exactly one');
   moves('snappedFine', 'snappedCoarse',
     'while with the lattice raised the same two cell sizes do move it',

--- a/tools/registry-check.mjs
+++ b/tools/registry-check.mjs
@@ -332,8 +332,8 @@ const MUTATIONS = {
   'crush-gates-the-grade': {
     file: 'web/main.js',
     edits: [[
-      '  return GRADE_GATES.some(',
-      '  return grade.uniforms.crush.value > 0 || GRADE_GATES.some(',
+      '  return PASS_GATES[table].some(',
+      '  return (table === \'grade\' && grade.uniforms.crush.value > 0) || PASS_GATES[table].some(',
     ]],
     fails: 'seven rows: the pass-gate row for crush, all five reading rows of 1b (each at 6 of '
       + '6 frames and about three quarters of every frame), and the boot comparison, whose '
@@ -997,6 +997,13 @@ const LANDING = {
   'stock.latitude': 'k.grade.uniforms.stockLatitude.value',
   'vignette.amount': '[k.grade.uniforms.vignette.value, k.grade.enabled]',
   crush: 'k.grade.uniforms.crush.value',
+  'datamosh.amount': '[k.mosh.uniforms.mosh.value, k.mosh.enabled]',
+  'datamosh.reach': 'k.mosh.uniforms.moshReach.value',
+  'datamosh.decay': 'k.mosh.uniforms.moshDecay.value',
+  'datamosh.splay': 'k.mosh.uniforms.moshSplay.value',
+  'datamosh.line': 'k.mosh.uniforms.moshLine.value',
+  'datamosh.grain': 'k.mosh.uniforms.moshGrain.value',
+  'datamosh.refresh': 'k.mosh.uniforms.moshRefresh.value',
   denoise: 'k.uniforms.denoise.value',
   edgeTol: 'k.uniforms.edgeTol.value',
   renderScale: 'k.renderer.getContext().drawingBufferWidth',
@@ -1127,6 +1134,15 @@ const EXPECT = {
     || all['grain.amount'] > 0 || v > 0 || all['streak.amount'] > 0
     || all['halation.amount'] > 0 || all['stock.amount'] > 0],
   crush: (v) => v,
+  // The master is the only term on the mosh table that gates, so the pass is open exactly when
+  // it is up - no `||` run like the grade's, where seven terms share one pass.
+  'datamosh.amount': (v) => [v, v > 0],
+  'datamosh.reach': (v) => v,
+  'datamosh.decay': (v) => v,
+  'datamosh.splay': (v) => v,
+  'datamosh.line': (v) => v,
+  'datamosh.grain': (v) => v,
+  'datamosh.refresh': (v) => v,
   denoise: (v) => (v ? 1 : 0),
   edgeTol: (v) => v,
   // three floors width * pixelRatio, and the context runs at deviceScaleFactor 1.
@@ -1235,6 +1251,13 @@ const SCRAMBLE = {
   'stock.latitude': 0.14,
   'vignette.amount': 0.73,
   crush: 0.062,
+  'datamosh.amount': 0.83,
+  'datamosh.reach': 23.5,
+  'datamosh.decay': 0.71,
+  'datamosh.splay': 0.34,
+  'datamosh.line': 0.38,
+  'datamosh.grain': 7,
+  'datamosh.refresh': 1.85,
   denoise: false,
   edgeTol: 340,
   renderScale: 85,
@@ -1252,6 +1275,11 @@ const NO_PIXEL_EFFECT = {
     + 'and a pinned run has replaced the loop',
   camera: 'nothing draws the program camera on the pinned run - the viewport is the '
     + 'free camera - so a pose reaches the camera object and no pixel',
+  'datamosh.refresh': 'it is a period in seconds and this run is 0.622s long, so no refresh '
+    + 'falls inside it at 1.2 or at 1.85 and the two values render the same frames. Measured '
+    + 'rather than assumed - the run prints its own span two sections up. It reaches pixels in '
+    + 'timeline-check section 7, where the arm is twelve seconds in and `--mutate '
+    + 'mosh-never-refreshes` reddens two rows',
 };
 
 const PAGE_HELPERS = `
@@ -1582,6 +1610,8 @@ const GOLDEN_ABSENT = new Set([
   'stock.amount', 'stock.balance', 'stock.split', 'stock.latitude',
   'progSize',
   'tPresetFile',
+  'datamosh.amount', 'datamosh.reach', 'datamosh.decay', 'datamosh.splay',
+  'datamosh.line', 'datamosh.grain', 'datamosh.refresh',
 ]);
 const absentBefore = (name, before) => GOLDEN_ABSENT.has(name) && before === undefined;
 

--- a/tools/syntax-check.mjs
+++ b/tools/syntax-check.mjs
@@ -511,8 +511,10 @@ const withoutStringBodies = (src) => {
   // The same anchors asked of the text the driver is handed. A file is not a program since the
   // shaders became a spine plus the packages' chunks, so each anchor must appear exactly once
   // summed over every assembled program - never per program - and the edit must move one.
-  const SPINES = { cloud: 'web/cloud-shader.js', grade: 'web/grade-shader.js' };
-  const SPINE_EXPORT = { cloud: 'cloudSpine', grade: 'gradeSpine' };
+  const SPINES = {
+    cloud: 'web/cloud-shader.js', grade: 'web/grade-shader.js', mosh: 'web/mosh-shader.js',
+  };
+  const SPINE_EXPORT = { cloud: 'cloudSpine', grade: 'gradeSpine', mosh: 'moshSpine' };
   const ASSEMBLER = 'web/shader-assembly.js';
   const isSpine = (file) => Object.values(SPINES).includes(file);
   const isChunk = (file) => /^effects-builtin\/[^/]+\/[^/]+\.glsl$/.test(file);

--- a/tools/timeline-check.mjs
+++ b/tools/timeline-check.mjs
@@ -479,19 +479,19 @@ const RGB_LOOK = JSON.parse(
 ).values;
 const BLACKWALL = { look: BLACKWALL_LOOK };
 
-const NETRUN_PATH = new URL('../presets-builtin/netrun.json', import.meta.url);
-const NETRUN_SHIPPED = existsSync(NETRUN_PATH)
-  ? JSON.parse(readFileSync(NETRUN_PATH, 'utf8')).values
-  : {
-    ...BLACKWALL_LOOK,
-    'datamosh.amount': 1,
-    'datamosh.reach': 14,
-    'datamosh.decay': 0.88,
-    'datamosh.splay': 1,
-    'datamosh.line': 0.55,
-    'datamosh.grain': 3,
-    'datamosh.refresh': 1.2,
-  };
+// Blackwall with the datamosh raised, stated here rather than read off a document: MOSH_SHORT_BY
+// and the band beside it were measured against these exact values, so a document swapped in
+// underneath would move the numbers this section asserts without touching the assertion.
+const MOSH_LOOK = {
+  ...BLACKWALL_LOOK,
+  'datamosh.amount': 1,
+  'datamosh.reach': 14,
+  'datamosh.decay': 0.88,
+  'datamosh.splay': 1,
+  'datamosh.line': 0.55,
+  'datamosh.grain': 3,
+  'datamosh.refresh': 1.2,
+};
 
 const CASCADE_PATH = new URL('../presets-builtin/cascade.json', import.meta.url);
 const CASCADE_SHIPPED = existsSync(CASCADE_PATH)
@@ -1333,7 +1333,7 @@ console.log('\n== 7. the mosh pass decodes from its own last refresh ==');
   // to converge in.
   const MOSH_SHORT_BY = 35;
   const NETRUN_LOOK = {
-    ...NETRUN_SHIPPED,
+    ...MOSH_LOOK,
     fade: 0,
     wake: 0,
     trails: 0,
@@ -1346,7 +1346,7 @@ console.log('\n== 7. the mosh pass decodes from its own last refresh ==');
   const control = await arm({ ...config, kind: 'seek', frames: 0, label: 'moshControl' });
 
   const plan = seeked.seek.plan;
-  console.log(`  method: ${existsSync(NETRUN_PATH) ? 'netrun.json' : 'Blackwall with the datamosh raised'}`
+  console.log('  method: Blackwall with the datamosh raised'
     + `, refresh ${MOSH_REFRESH}s, rate 1.00x, 30 fps out, target ${TARGET_SEC}s. Pre-roll `
     + `${plan.frames} frames (surface ${plan.surface}, trails ${plan.trails}, mosh ${plan.mosh}). `
     + `Playback rendered ${played.delta.renders}, the seek ${seeked.delta.renders}, the control `

--- a/tools/timeline-check.mjs
+++ b/tools/timeline-check.mjs
@@ -1332,7 +1332,7 @@ console.log('\n== 7. the mosh pass decodes from its own last refresh ==');
   // contended machine; at 35 it is comfortable and every other accumulator still has 25 frames
   // to converge in.
   const MOSH_SHORT_BY = 35;
-  const NETRUN_LOOK = {
+  const MOSH_ARM_LOOK = {
     ...MOSH_LOOK,
     fade: 0,
     wake: 0,
@@ -1340,7 +1340,7 @@ console.log('\n== 7. the mosh pass decodes from its own last refresh ==');
     'datamosh.decay': MOSH_DECAY,
     'datamosh.refresh': MOSH_REFRESH,
   };
-  const config = { look: NETRUN_LOOK, rate: 1, fps: 30, targetSec: TARGET_SEC, frames: null };
+  const config = { look: MOSH_ARM_LOOK, rate: 1, fps: 30, targetSec: TARGET_SEC, frames: null };
   const played = await arm({ ...config, kind: 'playback', label: 'moshPlayed' });
   const seeked = await arm({ ...config, kind: 'seek', label: 'moshSeeked' });
   const control = await arm({ ...config, kind: 'seek', frames: 0, label: 'moshControl' });

--- a/tools/timeline-check.mjs
+++ b/tools/timeline-check.mjs
@@ -103,7 +103,7 @@ const MUTATIONS = {
   // from a frame that was never a keyframe and lands somewhere playback never was.
   'mosh-never-refreshes': { file: 'web/main.js', edits: [[
     `    mosh.uniforms.moshIFrame.value = (moshFresh || !moshWasLive
-      || moshRefreshes(lastProgramTime, lastMoshPeriod, t, moshPeriod)) ? 1 : 0;`,
+      || (moshCycles && moshRefreshes(lastProgramTime, lastMoshPeriod, t, moshPeriod))) ? 1 : 0;`,
     '    mosh.uniforms.moshIFrame.value = (moshFresh || !moshWasLive) ? 1 : 0;',
   ]] },
   // The mosh contributes nothing to the pre-roll, so the seek starts wherever the surface memory

--- a/tools/timeline-check.mjs
+++ b/tools/timeline-check.mjs
@@ -34,6 +34,14 @@ const SAME_MAX = 2;
 const CONTROL_MIN = 16;
 const CONTROL_MIN_PCT = 1.0;
 
+// The isolating arm in section 7, which is a smaller signal than the no-pre-roll controls above
+// because what it removes is the older half of one pass's history rather than every accumulator
+// at once. Measured on this rig: 20/255 across 57.9% of the frame with the pass intact, and
+// exactly 0 under `--mutate mosh-no-history`, so the separation is total and the floor only has
+// to sit between them.
+const MOSH_CUT_MIN = 12;
+const MOSH_CUT_MIN_PCT = 10.0;
+
 const RAIN_SAME_MAX = 2;
 const RAIN_CONTROL_MIN = 64;
 const RAIN_CONTROL_MIN_PCT = 0.8;
@@ -42,7 +50,7 @@ const RAIN_CONTROL_MIN_MEAN = 0.08;
 const MUTATIONS = {
   // The pre-roll stops being a function of anything.
   'preroll-constant': { file: 'web/main.js', edits: [[
-    'const frames = Math.max(back.frames, trails);',
+    'const frames = Math.max(back.frames, trails, back3.frames);',
     'const frames = 8;',
   ]] },
   // Nothing is rendered ahead of the target.
@@ -78,10 +86,31 @@ const MUTATIONS = {
   // The accumulators are not cleared before a pre-roll.
   'no-reset': { file: 'web/main.js', edits: [[
     '  clearFeedback(\n'
-    + '    [statePrev, stateNext, afterimage._textureComp, afterimage._textureOld],\n'
+    + '    [statePrev, stateNext, afterimage._textureComp, afterimage._textureOld, ...mosh.history],\n'
     + "    'afterimage internals moved: the accumulator reset is no longer complete',\n"
     + '  );',
     '  /* mutation: accumulator reset skipped */',
+  ]] },
+  // The mosh pass stops reading the frame it drew last time, so it displaces the picture in
+  // front of it instead of holding one back. A seek still equals a playback - there is nothing
+  // to reproduce - and the control arm that renders with no pre-roll at all stops being able to
+  // tell itself apart from the playback, which is the row that says the feedback is real.
+  'mosh-no-history': { file: 'effects-builtin/datamosh/mosh.mosh.glsl', edits: [[
+    'vec3 held = texture2D(tOld, vUv - vec2(0.0, reach * texel.y)).rgb * moshDecay;',
+    'vec3 held = texture2D(tNew, vUv - vec2(0.0, reach * texel.y)).rgb * moshDecay;',
+  ]] },
+  // The refresh never fires on its period, so the memory has no ceiling: the pre-roll decodes
+  // from a frame that was never a keyframe and lands somewhere playback never was.
+  'mosh-never-refreshes': { file: 'web/main.js', edits: [[
+    `    mosh.uniforms.moshIFrame.value = (moshFresh || !moshWasLive
+      || moshRefreshes(lastProgramTime, lastMoshPeriod, t, moshPeriod)) ? 1 : 0;`,
+    '    mosh.uniforms.moshIFrame.value = (moshFresh || !moshWasLive) ? 1 : 0;',
+  ]] },
+  // The mosh contributes nothing to the pre-roll, so the seek starts wherever the surface memory
+  // and the trails happen to want, and the smear arrives with the wrong history behind it.
+  'mosh-preroll-zero': { file: 'web/main.js', edits: [[
+    '    const back3 = this.moshFramesBack(programSec);',
+    '    const back3 = { frames: 0, covered: true };',
   ]] },
   'age-clamp-low': { file: 'web/surface-memory.js', edits: [
     ['const MAX_AGE = 6.0;', 'const MAX_AGE = 4.0;'],
@@ -449,6 +478,20 @@ const RGB_LOOK = JSON.parse(
   readFileSync(new URL('../presets-builtin/rgb.json', import.meta.url), 'utf8'),
 ).values;
 const BLACKWALL = { look: BLACKWALL_LOOK };
+
+const NETRUN_PATH = new URL('../presets-builtin/netrun.json', import.meta.url);
+const NETRUN_SHIPPED = existsSync(NETRUN_PATH)
+  ? JSON.parse(readFileSync(NETRUN_PATH, 'utf8')).values
+  : {
+    ...BLACKWALL_LOOK,
+    'datamosh.amount': 1,
+    'datamosh.reach': 14,
+    'datamosh.decay': 0.88,
+    'datamosh.splay': 1,
+    'datamosh.line': 0.55,
+    'datamosh.grain': 3,
+    'datamosh.refresh': 1.2,
+  };
 
 const CASCADE_PATH = new URL('../presets-builtin/cascade.json', import.meta.url);
 const CASCADE_SHIPPED = existsSync(CASCADE_PATH)
@@ -1263,6 +1306,131 @@ console.log('\n== 6. the rain falls with the program clock, not with the frames 
     + 'equality above is about something', show(apart));
   check(apart.max > same.max * 8 + 8, 'the two verdicts are separated rather than adjacent',
     `control max ${apart.max} against ${same.max}`);
+}
+
+console.log('\n== 7. the mosh pass decodes from its own last refresh ==');
+{
+  // The refresh is 2.5s rather than the preset's, so the target is not on a boundary: at 12s
+  // the last refresh was at 10, and the pass therefore has 60 frames of memory behind it - more
+  // than the surface and the trails ask for between them, so the pre-roll below is the mosh's.
+  const MOSH_REFRESH = 2.5;
+  // **The surface memory and the trails are put down for this section, and that is the whole
+  // reason the control arm below means anything.** With them up, an arm rendered with no
+  // pre-roll differs from a playback whatever the mosh does - the shed points and the trail are
+  // missing too - so the row saying "the control lands somewhere else" passes on a build whose
+  // mosh reads no history at all. Measured: `--mutate mosh-no-history` reddened nothing under
+  // the preset's own fade, wake and trails. Zeroed, the mosh is the only thing in the chain
+  // that remembers, and the control is a statement about it.
+  // **The decay is put up near 1 as well, and that is the other thing this section had wrong.**
+  // The smear's memory is bounded twice over - by the refresh, and by the decay eating the trail
+  // a percent at a time - and at the shipped 0.88 the second one wins long before the first:
+  // 0.88^60 is 0.05%, so a build that never refreshed at all drew the same picture and
+  // `--mutate mosh-never-refreshes` reddened nothing. At 0.99 the refresh is what bounds it.
+  const MOSH_DECAY = 0.99;
+  // How far short of the refresh the isolating arm starts. Measured: at 20 the arm parted from
+  // the playback by 18/255, which clears the 16 this file asks for by too little to trust on a
+  // contended machine; at 35 it is comfortable and every other accumulator still has 25 frames
+  // to converge in.
+  const MOSH_SHORT_BY = 35;
+  const NETRUN_LOOK = {
+    ...NETRUN_SHIPPED,
+    fade: 0,
+    wake: 0,
+    trails: 0,
+    'datamosh.decay': MOSH_DECAY,
+    'datamosh.refresh': MOSH_REFRESH,
+  };
+  const config = { look: NETRUN_LOOK, rate: 1, fps: 30, targetSec: TARGET_SEC, frames: null };
+  const played = await arm({ ...config, kind: 'playback', label: 'moshPlayed' });
+  const seeked = await arm({ ...config, kind: 'seek', label: 'moshSeeked' });
+  const control = await arm({ ...config, kind: 'seek', frames: 0, label: 'moshControl' });
+
+  const plan = seeked.seek.plan;
+  console.log(`  method: ${existsSync(NETRUN_PATH) ? 'netrun.json' : 'Blackwall with the datamosh raised'}`
+    + `, refresh ${MOSH_REFRESH}s, rate 1.00x, 30 fps out, target ${TARGET_SEC}s. Pre-roll `
+    + `${plan.frames} frames (surface ${plan.surface}, trails ${plan.trails}, mosh ${plan.mosh}). `
+    + `Playback rendered ${played.delta.renders}, the seek ${seeked.delta.renders}, the control `
+    + `${control.delta.renders}.`);
+
+  const state = await page.evaluate(`(() => {
+    const k = globalThis.__kinect;
+    return {
+      on: k.mosh.enabled,
+      amount: k.mosh.uniforms.mosh.value,
+      refresh: k.mosh.uniforms.moshRefresh.value,
+      fade: k.uniforms.fadeTime.value,
+      wake: k.uniforms.wakeTime.value,
+      trails: k.afterimage.enabled,
+    };
+  })()`);
+  check(state.on && state.amount > 0.1,
+    'the look under this section actually has the mosh pass running',
+    `amount ${state.amount}, pass ${state.on ? 'on' : 'OFF'}`);
+  check(state.fade === 0 && state.wake === 0 && !state.trails,
+    'and it is the only thing in the chain that remembers, so the control arm below is a '
+    + 'statement about the mosh rather than about the two accumulators beside it',
+    `fade ${state.fade}, wake ${state.wake}, trails ${state.trails ? 'ON' : 'off'}`);
+
+  // The claim the whole design rests on: the memory has a ceiling, and it is the period the
+  // package declares. Without it no length of pre-roll would reproduce a frame.
+  const ceiling = Math.ceil(MOSH_REFRESH * 30);
+  check(plan.mosh > 0 && plan.mosh <= ceiling && plan.moshCovered,
+    `the mosh pre-roll is bounded by the refresh it declares, ${ceiling} frames at this period`,
+    `${plan.mosh} frames, ${plan.moshCovered ? 'covered' : 'NOT covered'}`);
+  check(plan.frames === plan.mosh && plan.mosh > plan.surface && plan.mosh > plan.trails,
+    'and it is the mosh that sets the length here, the other two being down',
+    `mosh ${plan.mosh} against surface ${plan.surface} and trails ${plan.trails}`);
+  check(plan.mosh === Math.round((TARGET_SEC - Math.floor(TARGET_SEC / MOSH_REFRESH) * MOSH_REFRESH) * 30),
+    'and the length is the distance back to the last refresh, which is where a decode starts',
+    `${plan.mosh} frames back from ${TARGET_SEC}s`);
+
+  // A target that is a refresh needs no mosh pre-roll at all, which is the same rule read from
+  // the other end: 10s is four periods of 2.5, so the pass draws the frame it was handed.
+  const onBoundary = await page.evaluate(
+    `globalThis.__kinect.timeline.transport().preroll(${Math.floor(TARGET_SEC / MOSH_REFRESH) * MOSH_REFRESH})`);
+  check(onBoundary.mosh === 0,
+    'a target that lands on a refresh asks for no mosh pre-roll, because nothing behind it is read',
+    `${onBoundary.mosh} frames at ${Math.floor(TARGET_SEC / MOSH_REFRESH) * MOSH_REFRESH}s`);
+
+  check(played.delta.renders > seeked.delta.renders * 2,
+    'the two arms did substantially different amounts of work',
+    `${played.delta.renders} renders against ${seeked.delta.renders}`);
+  check(seeked.delta.renders === plan.frames + 1,
+    'the seek rendered the pre-roll and the target and nothing else',
+    `${seeked.delta.renders} of ${plan.frames + 1}`);
+  check(played.camera === seeked.camera && played.camera === control.camera,
+    'the camera is identical across all three arms');
+
+  // **The arm that says the pass reads its own history, and it is a short pre-roll rather than
+  // no pre-roll.** The obvious control - render the target with nothing before it - is not about
+  // the mosh: the surface memory's own state texture is cleared by the same reset and reads
+  // differently on its first frame whatever the fade and wake say, so that arm parts from a
+  // playback on a build whose mosh reads no history at all. Measured: `--mutate mosh-no-history`
+  // left it at max 59/255 across 85% of the frame and the row passed. Twenty frames short of the
+  // refresh, every other accumulator has long since converged and the only thing missing is
+  // that many frames of the smear's own history.
+  const short = await arm({ ...config, kind: 'seek', frames: Math.max(1, plan.mosh - MOSH_SHORT_BY), label: 'moshShort' });
+  const same = await diff('moshPlayed', 'moshSeeked');
+  const apart = await diff('moshPlayed', 'moshControl');
+  const cut = await diff('moshPlayed', 'moshShort');
+  console.log(`\n  playback vs seek         ${show(same)}${same.max === 0 ? '  (byte-identical)' : ''}`);
+  console.log(`  playback vs ${MOSH_SHORT_BY} frames short ${show(cut)}`);
+  console.log(`  playback vs no pre-roll  ${show(apart)}`);
+
+  check(same.max <= SAME_MAX,
+    `a seek lands within ${SAME_MAX}/255 of the playback with the mosh dragging the picture`, show(same));
+  check(short.delta.renders === Math.max(1, plan.mosh - MOSH_SHORT_BY) + 1,
+    'the short arm rendered the frames it was asked for, so it is the history that is missing '
+    + 'rather than the arm', `${short.delta.renders} renders`);
+  check(cut.max >= MOSH_CUT_MIN && cut.pct >= MOSH_CUT_MIN_PCT,
+    `${MOSH_SHORT_BY} frames of pre-roll short of the refresh lands somewhere else, so the pass `
+    + 'is reading what it drew rather than displacing the frame it was handed', show(cut));
+  check(cut.max > same.max * 8 + 8, 'the two verdicts are separated rather than adjacent',
+    `short max ${cut.max} against ${same.max}`);
+  // Kept as a reading rather than as a claim about the mosh: it is every accumulator's absence
+  // at once, and the row above is the one that isolates this pass.
+  check(apart.max >= CONTROL_MIN,
+    'and a seek with no pre-roll at all is further still', show(apart));
 }
 
 

--- a/web/effect-manifests.js
+++ b/web/effect-manifests.js
@@ -21,7 +21,23 @@ export const MANIFEST_FORMAT = 1;
  * one. Frozen, because a closed set anybody could push onto is not a closed set.
  */
 export const EFFECT_PARAM_KINDS = Object.freeze(['scalar', 'step']);
-export const EFFECT_BIND_TABLES = Object.freeze(['points', 'grade']);
+export const EFFECT_BIND_TABLES = Object.freeze(['points', 'grade', 'mosh']);
+
+/**
+ * The tables whose pass is switched off while every term on it is zero, so a term there may
+ * declare `gates`. The cloud is drawn whatever the look says and has nothing to hold open.
+ */
+export const EFFECT_GATED_TABLES = Object.freeze(['grade', 'mosh']);
+
+/**
+ * The tables whose pass carries a frame of memory, so a term there has to say how long that
+ * memory can last. A feedback pass with no ceiling on its own history cannot be seeked into: no
+ * length of pre-roll reproduces a frame that depends on every frame before it, which is the
+ * failure `MAX_AGE` in `web/surface-memory.js` exists to prevent one table over. A package
+ * binding here declares exactly one parameter with `bounds`, in seconds, and the render loop
+ * refreshes the pass whenever that many seconds have gone by.
+ */
+export const EFFECT_BOUNDED_TABLES = Object.freeze(['mosh']);
 const EFFECT_BIND_TRANSFORM_TYPES = Object.freeze({
   axisDeg: 'vec2',
   centeredEdges: 'vec2',
@@ -117,6 +133,7 @@ export const tableFromPackages = (packages, order) => {
     };
     if (p.bind.transform !== undefined) entry.transform = p.bind.transform;
     if (p.bind.gates !== undefined) entry.gates = p.bind.gates;
+    if (p.bind.bounds !== undefined) entry.bounds = p.bind.bounds;
     if (p.reading !== undefined) entry.reading = p.reading;
     if (p.under !== undefined) entry.under = `${name.slice(0, name.indexOf('.'))}.${p.under}`;
     table[name] = Object.freeze(entry);

--- a/web/main.js
+++ b/web/main.js
@@ -24,7 +24,8 @@ import {
 import { ZOOM_PER_NOTCH, TICK_STEPS, tickLabel, makeViewWindow } from './view-window.js';
 import { clipIn, clipOut, clipBoundOrThrow, writeClipRange } from './clip-range.js';
 import {
-  EFFECT_BIND_TRANSFORMS, effectBindUniformType, tableFromPackages, withEffectGroups,
+  EFFECT_BIND_TRANSFORMS, EFFECT_GATED_TABLES, EFFECT_BOUNDED_TABLES, effectBindUniformType,
+  tableFromPackages, withEffectGroups,
 } from './effect-manifests.js';
 import { bloomChainSize } from './bloom-pass.js';
 import {
@@ -34,7 +35,8 @@ import {
   statePrev, stateNext, buildSurfaceMemory, stepSurfaceMemory, refuseAgeCeiling,
 } from './surface-memory.js';
 import {
-  composer, renderPass, afterimage, bloom, grade, buildPostChain, setGradeProgram,
+  composer, renderPass, afterimage, mosh, bloom, grade, buildPostChain, setGradeProgram,
+  setMoshProgram,
 } from './post-chain.js';
 import {
   geometry, uniforms, material, cloud, buildPointCloud, setAdditive, setCloudProgram,
@@ -42,6 +44,8 @@ import {
 } from './point-cloud.js';
 import { cloudSpine } from './cloud-shader.js';
 import { gradeSpine } from './grade-shader.js';
+import { moshSpine } from './mosh-shader.js';
+import { moshFramesBack, moshRefreshes } from './mosh-pass.js';
 import { assembleShaders } from './shader-assembly.js';
 
 const revSignature = (effects) => effects.map((e) => `${e.id} ${e.rev}`).join('\n');
@@ -141,8 +145,8 @@ async function fetchEffectPackages() {
 // `let`, because `PUT` and `DELETE /effects/:id` rebuild the set in place.
 let effectPackages = await fetchEffectPackages();
 
-// Every program this page compiles, in one call, so a refusal covers both spines.
-const SPINES = { cloud: cloudSpine, grade: gradeSpine };
+// Every program this page compiles, in one call, so a refusal covers every spine.
+const SPINES = { cloud: cloudSpine, grade: gradeSpine, mosh: moshSpine };
 let shaderPrograms = assembleShaders(SPINES, effectPackages);
 
 // Which of the two surfaces this page is, decided by the path.
@@ -202,7 +206,7 @@ function applyWorldTilt() {
   setNavigationUp(WORLD_UP);
 }
 
-buildPostChain(shaderPrograms.grade);
+buildPostChain(shaderPrograms.grade, shaderPrograms.mosh);
 
 let renderScale = 1;
 
@@ -397,6 +401,7 @@ function resize() {
   const chain = bloomChainSize(buf.x, buf.y);
   bloom.setSize(chain.width, chain.height);
   grade.uniforms.resolution.value.set(buf.x, buf.y);
+  mosh.uniforms.resolution.value.set(buf.x, buf.y);
   uniforms.bufferHeight.value = buf.y;
   // Everything above reallocates the drawing buffer and nothing above redraws into it.
   const buffer = renderer.getDrawingBufferSize(new THREE.Vector2());
@@ -412,7 +417,7 @@ addEventListener('resize', () => {
 resize();
 
 function postEnabled() {
-  return afterimage.enabled || bloom.enabled || grade.enabled;
+  return afterimage.enabled || mosh.enabled || bloom.enabled || grade.enabled;
 }
 
 // Two vertices per point while the surface memory is shedding, one otherwise.
@@ -421,15 +426,63 @@ function updateDrawRange() {
   geometry.setDrawRange(0, shedding ? POINTS * 2 : POINTS);
 }
 
-/** The grade terms whose being up makes the pass worth running, read off the packages. */
-let GRADE_GATES;
-const gradeGatesOf = (packages) => packages.flatMap((pkg) => Object.values(pkg.manifest.params ?? {})
-  .filter((p) => p.bind?.on === 'grade' && p.bind.gates)
-  .map((p) => p.bind.uniform));
+// Which uniform table each binding writes into. A map rather than a ternary per site, so a
+// build that grows a fourth table adds one entry here instead of another branch at five sites -
+// and a table nothing resolves throws on the write rather than landing the value in undefined.
+// Built here rather than at the top of the file because every one of the three is a live
+// binding the boot sequence above has just assigned.
+const UNIFORM_TABLES = Object.freeze({
+  points: uniforms, grade: grade.uniforms, mosh: mosh.uniforms,
+});
 
-function gradeNeeded() {
-  return GRADE_GATES.some((name) => grade.uniforms[name].value !== 0);
+/** The pass a gating term on each table holds open. */
+const PASS_OF_TABLE = Object.freeze({ grade, mosh });
+
+/** The terms whose being up makes each gated pass worth running, read off the packages. */
+let PASS_GATES;
+const passGatesOf = (packages) => Object.fromEntries(EFFECT_GATED_TABLES.map((table) => [
+  table,
+  packages.flatMap((pkg) => Object.values(pkg.manifest.params ?? {})
+    .filter((p) => p.bind?.on === table && p.bind.gates)
+    .map((p) => p.bind.uniform)),
+]));
+
+function passNeeded(table) {
+  const held = UNIFORM_TABLES[table];
+  return PASS_GATES[table].some((name) => held[name].value !== 0);
 }
+
+/**
+ * The dotted registry names of the terms that hold a pass with memory open.
+ *
+ * Read off the manifests rather than written down, for the reason `passGatesOf` is: a package id
+ * hard-coded in here is a fork installed under another name whose pre-roll silently stops being
+ * computed, with nothing red anywhere.
+ */
+const moshMastersOf = (packages) => packages.flatMap((pkg) => Object.entries(pkg.manifest.params ?? {})
+  .filter(([, p]) => EFFECT_BOUNDED_TABLES.includes(p.bind?.on) && p.bind.gates)
+  .map(([short]) => `${pkg.id}.${short}`));
+
+/** The term saying how long the mosh pass's memory lasts, by both its names, or null. */
+const moshBoundOf = (packages) => packages.flatMap((pkg) => Object.entries(pkg.manifest.params ?? {})
+  .filter(([, p]) => EFFECT_BOUNDED_TABLES.includes(p.bind?.on) && p.bind.bounds)
+  .map(([short, p]) => ({ name: `${pkg.id}.${short}`, uniform: p.bind.uniform })))[0] ?? null;
+
+let MOSH_MASTERS = [];
+let MOSH_BOUND = null;
+
+/** Whether the mosh pass is doing anything at a program position, and for how long it remembers. */
+const moshLiveAt = (programSec) => MOSH_MASTERS.some((name) => valueAtProgram(name, programSec) !== 0);
+const moshPeriodAt = (programSec) => (MOSH_BOUND ? valueAtProgram(MOSH_BOUND.name, programSec) : 0);
+
+// The look terms a draft puts down for the length of its one frame. Three of them are the core's
+// own accumulators and the rest are whatever the packages brought that accumulates, because a
+// draft is one frame rendered out of order and a term whose value depends on the frame before it
+// has nothing to read.
+const BYPASSED_CORE = Object.freeze(['fade', 'wake', 'trails']);
+let BYPASSED = [...BYPASSED_CORE];
+let BYPASS_ZERO = Object.fromEntries(BYPASSED.map((name) => [name, 0]));
+let BYPASSED_SET = new Set(BYPASSED);
 
 /** How far outside the cloud the fitted faces sit, as a share of the extent they bound. */
 const CROP_FIT_PAD = 0.15;
@@ -473,6 +526,8 @@ const EFFECT_PARAM_ORDER = [
   'halation.amount', 'halation.radius', 'halation.threshold', 'halation.tint',
   'stock.amount', 'stock.balance', 'stock.split', 'stock.latitude',
   'vignette.amount',
+  'datamosh.amount', 'datamosh.reach', 'datamosh.decay', 'datamosh.splay',
+  'datamosh.line', 'datamosh.grain', 'datamosh.refresh',
 ];
 
 // The list places the shipped set and is never a census of what is installed.
@@ -526,7 +581,7 @@ let PANEL_GROUPS;
 
 /** The write one effect parameter's binding describes, as the closure the registry stores. */
 function effectApply(bind) {
-  const table = () => (bind.on === 'grade' ? grade.uniforms : uniforms);
+  const table = () => UNIFORM_TABLES[bind.on];
   let write;
   if (bind.transform === 'axisDeg') {
     write = (v) => {
@@ -549,7 +604,7 @@ function effectApply(bind) {
     write = (v) => { table()[bind.uniform].value = v; };
   }
   if (!bind.gates) return write;
-  return (v) => { write(v); grade.enabled = gradeNeeded(); };
+  return (v) => { write(v); PASS_OF_TABLE[bind.on].enabled = passNeeded(bind.on); };
 }
 
 /** One run of `EFFECT_PARAMS`, as entries ready to spread into `PARAMS`. */
@@ -713,6 +768,7 @@ const buildParams = () => ({
   crush: { def: 0.018, min: 0, max: 0.2, step: 0.001, kind: 'scalar', tag: 'look',
     group: 'post', label: 'crush',
     apply: (v) => { grade.uniforms.crush.value = v; } },
+  ...effectSlice('datamosh.amount', 'datamosh.refresh'),
 
   denoise: { def: true, kind: 'step', tag: 'look',
     group: 'signal', label: 'cull speckle',
@@ -1251,7 +1307,7 @@ const uniformCellFits = (cell, bind) => Boolean(cell)
 function seedUniformCells() {
   for (const name of Object.keys(EFFECT_PARAMS)) {
     const bind = EFFECT_PARAMS[name];
-    const table = bind.on === 'grade' ? grade.uniforms : uniforms;
+    const table = UNIFORM_TABLES[bind.on];
     if (uniformCellFits(table[bind.uniform], bind)) continue;
     table[bind.uniform] = {
       value: effectBindUniformType(bind.transform) === 'vec2' ? new THREE.Vector2() : 0,
@@ -1266,16 +1322,14 @@ const boundUniforms = (table) => new Map(Object.values(table ?? {})
 /** What each uniform table held before any parameter had ever been written into it. */
 const snapshotUniformValues = (table) => new Map(Object.entries(table)
   .map(([name, cell]) => [name, cell?.value instanceof THREE.Vector2 ? cell.value.clone() : cell?.value]));
-const PRISTINE_UNIFORMS = {
-  points: snapshotUniformValues(uniforms),
-  grade: snapshotUniformValues(grade.uniforms),
-};
+const PRISTINE_UNIFORMS = Object.fromEntries(Object.entries(UNIFORM_TABLES)
+  .map(([table, held]) => [table, snapshotUniformValues(held)]));
 
 /** Every uniform a parameter used to write and none writes now, put back where it started. */
 function restoreDepartedUniforms(was, now) {
   for (const [key, bind] of was) {
     if (now.has(key)) continue;
-    const table = bind.on === 'grade' ? grade.uniforms : uniforms;
+    const table = UNIFORM_TABLES[bind.on];
     const cell = table[bind.uniform];
     if (!cell) continue;
     const pristine = PRISTINE_UNIFORMS[bind.on]?.get(bind.uniform);
@@ -1297,11 +1351,18 @@ function adoptEffectPackages(packages, programs, held = {}) {
   // The materials are mutated rather than replaced: everything downstream holds them.
   setCloudProgram(programs.cloud);
   setGradeProgram(programs.grade);
+  setMoshProgram(programs.mosh);
 
   EFFECT_PARAMS = tableFromPackages(packages, EFFECT_PARAM_ORDER);
   PANEL_GROUPS = withEffectGroups(CORE_PANEL_GROUPS, packages);
-  // Which grade terms hold the pass open, re-derived from the set that just arrived.
-  GRADE_GATES = gradeGatesOf(packages);
+  // Which terms hold each gated pass open, re-derived from the set that just arrived, and
+  // which of them the transport has to put down while it drafts.
+  PASS_GATES = passGatesOf(packages);
+  MOSH_MASTERS = moshMastersOf(packages);
+  MOSH_BOUND = moshBoundOf(packages);
+  BYPASSED = [...BYPASSED_CORE, ...MOSH_MASTERS];
+  BYPASS_ZERO = Object.fromEntries(BYPASSED.map((name) => [name, 0]));
+  BYPASSED_SET = new Set(BYPASSED);
   PARAMS = buildParams();
   READINGS = Object.keys(PARAMS).filter((n) => PARAMS[n].reading);
   refuseRegistryDisagreement();
@@ -1320,7 +1381,7 @@ function adoptEffectPackages(packages, programs, held = {}) {
   }
 
   // Asked again, because a gated parameter's own write cannot answer for a term that left.
-  grade.enabled = gradeNeeded();
+  for (const table of EFFECT_GATED_TABLES) PASS_OF_TABLE[table].enabled = passNeeded(table);
 }
 
 adoptEffectPackages(effectPackages, shaderPrograms);
@@ -3110,6 +3171,14 @@ function advanceSurfaceState(dtSec) {
 
 let lastProgramTime = 0;
 
+// What the mosh pass's last rendered frame was: whether the history behind it is worth reading
+// at all, and the refresh period in force when it was drawn. The second is remembered rather
+// than re-derived because the period keyframes, so the step between two frames is measured with
+// the value each end actually had.
+let moshFresh = true;
+let moshWasLive = false;
+let lastMoshPeriod = 0;
+
 // Screen-space history belongs to the camera pose that produced it.
 let renderedCamera = null;
 const renderedCameraPosition = new THREE.Vector3();
@@ -3155,14 +3224,17 @@ function clearAfterimage() {
   );
 }
 
-// Clears both feedback paths. Neither walks backwards, so a seek pre-rolls forward.
+// Clears every feedback path. None of them walks backwards, so a seek pre-rolls forward.
 function resetAccumulators() {
   counters.resets++;
   clearFeedback(
-    [statePrev, stateNext, afterimage._textureComp, afterimage._textureOld],
+    [statePrev, stateNext, afterimage._textureComp, afterimage._textureOld, ...mosh.history],
     'afterimage internals moved: the accumulator reset is no longer complete',
   );
   lastProgramTime = 0;
+  // Cleared history is black, and a mosh chunk reading it would draw black rather than nothing,
+  // so the next frame is a refresh whatever the period says.
+  moshFresh = true;
 }
 
 // Where an export takes its bytes. One position, since the readback shares the task.
@@ -3195,6 +3267,7 @@ function renderProgramFrame(t) {
     uniforms.spanSec.value = frame.spanSec;
     uniforms.time.value = t;
     grade.uniforms.time.value = t;
+    mosh.uniforms.time.value = t;
     uniforms.rainPhase.value = t;
 
     // Every track, look and camera alike, through the registry rather than onto the uniforms.
@@ -3206,6 +3279,18 @@ function renderProgramFrame(t) {
       clearAfterimage();
       counters.navigationHistoryClears++;
     }
+
+    // Whether this is the frame the mosh pass draws exactly what it was handed. Asked before
+    // `lastProgramTime` moves, because it is a question about the step between two frames: the
+    // period in force at each end, and the two ends of the step. The other two answers are
+    // states the pass cannot be asked about - a cleared history, and a pass that was switched
+    // off while the frames it would have remembered went by.
+    const moshPeriod = MOSH_BOUND ? mosh.uniforms[MOSH_BOUND.uniform].value : 0;
+    mosh.uniforms.moshIFrame.value = (moshFresh || !moshWasLive
+      || moshRefreshes(lastProgramTime, lastMoshPeriod, t, moshPeriod)) ? 1 : 0;
+    moshFresh = false;
+    moshWasLive = mosh.enabled;
+    lastMoshPeriod = moshPeriod;
 
     const dt = Math.max(0, t - lastProgramTime);
     lastProgramTime = t;
@@ -3483,10 +3568,6 @@ class IndexedPairSource extends StampedPairSource {
 // 1% of the previous image. Three's pass zeroes anything under 0.1 outright.
 const AFTERIMAGE_RESIDUAL = 0.01;
 
-const BYPASSED = ['fade', 'wake', 'trails'];
-const BYPASS_ZERO = { fade: 0, wake: 0, trails: 0 };
-const BYPASSED_SET = new Set(BYPASSED);
-
 // The most output frames one tick may render to catch up.
 const CATCHUP_FRAMES = 4;
 // How far behind real time playback has to fall before it says so.
@@ -3572,15 +3653,29 @@ class TimelineTransport {
     const back = retime.framesBackFor(programSec, surfaceSec, this.outputFps, this.lastFrame);
     const back2 = this.trailsFramesBack(programSec);
     const trails = back2.frames;
-    const frames = Math.max(back.frames, trails);
+    const back3 = this.moshFramesBack(programSec);
+    const frames = Math.max(back.frames, trails, back3.frames);
     return {
       surface: back.frames,
       surfaceCovered: back.covered,
       trails,
       trailsCovered: back2.covered,
+      mosh: back3.frames,
+      moshCovered: back3.covered,
       frames,
       sec: frames / this.outputFps,
     };
+  }
+
+  /**
+   * How many output frames back the mosh pass is decoded from: the nearest frame it refreshes on,
+   * which is where its history stops mattering. The walk itself is in `web/mosh-pass.js`, beside
+   * the pass whose memory it bounds and where bare node can reach it.
+   */
+  moshFramesBack(programSec) {
+    return moshFramesBack(
+      programSec, this.outputFps, moshLiveAt, moshPeriodAt, Math.max(1, this.lastFrame),
+    );
   }
 
   /** How many output frames back the afterimage is rebuilt from for nothing before to show. */
@@ -3739,7 +3834,7 @@ class TimelineTransport {
     const target = this.frameAt(programSec);
     const t = target / this.outputFps;
     const source = this.sourceFrameAt(t);
-    if (this.drafted || valueAtProgram('trails', t) > 0
+    if (this.drafted || valueAtProgram('trails', t) > 0 || moshLiveAt(t)
         || target !== this.frame || this.source.applied !== source + 1) {
       return this.seekNow(t);
     }
@@ -7178,7 +7273,8 @@ function drawChrome() {
     chromeCtx.fillText(`${(drawCount / 1000).toFixed(0)}k${shedding ? ' +shed' : ''}`, col2, y); y += lineH;
 
     // Post effects
-    const posts = [afterimage.enabled && 'trail', bloom.enabled && 'bloom', grade.enabled && 'grade'].filter(Boolean);
+    const posts = [afterimage.enabled && 'trail', mosh.enabled && 'mosh',
+      bloom.enabled && 'bloom', grade.enabled && 'grade'].filter(Boolean);
     chromeCtx.fillStyle = '#6d7683';
     chromeCtx.fillText('post', col1, y);
     chromeCtx.fillStyle = '#e8ecf1';
@@ -8352,7 +8448,9 @@ let pinnedPairs = null;
 
 /** Compile every program the look can reach, before the first frame anybody sees. */
 function warmPrograms() {
-  const was = { after: afterimage.enabled, bloom: bloom.enabled, grade: grade.enabled };
+  const was = {
+    after: afterimage.enabled, mosh: mosh.enabled, bloom: bloom.enabled, grade: grade.enabled,
+  };
   const wasAdditive = uniforms.softEdge.value === 1;
   // A shader that will not compile is not an exception anywhere, which is why this hook exists.
   const linkFailures = [];
@@ -8366,6 +8464,7 @@ function warmPrograms() {
   };
   try {
     afterimage.enabled = true;
+    mosh.enabled = true;
     bloom.enabled = true;
     grade.enabled = true;
     // Both blending states: `setAdditive` flips `material.needsUpdate` and blend
@@ -8379,6 +8478,7 @@ function warmPrograms() {
   } finally {
     renderer.debug.onShaderError = priorHook;
     afterimage.enabled = was.after;
+    mosh.enabled = was.mosh;
     bloom.enabled = was.bloom;
     grade.enabled = was.grade;
     resetAccumulators();
@@ -8453,7 +8553,7 @@ if (EDITING && !REQUESTED_TAKE) {
 // Handles for profiling and for poking at the scene from the console.
 globalThis.__kinect = {
   renderer, composer, scene, freeCamera, programCamera, uniforms, material,
-  bloom, afterimage, grade, geometry, resetAccumulators, renderProgramFrame,
+  bloom, afterimage, mosh, grade, geometry, resetAccumulators, renderProgramFrame,
 
   // A getter and not the object: the object is replaced when navigation's up changes.
   get controls() { return controls; },

--- a/web/main.js
+++ b/web/main.js
@@ -473,7 +473,14 @@ let MOSH_BOUND = null;
 
 /** Whether the mosh pass is doing anything at a program position, and for how long it remembers. */
 const moshLiveAt = (programSec) => MOSH_MASTERS.some((name) => valueAtProgram(name, programSec) !== 0);
-const moshPeriodAt = (programSec) => (MOSH_BOUND ? valueAtProgram(MOSH_BOUND.name, programSec) : 0);
+// Zero when cycling is disabled: moshRefreshes treats 0 as "refresh every frame", so the preroll
+// walk finds a keyframe immediately and returns 0. The render loop guards with moshCycles, so it
+// does not actually refresh - but the preroll correctly reports no memory to replay.
+const moshPeriodAt = (programSec) => {
+  if (!MOSH_BOUND) return 0;
+  if (!valueAtProgram('datamosh.cycleRefresh', programSec)) return 0;
+  return valueAtProgram(MOSH_BOUND.name, programSec);
+};
 
 // The look terms a draft puts down for the length of its one frame. Three of them are the core's
 // own accumulators and the rest are whatever the packages brought that accumulates, because a
@@ -527,7 +534,7 @@ const EFFECT_PARAM_ORDER = [
   'stock.amount', 'stock.balance', 'stock.split', 'stock.latitude',
   'vignette.amount',
   'datamosh.amount', 'datamosh.reach', 'datamosh.decay', 'datamosh.splay',
-  'datamosh.line', 'datamosh.grain', 'datamosh.refresh',
+  'datamosh.line', 'datamosh.grain', 'datamosh.cycleRefresh', 'datamosh.refresh',
 ];
 
 // The list places the shipped set and is never a census of what is installed.
@@ -3286,8 +3293,9 @@ function renderProgramFrame(t) {
     // states the pass cannot be asked about - a cleared history, and a pass that was switched
     // off while the frames it would have remembered went by.
     const moshPeriod = MOSH_BOUND ? mosh.uniforms[MOSH_BOUND.uniform].value : 0;
+    const moshCycles = mosh.uniforms.moshCycleRefresh?.value ?? 1;
     mosh.uniforms.moshIFrame.value = (moshFresh || !moshWasLive
-      || moshRefreshes(lastProgramTime, lastMoshPeriod, t, moshPeriod)) ? 1 : 0;
+      || (moshCycles && moshRefreshes(lastProgramTime, lastMoshPeriod, t, moshPeriod))) ? 1 : 0;
     moshFresh = false;
     moshWasLive = mosh.enabled;
     lastMoshPeriod = moshPeriod;

--- a/web/main.js
+++ b/web/main.js
@@ -534,7 +534,7 @@ const EFFECT_PARAM_ORDER = [
   'stock.amount', 'stock.balance', 'stock.split', 'stock.latitude',
   'vignette.amount',
   'datamosh.amount', 'datamosh.reach', 'datamosh.decay', 'datamosh.splay',
-  'datamosh.line', 'datamosh.grain', 'datamosh.cycleRefresh', 'datamosh.refresh',
+  'datamosh.line', 'datamosh.grain', 'datamosh.drift', 'datamosh.speed', 'datamosh.cycleRefresh', 'datamosh.refresh',
 ];
 
 // The list places the shipped set and is never a census of what is installed.

--- a/web/mosh-pass.js
+++ b/web/mosh-pass.js
@@ -1,0 +1,136 @@
+// The feedback pass, and the arithmetic that says how far back a seek has to start to reproduce
+// it. Both halves are here for one reason to change: the pass is what holds a frame of memory,
+// and the walk below is the ceiling on how long that memory can last. Nothing runs at import
+// time beyond declaring a class and a function, so the walk can be tested under bare node with
+// no renderer at all - the same split `web/bloom-pass.js` makes with `bloomChainSize`.
+
+import * as THREE from 'three';
+import { Pass, FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
+import { CopyShader } from 'three/addons/shaders/CopyShader.js';
+
+/**
+ * A pass that can read the frame it drew last time.
+ *
+ * Two targets and a swap, the shape three's own `AfterimagePass` uses: the program draws into
+ * `comp` reading `old`, the result is copied on to whatever the chain asked for, and the two
+ * swap so `old` holds what was just drawn. Half float rather than byte, because a pixel that
+ * has been through the feedback a dozen times has been quantised a dozen times, and eight bits
+ * of it band visibly on the smear.
+ *
+ * The program is handed in rather than built here, for the reason `buildPostChain` is handed
+ * the grade's: this module never learns there is an effect store, which is what lets the gate
+ * assemble the same text under bare node.
+ */
+export class MoshPass extends Pass {
+  constructor({ uniforms, vertexShader, fragmentShader }) {
+    super();
+    this.uniforms = uniforms;
+    this.material = new THREE.ShaderMaterial({ uniforms, vertexShader, fragmentShader });
+    this.copyMaterial = new THREE.ShaderMaterial({
+      uniforms: THREE.UniformsUtils.clone(CopyShader.uniforms),
+      vertexShader: CopyShader.vertexShader,
+      fragmentShader: CopyShader.fragmentShader,
+      blending: THREE.NoBlending,
+      depthTest: false,
+      depthWrite: false,
+    });
+    const target = () => new THREE.WebGLRenderTarget(1, 1, {
+      magFilter: THREE.NearestFilter,
+      minFilter: THREE.NearestFilter,
+      type: THREE.HalfFloatType,
+    });
+    this.comp = target();
+    this.old = target();
+    this.quad = new FullScreenQuad(this.material);
+    this.copyQuad = new FullScreenQuad(this.copyMaterial);
+  }
+
+  /** The two targets the history lives in, so a reset can clear them by name rather than by index. */
+  get history() {
+    return [this.comp, this.old];
+  }
+
+  render(renderer, writeBuffer, readBuffer) {
+    this.uniforms.tNew.value = readBuffer.texture;
+    this.uniforms.tOld.value = this.old.texture;
+
+    renderer.setRenderTarget(this.comp);
+    this.quad.render(renderer);
+
+    this.copyMaterial.uniforms.tDiffuse.value = this.comp.texture;
+    if (this.renderToScreen) {
+      renderer.setRenderTarget(null);
+    } else {
+      renderer.setRenderTarget(writeBuffer);
+      if (this.clear) renderer.clear();
+    }
+    this.copyQuad.render(renderer);
+
+    const held = this.old;
+    this.old = this.comp;
+    this.comp = held;
+  }
+
+  setSize(width, height) {
+    this.comp.setSize(width, height);
+    this.old.setSize(width, height);
+  }
+
+  dispose() {
+    this.comp.dispose();
+    this.old.dispose();
+    this.material.dispose();
+    this.copyMaterial.dispose();
+    this.quad.dispose();
+    this.copyQuad.dispose();
+  }
+}
+
+/**
+ * Whether the refresh falls between two consecutive rendered frames.
+ *
+ * The period is a look term like any other, so it keyframes, and `floor(t / period)` against a
+ * moving period is not a boundary anybody could seek to. What is well defined is the comparison
+ * the render loop actually makes: each frame divides its own program time by the period that was
+ * in force when it was drawn, and the refresh fires where the two answers differ. Both periods
+ * are handed in rather than looked up, because the loop remembers the previous frame's and the
+ * walk below evaluates it - one question, asked from two directions, and they may not drift.
+ *
+ * A period of zero or less is not a period: it refreshes every frame rather than dividing by
+ * nothing.
+ */
+export const moshRefreshes = (prevSec, prevPeriod, sec, period) => {
+  if (!(prevPeriod > 0) || !(period > 0)) return true;
+  return Math.floor(prevSec / prevPeriod) !== Math.floor(sec / period);
+};
+
+/**
+ * How many output frames back a seek has to start for the mosh pass to land where playback did.
+ *
+ * A frame the pass refreshes on is one it draws exactly what it was handed, so it is where a
+ * decode can start - a keyframe, which is the same thing an I-frame is in the format this look is
+ * about. The walk goes back a frame at a time looking for the nearest one, and there are three
+ * kinds: the refresh itself, the pass's first live frame (whose history is black, so it refreshes
+ * whatever the period says), and the head of the take. Zero is a legitimate answer: a target that
+ * is itself a refresh needs no pre-roll at all.
+ *
+ * **In frames rather than in seconds**, because that is what the loop renders: `seekNow` and
+ * playback both step `k / outputFps`, and a walk subtracting `1 / outputFps` off a float lands a
+ * whisker under a boundary and reports a refresh one frame early.
+ *
+ * `covered` is false when the ceiling ran out before any of the three, which is the honest answer
+ * rather than a number: something has made the memory outlast the bound its own parameter states.
+ */
+export function moshFramesBack(programSec, outputFps, liveAt, periodAt, ceilingFrames) {
+  if (!liveAt(programSec)) return { frames: 0, covered: true };
+  const target = Math.round(programSec * outputFps);
+  for (let n = 0; n <= ceilingFrames; n++) {
+    const frame = target - n;
+    if (frame <= 0) return { frames: n, covered: true };
+    const at = frame / outputFps;
+    const prev = (frame - 1) / outputFps;
+    if (!liveAt(prev)) return { frames: n, covered: true };
+    if (moshRefreshes(prev, periodAt(prev), at, periodAt(at))) return { frames: n, covered: true };
+  }
+  return { frames: ceilingFrames, covered: false };
+}

--- a/web/mosh-shader.js
+++ b/web/mosh-shader.js
@@ -1,0 +1,67 @@
+// The core of the mosh pass, and the joints the installed effects are spliced into.
+//
+// The same shape as `web/grade-shader.js` and for the same reasons: source text in ordered
+// segments, nothing imported, nothing interpolated, so `test/shader-assembly.test.mjs` can
+// assemble it under bare node with no page and no GPU. Every `uniform` in the assembled program
+// needs a key in `MOSH_UNIFORMS` in `web/post-chain.js`, which `test/cloud-shader.test.mjs` asks
+// of the assembled text rather than of this file.
+//
+// **What makes this spine different from the other two is that it reads the frame it drew last
+// time.** `tOld` is the pass's own previous output and `tNew` is what the chain handed it, so a
+// chunk here can hold pixels back rather than only transform the ones in front of it. That is the
+// whole reason the pass exists, and it is also the reason the spine owns the refresh below.
+
+const frozen = (entries) => Object.freeze(entries.map((e) => Object.freeze(e)));
+
+export const moshSpine = Object.freeze({
+  // No joints, for the reason the grade's vertex stage gives: a full-screen pass draws one quad
+  // and every term is a function of where its fragments land.
+  vertex: frozen([
+    { text: /* glsl */ `
+    varying vec2 vUv;
+    void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+  ` },
+  ]),
+  fragment: frozen([
+    { text: /* glsl */ `
+    uniform sampler2D tNew, tOld;
+    uniform vec2 resolution;
+    uniform float time, moshIFrame;
+` },
+    // The terms an effect declares for this pass.
+    { stage: 'm.decl' },
+    { text: /* glsl */ `\
+    varying vec2 vUv;
+
+    float hash(vec2 p) { return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453); }
+
+    void main() {
+      // The same 1080p reference the other two programs use, so a distance measured here is
+      // the same distance at any output size. \`ref\` is the frame in reference pixels and
+      // \`texel\` is one of them in uv.
+      float k = resolution.y / 1080.0;
+      vec2 ref = resolution / k;
+      vec2 texel = 1.0 / ref;
+      vec3 fresh = texture2D(tNew, vUv).rgb;
+      vec3 col = fresh;
+
+      // The refresh, which is this spine's own and not a chunk's: on an I-frame the pass is the
+      // frame it was handed, exactly, and every chunk below is skipped. The host raises it when
+      // the bounding term says this much program time has gone by since the last one, and on the
+      // first frame after a reset, where the history is black and a chunk reading it would draw
+      // black. It is what makes a seek reproduce a playback - a pre-roll starts at the last
+      // refresh and decodes forward, which is what seeking to a keyframe is.
+      if (moshIFrame < 0.5) {
+` },
+    // Everything a mosh package does, inside the refresh gate and in the order the pass runs
+    // them. A stage rather than a slot because these compose: each takes the colour the one
+    // above produced.
+    { stage: 'm.body' },
+    { text: /* glsl */ `\
+      }
+
+      gl_FragColor = vec4(col, 1.0);
+    }
+  ` },
+  ]),
+});

--- a/web/post-chain.js
+++ b/web/post-chain.js
@@ -44,7 +44,7 @@ const MOSH_UNIFORMS = {
   time: { value: 0 },
   moshIFrame: { value: 1 },
   resolution: { value: new THREE.Vector2(1, 1) },
-  // The datamosh package's seven, defaulting to what its manifest declares, so a page whose
+  // The datamosh package's ten, defaulting to what its manifest declares, so a page whose
   // registry has not landed yet holds the same look the first slider read will.
   mosh: { value: 0 },
   moshReach: { value: 14 },
@@ -52,6 +52,8 @@ const MOSH_UNIFORMS = {
   moshSplay: { value: 1 },
   moshLine: { value: 0.55 },
   moshGrain: { value: 3 },
+  moshDrift: { value: 0 },
+  moshSpeed: { value: 1 },
   moshCycleRefresh: { value: 0 },
   moshRefresh: { value: 1.2 },
 };

--- a/web/post-chain.js
+++ b/web/post-chain.js
@@ -52,6 +52,7 @@ const MOSH_UNIFORMS = {
   moshSplay: { value: 1 },
   moshLine: { value: 0.55 },
   moshGrain: { value: 3 },
+  moshCycleRefresh: { value: 0 },
   moshRefresh: { value: 1.2 },
 };
 

--- a/web/post-chain.js
+++ b/web/post-chain.js
@@ -1,9 +1,14 @@
 // Which passes the picture goes through after the cloud is drawn, and in what order.
 //
-// The order is the whole of this file's opinion: trails accumulate the raw cloud, bloom blows
-// out the hot edges of what the trails left, and the grade tears the finished image. Reordering
-// any two is a different look - a grade before the bloom would have the glow blooming the
-// tearing rather than the picture. No opinion about the passes themselves lives here.
+// The order is the whole of this file's opinion: trails accumulate the raw cloud, the mosh drags
+// what it holds of that along Y, bloom blows out the hot edges of what is left, and the grade
+// tears the finished image. Reordering any two is a different look - a grade before the bloom
+// would have the glow blooming the tearing rather than the picture, and a mosh after the grade
+// would smear the grain and the scanlines down the frame instead of drawing them over the
+// damage.
+// The mosh sits feed-side for the reason the glitch package's own tear does: a compression
+// artifact happened to the picture on its way here, before anything displayed it. No opinion
+// about the passes themselves lives here.
 //
 // Nothing is allocated and no GL is touched while this module evaluates. `new
 // EffectComposer(renderer)` is the sharpest case: it reads the renderer's pixel ratio and
@@ -12,6 +17,7 @@
 import * as THREE from 'three';
 import { renderer, scene, viewCamera } from './scene.js';
 import { BloomPass } from './bloom-pass.js';
+import { MoshPass } from './mosh-pass.js';
 import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { AfterimagePass } from 'three/addons/postprocessing/AfterimagePass.js';
@@ -24,8 +30,30 @@ import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 export let composer = null;
 export let renderPass = null;
 export let afterimage = null;
+export let mosh = null;
 export let bloom = null;
 export let grade = null;
+
+// Every cell the mosh's shader reads before a look lands. `tNew` and `tOld` are written by the
+// pass itself once a frame; `moshIFrame` is the render loop's, and it is 1 rather than 0 at rest
+// so that a pass switched on before anything has decided otherwise draws the frame it was handed
+// rather than reading history nobody has written.
+const MOSH_UNIFORMS = {
+  tNew: { value: null },
+  tOld: { value: null },
+  time: { value: 0 },
+  moshIFrame: { value: 1 },
+  resolution: { value: new THREE.Vector2(1, 1) },
+  // The datamosh package's seven, defaulting to what its manifest declares, so a page whose
+  // registry has not landed yet holds the same look the first slider read will.
+  mosh: { value: 0 },
+  moshReach: { value: 14 },
+  moshDecay: { value: 0.88 },
+  moshSplay: { value: 1 },
+  moshLine: { value: 0.55 },
+  moshGrain: { value: 3 },
+  moshRefresh: { value: 1.2 },
+};
 
 // Every cell the grade's shader reads, with the value it holds before a look lands. The text
 // that reads them is assembled elsewhere, so this is the whole of what stayed: a default a
@@ -92,7 +120,7 @@ const GRADE_UNIFORMS = {
  * module builds a pass without ever knowing there is a server, which is what lets the gate run
  * the same assembler under bare node.
  */
-export function buildPostChain(gradeProgram) {
+export function buildPostChain(gradeProgram, moshProgram) {
   composer = new EffectComposer(renderer);
   renderPass = new RenderPass(scene, viewCamera);
   composer.addPass(renderPass);
@@ -100,6 +128,14 @@ export function buildPostChain(gradeProgram) {
   afterimage = new AfterimagePass(0.0);
   afterimage.enabled = false;
   composer.addPass(afterimage);
+
+  mosh = new MoshPass({
+    uniforms: MOSH_UNIFORMS,
+    vertexShader: moshProgram.vertexShader,
+    fragmentShader: moshProgram.fragmentShader,
+  });
+  mosh.enabled = false;
+  composer.addPass(mosh);
 
   bloom = new BloomPass(0.0, 0.7, 0.2);
   bloom.enabled = false;
@@ -136,4 +172,14 @@ export function setGradeProgram(gradeProgram) {
   grade.material.vertexShader = gradeProgram.vertexShader;
   grade.material.fragmentShader = gradeProgram.fragmentShader;
   grade.material.needsUpdate = true;
+}
+
+/** The mosh's program, replaced without replacing the pass. `setGradeProgram` carries the why. */
+export function setMoshProgram(moshProgram) {
+  if (mosh.material.vertexShader === moshProgram.vertexShader
+    && mosh.material.fragmentShader === moshProgram.fragmentShader) return;
+  mosh.material.dispose();
+  mosh.material.vertexShader = moshProgram.vertexShader;
+  mosh.material.fragmentShader = moshProgram.fragmentShader;
+  mosh.material.needsUpdate = true;
 }


### PR DESCRIPTION
## What this adds

A new look called **Datamosh**. Every frame it pulls the picture a little way up or down, and whatever the picture leaves behind does not get cleared. So a bright spot stretches into a long vertical streak, and after a second or two the whole frame has come apart into needles. It is the netrunning sequence in Cyberpunk 2077 — the reference Tim sent is a city dissolving into vertical rain.

| off | on, at the settings the sweep starts from |
| --- | --- |
| ![datamosh off](https://github.com/user-attachments/assets/6ebf28e0-758e-49a6-8573-983a8109c6e8) | ![baseline](https://github.com/user-attachments/assets/eaffb825-2a97-48ba-a8c5-130dc786cf71) |

Both clips are the same two seconds of the same take with the same camera move, so the only difference is the smear. Every clip below is too. The whole sweep is further down, and the two presets it settled are below that.

## Why it needed new machinery

The app draws the 3D point cloud and then puts the frame through a chain of image passes — trails, glow, colour grade. Every pass so far reads the frame handed to it and hands one on. This one has to read **the frame it drew last time**, because the streak is made of pixels that are already gone from the scene. So it gets its own pass, `web/mosh-pass.js`: it draws into one image buffer while reading the one it drew into last time, then swaps them.

It sits between the trails and the glow. The reasoning is the one already written into the glitch effect: this is damage that happened to the picture on the way here, not something the display did, so the glow blooms the damage rather than the damage smearing the glow.

Every look control in this app comes from an **effect package** (a folder with a manifest and some shader code, installed at runtime, so a look can be added or removed without a rebuild). Keeping that true for these seven controls needed two things that did not exist:

- **A third shader spine.** A spine is the app's own shader code with named sockets in it; packages fill the sockets. There were two, one for the point cloud and one for the colour grade. A package can only bind a control to a shader variable in a program that gets assembled, so the new pass needed `web/mosh-shader.js`.
- **A third bind table** beside `points` and `grade` — the list of which uniform table a control writes into. Five places in `web/main.js` chose between the two with a ternary; they now read one frozen map, so a fourth table is one entry rather than a sixth branch.

## The part that took the design work: scrubbing still works

The editor promises that seeking to a moment in the timeline gives you exactly the image playback would have given you. A pass that remembers previous frames breaks that promise by default, because the image at 12 seconds now depends on every frame before it, and no amount of pre-rolling reproduces that.

So the memory states its own ceiling. The package declares one of its controls as `bounds` — a number of seconds — and the render loop makes the pass **forget everything** once that much time has passed, drawing exactly the frame it was handed. That moment is both the visual pulse the look wants and a place a decode can start from.

If you know video codecs: that is a keyframe, and seeking works the way seeking to a keyframe works. `moshFramesBack` walks back to the nearest one and the seek renders forward from there. If you don't: it means the app never has to replay more than a second or two to get an exact answer, and it knows exactly how much.

The app finds both that control and the on/off master by reading the installed manifests, not by their names, so someone who forks the package under a different name still gets a working timeline.

## What was measured

- **Seeking is exact.** With the smear running, a seek to 12 seconds is byte-for-byte the image playback produced. The pre-roll comes out at exactly the distance back to the last forget-everything moment — 60 frames, at a 2.5s setting — and a target that lands on one needs no pre-roll at all.
- **The look does not change with output size.** A 1920×1200 render matches a 960×600 one at a mean channel difference of 3.088/255 and a brightness ratio of 0.9998, so the controls are in reference pixels rather than screen pixels and a 4K export looks like the 1080p grade.
- **Determinism holds** with three memory-carrying passes running at once, which no shipped look had exercised before.

Six deliberate breakages were introduced one at a time and each was watched turn the checks red — that is how we know the checks can fail. Deleting `datamosh.grain` from a preset document fails 1 of `library-check`'s 506 naming the missing key, and restoring it returns 506 with none failed, so the two new documents are genuinely under the completeness rule rather than passing beside it. Pointing the pass at the incoming frame instead of its own history drops the isolating measurement from 20/255 to exactly zero. Removing the periodic forget makes the seek part from playback. Zeroing the pre-roll reddens five rows. Putting the distances back in screen pixels fails the resolution check on both halves.

## Two checks were lying, and both are fixed

- **A seek with no pre-roll cannot prove a memory pass works.** The same reset also clears the point cloud's own frame-to-frame memory, so that arm differs from playback even on a build where the new pass remembers nothing — it passed 87 of 87 with the pass deliberately broken. What isolates it is a *short* pre-roll: long enough for everything else to settle, short enough that only the smear's history is missing.
- **`effect-conformance-check` searched two shader programs by name**, so a third program's code was never looked for. It reads every program the page reports now, which covers a fourth by existing rather than by someone remembering.

Both are written up in `docs/instruments.md` beside the other cases of a check claiming something it was not testing.

## One number is missing, on purpose

There is no wall-clock cost for the pass. The measuring harness read a clock around a render loop, and `gl.finish()` — the call that is supposed to wait for the graphics card — does not actually wait on Apple's Metal driver. Fifty renders of 434,000 points timed 22 microseconds each, about forty times faster than the same work measures under the paced harness the existing cost table used. That is recorded in `docs/measurement.md` as a thing not to re-derive.

What is recorded is what can be stated exactly: the pass costs two full-screen draws per frame, and two half-float buffers — 33.2 MB at 1080p, 132.7 MB at 4K, allocated whether or not the look is switched on, which is how the existing trails pass behaves too.

## The sweep

Eighteen clips, rendered off the real app through the ordinary playback path rather than by screenshotting: the same take, the same two seconds from 6.0s, the same camera move, 20 frames at 10fps and 288 pixels wide. All of them sit over the shipped **Ember** preset unless the caption says otherwise, because the smear is nearly invisible on a light ground and picking a look off an unreadable clip is picking nothing. One control moves per clip; everything else stays at the values in the first row.

Baseline: `amount 1, reach 14, decay 0.88, splay 1, line 0.55, grain 3, refresh 1.2`.

### The fork: splay

`splay` is what makes this vertical rather than a general blur, and the two ends are different looks rather than more or less of one look. That is why both ends ship as presets instead of one winning.

| splay 0 — the whole frame streams upward | splay 0.5 | splay 1 — pulled apart from a line |
| --- | --- | --- |
| ![splay 0](https://github.com/user-attachments/assets/8f1f1c09-7ebb-4a38-9e4e-10e9bc7e2f02) | ![splay 0.5](https://github.com/user-attachments/assets/595c4c35-1164-4c06-b6e3-9529d5655ac6) | ![splay 1](https://github.com/user-attachments/assets/eaffb825-2a97-48ba-a8c5-130dc786cf71) |

At 0 every column drags together and the whole picture streams upward as one sheet. The direction is not a choice: the pass fills a pixel from the one below it, so there is no setting that melts the frame downward. At 1 the picture is pulled away from a horizontal line instead, so one side rises and the other falls and the frame comes apart from the middle out, which is what the Cyberpunk reference does.

**The split is real in these clips, and it is weaker here than the sweep makes it look.** This framing puts 32.8% of the light above the line and 67.2% below. Measured at the deepest accumulation before the refresh, the picture far below the line differs from splay 0 by 6.30/255 mean per channel with the added light sitting 9.6 rows lower, while far above the line it is bit-identical to splay 0 — the two halves genuinely move apart. But the separation is 0.059 of frame height against 0.186 at a centred framing, and the clip frames sampled here land after a refresh has fired, which halves it again.

The control that makes those numbers mean something is `line 0.10`, where the whole picture sits on one side: there the frame comes out byte-identical to splay 0 in every band, so the measurement is reading the split rather than reading the picture. Roughly 0.30 to 0.70 splits this framing.

A caution for anyone re-deriving this from the GIFs above rather than from the app: they are quantised to 32 colours, which crushes 91.5% of the picture into the darkest luma bucket and 43.9% of it to pure black. Measuring where the light sits off one of these clips gives 14% above the line where the app gives 32.8%, and a centroid taken on the near-empty upper band is noise. The clips are for looking at.

<details>
<summary><b>reach</b> — how far a streak is pulled each frame, in reference pixels</summary>

| reach 5 | reach 14 (baseline) | reach 34 |
| --- | --- | --- |
| ![reach 5](https://github.com/user-attachments/assets/6e87548c-9f02-4780-ac03-8ca7b8708a9a) | ![reach 14](https://github.com/user-attachments/assets/eaffb825-2a97-48ba-a8c5-130dc786cf71) | ![reach 34](https://github.com/user-attachments/assets/aca821f4-07be-45be-b089-334fbedb148d) |

</details>

<details>
<summary><b>decay</b> — how much of the held frame survives into the next one</summary>

| decay 0.7 | decay 0.88 (baseline) | decay 0.97 |
| --- | --- | --- |
| ![decay 0.7](https://github.com/user-attachments/assets/69045ea0-ceab-433f-92a7-c20652c233b1) | ![decay 0.88](https://github.com/user-attachments/assets/eaffb825-2a97-48ba-a8c5-130dc786cf71) | ![decay 0.97](https://github.com/user-attachments/assets/c0fc3c3c-9236-4aca-96fb-164a367347b4) |

Reach and decay together set how long a needle is: reach is the step, decay is how many steps survive. 0.97 is long enough that the streaks outlive the pulse.

</details>

<details>
<summary><b>line</b> — where the frame splits, when splay is up</summary>

| line 0.25 | line 0.55 (baseline) | line 0.8 |
| --- | --- | --- |
| ![line 0.25](https://github.com/user-attachments/assets/9265f81b-807f-478a-8a7a-45d4b3600d58) | ![line 0.55](https://github.com/user-attachments/assets/eaffb825-2a97-48ba-a8c5-130dc786cf71) | ![line 0.8](https://github.com/user-attachments/assets/9cd8ae42-ddf3-4066-a8dc-2adaa7e8c1f3) |

Nothing at all if `splay` is 0, which is why it is not the fork.

</details>

<details>
<summary><b>grain</b> — the width of a column that shares one pull distance</summary>

| grain 1 | grain 3 (baseline) | grain 16 |
| --- | --- | --- |
| ![grain 1](https://github.com/user-attachments/assets/443f9df3-65db-4cec-85d8-87d0b17043da) | ![grain 3](https://github.com/user-attachments/assets/eaffb825-2a97-48ba-a8c5-130dc786cf71) | ![grain 16](https://github.com/user-attachments/assets/faf2767b-11d8-4a0b-819b-b1ddc9b84d51) |

Fine grain reads as rain. Broad grain reads as torn strips.

</details>

<details>
<summary><b>refresh</b> — how often the pass forgets everything</summary>

| refresh 0.4s | refresh 1.2s (baseline) | refresh 3.0s |
| --- | --- | --- |
| ![refresh 0.4](https://github.com/user-attachments/assets/a69134bb-68ad-4d57-9f5f-8f0549fcfe37) | ![refresh 1.2](https://github.com/user-attachments/assets/eaffb825-2a97-48ba-a8c5-130dc786cf71) | ![refresh 3.0](https://github.com/user-attachments/assets/68e3e2a3-756b-41bf-b8e6-c685cfd238e6) |

This is the control that is also the seek bound, so a long setting costs more pre-roll on every scrub. At 3.0s a clip this short barely gets one pulse.

</details>

<details>
<summary><b>amount, a composed maximum, and two other grounds</b></summary>

| amount 0.5 | reach 34 + decay 0.97 |
| --- | --- |
| ![amount 0.5](https://github.com/user-attachments/assets/f8064c2f-176e-4e96-baec-6caebe70c9dd) | ![max](https://github.com/user-attachments/assets/60afe4fb-cb37-4a8c-a852-f21ba30c7a47) |

| baseline over bare defaults, no look under it | baseline over the Voxel preset |
| --- | --- |
| ![flat](https://github.com/user-attachments/assets/11f24c30-fc63-4ddf-8b73-683ae9fe3c7b) | ![over voxel](https://github.com/user-attachments/assets/83bfecd0-31b2-4feb-b22f-c1ae20c4c878) |

The bare-defaults clip is the honest one about how much of the look above is Ember rather than the smear.

</details>

## Two presets, because the fork was two looks

The splay fork was settled by shipping both ends rather than picking one, so `presets-builtin/` gains **`updraft`** (splay 0, the sheet streaming upward) and **`rift`** (splay 1, coming apart from the line). Both are `ember`'s grade with the datamosh over it, since the smear is close to invisible on a light ground, and each carries the reach, decay and grain its own reading wanted — 14 pixels at 0.92 over 6-pixel columns for the updraft, 20 at 0.9 over 2-pixel ones for the rift, which is ragged where the updraft is broad.

Neither is called `netrun`. The house rule in `presets-builtin/README.md` is that a look is not named after the work it references, which is why `cascade` draws a falling-glyph field and is not called something else. Two earlier drafts died on evidence rather than taste: `sluice` was backwards, because the pass fills a pixel from below it and the sheet therefore streams up (measured as a 32-row displacement toward the top, with every downward displacement correlating worse), and `shear` was wrong twice, since shear is motion *along* a dividing line where this pulls *across* one, and `docs/reference.md` already spends that word on the glitch effect's bands.

They are also the first documents that raise every accumulator the program has — trails and the surface memory out of `ember`, and the mosh over them — so `determinism-check` now reads `rift` instead of spelling a smear out inline beside a look it could not name.

**One thing about them is not graded, and it is written beside the values rather than only here.** `ember` underneath was graded against real footage; the six datamosh numbers over it were not. This worktree's only take is `make-sample` looped, which has no depth jitter, no dropped frames and none of the sparse bright glints a smear is really for. A pass over a real take is owed, and re-grading those six is its expected outcome rather than a sign anything regressed.

While in there, `timeline-check` was reading a `presets-builtin/netrun.json` that never shipped and falling back to inline values when it was missing. The lookup was the dead half of that branch and is gone; the measured constants stay, because `MOSH_SHORT_BY` was calibrated against those exact numbers and a document swapped in underneath would move what the section asserts without touching the assertion.

## Test results

| check | result |
| --- | --- |
| `syntax-check` | 82 files, 0 failed |
| `npm run test:unit` | 153/153 |
| `module-check` | 62 assertions, 0 failed |
| `library-check` | 506 assertions, 0 failed — the one that enforces "a preset names the whole look" |
| `timeline-check` | 0 failed |
| `determinism-check` | PASS, running `rift`, with mosh, bloom and grade live and the no-pre-roll control differing |
| `effect-check` | 147 assertions, 0 failed |
| `effect-conformance-check` | 135 assertions, 0 failed |
| `boot-check` | 11 assertions, 0 failed |
| `editor-check` | 575 assertions, 0 failed |
| `keyframe-check` | PASS |
| `registry-check` | 3 failed — the clean-tree floor on a synthetic take |
| `export-check` | 10 failed — same floor, verified by backing the tree out to HEAD and getting byte-identical numbers |

Not run, because nothing they cover was touched: `cpp-check`, `vendor-check`, `level-check`, `monitor-check`, `vcam-check`, `guard-check`, `jobs-check`, `sensor-view-check`, `registration-check`, `index-check`, `release-gate-check`.

Everything was driven against a 37.8s replay built by looping the synthetic sample, since this worktree has no real footage. That fixture has no depth jitter, no dropped frames and none of the sparse bright glints the look is really for, so the checks say the smear behaves correctly — not that it will sit well on a person in a room.
