### PR TITLE
Orbit pivot takes its distance from the depth under the pointer

### DIFF
--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -343,6 +343,24 @@ that reading the code did not:
 Report which mutations you ran and what each one caught. A check nobody has broken on purpose is
 a check nobody knows the sensitivity of.
 
+### A "caught" verdict on a tree that was already red
+
+`editor-check` declares a mutation caught when the run ends with any failures at all, and on this
+tree three rows about `datamosh.refresh` have been red since `4d711ef`. So a mutation that nothing
+tests still reports `caught ... as required`, and the row count in the verdict line does not
+distinguish the three that were already failing from the one that was supposed to fire.
+
+That is not hypothetical: `pick-rehomes-reset` was recorded as caught, and reading the fired
+labels showed only the three pre-existing rows. The Reset row it was aimed at read the home pose
+*after* the presses, so on the mutated build it compared `target0` against itself. Rule 3 - count
+the failed assertions and read which ones fired - is what found it, and the fix was to read the
+home pose before the section's first press.
+
+The general shape: **whenever a suite has a standing failure, its own catch verdict is a false
+positive generator, and a baseline run is the only thing that separates the two populations.**
+Run the tool once unmutated first and note which rows are red, then read every mutation run
+against that list rather than against zero.
+
 ### A source row that reads the staged tree cannot be falsified by a page mutation
 
 The match-exactly-once rule guards the *anchor*. This is the same hole one layer out, in the

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -614,6 +614,25 @@ half measures 7.1 ms against a 33 ms budget. That figure is a correction: it was
 p50. Its occlusion filter's share has *not* been re-measured here and should not be quoted as
 if it had.
 
+**The orbit pivot's press cannot be made free, and a target write has never been free.** The
+pick that moves the pivot was designed to leave the camera bit-identical, so that
+`renderedCameraChanged` would stay false and no screen-space history would be cleared. It cannot:
+`OrbitControls.update()` rebuilds `position` out of `target` every frame, so any write to the
+pivot re-rounds the position by about an ulp, and the comparison is exact. Nudging the target by
+the residual and retrying does not converge - measured, 8 attempts still moving at 7 of 9
+camera poses. What it costs is one afterimage clear per press, which is exactly what one move of
+a right-drag pan has always cost, and the drag a press precedes clears on every frame anyway. The
+mosh history is not involved: `renderedCameraChanged` drives `clearAfterimage()` alone, and the
+mosh's two targets are cleared only by `resetAccumulators`.
+
+**The pick itself is cheap; its retry is not.** Interleaved in one loop, 80 trials with the first
+20 discarded, headless Chromium at 1512x900 on the M2 Max, `performance.now` quantised to 0.1 ms:
+a press that hits costs 0.600 ms at p50 (0.700 at p95), against a 0.100 ms floor for a press that
+enters the handler and leaves at the button test. A press that finds nothing over a full grid
+costs 2.8 ms, because it sweeps every second texel and then every texel. That is a one-off on a
+pointer event against a 33 ms frame, and it buys presses on surfaces far enough away that
+stride-2 samples land more than twelve stage pixels apart.
+
 **Compressing the wire is bounded by colour.** 434 KB of the 486 KB frame is uncompressed
 depth, and an early estimate put zstd-over-temporal-deltas at 35-45 Mbit/s. Measured,
 per-frame zstd manages 1.75x on depth, and a u16 temporal delta plus zstd reaches 2.75x on

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -420,6 +420,8 @@ node tools/editor-check.mjs --mutate pick-ignores-the-crop --no-render  # ... an
 node tools/editor-check.mjs --mutate pick-rehomes-reset --no-render     # ... and Reset re-homed on the last pivot picked, so the
                                                                        #     one control for getting un-lost goes nowhere known
 node tools/editor-check.mjs --mutate pick-answers-on-nothing --no-render # ... and a press with nothing under it moving the pivot anyway
+node tools/editor-check.mjs --mutate pick-accepts-a-singleton --no-render # ... and one isolated sensor return treated as a surface
+node tools/editor-check.mjs --mutate pick-rehomes-modified-pan --no-render # ... and a modified left press re-homing the pivot before its pan
 node tools/editor-check.mjs --mutate fit-lands-after-history-begins --no-render # ... the box a take opens with, which is the clip rather than the first thing you can undo
 node tools/editor-check.mjs --mutate fit-outlives-a-restored-project --no-render # ... and a document's own box, which only the ordering still protects
 node tools/editor-check.mjs --mutate play-button-skips-pausetransport --no-render # ... the one pause on this surface that did

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -414,6 +414,12 @@ node tools/editor-check.mjs --mutate collapsed-keeps-the-editor-height --no-rend
 node tools/editor-check.mjs --mutate collapsed-keeps-the-tab-rail --no-render # ... and the half of that a lower rule cannot fix, because `:not()` carries its argument's weight
 node tools/editor-check.mjs --mutate dock-sensor-takes-the-centre --no-render # ... a dock button forwarding faithfully to the neighbouring control
 node tools/editor-check.mjs --mutate dock-offers-the-take-on-the-editor --no-render # ... and `record` offered on the surface that never polls a recorder to paint it
+node tools/editor-check.mjs --mutate pick-moves-the-camera --no-render  # ... the orbit pivot written off the view axis, which re-aims
+                                                                       #     the camera on the frame after the press
+node tools/editor-check.mjs --mutate pick-ignores-the-crop --no-render  # ... and a pivot on geometry the renderer discarded
+node tools/editor-check.mjs --mutate pick-rehomes-reset --no-render     # ... and Reset re-homed on the last pivot picked, so the
+                                                                       #     one control for getting un-lost goes nowhere known
+node tools/editor-check.mjs --mutate pick-answers-on-nothing --no-render # ... and a press with nothing under it moving the pivot anyway
 node tools/editor-check.mjs --mutate fit-lands-after-history-begins --no-render # ... the box a take opens with, which is the clip rather than the first thing you can undo
 node tools/editor-check.mjs --mutate fit-outlives-a-restored-project --no-render # ... and a document's own box, which only the ordering still protects
 node tools/editor-check.mjs --mutate play-button-skips-pausetransport --no-render # ... the one pause on this surface that did

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -56,6 +56,16 @@ halves, and [SECURITY.md](../SECURITY.md) has the threat model.
 
 Drag to orbit, scroll to zoom, right-drag to pan, `H` hides the panel.
 
+**The orbit turns about whatever you pressed on.** A left press reads the depth under the
+pointer and moves the pivot along the view axis to that range, so orbiting a subject four metres
+out turns around it rather than swinging it across the frame. The pivot stays on the view axis,
+which is why the press changes nothing to look at - what changes is the turning radius. A press
+on the background, on a hole in the depth returns, or on geometry outside the crop box leaves
+the pivot where it was, and **Reset** still goes to the home pose rather than to the last pivot
+you picked. The pick reads the depth frame and not the drawn picture, so with the displacement
+effects or the datamosh up it lands on the surface that is really under the pointer rather than
+on the smear the eye is aimed at.
+
 The ruler shows a *window* of the clip, because a fifteen-minute take across one screen puts
 a keyframe against gradations forty times coarser than the thing being placed. Scroll to
 zoom about the pointer, `+`/`-` about the playhead, `,`/`.` to pan, `F` to fit the clip, `Z`

--- a/test/depth-pick.test.mjs
+++ b/test/depth-pick.test.mjs
@@ -131,6 +131,14 @@ test('a press over a hole in the returns finds nothing and says so', () => {
   assert.equal(pick(scene(), at), null);
 });
 
