### PR TITLE
Limit trim marker grabs to the ruler

### DIFF
--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -1176,9 +1176,12 @@ incoming side wherever it was, so a fixture planted bent and then "fixed" with `
 reads 0, 0.2, 0.4, 0.1, 1 — crossed, and crossed in a way that looks tidy. `ends` is what
 writes a whole polygon, because it writes the departure and the arrival. The second is that a
 synthetic drag has to be aimed at a coordinate the browser will deliver *and* at an element
-that will receive it: `.tcut` is a full-height clip marker parked over the head of the strip by
-section 3, so a handle drag planted at 1s and 5s pressed the marker instead and the handle it
-meant to move never moved. Both failures read identically from the assertion — a handle sitting
+that will receive it: the in and out markers' grab zone used to run the whole column, so a
+handle drag planted at 1s and 5s pressed a marker instead and the handle it meant to move never
+moved. That zone is the ruler row alone now, and `grab-zone-over-the-lanes` is the control that
+holds it there — it puts the zone back over the lanes and reddens section 3's two hit-test rows,
+which ask what a press 8px inward of each line actually reaches. Both failures read identically
+from the assertion — a handle sitting
 where it started — and neither is distinguishable from a clamp doing its job, which is why the
 row asserts the point *landed on its neighbour* rather than that it stayed inside a bound.
 `document.elementFromPoint` at the press coordinate is what separated them, and it is the first

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -847,6 +847,27 @@ const MUTATIONS = {
     ]],
   },
 
+  // Must redden: section 3's two lane hit-test rows, and on a take long enough to put the press
+  // inside the zone, section 22's deselect cluster with them - 15 rows on a 246s fixture, 2 on a
+  // 76s one, where 5s along the lane is already clear of the marker. Section 3's reach rows stay
+  // green either way, because a zone running the whole column still covers the ruler, so a hit
+  // test below the ruler is the only arm here that can see this.
+  'grab-zone-over-the-lanes': {
+    file: 'web/index.html',
+    edits: [
+      ['  .tcut { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--accent);\n'
+        + '    pointer-events: none; z-index: 4; }',
+      '  .tcut { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--accent);\n'
+        + '    pointer-events: auto; z-index: 4; }'],
+      ['  .tcut::after { content: ""; position: absolute; top: 0; height: var(--ruler-h);\n'
+        + '    pointer-events: auto; cursor: ew-resize; }',
+      '  .tcut::after { content: ""; position: absolute; top: 0; bottom: 0;\n'
+        + '    pointer-events: auto; cursor: ew-resize; }'],
+    ],
+    fails: 'the markers\' grab zone running the whole column again, so lane whitespace beside the '
+      + 'line belongs to the marker and a press aimed at a lane trims the range instead',
+  },
+
   // Must redden: the Escape row in section 1. Other focus transfers stay intact, so the failure
   // names the return path rather than making every rack action lose its caret.
   'effect-rack-strands-focus': {
@@ -3905,7 +3926,12 @@ try {
     const el = document.getElementById(elId);
     if (!el) return 0;
     const r = el.getBoundingClientRect();
-    const mid = { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    // The ruler row's mid-height rather than the marker's. The marker box still runs the whole
+    // column, so its own middle is deep in the lanes where the zone deliberately does not reach.
+    const bed = document.getElementById('tBed');
+    if (!bed) return 0;
+    const bedR = bed.getBoundingClientRect();
+    const mid = { x: r.x + r.width / 2, y: bedR.y + bedR.height / 2 };
     let n = 0;
     for (let dx = -18; dx <= 18; dx++) {
       const hit = document.elementFromPoint(mid.x + dx, mid.y);
@@ -3939,7 +3965,8 @@ try {
   } else {
     const outMid = await page.evaluate(`(() => {
       const r = document.getElementById('tOut').getBoundingClientRect();
-      return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+      const bedR = document.getElementById('tBed').getBoundingClientRect();
+      return { x: r.x + r.width / 2, y: bedR.y + bedR.height / 2 };
     })()`);
     await page.mouse.move(outMid.x, outMid.y);
     await page.mouse.down();
@@ -4000,6 +4027,91 @@ try {
   const shortcutCleared = await range();
   check(shortcutCleared.out === null && shortcutCleared.in === 0,
     'Option-X restores the whole clip through the same user action', JSON.stringify(shortcutCleared));
+  // Where the zone must not reach. `elementFromPoint` rather than a box measurement, for the same
+  // reason the reach probe uses one: the zone is a pseudo-element and no box reports it. The walk
+  // steps past a key, an ease handle or a clip box, because all three sit at or above the markers
+  // and a probe under one cannot see this zone at all - what it is looking for is bare lane.
+  await page.evaluate('__kinect.editor.setClipRange(0, null)');
+  await settle();
+  const laneProbe = await page.evaluate(`(${(() => {
+    const beds = document.getElementById('tBeds');
+    const bed = document.getElementById('tBed');
+    if (!beds || !bed) return null;
+    const bedsR = beds.getBoundingClientRect();
+    const rulerR = bed.getBoundingClientRect();
+    const lanes = document.getElementById('tLanes');
+    const lanesR = lanes ? lanes.getBoundingClientRect() : null;
+    const ys = [];
+    if (lanesR && lanesR.height > 2) {
+      for (const lane of document.querySelectorAll('#tLanes .tlane')) {
+        const r = lane.getBoundingClientRect();
+        const y = r.y + r.height / 2;
+        if (y > lanesR.y + 1 && y < lanesR.bottom - 1) ys.push({ y, from: 'a keyed lane' });
+      }
+    }
+    // Then every row of the column below the ruler, so a run whose lanes are all covered still
+    // has somewhere bare to ask about rather than declining to ask.
+    for (let y = rulerR.bottom + 4; y < bedsR.bottom - 2; y += 8) ys.push({ y, from: 'below the ruler' });
+    const name = (el) => (el ? (el.id ? `#${el.id}` : `${el.tagName.toLowerCase()}.${el.getAttribute('class') || '(no class)'}`) : 'nothing');
+    const probe = (elId, inward) => {
+      const el = document.getElementById(elId);
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      const x = r.x + r.width / 2 + inward;
+      let last = null;
+      for (const cand of ys) {
+        const hit = document.elementFromPoint(x, cand.y);
+        const isMarker = Boolean(hit && hit.closest('.tcut'));
+        const covered = Boolean(hit && !isMarker && hit.closest('.tkey, .thandle, .tclip'));
+        last = { x, y: cand.y, from: cand.from, isMarker, covered, what: name(hit),
+          whitespace: Boolean(hit && !isMarker && !covered && hit.closest('#tBeds')) };
+        // A marker answering is the finding; bare lane is the answer this wants. Anything drawn
+        // over the zone is neither, so the walk carries on to the next row.
+        if (isMarker || last.whitespace) return last;
+      }
+      return last;
+    };
+    return { in: probe('tIn', 8), out: probe('tOut', -8) };
+  }).toString()})()`);
+  const laneReach = (side) => {
+    const at = laneProbe && laneProbe[side];
+    if (!at) return 'there is no marker to probe';
+    return `at (${Math.round(at.x)}, ${Math.round(at.y)}) ${at.from}, the press reaches ${at.what}`;
+  };
+  check(Boolean(laneProbe && laneProbe.in && !laneProbe.in.isMarker),
+    'the in marker answers no press 8px inward of its line once the ruler row has ended',
+    laneReach('in'));
+  check(Boolean(laneProbe && laneProbe.out && !laneProbe.out.isMarker),
+    'and neither does the out marker, on the side its own zone reaches',
+    laneReach('out'));
+
+  // Asked only where the press would land on bare lane. On a clip it would be a clip drag, which
+  // moves the edit and poisons every section after this one - named and skipped rather than run.
+  if (laneProbe && laneProbe.in && laneProbe.in.whitespace) {
+    const heldSelection = await page.evaluate('__kinect.editor.clipSelection()');
+    const beforeLaneDrag = await range();
+    await page.mouse.move(laneProbe.in.x, laneProbe.in.y);
+    await page.mouse.down();
+    await page.mouse.move(laneProbe.in.x + 300, laneProbe.in.y, { steps: 8 });
+    await page.mouse.up();
+    await settle();
+    const afterLaneDrag = await range();
+    check(near(afterLaneDrag.in, beforeLaneDrag.in, 1e-6) && afterLaneDrag.out === beforeLaneDrag.out,
+      'and a 300px drag from that lane point leaves the export range where it was',
+      `${JSON.stringify(beforeLaneDrag)} -> ${JSON.stringify(afterLaneDrag)}`);
+    // The press deselects, which is the gesture this change hands back to the lane. Put the
+    // selection and the range back so the sections after this one get the fixture they expect.
+    await page.evaluate(`(${((id) => {
+      __kinect.editor.setClipRange(0, null);
+      if (id) __kinect.editor.selectClipRow(id);
+    }).toString()})(${JSON.stringify(heldSelection)})`);
+    await settle();
+  } else {
+    note('a drag from that point is not asked',
+      `it reaches ${laneProbe && laneProbe.in ? laneProbe.in.what : 'nothing'} rather than bare lane, `
+      + 'and dragging a clip there would move the edit under the sections after this one');
+  }
+
   // Cleanup is not another claim. On `whole-clip-does-nothing` both user paths have already
   // reddened; leave the later transport sections their ordinary whole-clip fixture rather than
   // turning one missing action into unrelated speed and playback failures.

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -847,11 +847,8 @@ const MUTATIONS = {
     ]],
   },
 
-  // Must redden: section 3's two lane hit-test rows, and on a take long enough to put the press
-  // inside the zone, section 22's deselect cluster with them - 15 rows on a 246s fixture, 2 on a
-  // 76s one, where 5s along the lane is already clear of the marker. Section 3's reach rows stay
-  // green either way, because a zone running the whole column still covers the ruler, so a hit
-  // test below the ruler is the only arm here that can see this.
+  // Must redden section 3's lane hit tests and, when the press lands inside the zone, section 22's
+  // deselect cluster. Only the below-ruler probes distinguish a full-height marker hit zone.
   'grab-zone-over-the-lanes': {
     file: 'web/index.html',
     edits: [

--- a/web/index.html
+++ b/web/index.html
@@ -59,6 +59,7 @@
        takes whatever the fixed ones leave. */
     --timeline-h: 112px;
     --tlanes-h: 0px;
+    --ruler-h: 32px;
   }
   * { box-sizing: border-box; }
   html, body { height: 100%; margin: 0; background: #05070a; color: var(--ink);
@@ -999,7 +1000,7 @@
      is exactly the surface step 4 left behind. Every other row is fixed and adds
      to it — only parameters that actually carry keys get one. */
   .trow { position: relative; flex: none; border-top: 1px solid var(--line); }
-  .trow.ruler { flex: none; height: 32px; border-top: 0; }
+  .trow.ruler { flex: none; height: var(--ruler-h); border-top: 0; }
   .tcol.rail .trow { display: flex; align-items: center; justify-content: space-between;
     gap: 6px; padding: 0 8px; overflow: hidden; }
   .tcol.rail .trow span { color: var(--dim); font-size: 11px; overflow: hidden;
@@ -1100,11 +1101,8 @@
   .tmk:focus-visible { outline: 0; color: var(--ink); }
   .tmk.sel { color: var(--ink); }
 
-  /* Above the keys, which is why this is 6 and not the 3 it was. The diamonds had to
-     rise over the cut markers' grab zone - see `.tkey` for the press that zone was
-     eating - and a playhead left underneath them would be broken by every key it swept
-     past, on the one line you follow while the take is rolling. It is
-     `pointer-events: none`, so lifting it takes no gesture off anything. */
+  /* Above the keys, so a diamond does not break the one line you follow while the take
+     is rolling. `pointer-events: none`, so sitting this high takes no gesture off anything. */
   .tplayhead { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--ink);
     pointer-events: none; z-index: 6; }
   .tplayhead::before { content: ""; position: absolute; top: 0; left: -5px;
@@ -1122,31 +1120,19 @@
      dragged to set the clip range. A triangle points inward so the two do not
      collide when they are close. */
   .tcut { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--accent);
-    cursor: ew-resize; z-index: 4; }
-  /* The grab zone, which is not the line. A 1px target plus a 10px triangle at one
-     end is a control you have to aim at, and these two are how a clip gets trimmed -
-     measured at 1.0px wide before this. The line stays 1px because a thick one would
-     be a poor ruler; only the hit area grows.
-
-     Each one reaches *inward*, and that is not symmetry for its own sake. `out` sits
-     at `left: 100%` while nothing is trimmed, which puts it exactly on the right edge
-     of the strip - so a zone centred on it hangs half outside the window, and
-     `elementFromPoint` found 5 grabbable pixels there rather than 11. Reaching into
-     the kept range instead keeps the whole zone on screen at either extreme, and it
-     is where the pointer wants to be anyway: you drag the edge of the block you are
-     keeping. Where the two nearly coincide `out` wins, being later in the markup.
-
-     It still reaches down over the lanes, and it is `.tkey`/`.thandle` standing above
-     it that keeps that from mattering: the zone owns the lane whitespace, a key owns
-     itself. Lowering the zone here instead would have handed the ruler's marks the
-     same win over it, on the one surface where trimming is the whole point. */
-  .tcut::after { content: ""; position: absolute; top: 0; bottom: 0; }
+    pointer-events: none; z-index: 4; }
+  /* The grab zone, which is not the line: a 1px target is a control you have to aim at. The
+     ruler row only, so the lanes below keep their own presses. Each side reaches *inward*
+     rather than centring, because `out` sits at `left: 100%` untrimmed and a centred zone
+     would hang half off the strip. */
+  .tcut::after { content: ""; position: absolute; top: 0; height: var(--ruler-h);
+    pointer-events: auto; cursor: ew-resize; }
   .tcut-in::after { left: -4px; width: 16px; }
   .tcut-out::after { left: -12px; width: 16px; }
   .tcut::before { content: ""; position: absolute; top: 0; left: -5px;
     border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 7px solid var(--accent); }
-  .tcut.tcut-out::before { left: -4px; border-left: 4px solid var(--accent); border-right: 4px solid transparent; border-top: 0; border-bottom: 7px solid var(--accent); top: auto; bottom: 0; }
-  .tcut.tcut-in::before { left: -4px; border-left: 4px solid transparent; border-right: 4px solid var(--accent); border-top: 0; border-bottom: 7px solid var(--accent); top: auto; bottom: 0; }
+  .tcut.tcut-out::before { left: -4px; border-left: 4px solid var(--accent); border-right: 4px solid transparent; border-top: 0; border-bottom: 7px solid var(--accent); top: calc(var(--ruler-h) - 7px); }
+  .tcut.tcut-in::before { left: -4px; border-left: 4px solid transparent; border-right: 4px solid var(--accent); border-top: 0; border-bottom: 7px solid var(--accent); top: calc(var(--ruler-h) - 7px); }
 
   /* ── keyframe lanes ────────────────────────────────────────────────────────
      A lane draws the curve it is a lane for, because ease handles need something
@@ -1167,22 +1153,9 @@
      box are dead, so the target is smaller than it measures. The diamonds were 9px and
      the handles 7px, which is an aim rather than a click, and these two are the whole
      of keyframe editing. The drawn shapes stay small; only the reach grows. */
-  /* **Above the cut markers rather than under them, which is what stops a press meant
-     for a key from trimming the clip instead.** `#tIn` and `#tOut` are 1px lines whose
-     grab zone reaches 16px inward at `z-index: 4`, and they run the whole column from
-     the ruler down past the last lane - so that zone lies over the lanes as well as
-     over the ruler, where trimming is the only gesture there is. Nothing between a
-     diamond and those markers opens a stacking context - `.tlane`, `.trow` and
-     `#tLanes` are all `z-index: auto` - so the two numbers were compared directly and
-     4 beat 2. Measured at a 640-wide viewport on the 243s `fixture-1g`: the bed runs
-     525px from x 115, the bloom key at 4s draws centred on x 123.6, `#tIn`'s zone owns
-     x 114.5 to 126.5, and clicking that key's own centre selected nothing, drew no
-     handle, and moved the clip-in to 00:03.986 - a silent retrim from a press aimed at
-     a keyframe. Raising these two leaves the zone everything it still needs, the ruler
-     and the lane whitespace between keys, and gives a key the pixels it is drawn on.
-     The one cost is that a diamond now paints over a marker's line where they cross,
-     which is the right way round: the line has the shading either side of it to say
-     where the range ends, and a key has only itself. */
+  /* Above the cut markers, so a diamond paints over a marker's line where the two cross:
+     the line has the shading either side of it to say where the range ends, and a key has
+     only itself. */
   /* A clip, drawn as the thing that is there. The trim chrome on the ruler is the negative of
      this - two shades of the excluded region - and `.tminirange` is the precedent this follows:
      a positive box for a positive fact. */

