### PR TITLE
Give every effect a panel group of its own

### DIFF
--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -704,11 +704,14 @@ that into a sentence.
 
 **Its section 6e stands on something nobody wrote down until it nearly broke.** The two
 `page.click('.kf[aria-label="bloom keyframe"]')` calls need that diamond *visible*, and `bloom`
-lives in the `optical` panel group, which collapses when every parameter in it is at its
-default. They work only because 6e applies the Blackwall look first and that look moves `bloom`,
-`rgbsplit.amount`, `raster.amount` and `grain.amount` off their defaults, so the group has derived itself open by
-the time the click lands. Nothing in either file says so, and the two ends can move
-independently: a look re-graded to leave `optical` alone, or a change to the reveal predicate,
+lives in the `post` panel group, which collapses when every parameter in it is at its
+default. They work only because 6e applies the Blackwall look first and that look moves `bloom`
+off its default, so the group has derived itself open by the time the click lands. That used to
+be four parameters carrying it - Blackwall moves `rgbsplit.amount`, `grain.amount` and
+`vignette.amount` too, and all three sat in `post` - and each of those effects now has a panel
+group of its own, so `post` holds `bloom` and `crush` and Blackwall leaves `crush` where it found
+it. The clicked parameter is now the only thing opening the group it is in. Nothing in either file says so, and the two ends can move
+independently: a look re-graded to leave `bloom` at zero, or a change to the reveal predicate,
 turns those clicks into thirty-second timeouts - which arrive as a crash with **zero failed
 assertions**, the shape this repo has twice recorded being written down as a bug found. If you
 touch either end, run `keyframe-check`; `editor-check`'s row 'moving one parameter off its

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -364,9 +364,43 @@ document that holds it: the lattice at 1.0 on a 5.5cm cell, `glyph.amount` at 1.
 and the rain key at 0.6, the rain at 0.8 falling 0.55 m/s with heads 1.3m apart, over a depth
 reading with a green duotone, a toe and bloom on top.
 
+**Every effect is one panel group of its own, and a core group holds only the spine's own
+controls.** Twelve effects used to draw loose inside `Style`, `Post`, `Displacement` and
+`Region`, mixed in with `rim`, `bloom`, `crush`, `cell m` and the region box — so they had no
+heading to collapse, and the hover-X that takes an effect out of the rack never appeared on
+them, because `groupOwner` refuses a group with more than one owner. Each of them now declares
+its own group and its own heading. The rule is a convention rather than a refusal: the install
+door still accepts a parameter that names a core group, because an effect may one day have a
+term that genuinely belongs beside the spine's, and a door that forbade it would be a rule
+written where the exception cannot be made. A term under its own heading drops the prefix it
+only carried to stay legible loose in a shared group, so `duotone hue` is `hue` and `streak
+angle` is `angle`; `halation` and `stock` keep theirs, which is the inconsistency this convention
+inherited rather than one it introduced.
+
+**One effect is one group even when its terms belong to two stages.** `Turbulence` is the case:
+three of its terms displace and the fourth, `scramble`, reads the region box, and they sit
+together under one heading so the hover-X removes the whole effect rather than three quarters of
+it. Where the slider is drawn and what the shader does are separate facts — `scramble` still
+consumes the region service at gate order 200, between `push` and `mask`, wherever the panel puts
+it.
+
+**On the Look tab nothing moved.** `Thermal`, `Edges` and `Duotone` sit where their rows sat
+inside `Style`, ahead of `Rain`; `RGB split`, `Grain`, `Streak` and `Vignette` sit where theirs
+sat inside `Post`, ahead of `Datamosh`. A grouping change that also re-laid out the panel would
+be two changes arriving as one, and the second is the one nobody asked for.
+
+**The Region tab reads the box first and then the readings of it, in the order the shader takes
+them.** `Region (metres)`, then `Region push`, `Turbulence`, `Region mask` and `Ripple` at gate
+orders 100 to 400, then `Displacement` and `Lattice`. Reading down the tab is reading the
+pipeline, which is worth more than keeping `Turbulence` next to the other thing that displaces:
+a panel that draws its stages out of order teaches the wrong thing every time somebody looks
+at it. That order is the reason `region` sits before `displacement`
+in the panel spine, which is the one place the spine's order is a statement about meaning rather
+than about history.
+
 **`ripple.amount`** is the region read a fourth way, after displacing, scrambling and masking: a wave
 travelling out along the radius, in metres at a full weight, so the volume breathes where
-`push` only swells it. `ripple per m` is its spacing and `ripple hz` its speed — and the wave
+`push` only swells it. `per m` is its spacing and `hz` its speed — and the wave
 advances in eighths of a cycle rather than sliding, which is the character rather than a
 limitation: the surface arrives at each step instead of gliding between them, so it reads as
 machinery rather than as breathing. A speed of 0 freezes it where it stands rather than
@@ -398,7 +432,7 @@ saved before it existed loses its corner falloff until it names one.
 **`streak.amount`** bleeds light across the frame. Each pixel gathers back along the streak's axis and
 keeps the brightest thing it finds, decayed by distance, so a highlight smears the way a sensor
 smears one down a column of wells — sixteen taps at geometric spacing, reaching about 168 pixels