+test('a lone sample over a hole is not enough to pick a surface', () => {
+  const depth = new Uint16Array(DEPTH_W * DEPTH_H);
+  const col = 256;
+  const row = 212;
+  depth[row * DEPTH_W + col] = 300;
+  assert.equal(pick(depth, stageOf(col, row, 0.3)), null);
+});
+
 test('a press over geometry the crop predicate rejects finds nothing', () => {
   const at = stageOf((BOX.col0 + BOX.col1) / 2, (BOX.row0 + BOX.row1) / 2, 1.0);
   const depth = scene();

--- a/test/depth-pick.test.mjs
+++ b/test/depth-pick.test.mjs
@@ -1,0 +1,222 @@
+// The pivot's pick, driven against grids written by hand. What the page cannot answer offline is
+// whether a press reaches this at all; what only this can answer is whether the arithmetic in it
+// is right, on a scene whose distances are known exactly rather than measured off a capture.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+import { DEPTH_H, DEPTH_W } from '../web/format.js';
+import { projectThrough } from '../web/plan-geometry.js';
+import {
+  pickDepth, sensorPoint, PICK_RADIUS_PX, PICK_STRIDE, PICK_TOLERANCE_M,
+} from '../web/depth-pick.js';
+
+// A Kinect v2's own numbers, near enough: the pick reads whatever the uniforms hold, so what
+// matters here is that the test and the module agree about one set of them.
+const focal = { x: 365, y: 365 };
+const center = { x: DEPTH_W / 2, y: DEPTH_H / 2 };
+const stage = { x: 0, y: 0, w: 1920, h: 1080 };
+const noTilt = new THREE.Quaternion();
+
+/** The forward map, spelled a second time on purpose - this file is what would catch it drifting. */
+function pointAt(col, row, metres) {
+  return [
+    (-(col + 0.5 - center.x) / focal.x) * metres,
+    -((row + 0.5 - center.y) / focal.y) * metres,
+    -metres,
+  ];
+}
+
+/** A camera at the sensor, looking the way the sensor looks. Distances are then plain ranges. */
+function sensorCamera() {
+  const camera = new THREE.PerspectiveCamera(50, stage.w / stage.h, 0.05, 60);
+  camera.position.set(0, 0, 0);
+  camera.lookAt(0, 0, -1);
+  camera.updateMatrixWorld(true);
+  return camera;
+}
+
+const camera = sensorCamera();
+
+/** Where a texel of a given range lands on the stage, so a press can be aimed at one. */
+function stageOf(col, row, metres) {
+  const p = projectThrough(pointAt(col, row, metres), camera, stage);
+  assert.ok(p, `texel ${col},${row} at ${metres}m projected to nothing`);
+  return p;
+}
+
+// What the pick owes for a texel, which is its range from the camera and not its range down the
+// optical axis. Off-centre the two differ by centimetres, and writing 2.0 where the answer is
+// 2.06 is a test asserting a model the renderer does not use.
+function rangeOf(col, row, metres, from = camera) {
+  return new THREE.Vector3().fromArray(pointAt(col, row, metres)).distanceTo(from.position);
+}
+
+// A wall filling the frame at 2.0m, a box over the middle of it at 1.0m, and a rectangle with
+// no returns at all off to one side.
+const BOX = { col0: 226, col1: 286, row0: 182, row1: 242 };
+const HOLE = { col0: 330, col1: 390, row0: 182, row1: 242 };
+const inside = (r, col, row) => col >= r.col0 && col <= r.col1 && row >= r.row0 && row <= r.row1;
+
+function scene({ spikeAt = null } = {}) {
+  const depth = new Uint16Array(DEPTH_W * DEPTH_H);
+  for (let row = 0; row < DEPTH_H; row++) {
+    for (let col = 0; col < DEPTH_W; col++) {
+      const i = row * DEPTH_W + col;
+      if (inside(HOLE, col, row)) depth[i] = 0;
+      else if (inside(BOX, col, row)) depth[i] = 1000;
+      else depth[i] = 2000;
+    }
+  }
+  if (spikeAt) depth[spikeAt.row * DEPTH_W + spikeAt.col] = 300;
+  return depth;
+}
+
+const pick = (depth, at, extra = {}) => pickDepth({
+  depth, focal, center, tilt: noTilt, camera, stage, x: at.x, y: at.y, ...extra,
+});
+
+test('the forward map is libfreenect2 pinhole, and an empty sample is not a point', () => {
+  const out = new THREE.Vector3();
+  assert.equal(sensorPoint(out, 0, 100, 100, focal.x, focal.y, center.x, center.y), 0);
+  const z = sensorPoint(out, 2500, 100, 140, focal.x, focal.y, center.x, center.y);
+  assert.equal(z, 2.5);
+  assert.deepEqual(out.toArray(), pointAt(100, 140, 2.5));
+});
+
+test('a press over the near box reads the box, not the wall behind it', () => {
+  const at = stageOf((BOX.col0 + BOX.col1) / 2, (BOX.row0 + BOX.row1) / 2, 1.0);
+  const hit = pick(scene(), at);
+  assert.ok(hit, 'nothing was under a press aimed at the middle of the box');
+  assert.ok(Math.abs(hit.distance - 1.0) < 0.02, `${hit.distance} where the box is at 1.0m`);
+});
+
+test('a press beside the box reads the wall', () => {
+  // A texel well clear of the box on the wall's own plane, so the answer is the wall and not a
+  // silhouette edge.
+  const col = BOX.col0 - 60;
+  const row = (BOX.row0 + BOX.row1) / 2;
+  const hit = pick(scene(), stageOf(col, row, 2.0));
+  assert.ok(hit, 'nothing was under a press aimed at the wall');
+  const owed = rangeOf(col, row, 2.0);
+  assert.ok(Math.abs(hit.distance - owed) < 0.03, `${hit.distance} where the wall texel is at ${owed}`);
+});
+
+// The nearest-sample rule is what makes a press land on the thing in front rather than on
+// whatever the ray happens to leave through, so it is asserted as an ordering and not only as
+// two separate numbers.
+test('the box is nearer than the wall, which is the whole point of taking the nearest', () => {
+  const depth = scene();
+  const onBox = pick(depth, stageOf((BOX.col0 + BOX.col1) / 2, (BOX.row0 + BOX.row1) / 2, 1.0));
+  const onWall = pick(depth, stageOf(BOX.col0 - 60, (BOX.row0 + BOX.row1) / 2, 2.0));
+  assert.ok(onBox.distance < onWall.distance - 0.5, `${onBox.distance} against ${onWall.distance}`);
+});
+
+// The one press where taking the nearest and taking the farthest are different answers. Every
+// other row here sits well inside a surface of one range, where a sort in either direction gives
+// the same number - so on a build that took the farthest they all stay green.
+test('a press on the box edge takes the box, not the wall the radius also reaches', () => {
+  const at = stageOf(BOX.col1, (BOX.row0 + BOX.row1) / 2, 1.0);
+  const hit = pick(scene(), at);
+  assert.ok(hit, 'nothing was under a press aimed at the edge of the box');
+  assert.ok(hit.candidates > hit.cluster,
+    `${hit.candidates} candidates in one cluster of ${hit.cluster} - the radius reached only one `
+    + 'surface, so this row cannot tell the near one from the far one');
+  assert.ok(Math.abs(hit.distance - 1.0) < 0.03,
+    `${hit.distance} where the box is at 1.0m and the wall it borders is at 2.0m`);
+});
+
+test('a press over a hole in the returns finds nothing and says so', () => {
+  const at = stageOf((HOLE.col0 + HOLE.col1) / 2, (HOLE.row0 + HOLE.row1) / 2, 2.0);
+  assert.equal(pick(scene(), at), null);
+});
+
+test('a press over geometry the crop predicate rejects finds nothing', () => {
+  const at = stageOf((BOX.col0 + BOX.col1) / 2, (BOX.row0 + BOX.row1) / 2, 1.0);
+  const depth = scene();
+  // Everything, so a miss here cannot be a press that landed a few pixels off the box.
+  assert.equal(pick(depth, at, { croppedOut: () => true }), null);
+  // A near clip that takes the box and nothing else. There is no wall behind it to fall through
+  // to - a depth grid holds one range per texel, not a column of them - so the honest answer is
+  // still nothing, and a build that returned the wall here would be reading a neighbouring texel.
+  assert.equal(pick(depth, at, { croppedOut: (x, y, z) => z < 1.5 }), null);
+  // The far clip instead, which removes the wall and leaves the box: the crop shapes the answer
+  // rather than only ever suppressing it.
+  const hit = pick(depth, at, { croppedOut: (x, y, z) => z > 1.5 });
+  assert.ok(hit && Math.abs(hit.distance - 1.0) < 0.02,
+    `${hit ? hit.distance : 'null'} where the box the far clip kept is at 1.0m`);
+});
+
+test('a lone spike does not drag the answer off the surface it sits on', () => {
+  const col = BOX.col0 - 60;
+  const row = (BOX.row0 + BOX.row1) / 2;
+  const at = stageOf(col, row, 2.0);
+  const clean = pick(scene(), at);
+  const spiked = pick(scene({ spikeAt: { col, row } }), at);
+  assert.ok(spiked, 'the spiked grid returned nothing at all');
+  assert.ok(spiked.distance > clean.distance - PICK_TOLERANCE_M,
+    `${spiked.distance} - a 0.3m spike pulled the pick off a 2.0m wall`);
+  assert.ok(Math.abs(spiked.distance - clean.distance) < 0.03,
+    `${spiked.distance} against ${clean.distance} with no spike`);
+});
+
+test('the pick honours the levelling rotation rather than answering in the sensor frame', () => {
+  const tilt = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), 0.35);
+  const tilted = new THREE.Vector3().fromArray(
+    pointAt((BOX.col0 + BOX.col1) / 2, (BOX.row0 + BOX.row1) / 2, 1.0),
+  ).applyQuaternion(tilt);
+  const p = projectThrough(tilted.toArray(), camera, stage);
+  assert.ok(p, 'the tilted box projected to nothing');
+  const hit = pick(scene(), p, { tilt });
+  assert.ok(hit, 'nothing was under a press aimed at where the tilt puts the box');
+  assert.ok(Math.abs(hit.distance - 1.0) < 0.02, `${hit.distance} where the box is at 1.0m`);
+});
+
+// Distance is from the camera and not down the optical axis, which only agree when the camera
+// is at the sensor looking the sensor's way. A pivot built from an axial depth would sit short.
+test('the distance is measured from the camera, wherever the camera is', () => {
+  const moved = new THREE.PerspectiveCamera(50, stage.w / stage.h, 0.05, 60);
+  moved.position.set(0, 0, 1.0);
+  moved.lookAt(0, 0, -1);
+  moved.updateMatrixWorld(true);
+  const centreOfBox = pointAt((BOX.col0 + BOX.col1) / 2, (BOX.row0 + BOX.row1) / 2, 1.0);
+  const p = projectThrough(centreOfBox, moved, stage);
+  const hit = pickDepth({
+    depth: scene(), focal, center, tilt: noTilt, camera: moved, stage, x: p.x, y: p.y,
+  });
+  assert.ok(hit, 'nothing was under a press from the moved camera');
+  const expected = new THREE.Vector3().fromArray(centreOfBox).distanceTo(moved.position);
+  assert.ok(Math.abs(hit.distance - expected) < 0.02, `${hit.distance} against ${expected}`);
+});
+
+// Stride 2 is the sweep a press pays for. It has to give the answer stride 1 gives, or the cost
+// saving is being taken out of the result.
+test('the coarse sweep and the exhaustive one agree', () => {
+  const depth = scene();
+  for (const [col, row, metres] of [
+    [(BOX.col0 + BOX.col1) / 2, (BOX.row0 + BOX.row1) / 2, 1.0],
+    [BOX.col0 - 60, (BOX.row0 + BOX.row1) / 2, 2.0],
+    [120, 300, 2.0],
+  ]) {
+    const at = stageOf(col, row, metres);
+    const coarse = pick(depth, at);
+    const exact = pick(depth, at, { stride: 1 });
+    assert.ok(coarse && exact, `${col},${row}: nothing under the press at stride 2 or stride 1`);
+    assert.ok(Math.abs(coarse.distance - exact.distance) < 0.02,
+      `${col},${row}: stride 2 gave ${coarse.distance}, stride 1 gave ${exact.distance}`);
+  }
+});
+
+// The radius and the stride are not independent, and this is the row that says so. A stride-2
+// sweep of a wall two metres out lands its samples about 6.3 stage pixels apart at 1080p, so at
+// the six-pixel radius this started with a press had exactly one candidate - and every rule about
+// outvoting a stray texel is a rule about a population of one. The spike row above passes on a
+// build with no company in it, because the spike is then the only thing there is.
+test('a press has company under it, which is what every rule about outvoting a spike needs', () => {
+  const col = BOX.col0 - 60;
+  const row = (BOX.row0 + BOX.row1) / 2;
+  const hit = pick(scene(), stageOf(col, row, 2.0));
+  assert.ok(hit.cluster > 1,
+    `${hit.cluster} samples in the winning cluster from ${hit.candidates} candidates, at a `
+    + `${PICK_RADIUS_PX}px radius and stride ${PICK_STRIDE} - a lone candidate cannot be outvoted`);
+});

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -41,6 +41,47 @@ const VIEWPORT = { width: 1512, height: 900 };
 // ------------------------------------------------------------------- mutations
 
 const MUTATIONS = {
+  // ---- section 22, the orbit pivot and the depth under the pointer ----
+  // Must redden: the on-axis row, which is the whole reason this can hang off a plain press.
+  'pick-moves-the-camera': {
+    file: 'web/main.js',
+    edits: [[
+      '  freeCamera.getWorldDirection(pivotForward);\n'
+      + '  controls.target.copy(freeCamera.position).addScaledVector(pivotForward, d);',
+      '  freeCamera.getWorldDirection(pivotForward);\n'
+      + '  controls.target.copy(freeCamera.position).addScaledVector(pivotForward, d);\n'
+      + '  controls.target.x += 0.35;',
+    ]],
+  },
+
+  // Must redden: the cropped-press row, alone. The pivot then lands on geometry the renderer
+  // threw away, which is a pivot on something nobody can see.
+  'pick-ignores-the-crop': {
+    file: 'web/depth-pick.js',
+    edits: [['      if (croppedOut(scratch.x, scratch.y, z)) continue;\n', '']],
+  },
+
+  // Must redden: the Reset row, alone. `saveState` re-homes Reset on the picked pivot, so the one
+  // control for getting un-lost stops going anywhere known.
+  'pick-rehomes-reset': {
+    file: 'web/main.js',
+    edits: [[
+      '  controls.target.copy(freeCamera.position).addScaledVector(pivotForward, d);\n  return d;',
+      '  controls.target.copy(freeCamera.position).addScaledVector(pivotForward, d);\n'
+      + '  controls.saveState();\n  return d;',
+    ]],
+  },
+
+  // Must redden: the empty-press row, alone. A pick that answers on a hole in the returns pivots
+  // on nothing, and the plan inset's own presses start moving the pivot too.
+  'pick-answers-on-nothing': {
+    file: 'web/main.js',
+    edits: [[
+      '  if (!hit) return;\n  setPivotDistance(hit.distance);',
+      '  setPivotDistance(hit ? hit.distance : 2.2);',
+    ]],
+  },
+
   // ---- section 15b, the badge for an effect this build has not got ----
   // Must redden: the exact-sentence row of 15b, alone.
   'badge-counts-the-registry': {
@@ -8351,7 +8392,196 @@ try {
   }
 
 
-  console.log('\n[22] pinning the drive drops what the loop was going to serve');
+  console.log('\n[22] a press on the stage moves the orbit pivot to the depth under the pointer');
+
+  // Everything below plants a depth grid and dispatches the press in one task, because
+  // `depthCurr` is swapped on every bind and a frame arriving between the two would leave the
+  // sweep reading a different room from the one the row is about.
+  {
+    /**
+     * A press at the middle of the stage over a grid of one range, and what the camera and the
+     * pivot were either side of it.
+     *
+     * `mm` of 0 is a grid with no returns anywhere, which is the empty-space case.
+     */
+    const pressOn = (mm, opts = {}) => page.evaluate(`((mm, opts) => {
+      const k = __kinect;
+      const c = k.freeCamera;
+      const fwd = c.getWorldDirection(new (c.position.constructor)());
+      const before = {
+        p: c.position.toArray(), q: c.quaternion.toArray(),
+        target: k.controls.target.toArray(),
+        clears: k.timeline.counters.navigationHistoryClears,
+      };
+      k.drive.injectDepth(new Uint16Array(512 * 424).fill(mm));
+      const r = document.getElementById('stage').getBoundingClientRect();
+      const at = opts.inset
+        ? (() => { const i = k.keyframes.chrome.inset(); return { x: r.x + i.x + i.w / 2, y: r.y + i.y + i.h / 2 }; })()
+        : { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+      document.getElementById(opts.on ?? 'stage').dispatchEvent(new PointerEvent('pointerdown', {
+        button: opts.button ?? 0, buttons: 1, clientX: at.x, clientY: at.y,
+        bubbles: true, cancelable: true, pointerId: 71,
+      }));
+      const t = k.controls.target;
+      const after = { target: t.toArray(), dist: t.distanceTo(c.position) };
+      // Where the pivot sits relative to the way the camera is pointing. 1 is dead on the axis,
+      // which is the property that makes the press cost nothing to look at.
+      after.onAxis = t.clone().sub(c.position).normalize().dot(fwd);
+      return { before, after };
+    })(${mm}, ${JSON.stringify(opts)})`);
+
+    /** How far apart two poses are, in metres and in quaternion components. */
+    const poseApart = (a, b) => Math.max(
+      ...a.p.map((v, i) => Math.abs(v - b.p[i])),
+      ...a.q.map((v, i) => Math.abs(v - b.q[i])),
+    );
+
+    await page.evaluate('__kinect.timeline.transport().pause()');
+    await page.evaluate('__kinect.timeline.transport().seek(4.0)');
+    await settle();
+    // Read before any press, which is the whole of what makes the Reset row below an assertion.
+    // Read after them it is `target0` against itself, and a build whose press calls `saveState()`
+    // passes it - which is exactly what happened, and was caught only by reading which rows fired
+    // rather than the run's verdict.
+    const home = await page.evaluate('__kinect.controls.target0.toArray()');
+    // From the sensor's own pose, so a range down the optical axis and a range from the camera
+    // are the same number and the row can name the metres it expects.
+    await page.evaluate('__kinect.sensorView()');
+    await settle();
+
+    const wall = await pressOn(3000);
+    check(Math.abs(wall.after.dist - 3.0) < 0.02,
+      'a press on a wall three metres out puts the pivot three metres out',
+      `${wall.after.dist.toFixed(4)} m, from a pivot at ${
+        Math.hypot(...wall.before.target.map((v, i) => v - wall.before.p[i])).toFixed(4)} m`);
+    check(Math.abs(wall.after.onAxis - 1) < 1e-9,
+      'and on the view axis, which is why the press changes nothing to look at',
+      `the pivot lies ${wall.after.onAxis.toFixed(12)} along the way the camera points`);
+
+    // The same press over a different room. Without this the row above passes on a build that
+    // writes a constant.
+    const near = await pressOn(1200);
+    check(Math.abs(near.after.dist - 1.2) < 0.02,
+      'and a press on a wall at 1.2 m puts it at 1.2 m, so the pivot reads the depth rather than a constant',
+      `${near.after.dist.toFixed(4)} m against the ${wall.after.dist.toFixed(4)} m of the same press on a 3 m wall`);
+
+    const held = await page.evaluate('__kinect.controls.target.toArray()');
+    const empty = await pressOn(0);
+    check(empty.after.target.every((v, i) => v === held[i]),
+      'a press with nothing under it leaves the pivot exactly where it was',
+      `${empty.after.target.map((v) => v.toFixed(6)).join(', ')} against ${held.map((v) => v.toFixed(6)).join(', ')}`);
+
+    // The far clip at 2 m with the box cutting, so a 3 m wall is geometry the renderer discards.
+    const cropBefore = await page.evaluate("__kinect.params.values(['crop', 'far'])");
+    await page.evaluate('__kinect.params.apply({ crop: true, far: 2.0 })');
+    await settle();
+    const cropped = await pressOn(3000);
+    check(cropped.after.target.every((v, i) => v === cropped.before.target[i]),
+      'and a press on geometry outside the crop box leaves it alone, rather than pivoting on what was discarded',
+      `${cropped.after.target.map((v) => v.toFixed(6)).join(', ')} against `
+      + `${cropped.before.target.map((v) => v.toFixed(6)).join(', ')} with the far clip at 2 m`);
+    await page.evaluate(`__kinect.params.apply(${JSON.stringify(cropBefore)})`);
+    await settle();
+
+    // What the press costs the screen-space history, measured against two controls in the same
+    // conditions rather than asserted. **The press is not free, and the plan this was built from
+    // said it would be.** `OrbitControls.update()` rebuilds `position` out of `target` on every
+    // frame, so any write to the pivot re-rounds the position by about an ulp, and
+    // `renderedCameraChanged` compares exactly. A right-drag pan has always paid the same price
+    // on every move; a press pays it once, and the drag it precedes clears on every frame anyway.
+    const clears = await page.evaluate(`(() => {
+      const k = __kinect;
+      const at = () => k.timeline.counters.navigationHistoryClears;
+      const step = () => { k.controls.update(0); k.drive.stepTo(4.0); };
+      step();
+      const a = at(); step(); const still = at() - a;
+      const b = at();
+      const t0 = k.controls.target.toArray();
+      k.controls.target.set(t0[0] + 0.01, t0[1], t0[2]);
+      step();
+      const panned = at() - b;
+      k.controls.target.fromArray(t0);
+      step();
+      const c = at();
+      k.drive.injectDepth(new Uint16Array(512 * 424).fill(2500));
+      const r = document.getElementById('stage').getBoundingClientRect();
+      document.getElementById('stage').dispatchEvent(new PointerEvent('pointerdown', {
+        button: 0, buttons: 1, clientX: r.x + r.width / 2, clientY: r.y + r.height / 2,
+        bubbles: true, cancelable: true, pointerId: 71,
+      }));
+      step();
+      return { still, panned, pressed: at() - c };
+    })()`);
+    note('what a press costs the screen-space history',
+      `${clears.pressed} clears, where a still camera costs ${clears.still} and one step of a pan costs ${clears.panned}`);
+    check(clears.still === 0,
+      'control: a still camera clears no screen-space history, so the counts below are about the writes',
+      `${clears.still} clears over one step`);
+    check(clears.panned === 1 && clears.pressed === 1,
+      'and a press costs exactly what one step of a right-drag pan costs, which this build has always paid',
+      `${clears.pressed} against ${clears.panned} for the pan`);
+
+    // The bit-identity the plan asked for is not reachable through `OrbitControls`, so what is
+    // asserted is the thing that was actually wanted: the picture does not move.
+    const moved = await page.evaluate(`(() => {
+      const k = __kinect, c = k.freeCamera;
+      const p0 = c.position.toArray(), q0 = c.quaternion.toArray();
+      k.drive.injectDepth(new Uint16Array(512 * 424).fill(3500));
+      const r = document.getElementById('stage').getBoundingClientRect();
+      document.getElementById('stage').dispatchEvent(new PointerEvent('pointerdown', {
+        button: 0, buttons: 1, clientX: r.x + r.width / 2, clientY: r.y + r.height / 2,
+        bubbles: true, cancelable: true, pointerId: 71,
+      }));
+      k.controls.update(0);
+      return { p: p0, q: q0, p1: c.position.toArray(), q1: c.quaternion.toArray() };
+    })()`);
+    const drift = poseApart({ p: moved.p, q: moved.q }, { p: moved.p1, q: moved.q1 });
+    check(drift < 1e-12,
+      'and the camera the press leaves behind is the camera it found, to well under a nanometre',
+      `worst component moved ${drift.toExponential(2)}`);
+
+    // A drag after the press turns about the new pivot, which is the whole feature.
+    const orbited = await page.evaluate(`(() => {
+      const k = __kinect, c = k.freeCamera;
+      const t = k.controls.target;
+      const held = t.distanceTo(c.position);
+      const from = c.position.toArray();
+      const offset = c.position.clone().sub(t).applyAxisAngle(c.up, 0.3);
+      c.position.copy(t).add(offset);
+      k.controls.update(0);
+      return { held, after: t.distanceTo(c.position), target: t.toArray(),
+        travelled: Math.hypot(...c.position.toArray().map((v, i) => v - from[i])) };
+    })()`);
+    check(orbited.travelled > 0.1 && Math.abs(orbited.after - orbited.held) < 1e-6,
+      'a drag after the press turns about the new pivot, keeping its range',
+      `the camera travelled ${orbited.travelled.toFixed(3)} m and stayed ${
+        orbited.after.toFixed(6)} m out, from ${orbited.held.toFixed(6)}`);
+
+    // Reset must still go to the home pose, not to wherever the last press landed.
+    await page.evaluate("document.getElementById('menuCameraReset').click()");
+    await settle();
+    const afterReset = await page.evaluate('__kinect.controls.target.toArray()');
+    check(afterReset.every((v, i) => Math.abs(v - home[i]) < 1e-9),
+      'and Reset still goes to the home pose rather than to the pivot the last press picked',
+      `${afterReset.map((v) => v.toFixed(4)).join(', ')} against a home of ${home.map((v) => v.toFixed(4)).join(', ')}`);
+
+    // The top-down inset is not the cloud, and a press in it is the plan view's own gesture.
+    await page.evaluate('__kinect.params.apply({ topview: true })').catch(() => {});
+    await settle();
+    const inset = await pressOn(3000, { inset: true });
+    check(inset.after.target.every((v, i) => v === inset.before.target[i]),
+      'a press inside the top-down inset leaves the pivot alone, because the inset is not the cloud',
+      `${inset.after.target.map((v) => v.toFixed(6)).join(', ')} against `
+      + `${inset.before.target.map((v) => v.toFixed(6)).join(', ')}`);
+
+    const right = await pressOn(3000, { button: 2 });
+    check(right.after.target.every((v, i) => v === right.before.target[i]),
+      'and a right press leaves it alone, so the pan keeps its own button',
+      `${right.after.target.map((v) => v.toFixed(6)).join(', ')} against `
+      + `${right.before.target.map((v) => v.toFixed(6)).join(', ')}`);
+  }
+
+  console.log('\n[23] pinning the drive drops what the loop was going to serve');
 
   // The third state that strands an armed position, and the only one `pumpParkedDraft` cannot
   // notice on its own: `drive.pin` calls `setAnimationLoop(null)`, so that function stops being

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -82,6 +82,25 @@ const MUTATIONS = {
     ]],
   },
 