--- a/web/main.js
+++ b/web/main.js
@@ -6379,8 +6379,9 @@ for (const handle of [ui.in, ui.out]) {
     if (!timeline) return;
     handle.setPointerCapture(e.pointerId);
     handleDrag = { side, from: e.clientX, moved: false };
-    // Held back rather than let through: the strip below deselects on every press that is not on
-    // a clip, and grabbing a marker is not that press. `pointerup` hands it back if no drag came.
+    // `#tIn` and `#tOut` are siblings of `#tBed` rather than children, so this takes nothing off
+    // the ruler's scrub. What it stops is the bubble to `ui.beds`, which deselects on a press
+    // landing outside a clip - and grabbing a marker is not that press.
     e.stopPropagation();
   });
   handle.addEventListener('pointermove', (e) => {
@@ -6403,15 +6404,9 @@ for (const handle of [ui.in, ui.out]) {
       if (handleDrag?.side !== side) return;
       const dragged = handleDrag.moved;
       handleDrag = null;
-      // A press that never moved is not a trim. The grab zone reaches 12px inward over the lane
-      // whitespace a person presses to come off a clip, so on a long enough program the whole gap
-      // before the first clip is inside it and the deselect could not be made - and a click there
-      // set the in-point to whatever second it landed on. Both stop here: the range is untouched
-      // and the press goes where it was aimed.
-      if (!dragged) {
-        deselectClipRow();
-        return;
-      }
+      // A press that never moved is not a trim, so the range is left where it is. The zone is the
+      // ruler row alone, so a press meant for a lane never arrives here to be handed back.
+      if (!dragged) return;
       const t = programAtPointer(e);
       if (handle === ui.in) {
         setClipInOut({ in: Math.max(0, Math.min(t, clipOut ?? timeline.duration)) });


### PR DESCRIPTION
## Problem
The trim markers were too easy to grab in the wrong place. Their invisible drag area ran down over the timeline lanes, so a press meant for lane whitespace could hit a marker instead and change the export range.

## Solution
Keep the marker drag area on the ruler row only. The marker line can still run through the timeline as a visual guide, but only the ruler part catches trim drags. The editor proof now checks both sides: marker grabs still work on the ruler, and presses below the ruler do not hit the markers.

Testing evidence in the diff:
- Added the `grab-zone-over-the-lanes` mutation to `tools/editor-check.mjs`.
- Extended section 3 of `editor-check` with hit-test rows for lane presses 8px inward of the in and out markers.
- Updated `docs/proof-tools.md` to record the new proof control.