-at the 1080p reference. `streak angle` beside it is which way, in degrees, and **0 is straight
+at the 1080p reference. `angle` beside it is which way, in degrees, and **0 is straight
 down**, which is what this term did when it did nothing else: a look authored before the control
 existed names no angle and keeps the fall it was graded with, to the bit. Positive turns the
 smear clockwise on the glass, so 90 runs it across to the left, 180 sends it up and -90 across to
@@ -662,7 +696,10 @@ declares `gates` has to be something the grade gate can read, so not either vect
 whose two-component value is not a scalar amount, and not a table the gate does not collect, a
 step may not be finer than `1e-6`, which is a grid neither the rounding nor a 32-bit float can resolve, and a
 parameter may only name a panel group this build holds or one its own package declares, with a
-package group key that collides with either refused by name. A refused package leaves nothing
+package group key that collides with either refused by name. A parameter names its group and
+nothing else about the panel: which tab it draws on is the group's fact, so a manifest carries no
+tab of its own. It used to carry one that nothing read and that five effects stated wrongly,
+which is the shape of thing a reader believes because no check ever contradicted it. A refused package leaves nothing
 behind.
 
 **A page that is open when an install happens rebuilds itself.** Both shader programs are
@@ -786,12 +823,12 @@ a tint, because its two poles carry luminance as well as hue — the near one ru
 and the far one toward hot, so one term gives both the depth-keyed palette and the near-black
 figure against a burning core. A plain global toe cannot draw that second thing at all, since
 it darkens near and far alike, which is why there is no separate silhouette control to look
-for. `duotone depth` is how far the image lands between the poles, `duotone hue` turns both of
-them together, and `duotone split` is the depth they meet at, as a fraction of the clip range
+for. `duotone` is how far the image lands between the poles, `hue` turns both of
+them together, and `split` is the depth they meet at, as a fraction of the clip range
 — so the crossover is a place in the room rather than a fraction of the frame. The pair itself
 is baked, the way `heatRamp` and `depthRamp` are: what is parameterised is how you use them.
 
-**`duotone motion`** keys those same two poles on speed as well, so whatever is moving through
+**`duotone.motion`** keys those same two poles on speed as well, so whatever is moving through
 the room comes out hot against a room graded by distance. It is the reading the depth key
 cannot draw on its own: a subject and the wall behind it are graded by where they stand, so a
 person walking through a scene is exactly as cold as the air they walk through until something

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -384,10 +384,16 @@ it. Where the slider is drawn and what the shader does are separate facts — `s
 consumes the region service at gate order 200, between `push` and `mask`, wherever the panel puts
 it.
 
-**On the Look tab nothing moved.** `Thermal`, `Edges` and `Duotone` sit where their rows sat
-inside `Style`, ahead of `Rain`; `RGB split`, `Grain`, `Streak` and `Vignette` sit where theirs
-sat inside `Post`, ahead of `Datamosh`. A grouping change that also re-laid out the panel would
-be two changes arriving as one, and the second is the one nobody asked for.
+**On the Look tab one row moved, and it had to.** `Thermal`, `Edges` and `Duotone` sit where
+their rows sat inside `Style`, ahead of `Rain`; `RGB split`, `Grain`, `Streak` and `Vignette` sit
+where theirs sat inside `Post`, ahead of `Datamosh`. A grouping change that also re-laid out the
+panel would be two changes arriving as one, and the second is the one nobody asked for. The
+exception is `crush`, which the registry declares after those four effects and which therefore
+drew below them: a core group is emitted whole before the groups anchored under it, so a term
+that stays in `Post` cannot stay below effects that have left it. `Post` is now `bloom` and
+`crush` together, which is the pair the grade pass already describes - the rolloff and the
+black-toe crush ride along with the same pass - so the one row this cost is a row that reads
+better where it landed.
 
 **The Region tab reads the box first and then the readings of it, in the order the shader takes
 them.** `Region (metres)`, then `Region push`, `Turbulence`, `Region mask` and `Ripple` at gate

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -394,7 +394,10 @@ them.** `Region (metres)`, then `Region push`, `Turbulence`, `Region mask` and `
 orders 100 to 400, then `Displacement` and `Lattice`. Reading down the tab is reading the
 pipeline, which is worth more than keeping `Turbulence` next to the other thing that displaces:
 a panel that draws its stages out of order teaches the wrong thing every time somebody looks
-at it. That order is the reason `region` sits before `displacement`
+at it. **The two numbers are equal by hand and nothing holds them equal** — a fifth effect
+consuming the region service, or a gate order changed without its panel order following, draws
+the tab out of pipeline order and makes this paragraph wrong rather than merely stale. That
+order is the reason `region` sits before `displacement`
 in the panel spine, which is the one place the spine's order is a statement about meaning rather
 than about history.
 