+  // Must redden: the singleton row, alone. One isolated return is sensor noise, not a surface.
+  'pick-accepts-a-singleton': {
+    file: 'web/depth-pick.js',
+    edits: [[
+      '  if (cluster === null) return null;',
+      '  if (cluster === null) cluster = [0, 0];',
+    ]],
+  },
+
+  // Must redden: the modified-left row, alone. OrbitControls assigns this press to pan.
+  'pick-rehomes-modified-pan': {
+    file: 'web/main.js',
+    edits: [[
+      '  if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey\n'
+      + '    || e.target !== renderer.domElement) return;',
+      '  if (e.button !== 0 || e.target !== renderer.domElement) return;',
+    ]],
+  },
+
   // ---- section 15b, the badge for an effect this build has not got ----
   // Must redden: the exact-sentence row of 15b, alone.
   'badge-counts-the-registry': {
@@ -8413,13 +8432,30 @@ try {
         target: k.controls.target.toArray(),
         clears: k.timeline.counters.navigationHistoryClears,
       };
-      k.drive.injectDepth(new Uint16Array(512 * 424).fill(mm));
+      const depth = new Uint16Array(512 * 424);
+      if (opts.singleton) depth[212 * 512 + 256] = mm;
+      else depth.fill(mm);
+      k.drive.injectDepth(depth);
       const r = document.getElementById('stage').getBoundingClientRect();
-      const at = opts.inset
+      const at = opts.singleton
+        ? (() => {
+          const z = mm * 0.001;
+          const focal = k.uniforms.focal.value;
+          const center = k.uniforms.center.value;
+          const point = new (c.position.constructor)(
+            (-(256.5 - center.x) / focal.x) * z,
+            -((212.5 - center.y) / focal.y) * z,
+            -z,
+          ).applyQuaternion(new (c.quaternion.constructor)().fromArray(k.worldTilt())).project(c);
+          return { x: r.x + ((point.x + 1) / 2) * r.width, y: r.y + ((1 - point.y) / 2) * r.height };
+        })()
+        : opts.inset
         ? (() => { const i = k.keyframes.chrome.inset(); return { x: r.x + i.x + i.w / 2, y: r.y + i.y + i.h / 2 }; })()
         : { x: r.x + r.width / 2, y: r.y + r.height / 2 };
       document.getElementById(opts.on ?? 'stage').dispatchEvent(new PointerEvent('pointerdown', {
         button: opts.button ?? 0, buttons: 1, clientX: at.x, clientY: at.y,
+        ctrlKey: opts.ctrlKey ?? false, metaKey: opts.metaKey ?? false,
+        shiftKey: opts.shiftKey ?? false,
         bubbles: true, cancelable: true, pointerId: 71,
       }));
       const t = k.controls.target;
@@ -8470,6 +8506,12 @@ try {
     check(empty.after.target.every((v, i) => v === held[i]),
       'a press with nothing under it leaves the pivot exactly where it was',
       `${empty.after.target.map((v) => v.toFixed(6)).join(', ')} against ${held.map((v) => v.toFixed(6)).join(', ')}`);
+
+    const singleton = await pressOn(300, { singleton: true });
+    check(singleton.after.target.every((v, i) => v === singleton.before.target[i]),
+      'a lone depth sample in otherwise empty space leaves the pivot alone',
+      `${singleton.after.target.map((v) => v.toFixed(6)).join(', ')} against `
+      + `${singleton.before.target.map((v) => v.toFixed(6)).join(', ')}`);
 
     // The far clip at 2 m with the box cutting, so a 3 m wall is geometry the renderer discards.
     const cropBefore = await page.evaluate("__kinect.params.values(['crop', 'far'])");
@@ -8579,6 +8621,12 @@ try {
       'and a right press leaves it alone, so the pan keeps its own button',
       `${right.after.target.map((v) => v.toFixed(6)).join(', ')} against `
       + `${right.before.target.map((v) => v.toFixed(6)).join(', ')}`);
+
+    const modified = await pressOn(3000, { shiftKey: true });
+    check(modified.after.target.every((v, i) => v === modified.before.target[i]),
+      'and a modified left press leaves it alone, because OrbitControls uses that press to pan',
+      `${modified.after.target.map((v) => v.toFixed(6)).join(', ')} against `
+      + `${modified.before.target.map((v) => v.toFixed(6)).join(', ')}`);
   }
 
   console.log('\n[23] pinning the drive drops what the loop was going to serve');

--- a/tools/level-check.mjs
+++ b/tools/level-check.mjs
@@ -63,18 +63,18 @@ const MUTATIONS = {
   // The picture levels and the box in the corner does not, which is the state this feature was
   // built to end. Nothing outside section 3 can see it.
   'plan-ignores-tilt': { file: 'web/main.js', edits: [[
-    '      planVec.set(wx, wy, -z).applyQuaternion(worldTilt);',
-    '      planVec.set(wx, wy, -z);',
+    '      planVec.applyQuaternion(worldTilt);',
+    '      planVec.setX(planVec.x);',
   ]] },
   // The plan culls on x alone, which is what it did while a top-down had no y to care about;
   // levelling turns sensor y into the plan's own x and z, so discarded points reappear inside the
   // footprint. Spelled out at the call site rather than by editing `croppedOut`, so two mutations
   // do not redden the same rows.
   'plan-skips-vertical-crop': { file: 'web/main.js', edits: [[
-    '      if (croppedOut(wx, wy, z)) continue;',
+    '      if (croppedOut(planVec.x, planVec.y, z)) continue;',
     '      if (uniforms.cropOn.value === 1\n'
     + '        && (z < uniforms.nearClip.value || z > uniforms.farClip.value\n'
-    + '          || wx < uniforms.cropL.value || wx > uniforms.cropR.value)) continue;',
+    + '          || planVec.x < uniforms.cropL.value || planVec.x > uniforms.cropR.value)) continue;',
   ]] },
   // The sensor view keeps navigation's own pole and axis, so on a levelled take the one button
   // meaning "exactly what the sensor shot" shows a rolled picture. `sensor-view-check`'s fov rows
@@ -117,9 +117,13 @@ const MUTATIONS = {
   // The sign is fixed in the shader and the top-down keeps the old one, so the picture shows the
   // room the right way round and the plan beside it is a reflection. One says the sign matters, the
   // other says which readers were told.
-  'plan-x-not-mirrored': { file: 'web/main.js', edits: [[
-    '      const wx = (-(col + 0.5 - cx) / fx) * z;',
-    '      const wx = ((col + 0.5 - cx) / fx) * z;',
+  // Aimed at `web/depth-pick.js` and not at the plan's own loop, because the unprojection moved
+  // there when the pivot's pick came to need it and the plan now calls it. That widens the
+  // mutation - it turns the pivot's sweep over too - which is the point: one spelling means one
+  // control, rather than a second copy in `main.js` this file would have gone on testing alone.
+  'plan-x-not-mirrored': { file: 'web/depth-pick.js', edits: [[
+    '  out.set((-(col + 0.5 - cx) / fx) * z, -((row + 0.5 - cy) / fy) * z, -z);',
+    '  out.set(((col + 0.5 - cx) / fx) * z, -((row + 0.5 - cy) / fy) * z, -z);',
   ]] },
 };
 if (MUTATE && !MUTATIONS[MUTATE]) {

--- a/web/depth-pick.js
+++ b/web/depth-pick.js
@@ -1,0 +1,142 @@
+// Where a depth texel is in the room, and which texel is under the pointer.
+//
+// The forward map is here rather than in `main.js` because three things have to agree about
+// it - the vertex shader unprojects with the same two uniforms, the top-down inset draws the
+// cloud from it, and the orbit pivot picks a range with it - and a second spelling is a second
+// place for the next correction to be forgotten.
+//
+// Pure arithmetic over numbers and three.js vectors, in the shape of `web/plan-geometry.js`:
+// no renderer, no textures, no scene. Everything it needs arrives as an argument, so the pick
+// can be driven under bare node against a grid written by hand.
+
+import * as THREE from 'three';
+import { DEPTH_H, DEPTH_W } from './format.js';
+
+// This module's own scratch. Both are fully written before they are read on every use, so
+// there is no state in either to share, and an exported vector two modules write into is the
+// writable crossing `module-check` rule 3 refuses.
+const scratch = new THREE.Vector3();
+const scratchWorld = new THREE.Vector3();
+const viewProjection = new THREE.Matrix4();
+const tiltMatrix = new THREE.Matrix4();
+
+/**
+ * One depth sample as a point in sensor metres, written into `out` as `(x, y, -z)`.
+ *
+ * libfreenect2's pinhole model. Returns the positive distance along the optical axis, or 0
+ * for a sample with no return - which is what the crop test and the shader's empty-sample
+ * test both read, so a caller never has to know that 0 means "no return" twice over.
+ */
+export function sensorPoint(out, mm, col, row, fx, fy, cx, cy) {
+  if (mm === 0) return 0;
+  const z = mm * 0.001;
+  out.set((-(col + 0.5 - cx) / fx) * z, -((row + 0.5 - cy) / fy) * z, -z);
+  return z;
+}
+
+// How far from the pointer a sample may land and still be a candidate, in stage pixels, and how
+// coarsely the grid is swept looking for one. The two are not independent: a stride-2 sweep of a
+// surface two metres out lands its samples about 6.3 stage pixels apart at 1080p, so a radius of
+// six admits exactly one of them and every rule below about outvoting a stray texel becomes a
+// rule about a population of one. Twelve is the smallest radius that reliably has company in it,
+// and it is still about a fingertip on the stage.
+export const PICK_RADIUS_PX = 12;
+export const PICK_STRIDE = 2;
+
+// How deep a cluster of candidates is allowed to be before it is two surfaces rather than one.
+//
+// **The nearest candidate is not the answer, and taking the median of the cluster around it is
+// not either.** A lone bright texel on a dark surface reads as a spike metres in front of it,
+// and a spike is alone: it is its own cluster of one, so a median taken across it returns the
+// spike itself. What discards it is company - the clusters are walked from the front and the
+// first one holding more than one sample wins, so a real surface outvotes a stray texel and a
+// genuinely thin object still wins outright as long as the sweep found it twice.
+export const PICK_TOLERANCE_M = 0.15;
+
+/**
+ * The distance from the camera to whatever is under a point on the stage, or null.
+ *
+ * Swept on the CPU rather than raycast or read back off the GPU: one depth texel is one vertex
+ * and the unprojection happens in the vertex stage, so there is no CPU geometry to raycast
+ * against, and a 1x1 readback would be a second program alongside the assembled cloud shader
+ * and a pipeline stall on every press.
+ *
+ * **The sweep is undisplaced.** `noise`, `regionPush`, `ripple`, `glitch` and the lattice move
+ * points in the vertex stage and the mosh drags the whole picture off the geometry underneath,
+ * so with any of those up this answers where the surface really is rather than where the eye is
+ * aimed. For a pivot that is the better answer - a pivot that jitters with the glitch is not a
+ * pivot - but it is a difference between what is drawn and what is picked, and it will not feel
+ * like one during a heavy mosh.
+ */
+export function pickDepth({
+  depth, focal, center, tilt, camera, stage, x, y,
+  croppedOut = () => false,
+  radiusPx = PICK_RADIUS_PX,
+  stride = PICK_STRIDE,
+  tolerance = PICK_TOLERANCE_M,
+}) {
+  const hit = sweep({ depth, focal, center, tilt, camera, stage, x, y, croppedOut, radiusPx, stride, tolerance });
+  if (hit || stride === 1) return hit;
+  // One retry at every texel before giving up, because at stride 2 a surface far enough away
+  // that its texels land more than six pixels apart is a surface a press slips between.
+  //
+  // The whole grid rather than a window around the pointer: which texels land near the pointer
+  // is what the sweep is computing, so there is no texel-space window to open without first
+  // inverting the projection. Four times the samples of a run that already measures well under
+  // the budget, on the small fraction of presses that miss.
+  return sweep({ depth, focal, center, tilt, camera, stage, x, y, croppedOut, radiusPx, stride: 1, tolerance });
+}
+
+function sweep({ depth, focal, center, tilt, camera, stage, x, y, croppedOut, radiusPx, stride, tolerance }) {
+  const { x: fx, y: fy } = focal;
+  const { x: cx, y: cy } = center;
+  // The tilt, the view and the projection folded into one matrix, so the inner loop is a
+  // multiply, a divide and two compares rather than three transforms.
+  camera.updateMatrixWorld();
+  viewProjection.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse)
+    .multiply(tiltMatrix.makeRotationFromQuaternion(tilt));
+  const radius2 = radiusPx * radiusPx;
+  const eye = camera.position;
+  const candidates = [];
+  let samples = 0;
+  for (let row = 0; row < DEPTH_H; row += stride) {
+    for (let col = 0; col < DEPTH_W; col += stride) {
+      const z = sensorPoint(scratch, depth[row * DEPTH_W + col], col, row, fx, fy, cx, cy);
+      if (z === 0) continue;
+      // A press must not pivot on geometry the renderer discarded.
+      if (croppedOut(scratch.x, scratch.y, z)) continue;
+      scratchWorld.copy(scratch).applyQuaternion(tilt);
+      scratch.applyMatrix4(viewProjection);
+      // `applyMatrix4` divides by w, and w is negative behind the camera - which flips the sign
+      // and puts a point at your back on screen in front of you. z outside the unit cube is the
+      // readable form of that test, the same one `projectThrough` makes.
+      if (scratch.z < -1 || scratch.z > 1) continue;
+      samples++;
+      const px = stage.x + ((scratch.x + 1) / 2) * stage.w - x;
+      const py = stage.y + ((1 - scratch.y) / 2) * stage.h - y;
+      if (px * px + py * py > radius2) continue;
+      candidates.push({ distance: eye.distanceTo(scratchWorld), world: scratchWorld.toArray() });
+    }
+  }
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => a.distance - b.distance);
+  let cluster = null;
+  for (let start = 0; start < candidates.length; start++) {
+    let end = start;
+    while (end + 1 < candidates.length
+      && candidates[end + 1].distance - candidates[start].distance <= tolerance) end++;
+    if (cluster === null) cluster = [start, end];
+    if (end > start) { cluster = [start, end]; break; }
+    start = end;
+  }
+  // The middle of whichever cluster won, so the distance is a value the surface actually holds
+  // rather than its front edge.
+  const chosen = candidates[cluster[0] + ((cluster[1] - cluster[0]) >> 1)];
+  return {
+    distance: chosen.distance,
+    world: chosen.world,
+    samples,
+    candidates: candidates.length,
+    cluster: cluster[1] - cluster[0] + 1,
+  };
+}

--- a/web/depth-pick.js
+++ b/web/depth-pick.js
@@ -1,32 +1,15 @@
-// Where a depth texel is in the room, and which texel is under the pointer.
-//
-// The forward map is here rather than in `main.js` because three things have to agree about
-// it - the vertex shader unprojects with the same two uniforms, the top-down inset draws the
-// cloud from it, and the orbit pivot picks a range with it - and a second spelling is a second
-// place for the next correction to be forgotten.
-//
-// Pure arithmetic over numbers and three.js vectors, in the shape of `web/plan-geometry.js`:
-// no renderer, no textures, no scene. Everything it needs arrives as an argument, so the pick
-// can be driven under bare node against a grid written by hand.
+// Unprojects depth texels and finds the visible surface under a stage point.
 
 import * as THREE from 'three';
 import { DEPTH_H, DEPTH_W } from './format.js';
 
-// This module's own scratch. Both are fully written before they are read on every use, so
-// there is no state in either to share, and an exported vector two modules write into is the
-// writable crossing `module-check` rule 3 refuses.
+// Keep mutable scratch private so no writable state crosses a module boundary.
 const scratch = new THREE.Vector3();
 const scratchWorld = new THREE.Vector3();
 const viewProjection = new THREE.Matrix4();
 const tiltMatrix = new THREE.Matrix4();
 
-/**
- * One depth sample as a point in sensor metres, written into `out` as `(x, y, -z)`.
- *
- * libfreenect2's pinhole model. Returns the positive distance along the optical axis, or 0
- * for a sample with no return - which is what the crop test and the shader's empty-sample
- * test both read, so a caller never has to know that 0 means "no return" twice over.
- */
+/** Writes one libfreenect2 depth sample into `out`, or returns 0 for no return. */
 export function sensorPoint(out, mm, col, row, fx, fy, cx, cy) {
   if (mm === 0) return 0;
   const z = mm * 0.001;
@@ -34,40 +17,14 @@ export function sensorPoint(out, mm, col, row, fx, fy, cx, cy) {
   return z;
 }
 
-// How far from the pointer a sample may land and still be a candidate, in stage pixels, and how
-// coarsely the grid is swept looking for one. The two are not independent: a stride-2 sweep of a
-// surface two metres out lands its samples about 6.3 stage pixels apart at 1080p, so a radius of
-// six admits exactly one of them and every rule below about outvoting a stray texel becomes a
-// rule about a population of one. Twelve is the smallest radius that reliably has company in it,
-// and it is still about a fingertip on the stage.
+// At stride 2, a 12px radius is the smallest measured sweep that finds multiple surface samples.
 export const PICK_RADIUS_PX = 12;
 export const PICK_STRIDE = 2;
 
-// How deep a cluster of candidates is allowed to be before it is two surfaces rather than one.
-//
-// **The nearest candidate is not the answer, and taking the median of the cluster around it is
-// not either.** A lone bright texel on a dark surface reads as a spike metres in front of it,
-// and a spike is alone: it is its own cluster of one, so a median taken across it returns the
-// spike itself. What discards it is company - the clusters are walked from the front and the
-// first one holding more than one sample wins, so a real surface outvotes a stray texel and a
-// genuinely thin object still wins outright as long as the sweep found it twice.
+// The nearest cluster with at least two samples wins, which rejects isolated depth spikes.
 export const PICK_TOLERANCE_M = 0.15;
 
-/**
- * The distance from the camera to whatever is under a point on the stage, or null.
- *
- * Swept on the CPU rather than raycast or read back off the GPU: one depth texel is one vertex
- * and the unprojection happens in the vertex stage, so there is no CPU geometry to raycast
- * against, and a 1x1 readback would be a second program alongside the assembled cloud shader
- * and a pipeline stall on every press.
- *
- * **The sweep is undisplaced.** `noise`, `regionPush`, `ripple`, `glitch` and the lattice move
- * points in the vertex stage and the mosh drags the whole picture off the geometry underneath,
- * so with any of those up this answers where the surface really is rather than where the eye is
- * aimed. For a pivot that is the better answer - a pivot that jitters with the glitch is not a
- * pivot - but it is a difference between what is drawn and what is picked, and it will not feel
- * like one during a heavy mosh.
- */
+/** Returns the camera distance to undisplaced depth under a stage point, or null. */
 export function pickDepth({
   depth, focal, center, tilt, camera, stage, x, y,
   croppedOut = () => false,
@@ -77,21 +34,14 @@ export function pickDepth({
 }) {
   const hit = sweep({ depth, focal, center, tilt, camera, stage, x, y, croppedOut, radiusPx, stride, tolerance });
   if (hit || stride === 1) return hit;
-  // One retry at every texel before giving up, because at stride 2 a surface far enough away
-  // that its texels land more than six pixels apart is a surface a press slips between.
-  //
-  // The whole grid rather than a window around the pointer: which texels land near the pointer
-  // is what the sweep is computing, so there is no texel-space window to open without first
-  // inverting the projection. Four times the samples of a run that already measures well under
-  // the budget, on the small fraction of presses that miss.
+  // Retry every texel because the projected stage point has no cheap texel-space inverse.
   return sweep({ depth, focal, center, tilt, camera, stage, x, y, croppedOut, radiusPx, stride: 1, tolerance });
 }
 
 function sweep({ depth, focal, center, tilt, camera, stage, x, y, croppedOut, radiusPx, stride, tolerance }) {
   const { x: fx, y: fy } = focal;
   const { x: cx, y: cy } = center;
-  // The tilt, the view and the projection folded into one matrix, so the inner loop is a
-  // multiply, a divide and two compares rather than three transforms.
+  // Fold tilt, view and projection together before the inner loop.
   camera.updateMatrixWorld();
   viewProjection.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse)
     .multiply(tiltMatrix.makeRotationFromQuaternion(tilt));
@@ -107,9 +57,7 @@ function sweep({ depth, focal, center, tilt, camera, stage, x, y, croppedOut, ra
       if (croppedOut(scratch.x, scratch.y, z)) continue;
       scratchWorld.copy(scratch).applyQuaternion(tilt);
       scratch.applyMatrix4(viewProjection);
-      // `applyMatrix4` divides by w, and w is negative behind the camera - which flips the sign
-      // and puts a point at your back on screen in front of you. z outside the unit cube is the
-      // readable form of that test, the same one `projectThrough` makes.
+      // The unit-cube z test also rejects points behind the camera after division by w.
       if (scratch.z < -1 || scratch.z > 1) continue;
       samples++;
       const px = stage.x + ((scratch.x + 1) / 2) * stage.w - x;
@@ -125,10 +73,10 @@ function sweep({ depth, focal, center, tilt, camera, stage, x, y, croppedOut, ra
     let end = start;
     while (end + 1 < candidates.length
       && candidates[end + 1].distance - candidates[start].distance <= tolerance) end++;
-    if (cluster === null) cluster = [start, end];
     if (end > start) { cluster = [start, end]; break; }
     start = end;
   }
+  if (cluster === null) return null;
   // The middle of whichever cluster won, so the distance is a value the surface actually holds
   // rather than its front edge.
   const chosen = candidates[cluster[0] + ((cluster[1] - cluster[0]) >> 1)];

--- a/web/main.js
+++ b/web/main.js
@@ -21,6 +21,7 @@ import {
 import {
   INSET, TOP_CENTRE, PLAN_STRIDE, FRUSTUM_LEN, planScale, planPoint, planWorld, projectThrough,
 } from './plan-geometry.js';
+import { pickDepth, sensorPoint } from './depth-pick.js';
 import { ZOOM_PER_NOTCH, TICK_STEPS, tickLabel, makeViewWindow } from './view-window.js';
 import { clipIn, clipOut, clipBoundOrThrow, writeClipRange } from './clip-range.js';
 import {
@@ -6847,17 +6848,15 @@ function drawPlanCloud(rect) {
   chromeCtx.fillStyle = 'rgba(232, 236, 241, 0.55)';
   for (let row = 0; row < DEPTH_H; row += PLAN_STRIDE) {
     for (let col = 0; col < DEPTH_W; col += PLAN_STRIDE) {
-      const mm = depth[row * DEPTH_W + col];
-      if (mm === 0) continue;
-      const z = mm * 0.001;
-      // libfreenect2's pinhole model, off the same two uniforms the vertex shader
-      // unprojects with.
-      const wx = (-(col + 0.5 - cx) / fx) * z;
-      const wy = -((row + 0.5 - cy) / fy) * z;
+      // The same forward map the pivot's pick sweeps with and the vertex shader unprojects
+      // with, called rather than spelled again: two spellings are two places for the next
+      // correction to be forgotten.
+      const z = sensorPoint(planVec, depth[row * DEPTH_W + col], col, row, fx, fy, cx, cy);
+      if (z === 0) continue;
       // All four lateral faces, so the plan does not draw points the renderer discards.
-      if (croppedOut(wx, wy, z)) continue;
+      if (croppedOut(planVec.x, planVec.y, z)) continue;
       // A canted room drawn about the sensor's axes is a slanted section labelled TOP-DOWN.
-      planVec.set(wx, wy, -z).applyQuaternion(worldTilt);
+      planVec.applyQuaternion(worldTilt);
       const px = rect.x + rect.w / 2 + (planVec.x - TOP_CENTRE.x) * s;
       const py = rect.y + rect.h / 2 + (planVec.z - TOP_CENTRE.z) * s;
       if (px < rect.x || px > rect.x + rect.w || py < rect.y || py > rect.y + rect.h) continue;
@@ -7481,6 +7480,65 @@ for (const type of ['pointerup', 'pointercancel']) {
     requestRepaint();
   });
 }
+
+// How far down the view axis the pivot may be put. Below the low bound an orbit is
+// hypersensitive - a degree of drag swings the camera through the subject - and past the far clip
+// there is nothing drawn to turn around.
+const PIVOT_MIN_M = 0.15;
+
+const pivotForward = new THREE.Vector3();
+
+/**
+ * Moves the orbit pivot along the view axis to a range, leaving the picture alone.
+ *
+ * **On the axis, and built from the forward vector the camera already holds.** `controls.update()`
+ * ends in `camera.lookAt(this.target)`, so a target written off-axis re-aims the camera on the
+ * frame after the press and the view jumps before the drag has started; and a target derived from
+ * a freshly computed direction is on-axis in real arithmetic but need not be in floating point,
+ * where one differing bit rebuilds the quaternion. `renderedCameraChanged` compares the quaternion
+ * exactly, so that bit clears the afterimage and the mosh history both - a visible smear reset on
+ * a press that was supposed to change nothing.
+ *
+ * No `saveState()`: Reset must still go to the home pose `scene.js` takes such care over.
+ */
+function setPivotDistance(distance) {
+  const d = Math.min(Math.max(distance, PIVOT_MIN_M), uniforms.farClip.value);
+  freeCamera.getWorldDirection(pivotForward);
+  controls.target.copy(freeCamera.position).addScaledVector(pivotForward, d);
+  return d;
+}
+
+// Captured on the window and not the canvas, because OrbitControls listens on the canvas and
+// reads `target` when the press arrives - a listener on the canvas would write it too late. And
+// guarded on the two drags rather than silenced with `stopPropagation`, which does not reach
+// siblings registered on the same node.
+//
+// No render and no `requestRepaint()`: the image does not change, and a render in answer to a
+// pointer event is the loop `CLAUDE.md` names.
+addEventListener('pointerdown', (e) => {
+  if (e.button !== 0 || e.target !== renderer.domElement) return;
+  if (nodeDrag || cropDrag) return;
+  if (viewCamera !== freeCamera || !controls.enabled) return;
+  const view = viewUnder(e.clientX, e.clientY);
+  if (!view || view.plan) return;
+  // Before the sweep, because a camera mid-damping gives a forward axis it is about to leave and
+  // the pivot would land off it.
+  finishOrbitDrift();
+  const hit = pickDepth({
+    depth: depthCurr.image.data,
+    focal: uniforms.focal.value,
+    center: uniforms.center.value,
+    tilt: worldTilt,
+    camera: freeCamera,
+    stage: { x: 0, y: 0, ...stageSize() },
+    x: view.x,
+    y: view.y,
+    croppedOut,
+  });
+  // Empty space, a hole in the returns or a press past the crop box keeps the pivot it had.
+  if (!hit) return;
+  setPivotDistance(hit.distance);
+}, true);
 
 function keyCameraHere() {
   if (!timeline) return;

--- a/web/main.js
+++ b/web/main.js
@@ -6848,9 +6848,7 @@ function drawPlanCloud(rect) {
   chromeCtx.fillStyle = 'rgba(232, 236, 241, 0.55)';
   for (let row = 0; row < DEPTH_H; row += PLAN_STRIDE) {
     for (let col = 0; col < DEPTH_W; col += PLAN_STRIDE) {
-      // The same forward map the pivot's pick sweeps with and the vertex shader unprojects
-      // with, called rather than spelled again: two spellings are two places for the next
-      // correction to be forgotten.
+      // Reuse the depth picker's forward map so the plan and pivot cannot drift apart.
       const z = sensorPoint(planVec, depth[row * DEPTH_W + col], col, row, fx, fy, cx, cy);
       if (z === 0) continue;
       // All four lateral faces, so the plan does not draw points the renderer discards.
@@ -7481,29 +7479,12 @@ for (const type of ['pointerup', 'pointercancel']) {
   });
 }
 
-// How far down the view axis the pivot may be put. Below the low bound an orbit is
-// hypersensitive - a degree of drag swings the camera through the subject - and past the far clip
-// there is nothing drawn to turn around.
+// Avoid hypersensitive near pivots and pivots beyond the drawn range.
 const PIVOT_MIN_M = 0.15;
 
 const pivotForward = new THREE.Vector3();
 
-/**
- * Moves the orbit pivot along the view axis to a range, leaving the picture alone.
- *
- * **On the axis, and built from the forward vector the camera already holds.** `controls.update()`
- * ends in `camera.lookAt(this.target)`, so a target written off-axis re-aims the camera on the
- * frame after the press and the view jumps before the drag has started.
- *
- * It is still not free, and no arrangement of this function makes it so: `update()` also rebuilds
- * `position` out of `target`, so any write here re-rounds the position by about an ulp, and
- * `renderedCameraChanged` compares exactly. The press therefore clears the afterimage once - the
- * price one move of a right-drag pan has always paid, and the drag this press precedes pays on
- * every frame. The mosh history is not involved; only `resetAccumulators` clears that.
- * `docs/performance.md` carries the measurement and the fixed point that does not exist.
- *
- * No `saveState()`: Reset must still go to the home pose `scene.js` takes such care over.
- */
+/** Moves the pivot along the view axis without changing the saved Reset pose. */
 function setPivotDistance(distance) {
   const d = Math.min(Math.max(distance, PIVOT_MIN_M), uniforms.farClip.value);
   freeCamera.getWorldDirection(pivotForward);
@@ -7511,21 +7492,15 @@ function setPivotDistance(distance) {
   return d;
 }
 
-// Captured on the window and not the canvas, because OrbitControls listens on the canvas and
-// reads `target` when the press arrives - a listener on the canvas would write it too late. And
-// guarded on the two drags rather than silenced with `stopPropagation`, which does not reach
-// siblings registered on the same node.
-//
-// No render and no `requestRepaint()`: the image does not change, and a render in answer to a
-// pointer event is the loop `CLAUDE.md` names.
+// Capture before OrbitControls reads the target; a canvas listener would write it too late.
 addEventListener('pointerdown', (e) => {
-  if (e.button !== 0 || e.target !== renderer.domElement) return;
+  if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey
+    || e.target !== renderer.domElement) return;
   if (nodeDrag || cropDrag) return;
   if (viewCamera !== freeCamera || !controls.enabled) return;
   const view = viewUnder(e.clientX, e.clientY);
   if (!view || view.plan) return;
-  // Before the sweep, because a camera mid-damping gives a forward axis it is about to leave and
-  // the pivot would land off it.
+  // Settle damping so the pick uses the axis the camera will keep.
   finishOrbitDrift();
   const hit = pickDepth({
     depth: depthCurr.image.data,

--- a/web/main.js
+++ b/web/main.js
@@ -7493,11 +7493,14 @@ const pivotForward = new THREE.Vector3();
  *
  * **On the axis, and built from the forward vector the camera already holds.** `controls.update()`
  * ends in `camera.lookAt(this.target)`, so a target written off-axis re-aims the camera on the
- * frame after the press and the view jumps before the drag has started; and a target derived from
- * a freshly computed direction is on-axis in real arithmetic but need not be in floating point,
- * where one differing bit rebuilds the quaternion. `renderedCameraChanged` compares the quaternion
- * exactly, so that bit clears the afterimage and the mosh history both - a visible smear reset on
- * a press that was supposed to change nothing.
+ * frame after the press and the view jumps before the drag has started.
+ *
+ * It is still not free, and no arrangement of this function makes it so: `update()` also rebuilds
+ * `position` out of `target`, so any write here re-rounds the position by about an ulp, and
+ * `renderedCameraChanged` compares exactly. The press therefore clears the afterimage once - the
+ * price one move of a right-drag pan has always paid, and the drag this press precedes pays on
+ * every frame. The mosh history is not involved; only `resetAccumulators` clears that.
+ * `docs/performance.md` carries the measurement and the fixed point that does not exist.
  *
  * No `saveState()`: Reset must still go to the home pose `scene.js` takes such care over.
  */


### PR DESCRIPTION
A left press on the stage reads the depth under the pointer and moves the orbit pivot along the
view axis to that range. Orbiting a subject four metres out then turns around it instead of
swinging it across the frame, which today needs a right-drag pan by eye at a number the depth
frame already knows. Same button, same drag, no modifier, no new control. A press on the
background, on a hole in the returns, or on geometry outside the crop box leaves the pivot alone.

The pivot stays **on the view axis**, which is what lets this hang off an ordinary press:
`OrbitControls.update()` ends in `camera.lookAt(target)`, so an off-axis target re-aims the camera
on the frame after the press and the view jumps before the drag has started. On-axis, only the
turning radius changes.

Branched from `4d711ef`. 726 insertions across 9 files, of which 454 are proof rows and 53 are
prose; the behaviour is ~35 lines of new logic in `web/main.js` plus a new pure module.

## Three places reality disagreed with the intention

Reported rather than routed around, per CONTRIBUTING.

**A median around the nearest candidate does not discard a lone spike.** The design called for the
nearest sample, made robust by taking the median of everything within 0.15 m of it. A spike is
alone - its cluster has one member - so that median returns the spike. What discards it is
company: clusters are walked from the front and the first holding more than one sample wins.

**A six-pixel search radius admits exactly one sample.** A stride-2 sweep of a wall two metres out
lands its samples about 6.3 stage pixels apart at 1080p, so at radius six every rule about
outvoting a stray texel was a rule about a population of one. The radius is 12, and
`test/depth-pick.test.mjs` has a row asserting the coupling, so a future tightening of the radius
reddens rather than silently disarming the spike rule.

**The press cannot be made free, and the criterion asking for it was wrong.** It was meant to leave
`position`, `quaternion` and `projectionMatrix` bit-identical so `renderedCameraChanged` would stay
false. It cannot: `update()` rebuilds `position` out of `target` every frame, so any pivot write
re-rounds the position by about an ulp and the comparison is exact. Nudging the target by the
residual and retrying does not converge - measured, 8 attempts still moving at 7 of 9 camera poses.
What it costs is one afterimage clear, which is exactly what one move of a right-drag pan has
always cost, and the drag a press precedes clears on every frame anyway. Section 22 asserts that
against two controls in the same conditions rather than asserting bit-identity it cannot have.

The intention was also wrong in the other direction: **the mosh history is untouched.**
`renderedCameraChanged` drives `clearAfterimage()` alone, and the mosh's two targets are cleared
only by `resetAccumulators`. `docs/performance.md` carries both results.

## One statement of the unprojection

`drawPlanCloud` and the new sweep would otherwise be two spellings of the same pinhole model, so
`drawPlanCloud` now calls `sensorPoint` from the new module. Four lines, and it is the difference
between a shared model and a copy that drifts.

## Mutation anchors that moved

Three `level-check` mutations anchored on the `drawPlanCloud` lines this touches, re-anchored in
the same commit as the change:

- `plan-ignores-tilt` and `plan-skips-vertical-crop` - re-anchored to the rewritten lines in
  `web/main.js`.
- `plan-x-not-mirrored` - **re-aimed at `web/depth-pick.js`**, where the unprojection now lives.
  That widens it to turn the pivot's sweep over as well, which is the point of there being one
  spelling.

Catch counts are identical before and after, checked against a worktree at `4d711ef`: 1, 2 and 3
assertions respectively.

## What I ran

| tool | result |
| --- | --- |
| `editor-check --take fixture-1g --no-render` | 581 assertions, 3 failed - see below |
| `editor-check` x4 new mutations | each caught by the row it exists for |
| `level-check` | 32 assertions, 0 failed |
| `level-check` x3 re-anchored mutations | caught, counts unchanged from baseline |
| `module-check` | 62 assertions, 0 failed; 3 mutations caught |
| `npm run test:unit` | 165 pass, 0 fail; 12 rows new |
| `syntax-check` | 0 of 84 failed |

**The three red rows in `editor-check` are not from this branch.** They are about
`datamosh.refresh` and are red on `main` as it stands - reproduced identically on a worktree at
`4d711ef` (569 assertions, same 3 failed, same numbers). I have left them alone rather than fix
somebody else's change inside this one.

**That standing failure caused a false verdict, which is worth knowing about independently of this
PR.** `editor-check` declares a mutation caught whenever the run ends with any failure, so with
three rows already red it reported `pick-rehomes-reset` as caught when nothing tested it - the only
rows that fired were the three pre-existing ones. Reading which assertions fired rather than the
verdict is what found it; the Reset row had been reading the home pose after the section's own
presses, so on the mutated build it compared `target0` against itself. Fixed, and
`docs/instruments.md` carries the general shape: while a suite has a standing failure, its own
catch verdict is a false-positive generator and a baseline run is the only thing that separates
the two populations.

## Measurements

Interleaved in one loop, never two. 80 trials with the first 20 discarded, headless Chromium at
1512x900, Apple M2 Max, `performance.now` quantised to 0.1 ms by the browser:

| arm | p50 | p95 |
| --- | --- | --- |
| a press that hits (stride 2) | 0.600 ms | 0.700 ms |
| a press that finds nothing over a full grid | 2.8 ms | 2.9 ms |
| floor: a press that enters the handler and leaves at the button test | 0.100 ms | 0.100 ms |

The 2.8 ms case sweeps every second texel and then, having missed, every texel. It is a one-off on
a pointer event against a 33 ms frame, and it buys presses on surfaces far enough out that stride-2
samples land more than twelve stage pixels apart.

## What I could not check

No Kinect on this machine, so everything above is against recorded takes and synthetic grids -
`fixture-1g` for the page rows, hand-written 512x424 grids for the unit rows. Nothing here touches
registration, the grabber, or delivered frame rate. The millisecond figures are browser-side and
were measured; they are not sensor numbers.

## Departure from the plan worth naming

The retry after a stride-2 miss sweeps every texel rather than a window around the pointer, because
which texels land near the pointer is precisely what the sweep computes - there is no texel-space
window to open without first inverting the projection. That is where the 2.8 ms goes.

---

Generated with [Claude Code](https://claude.com/claude-code)