--- a/effects-builtin/blackwall/manifest.json
+++ b/effects-builtin/blackwall/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "blackwall",
       "panel": {
-        "group": "blackwall",
-        "tab": "look"
+        "group": "blackwall"
       },
       "bind": {
         "on": "points",
@@ -30,8 +29,7 @@
       "kind": "scalar",
       "label": "sweep",
       "panel": {
-        "group": "blackwall",
-        "tab": "look"
+        "group": "blackwall"
       },
       "bind": {
         "on": "points",
@@ -47,8 +45,7 @@
       "kind": "scalar",
       "label": "scan",
       "panel": {
-        "group": "blackwall",
-        "tab": "look"
+        "group": "blackwall"
       },
       "bind": {
         "on": "points",

--- a/effects-builtin/contour/manifest.json
+++ b/effects-builtin/contour/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "contour",
       "panel": {
-        "group": "contour",
-        "tab": "look"
+        "group": "contour"
       },
       "bind": {
         "on": "points",
@@ -30,8 +29,7 @@
       "kind": "scalar",
       "label": "bands /m",
       "panel": {
-        "group": "contour",
-        "tab": "look"
+        "group": "contour"
       },
       "bind": {
         "on": "points",
@@ -47,8 +45,7 @@
       "kind": "scalar",
       "label": "thickness",
       "panel": {
-        "group": "contour",
-        "tab": "look"
+        "group": "contour"
       },
       "bind": {
         "on": "points",

--- a/effects-builtin/datamosh/manifest.json
+++ b/effects-builtin/datamosh/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "datamosh",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -30,8 +29,7 @@
       "kind": "scalar",
       "label": "reach px",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -47,8 +45,7 @@
       "kind": "scalar",
       "label": "decay",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -64,8 +61,7 @@
       "kind": "scalar",
       "label": "splay",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -81,8 +77,7 @@
       "kind": "scalar",
       "label": "line",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -98,8 +93,7 @@
       "kind": "scalar",
       "label": "grain px",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -115,8 +109,7 @@
       "kind": "scalar",
       "label": "drift",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -132,8 +125,7 @@
       "kind": "scalar",
       "label": "speed",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -146,8 +138,7 @@
       "kind": "step",
       "label": "cycle",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",
@@ -163,8 +154,7 @@
       "kind": "scalar",
       "label": "refresh s",
       "panel": {
-        "group": "datamosh",
-        "tab": "look"
+        "group": "datamosh"
       },
       "bind": {
         "on": "mosh",

--- a/effects-builtin/duotone/manifest.json
+++ b/effects-builtin/duotone/manifest.json
@@ -10,10 +10,9 @@
       "max": 1,
       "step": 0.01,
       "kind": "scalar",
-      "label": "duotone depth",
+      "label": "duotone",
       "panel": {
-        "group": "style",
-        "tab": "look"
+        "group": "duotone"
       },
       "bind": {
         "on": "points",
@@ -27,10 +26,9 @@
       "max": 180,
       "step": 1,
       "kind": "scalar",
-      "label": "duotone hue",
+      "label": "hue",
       "panel": {
-        "group": "style",
-        "tab": "look"
+        "group": "duotone"
       },
       "bind": {
         "on": "points",
@@ -45,10 +43,9 @@
       "max": 1,
       "step": 0.01,
       "kind": "scalar",
-      "label": "duotone split",
+      "label": "split",
       "panel": {
-        "group": "style",
-        "tab": "look"
+        "group": "duotone"
       },
       "bind": {
         "on": "points",
@@ -62,10 +59,9 @@
       "max": 9.5,
       "step": 0.05,
       "kind": "scalar",
-      "label": "duotone span m",
+      "label": "span m",
       "panel": {
-        "group": "style",
-        "tab": "look"
+        "group": "duotone"
       },
       "bind": {
         "on": "points",
@@ -79,10 +75,9 @@
       "max": 1,
       "step": 0.01,
       "kind": "scalar",
-      "label": "duotone motion",
+      "label": "motion",
       "panel": {
-        "group": "style",
-        "tab": "look"
+        "group": "duotone"
       },
       "bind": {
         "on": "points",
@@ -91,6 +86,17 @@
       "under": "amount"
     }
   },
+  "panelGroups": [
+    {
+      "key": "duotone",
+      "label": "Duotone",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "style",
+      "order": 30
+    }
+  ],
   "chunks": [
     {
       "stage": "f.tone",

--- a/effects-builtin/edges/manifest.json
+++ b/effects-builtin/edges/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "edges",
       "panel": {
-        "group": "style",
-        "tab": "look"
+        "group": "edges"
       },
       "bind": {
         "on": "points",
@@ -22,6 +21,17 @@
       "role": "master"
     }
   },
+  "panelGroups": [
+    {
+      "key": "edges",
+      "label": "Edges",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "style",
+      "order": 20
+    }
+  ],
   "chunks": [
     {
       "stage": "f.tone",

--- a/effects-builtin/ghost/manifest.json
+++ b/effects-builtin/ghost/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "ghost",
       "panel": {
-        "group": "ghost",
-        "tab": "look"
+        "group": "ghost"
       },
       "bind": {
         "on": "points",
@@ -30,8 +29,7 @@
       "kind": "scalar",
       "label": "rim",
       "panel": {
-        "group": "ghost",
-        "tab": "look"
+        "group": "ghost"
       },
       "bind": {
         "on": "points",
@@ -47,8 +45,7 @@
       "kind": "scalar",
       "label": "fill",
       "panel": {
-        "group": "ghost",
-        "tab": "look"
+        "group": "ghost"
       },
       "bind": {
         "on": "points",

--- a/effects-builtin/glitch/manifest.json
+++ b/effects-builtin/glitch/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "amount",
       "panel": {
-        "group": "glitch",
-        "tab": "look"
+        "group": "glitch"
       },
       "bind": {
         "on": "points",
@@ -29,8 +28,7 @@
       "kind": "scalar",
       "label": "density",
       "panel": {
-        "group": "glitch",
-        "tab": "look"
+        "group": "glitch"
       },
       "bind": {
         "on": "points",
@@ -46,8 +44,7 @@
       "kind": "scalar",
       "label": "shove m",
       "panel": {
-        "group": "glitch",
-        "tab": "look"
+        "group": "glitch"
       },
       "bind": {
         "on": "points",
@@ -63,8 +60,7 @@
       "kind": "scalar",
       "label": "flare",
       "panel": {
-        "group": "glitch",
-        "tab": "look"
+        "group": "glitch"
       },
       "bind": {
         "on": "points",
@@ -80,8 +76,7 @@
       "kind": "scalar",
       "label": "band rows",
       "panel": {
-        "group": "glitch",
-        "tab": "look"
+        "group": "glitch"
       },
       "bind": {
         "on": "points",
@@ -97,8 +92,7 @@
       "kind": "scalar",
       "label": "axis",
       "panel": {
-        "group": "glitch",
-        "tab": "look"
+        "group": "glitch"
       },
       "bind": {
         "on": "points",
@@ -114,8 +108,7 @@
       "kind": "scalar",
       "label": "rate hz",
       "panel": {
-        "group": "glitch",
-        "tab": "look"
+        "group": "glitch"
       },
       "bind": {
         "on": "points",

--- a/effects-builtin/glyph/manifest.json
+++ b/effects-builtin/glyph/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "glyph",
       "panel": {
-        "group": "glyph",
-        "tab": "look"
+        "group": "glyph"
       },
       "bind": {
         "on": "points",
@@ -29,8 +28,7 @@
       "kind": "scalar",
       "label": "tone key",
       "panel": {
-        "group": "glyph",
-        "tab": "look"
+        "group": "glyph"
       },
       "bind": {
         "on": "points",
@@ -46,8 +44,7 @@
       "kind": "scalar",
       "label": "hash key",
       "panel": {
-        "group": "glyph",
-        "tab": "look"
+        "group": "glyph"
       },
       "bind": {
         "on": "points",
@@ -63,8 +60,7 @@
       "kind": "scalar",
       "label": "rain key",
       "panel": {
-        "group": "glyph",
-        "tab": "look"
+        "group": "glyph"
       },
       "bind": {
         "on": "points",

--- a/effects-builtin/grain/manifest.json
+++ b/effects-builtin/grain/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "grain",
       "panel": {
-        "group": "post",
-        "tab": "look"
+        "group": "grain"
       },
       "bind": {
         "on": "grade",
@@ -23,6 +22,17 @@
       "role": "master"
     }
   },
+  "panelGroups": [
+    {
+      "key": "grain",
+      "label": "Grain",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "post",
+      "order": 20
+    }
+  ],
   "chunks": [
     {
       "stage": "g.body",

--- a/effects-builtin/halation/manifest.json
+++ b/effects-builtin/halation/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "halation",
       "panel": {
-        "group": "halation",
-        "tab": "look"
+        "group": "halation"
       },
       "bind": {
         "on": "grade",
@@ -30,8 +29,7 @@
       "kind": "scalar",
       "label": "halation radius",
       "panel": {
-        "group": "halation",
-        "tab": "look"
+        "group": "halation"
       },
       "bind": {
         "on": "grade",
@@ -47,8 +45,7 @@
       "kind": "scalar",
       "label": "halation threshold",
       "panel": {
-        "group": "halation",
-        "tab": "look"
+        "group": "halation"
       },
       "bind": {
         "on": "grade",
@@ -64,8 +61,7 @@
       "kind": "scalar",
       "label": "halation tint",
       "panel": {
-        "group": "halation",
-        "tab": "look"
+        "group": "halation"
       },
       "bind": {
         "on": "grade",

--- a/effects-builtin/lattice/manifest.json
+++ b/effects-builtin/lattice/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "lattice",
       "panel": {
-        "group": "displacement",
-        "tab": "look"
+        "group": "lattice"
       },
       "bind": {
         "on": "points",
@@ -22,6 +21,17 @@
       "role": "master"
     }
   },
+  "panelGroups": [
+    {
+      "key": "lattice",
+      "label": "Lattice",
+      "tab": "region",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "displacement",
+      "order": 100
+    }
+  ],
   "chunks": [
     {
       "stage": "v.displace",

--- a/effects-builtin/mask/manifest.json
+++ b/effects-builtin/mask/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "mask",
       "panel": {
-        "group": "region",
-        "tab": "look"
+        "group": "mask"
       },
       "bind": {
         "on": "points",
@@ -22,6 +21,17 @@
       "role": "master"
     }
   },
+  "panelGroups": [
+    {
+      "key": "mask",
+      "label": "Region mask",
+      "tab": "region",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "region",
+      "order": 300
+    }
+  ],
   "consumes": [
     {
       "service": "region",

--- a/effects-builtin/noise/manifest.json
+++ b/effects-builtin/noise/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "turbulence",
       "panel": {
-        "group": "displacement",
-        "tab": "look"
+        "group": "noise"
       },
       "bind": {
         "on": "points",
@@ -29,8 +28,7 @@
       "kind": "scalar",
       "label": "grain m",
       "panel": {
-        "group": "displacement",
-        "tab": "look"
+        "group": "noise"
       },
       "bind": {
         "on": "points",
@@ -46,8 +44,7 @@
       "kind": "scalar",
       "label": "speed",
       "panel": {
-        "group": "displacement",
-        "tab": "look"
+        "group": "noise"
       },
       "bind": {
         "on": "points",
@@ -63,8 +60,7 @@
       "kind": "scalar",
       "label": "scramble",
       "panel": {
-        "group": "region",
-        "tab": "look"
+        "group": "noise"
       },
       "bind": {
         "on": "points",
@@ -72,6 +68,17 @@
       }
     }
   },
+  "panelGroups": [
+    {
+      "key": "noise",
+      "label": "Turbulence",
+      "tab": "region",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "region",
+      "order": 200
+    }
+  ],
   "consumes": [
     {
       "service": "region",

--- a/effects-builtin/push/manifest.json
+++ b/effects-builtin/push/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "push",
       "panel": {
-        "group": "region",
-        "tab": "look"
+        "group": "push"
       },
       "bind": {
         "on": "points",
@@ -22,6 +21,17 @@
       "role": "master"
     }
   },
+  "panelGroups": [
+    {
+      "key": "push",
+      "label": "Region push",
+      "tab": "region",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "region",
+      "order": 100
+    }
+  ],
   "consumes": [
     {
       "service": "region",

--- a/effects-builtin/rain/manifest.json
+++ b/effects-builtin/rain/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "rain",
       "panel": {
-        "group": "rain",
-        "tab": "look"
+        "group": "rain"
       },
       "bind": {
         "on": "points",
@@ -29,8 +28,7 @@
       "kind": "scalar",
       "label": "fall m/s",
       "panel": {
-        "group": "rain",
-        "tab": "look"
+        "group": "rain"
       },
       "bind": {
         "on": "points",
@@ -46,8 +44,7 @@
       "kind": "scalar",
       "label": "head gap m",
       "panel": {
-        "group": "rain",
-        "tab": "look"
+        "group": "rain"
       },
       "bind": {
         "on": "points",
@@ -63,8 +60,7 @@
       "kind": "scalar",
       "label": "trail m",
       "panel": {
-        "group": "rain",
-        "tab": "look"
+        "group": "rain"
       },
       "bind": {
         "on": "points",

--- a/effects-builtin/raster/manifest.json
+++ b/effects-builtin/raster/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "scanlines",
       "panel": {
-        "group": "raster",
-        "tab": "look"
+        "group": "raster"
       },
       "bind": {
         "on": "grade",
@@ -30,8 +29,7 @@
       "kind": "scalar",
       "label": "angle",
       "panel": {
-        "group": "raster",
-        "tab": "look"
+        "group": "raster"
       },
       "bind": {
         "on": "grade",
@@ -48,8 +46,7 @@
       "kind": "scalar",
       "label": "pitch",
       "panel": {
-        "group": "raster",
-        "tab": "look"
+        "group": "raster"
       },
       "bind": {
         "on": "grade",
@@ -65,8 +62,7 @@
       "kind": "scalar",
       "label": "hardness",
       "panel": {
-        "group": "raster",
-        "tab": "look"
+        "group": "raster"
       },
       "bind": {
         "on": "grade",

--- a/effects-builtin/rgbsplit/manifest.json
+++ b/effects-builtin/rgbsplit/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "rgb split",
       "panel": {
-        "group": "post",
-        "tab": "look"
+        "group": "rgbsplit"
       },
       "bind": {
         "on": "grade",
@@ -23,6 +22,17 @@
       "role": "master"
     }
   },
+  "panelGroups": [
+    {
+      "key": "rgbsplit",
+      "label": "RGB split",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "post",
+      "order": 10
+    }
+  ],
   "chunks": [
     {
       "slot": "g.fetch",

--- a/effects-builtin/ripple/manifest.json
+++ b/effects-builtin/ripple/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "ripple m",
       "panel": {
-        "group": "region",
-        "tab": "look"
+        "group": "ripple"
       },
       "bind": {
         "on": "points",
@@ -27,10 +26,9 @@
       "max": 10,
       "step": 0.1,
       "kind": "scalar",
-      "label": "ripple per m",
+      "label": "per m",
       "panel": {
-        "group": "region",
-        "tab": "look"
+        "group": "ripple"
       },
       "bind": {
         "on": "points",
@@ -44,10 +42,9 @@
       "max": 4,
       "step": 0.05,
       "kind": "scalar",
-      "label": "ripple hz",
+      "label": "hz",
       "panel": {
-        "group": "region",
-        "tab": "look"
+        "group": "ripple"
       },
       "bind": {
         "on": "points",
@@ -56,6 +53,17 @@
       "under": "amount"
     }
   },
+  "panelGroups": [
+    {
+      "key": "ripple",
+      "label": "Ripple",
+      "tab": "region",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "region",
+      "order": 400
+    }
+  ],
   "consumes": [
     {
       "service": "region",

--- a/effects-builtin/stock/manifest.json
+++ b/effects-builtin/stock/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "film stock",
       "panel": {
-        "group": "stock",
-        "tab": "look"
+        "group": "stock"
       },
       "bind": {
         "on": "grade",
@@ -30,8 +29,7 @@
       "kind": "scalar",
       "label": "stock balance",
       "panel": {
-        "group": "stock",
-        "tab": "look"
+        "group": "stock"
       },
       "bind": {
         "on": "grade",
@@ -47,8 +45,7 @@
       "kind": "scalar",
       "label": "stock split",
       "panel": {
-        "group": "stock",
-        "tab": "look"
+        "group": "stock"
       },
       "bind": {
         "on": "grade",
@@ -64,8 +61,7 @@
       "kind": "scalar",
       "label": "stock latitude",
       "panel": {
-        "group": "stock",
-        "tab": "look"
+        "group": "stock"
       },
       "bind": {
         "on": "grade",

--- a/effects-builtin/streak/manifest.json
+++ b/effects-builtin/streak/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "streak",
       "panel": {
-        "group": "post",
-        "tab": "look"
+        "group": "streak"
       },
       "bind": {
         "on": "grade",
@@ -28,10 +27,9 @@
       "max": 180,
       "step": 1,
       "kind": "scalar",
-      "label": "streak angle",
+      "label": "angle",
       "panel": {
-        "group": "post",
-        "tab": "look"
+        "group": "streak"
       },
       "bind": {
         "on": "grade",
@@ -41,6 +39,17 @@
       "under": "amount"
     }
   },
+  "panelGroups": [
+    {
+      "key": "streak",
+      "label": "Streak",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "post",
+      "order": 30
+    }
+  ],
   "chunks": [
     {
       "stage": "g.decl",

--- a/effects-builtin/thermal/manifest.json
+++ b/effects-builtin/thermal/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "thermal",
       "panel": {
-        "group": "style",
-        "tab": "look"
+        "group": "thermal"
       },
       "bind": {
         "on": "points",
@@ -22,6 +21,17 @@
       "role": "master"
     }
   },
+  "panelGroups": [
+    {
+      "key": "thermal",
+      "label": "Thermal",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "style",
+      "order": 10
+    }
+  ],
   "chunks": [
     {
       "stage": "f.tone",

--- a/effects-builtin/vignette/manifest.json
+++ b/effects-builtin/vignette/manifest.json
@@ -12,8 +12,7 @@
       "kind": "scalar",
       "label": "vignette",
       "panel": {
-        "group": "post",
-        "tab": "look"
+        "group": "vignette"
       },
       "bind": {
         "on": "grade",
@@ -23,6 +22,17 @@
       "role": "master"
     }
   },
+  "panelGroups": [
+    {
+      "key": "vignette",
+      "label": "Vignette",
+      "tab": "look",
+      "lookgroup": true,
+      "collapses": true,
+      "after": "post",
+      "order": 40
+    }
+  ],
   "chunks": [
     {
       "stage": "g.body",

--- a/test/effect-door.test.mjs
+++ b/test/effect-door.test.mjs
@@ -236,9 +236,10 @@ test('a package may only put its rows in a group that exists, and may not claim 
   assert.match(brokenBy('thermal', (c) => { c.manifest.params.amount.panel.group = 'stlye'; }),
     /asks for the panel group "stlye"/, 'a parameter naming no group anybody holds is refused');
   assert.equal(brokenBy('rain', (c) => { c.manifest.params.amount.panel.group = 'post'; }), null,
-    'a parameter naming a core group is what thirteen shipped packages do');
+    'a parameter may name a core group: the escape hatch the door deliberately keeps open for a '
+    + 'term that belongs beside the spine\'s, which no shipped package uses now that each owns a group');
   assert.equal(brokenBy('rain', (c) => { c.manifest.params.amount.panel.group = 'rain'; }), null,
-    'and a parameter naming its own package\'s group is what the other three do');
+    'and a parameter naming its own package\'s group is what all twenty-two shipped packages do');
 
   assert.match(brokenBy('rain', (c) => {
     c.manifest.panelGroups[0].key = 'post';

--- a/test/effect-store-gate.test.mjs
+++ b/test/effect-store-gate.test.mjs
@@ -112,7 +112,17 @@ test('the fork that changed is the one set aside, not the one it broke', () => {
 test('a package called refuse is an ordinary package again', () => {
   // The id `refuse` specifically, because that is the one the old routing collision was
   // about; a row using any other id would pass on the build that had the defect.
-  const named = { ...builtinManifest('thermal'), id: 'refuse', title: 'A package named for what was once a route' };
+  // The donor's group key travels with the fork, so it is renamed too: every builtin owns a
+  // group now, and a fork keeping the donor's key collides with the donor rather than standing.
+  const donor = builtinManifest('thermal');
+  const named = {
+    ...donor,
+    id: 'refuse',
+    title: 'A package named for what was once a route',
+    panelGroups: donor.panelGroups.map((g) => ({ ...g, key: 'refuse', label: 'Refuse' })),
+    params: Object.fromEntries(Object.entries(donor.params)
+      .map(([short, spec]) => [short, { ...spec, panel: { ...spec.panel, group: 'refuse' } }])),
+  };
   withStore((dir) => {
     const at = join(dir, 'refuse');
     mkdirSync(at, { recursive: true });

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -865,7 +865,8 @@ const MUTATIONS = {
     ]],
   },
 
-  // Must redden: the keyed-at-default row, and that row alone.
+  // Must redden: the keyed-at-default row in 15d and the rack's own track row, because both
+  // read the keyframe term through `paramTouched`. Measured on this tree and on HEAD.
   'reveal-ignores-tracks': {
     file: 'web/main.js',
     edits: [[
@@ -7984,7 +7985,7 @@ try {
       `${fresh.reduce((n, g) => n + g.inDom, 0)} rows in the document, ${fresh.reduce((n, g) => n + g.onScreen, 0)} on screen`);
 
     // ---- 15c. moving a value opens the group that holds it
-    // `bloom` because it is in `optical` and because `keyframe-check` clicks its keyframe
+    // `bloom` because it is in `post` and because `keyframe-check` clicks its keyframe
     // diamond, a control Playwright will only press when it is visible.
     await page.evaluate("__kinect.params.set('bloom', 0.75)");
     await settle();
@@ -7999,23 +8000,23 @@ try {
 
     await freshLook();
     await settle();
-    const styleDefault = await defaultOf('thermal.amount');
-    const styleSpec = await page.evaluate("__kinect.params.spec('thermal.amount')");
+    const thermalDefault = await defaultOf('thermal.amount');
+    const thermalSpec = await page.evaluate("__kinect.params.spec('thermal.amount')");
     // Whichever end of the travel the default is not, so this cannot become a write of the value
     // that was already there - which would leave the group untouched and the row below asserting
     // the state it started in.
-    await page.evaluate(`__kinect.params.set('thermal.amount', ${styleDefault === styleSpec.max ? styleSpec.min : styleSpec.max})`);
+    await page.evaluate(`__kinect.params.set('thermal.amount', ${thermalDefault === thermalSpec.max ? thermalSpec.min : thermalSpec.max})`);
     await settle();
-    const styleNow = await page.evaluate("__kinect.params.get('thermal.amount')");
+    const thermalNow = await page.evaluate("__kinect.params.get('thermal.amount')");
     const readingsQuiet = await page.evaluate(`__kinect.readings().every((n) =>
       __kinect.params.get(n) === __kinect.params.normalise(n, __kinect.params.spec(n).default))`);
-    check(styleNow !== styleDefault && readingsQuiet,
-      'one style parameter moved with every reading left at its default, or the row below tests nothing',
-      `thermal.amount reads ${styleNow} against a default of ${styleDefault}, readings untouched: ${readingsQuiet}`);
-    const tuned = await groupOf('style');
+    check(thermalNow !== thermalDefault && readingsQuiet,
+      'one effect parameter moved with every reading left at its default, or the row below tests nothing',
+      `thermal.amount reads ${thermalNow} against a default of ${thermalDefault}, readings untouched: ${readingsQuiet}`);
+    const tuned = await groupOf('thermal');
     check(!tuned.shut && tuned.onScreen === tuned.available,
-      'moving a style parameter opens the style group, so the open set is the whole diff',
-      `style: shut=${tuned.shut}, ${tuned.onScreen} of ${tuned.available} available rows on screen, ${tuned.inDom} in the registry`);
+      'moving an effect parameter opens that effect\'s own group, so the open set is the whole diff',
+      `thermal: shut=${tuned.shut}, ${tuned.onScreen} of ${tuned.available} available rows on screen, ${tuned.inDom} in the registry`);
 
     // ---- 15d. a keyframe counts even where the value does not
     // The whole reason the predicate has a keyframe term, and the one row `reveal-ignores-tracks`
@@ -8034,10 +8035,10 @@ try {
     check(parked === grainDefault,
       'the keyed parameter really is sitting on its default at the parked frame, or the row below tests nothing',
       `grain reads ${parked} against a default of ${grainDefault}`);
-    const keyed = await groupOf('post');
+    const keyed = await groupOf('grain');
     check(!keyed.shut && keyed.onScreen === keyed.available,
       'a keyframe opens the group even where the value it holds is the default',
-      `post: shut=${keyed.shut}, ${keyed.onScreen} of ${keyed.available} available rows on screen, ${keyed.inDom} in the registry`);
+      `grain: shut=${keyed.shut}, ${keyed.onScreen} of ${keyed.available} available rows on screen, ${keyed.inDom} in the registry`);
 
     // ---- 15e. a shut group that is in use says so
     // Pressed rather than assumed shut, because the state it starts in is exactly what

--- a/web/index.html
+++ b/web/index.html
@@ -143,7 +143,7 @@
 
   .group { border-top: 1px solid var(--line); padding-top: 8px; margin-top: 8px; }
   #recordGroup, #cameraGroup, [data-group="framing"],
-  #lookPresetGroup, #effectRackGroup, [data-group="colour"], [data-group="displacement"] { border-top: 0; }
+  #lookPresetGroup, #effectRackGroup, [data-group="colour"], [data-group="region"] { border-top: 0; }
   /* OBS is an editor command and dialog in the Pencil shell. The recorder keeps this
      inline block because its output is part of the live shooting setup. */
   body.editing #programOutGroup { display: none; }

--- a/web/main.js
+++ b/web/main.js
@@ -652,9 +652,10 @@ const CORE_PANEL_GROUPS = [
     ]),
   },
   { key: 'signal', label: 'Signal', tab: 'look', lookgroup: true, collapses: true },
-  { key: 'displacement', label: 'Displacement', tab: 'region', lookgroup: true, collapses: true },
-  // One region in the room, read three ways. Everything here is metres in the sensor frame.
+  // The box itself, in metres in the sensor frame. The groups spliced under it are its readings,
+  // which is why it comes before displacement here.
   { key: 'region', label: 'Region (metres)', tab: 'region', lookgroup: true, collapses: true },
+  { key: 'displacement', label: 'Displacement', tab: 'region', lookgroup: true, collapses: true },
   { key: 'points', label: 'Points', tab: 'look', lookgroup: true, collapses: true },
   { key: 'motion', label: 'Motion', tab: 'look', lookgroup: true, collapses: true },
   { key: 'post', label: 'Post', tab: 'look', lookgroup: true, collapses: true },
@@ -805,7 +806,7 @@ const buildParams = () => ({
 
   ...effectSlice('glitch.amount', 'glitch.rate'),
 
-  // One region, authored once and read three ways. Three scalars rather than a `point` kind.
+  // One region, authored once and read four ways. Three scalars rather than a `point` kind.
   regionX: { def: 0, min: -3, max: 3, step: 0.05, kind: 'scalar', tag: 'look', scope: 'clip',
     group: 'region', label: 'x',
     apply: (v) => { uniforms.regionCentre.value.x = v; } },


### PR DESCRIPTION
Closes #97.

Twelve of the 22 shipped effects put their parameters straight into a core panel group, so their sliders drew loose inside `Style`, `Post`, `Displacement` and `Region` next to spine controls a user cannot remove. They had no heading to collapse and no remove button, because `groupOwner` returns null for a group with more than one owner and so the hover-X added in 6e558a8 never appeared on them. The issue named four; the real set is twelve, and all twelve now declare a group of their own.

**The page goes from 10 remove buttons to 22**, measured in a browser rather than inferred.

| core group | spine controls it keeps | effects that left |
| --- | --- | --- |
| `style` | rim | duotone, edges, thermal |
| `post` | bloom, crush | grain, rgbsplit, streak, vignette |
| `displacement` | cell m | lattice, noise |
| `region` | the box | mask, push, ripple |

## The decisions behind it

**It stays a convention, not a refusal.** `server/effect-door.js` is untouched and still accepts a parameter naming a core group, because an effect may one day carry a term that genuinely belongs beside the spine's, and a door that forbade it would be a rule written where the exception cannot be made.

**Turbulence is one group even though its terms belong to two stages.** Three displace and `scramble` reads the region box. Splitting it would resurrect the ownership problem the rest of this removes. Gate order is untouched — where a slider is drawn and what the shader does are separate facts.

**The Region tab now reads the box and then the readings of it in the order the shader takes them:** Region (metres), Region push, Turbulence, Region mask, Ripple, then Displacement and Lattice. That is why `region` moves above `displacement` in the panel spine, and why the no-top-border rule in `web/index.html` follows it. Reading down the tab is now reading the pipeline. Those numbers agree by hand and nothing holds them equal, which the doc now says out loud.

**Eight labels lose a prefix they only carried to stay legible loose in a shared group** — `duotone hue` is `hue`, `streak angle` is `angle`. `halation` and `stock` keep theirs; that inconsistency is inherited, not introduced.

**`panel.tab` is deleted from all 22 manifests.** Nothing read it — `tableFromPackages` copies only `panel.group` and the tab comes from the group — the door never validated it, and five effects stated it wrongly.

No dotted parameter name changes, so presets, clips and keyframe tracks need no migration.

## What an external review caught

`crush` moved, and it had to. The registry declares it *after* the slice carrying RGB split through Vignette, so the old shared `Post` group drew bloom, those four, then crush. A core group is emitted whole before the groups anchored under it, so a term staying in `Post` cannot stay below effects that have left it. `Post` is now bloom and crush — the pair the grade pass already describes. My first reading of the source got this order wrong; the browser settled it on both trees.

No instrument in this repo can see that class of change: nothing asserts the panel's row order across a regrouping.

## Instrument repairs, none of them weakening an assertion

`editor-check` moved `thermal.amount` and asserted the `style` group opened, and keyed `grain.amount` and asserted `post` opened. Both couplings held only while those effects lived in core groups, so the rows now name the groups that hold them. Its `reveal-ignores-tracks` note claimed to redden one row; measured on this tree *and* on a pristine HEAD tree it reddens two, because the rack's own track row reads the same keyframe term.

`test/effect-store-gate.test.mjs` forks thermal's manifest under the id `refuse`, which worked only while thermal declared no group. The fork now carries its own key. The door's collision rule that caught it was not touched.

`docs/proof-tools.md` said `bloom` lives in an `optical` panel group. No such group exists in this build — it is `post` — and the same ghost sat in a comment inside `editor-check`. Both corrected, and the paragraph now records that `keyframe-check` 6e's clicks used to be held open by four Blackwall-moved parameters in `post`, three of which leave here, so the clicked parameter is now the only thing opening its own group.

## Proof

`syntax-check` 92 files, 0 failed, with `anchors/ all 669 in 19 tables match once` byte-identical to the pre-edit baseline. `test:unit` 188/188. `module-check` 62 assertions, 0 failed.

`editor-check` on `fixture-1g` reads **710 assertions, 14 failed**, against a pristine HEAD tree's **705 and 14** — the same 14 rows compared by text, all in a clip-deselection cluster and all pre-existing. The two rows that failed only here were the stale couplings above, green after repair. `reveal-ignores-tracks` still reddens the keyed-at-default row and reverts `web/main.js` cleanly.

Driven in Chromium against a replay of `fixture-1g`: both tabs render in the intended order; hovering Thermal's heading reveals its X; clicking it resets `thermal.amount` from 0.6 to 0, hides the row and empties the rack. The same drive against a HEAD tree finds 10 remove buttons, no `thermal` group at all, and a Region tab of two core groups — the selector clicked here does not exist there.

**Not covered:** no GPU conformance or export run, and no second unplaced package, so ordering between two appended groups is still asserted nowhere.
