### PR TITLE
Replace clip retime curves with speed and in-point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ exit code (rule 3).
 | `index-check.mjs` | the index, the hash, the frame API | `--url`, and a fixture past 2 GiB |
 | `registry-check.mjs` | one registry, sliders as views of it, every look term live | `--url` |
 | `timeline-check.mjs` | seek equals playback | `--url`, a take of ≥12s |
-| `keyframe-check.mjs` | tracks, the retime curve, undo | `--url`, a take of ≥24s |
+| `keyframe-check.mjs` | tracks, undo | `--url`, a take of ≥24s |
 | `export-check.mjs` | resolution, export, the file | `--url`, ffmpeg and ffprobe |
 | `editor-check.mjs` | the editor's controls exist, and pressing them changes something | `--url`, a take of ≥32s |
 | `library-check.mjs` | the library, the recorder, the routes | a free port span |

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ camera is standing. The keyframe arrows beside the transport step between keys w
 hunting for the diamonds.
 
 Two clocks read under the transport. **program** is a position in the output, **source** a
-position in the capture; at 1.00× they agree, and pulling **speed** or keying the retime
-lane makes them diverge, so the footage slows while the camera keeps its own pace. See
+position in the capture; at 1.00× they advance together, and pulling **speed** makes them
+diverge, so the footage slows while the camera keeps its own pace. See
 [program time](docs/architecture.md#program-time-is-the-edit-coordinate).
 
 Nearly every slider carries a keyframe button, so a clip can dissolve from depth into

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ A native grabber pulls depth and registered colour from
 [libfreenect2](https://github.com/OpenKinect/libfreenect2), a Node server fans the frames
 out over WebSocket, and a Three.js viewer unprojects them on the GPU using the sensor's own
 intrinsics. On top sit a recorder, a take library that reconciles between two machines, a
-keyframe editor with a retime curve, and a render queue that exports through ffmpeg.
+keyframe editor, and a render queue that exports through ffmpeg.
 
 Depth and colour are captured on separate listeners: the colour camera halves to 15fps in
 dim light while depth stays at 30, and a synced listener would throw away every other depth
@@ -60,9 +60,9 @@ browser is on the server's machine, and is refused for the take being recorded, 
 manager stats, indexes and previews the file the recorder is writing to.
 
 **The editor** keyframes the camera through the recorded volume on its own track and the
-look on others, with a retime curve mapping program time onto source time. Seeking to a
-frame and playing to that frame produce the same image, which `tools/timeline-check.mjs`
-proves.
+look on others, and each clip's `speed` and `sourceStart` map program time onto source time.
+Seeking to a frame and playing to that frame produce the same image, which
+`tools/timeline-check.mjs` proves.
 
 **The render queue** produces video from finished edits, claimed by a worker pinned to the
 renderer class it will draw with. [Get a video out](../README.md#5-get-a-video-out) has the
@@ -345,22 +345,23 @@ deliverable's sidecar records what was skipped rather than rewriting the clip.
 ## Program time is the edit coordinate
 
 Source time is a position inside the capture; program time a position inside the output.
-They advance together at normal speed and diverge under a ramp, a hold or a reverse, so
-every keyframe has to be stamped in one of them. Every track here, including the retime
-curve, is in program seconds - which second they are counted from is a separate question,
-answered under a clip's look below - and rendering is forward-only: `programTime = k / outputFps`,
-evaluate the tracks, `sourceMs = retime(programTime)`, binary-search the index.
+They advance together at 1.00x and diverge at any other speed, so every keyframe has to be
+stamped in one of them. Every track here is in program seconds - which second they are counted
+from is a separate question, answered under a clip's look below - and rendering is forward-only:
+`programTime = k / outputFps`, evaluate the tracks,
+`sourceSec = sourceStart + (programTime - start) * speed`, binary-search the index.
 
-- **Export needs no inverse.** Keying in source time would force export to invert the retime
-  curve, which requires it to stay monotonic, so a hold or a reverse breaks it outright.
+- **Export needs no inverse.** Export walks program time forward and a constant speed maps it
+  onto source time with one multiply. The inverse is a division where anything wants it, so
+  keying in program time costs export nothing.
 - **The camera keeps its own pace when the footage slows**, which is the creative point: a
-  photographer's movement is independent of what they are filming. A ramp leaves the program
-  length alone, so a camera key at program 10s stays there. The speed control changes the selected
-  clip's output length and rescales that clip's local look and placement keys around the curve's
-  rate pivot. Project tracks, camera keys and output cuts keep their authored program seconds.
-- **`fade` and `wake` stay in source time**, because they drive surface memory, which
-  advances per source frame. Dividing by the local retime slope would divide by zero at a
-  hold, snapping every trail off exactly where a freeze should hold it.
+  photographer's movement is independent of what they are filming. The speed control changes the
+  selected clip's output length and rescales that clip's local look and placement keys from the
+  clip's head. Project tracks, camera keys and output cuts keep their authored program seconds,
+  so a camera key at program 10s stays there.
+- **`fade` and `wake` stay in source time**, because they drive surface memory, which advances
+  per source frame. How long a surface remembers is a fact about the footage rather than about
+  the output it is being cut into.
 - **`outputFps` is the project's, not the deliverable's**, and the line above is why: it is
   the denominator of the edit's own coordinate, so two deliverables at two rates would be
   two different edits rather than one edit written out twice. `trails` makes it visible —
@@ -385,13 +386,13 @@ time, so constant motion through index space is visibly variable motion through 
 
 ## Clips, and what a cut costs
 
-A clip owns a source, a cloud, a retime curve, a `start` and a `length`. It covers
+A clip owns a source, a cloud, a `speed`, a `sourceStart`, a `start` and a `length`. It covers
 `[start, start + length)` - half-open, so two clips abutting at a cut do not both draw on the
 frame the cut lands on, with the one exception that the instant an edit ends on belongs to
 whatever ended there rather than to nothing. `length` is the document's own field and it is read
 back as the answer: a trim is where the edit stops using the take, which is a different fact from
-how much take there is rather than a second spelling of it, and null means "everything the curve
-affords". A gap between clips renders an empty composite.
+how much take there is rather than a second spelling of it, and null means "everything the take
+has past its `sourceStart`, at its speed". A gap between clips renders an empty composite.
 
 **Each clip draws through `Group(transform) -> Group(level) -> Points`.** The outer group is where
 the clip sits in the room; the inner one carries the levelling quaternion, which is a clip-scope
@@ -422,14 +423,13 @@ a clip appearing mid-playback would show no fade and no wake on the frame after 
 same instant reached by seeking looks right. For its own surface span before its in-point the clip
 binds its textures and steps its memory with `visible = false`, and the prefetch looks across the
 clip boundary so those frames are resident when the warm starts. The window is bounded by what
-the clip's head affords: the curve extrapolates outside its domain, so the walk stops where source
-time would run before the take began - and it stops where source time stops *moving*, because a
-clip entering mid-hold reaches the frame already bound however far back it is walked. A clip whose
-footage starts at source 0 and one entering mid-hold both enter deterministically cold, and so
-does a seek to that instant, which is why the invariant holds rather than being violated.
+the clip's head affords: the walk stops at the head of the take, which is `sourceStart` seconds of
+footage back. A clip whose footage starts at source 0 has no window at all and enters
+deterministically cold, and so does a seek to that instant, which is why the invariant holds
+rather than being violated.
 
 Pre-roll splits along the same seam. The surface half is per clip, because surface memory is per
-cloud and one clip's curve can need three times another's to cover the same span of persistence,
+cloud and one clip's speed can need three times another's to cover the same span of persistence,
 so the project's is the longest of them. The trails half is one screen-space buffer over the
 composite and is asked once. There is one stall policy and not two: a render waits for every clip
 it touches, drawn or warming, and playback's catch-up budget bounds how far behind the playhead
@@ -456,22 +456,17 @@ exactly as expensive as it was. The ceiling and the span a plan may ask for are 
 forms and cannot be moved apart: a cache smaller than the span a fetch may request evicts what
 that fetch has just put in it.
 
-**A head trim is written into the curve, because that is where an in-point lives.** A clip has no
-source-offset field: with no keys its curve reads `programSec * rate` and states an in-point of
-zero, and with one key at the origin it reads `value + programSec * rate`. So dragging a clip's
-head writes that single key and moves `start` and the trim together, which holds the out-point and
-the footage under the body still. Three places ask whether a curve is still a rate and two of them
-already answered "fewer than two keys" — `sourceSecAt` and `slopeAt`; the speed slider's disable
-was the third and said "any keys at all", so it went quiet on a curve it could still drive. The
-three agree now. A curve of more than one key states far more than an in-point and shifting its
-domain is a different edit, so the head edge refuses it with the reason rather than being an edge
-that silently works on some clips and not others.
+**A head trim writes the clip's `sourceStart`.** Dragging a clip's head moves `start` and the
+trim together, which holds the out-point and the footage under the body still: the same project
+second stands on the same source frame afterwards. `sourceStart` is source seconds at the clip's
+head, so trimming back to the head of the take returns it to exactly 0, and the speed slider goes
+on working through a trim because a trim writes no key and touches no lane.
 
 **Which clip is selected is session state and never in the document**, beside `suppressedEffects`
-rather than in the project. It decides where a look write lands, which curve the retime lane
-draws, and which clip the take's marks are drawn against - but which clip somebody is looking at
-is not part of the edit, and a document recording it would make two people's saves of the same
-work differ over nothing. A reopened project selects nothing.
+rather than in the project. It decides where a look write lands and which clip the take's marks
+are drawn against - but which clip somebody is looking at is not part of the edit, and a document
+recording it would make two people's saves of the same work differ over nothing. A reopened
+project selects nothing.
 
 **Adding and removing a clip is an ordinary undo step**, because clips live in the body
 `history.snapshot()` stringifies. An add copies the selected clip's look, or the first clip's
@@ -549,9 +544,9 @@ field with it rather than moving through the room's. The transpose identity thos
 survives, because it is the 3x3 that matters and a translation is not in it.
 
 Where a look write lands is an explicit indirection - the clip under evaluation, else the selected
-clip - and not a binding repointed for the walk. The selection is the operator's: the panel, the
-lanes and the retime curve are all views of it, so a render that moved it would be mutating what
-somebody is looking at in order to draw a frame. `withClip` is the one door that changes the
+clip - and not a binding repointed for the walk. The selection is the operator's: the panel and
+the lanes are both views of it, so a render that moved it would be mutating what somebody is
+looking at in order to draw a frame. `withClip` is the one door that changes the
 answer, and it moves two things together because neither is enough on its own: the tables decide
 where the value is stored, and the render core's selection decides which uniform table, material
 and levelling group the registry's `apply` reaches.
@@ -615,10 +610,10 @@ body over, so the name, the clip count, the shape and the rate cost nothing to s
 the only thing fetched, and they are drawn by the same depth splat the library's tiles use, which
 is what makes the two pages read as one program. What the finger moves through is program time and
 not one take's frames: the clip covering that second is found by its `start` and `length`, its
-retime curve maps the second into source time, and the skim changes capture at a cut - so the
-bar's length is the edit's length and a cut in the edit is a cut in the skim. The look is the part
-that cannot come along, because nothing on this page holds the grade, the effects or the camera.
-A project skims as raw geometry and reads as a proxy rather than as a small render.
+`speed` and `sourceStart` map the second into source time, and the skim changes capture at a cut -
+so the bar's length is the edit's length and a cut in the edit is a cut in the skim. The look is
+the part that cannot come along, because nothing on this page holds the grade, the effects or
+the camera. A project skims as raw geometry and reads as a proxy rather than as a small render.
 
 **A project whose footage is not on this machine says so on its row, and the control goes to the
 library.** The loader refuses a document naming a take no local capture hashes, and reclaiming one
@@ -685,11 +680,12 @@ same suspicion.
 its clips, so a project missing one take is three clips that resolve and one that does not: the
 span the missing clip covers goes empty, and where that clip carries a length of its own its
 width says how much of the edit the hole costs, beside the row that already names the take. A
-clip nobody trimmed carries no length - `null` there means it runs for everything its curve
-affords, which resolves through the take's own duration - so on the machine that has not got the
-take there is no width to draw, and the row names it rather than measuring it. It
-also leaves one behaviour rather than two - a clip either resolves to a frame or it does not, and
-nothing has to ask whether a project is dark before deciding to answer a drag.
+clip nobody trimmed carries no length - `null` there means it runs for everything the take has
+past its `sourceStart` at its speed, which resolves through the take's own duration - so on the
+machine that has not got the take there is no width to draw, and the row names it rather than
+measuring it. It also leaves one behaviour rather than two - a clip either resolves to a frame
+or it does not, and nothing has to ask whether a project is dark before deciding to answer a
+drag.
 
 **A write carries the revision it was made against, and a stale one is refused.** The store
 already hands a `rev` back on every read and every write, and a projects page makes opening one

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -2144,8 +2144,9 @@ A third flaw came out of this on step 5: a mutation replacing the pre-roll's win
 with the tangent it replaced was caught by only one of five probe positions, because four of
 them sat inside a single straight segment of the retime curve where the tangent *is* the
 curve. The probes were moved onto the knees and onto an eased ramp and the same mutation now
-fails four. Ask what the wrong implementation would agree with, and probe somewhere it
-cannot.
+fails four. The live section went when the retime curve was removed, so this record is what
+survives of the finding. Ask what the wrong implementation would agree with, and probe somewhere
+it cannot.
 
 ### A probe can be in the right place and still start one link past the break
 

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -1764,8 +1764,8 @@ whole tool says nothing about which question the tool was asking.
 through `process.platform`, so a macOS developer and a Linux CI run check different strings
 and neither checks the third. And the minimap's copy of the mark conversion still has no
 control over it at all: `markTicks()` only ever reads the ruler strip, so that second site
-could stop going through the retime curve entirely and every row in the suite would stay
-green. Two sites doing one conversion is what made this anchor stale in the first place.
+could stop going through the selected clip's timing entirely and every row in the suite would
+stay green. Two sites doing one conversion is what made this anchor stale in the first place.
 
 **And reading a table by importing the tool's prefix made this row need what the tool needs,
 which CI found and a developer's machine cannot.** The cut ran from the top of the file so that a
@@ -3341,10 +3341,12 @@ before, when the letterbox arrived, and the comment beside it says so.
 
 Bumping the constant would close the instance and leave the class: the next row added to the
 strip breaks it again, identically. `keyframe-check` had the answer already - its
-`CHROME_H_GUESS` is documented as a first guess and the real height is measured after load and
-the viewport corrected - so `openPage` now goes through `setStage`, which measures. **When a
-tool needs a number the page owns, have it ask the page once rather than agree with it in a
-comment.**
+`CHROME_H_GUESS` is documented as a first guess and the real height is measured after load.
+`export-check` now goes through `setStage`, which measures and corrects the viewport until the
+drawing buffer itself reads the requested size. The repeat matters because the default lane
+height is a fraction of the viewport being corrected: one measurement changes the answer.
+**When a tool needs a number the page owns, have it ask the page and read the result rather than
+agree with it in a comment.**
 
 **Letterboxing the editor stage moved every pointer coordinate and every buffer-size
 expectation, and four proof tools found out one at a time.** `export-check` needed two separate

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -140,7 +140,7 @@ and 640 KiB. The slope through the two loaded points is **1,263 KiB per frame**,
 The ceiling is that figure turned into a frame count: a budget of **768 MB buys 618 frames**, and a
 plan may ask one take for 602 of them. It is generous by the measure it was chosen against - eight
 clips at two and a half seconds of persistence each - and **what still caps is eight clips of one
-take each pre-rolling more than about 2.5 seconds**, or a retime curve slow enough that one clip's
+take each pre-rolling more than about 2.5 seconds**, or a speed slow enough that one clip's
 window alone runs past 602 source frames. A cap reports the arithmetic that produced it:
 `lastSeek.bound` names the take, how many clips are on it, what they asked for and what the
 ceiling is, and the strip says it once per distinct cap.

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -41,7 +41,7 @@ node tools/index-check.mjs --stage                        # ... the same run aga
                                                           #   the conditions their failure happened in
 node tools/registry-check.mjs --url http://localhost:8080 # step 3: one registry, sliders as views
 node tools/timeline-check.mjs --url http://localhost:8080 --take fixture-1g # step 4: seek equals playback
-node tools/keyframe-check.mjs --url http://localhost:8080 --take fixture-1g # step 5: tracks, retime curve, undo
+node tools/keyframe-check.mjs --url http://localhost:8080 --take fixture-1g # step 5: tracks, undo
 node tools/export-check.mjs --url http://localhost:8080   # step 6: resolution, export, the file
 node tools/library-check.mjs                              # step 7: library, recorder, routes
 node tools/editor-check.mjs --url http://localhost:8080 --take fixture-1g # the editor's controls: that they exist, that pressing them changes something
@@ -610,15 +610,15 @@ control, since a null result cannot demonstrate sensitivity.
 one clip: the composite, the cut, and what a clip enters holding. Its fixture is five clips over
 two takes, listed in an order that is deliberately not the order of their ids, and every clip in
 it is uncomfortable on purpose - a two-second half-speed head, a head shorter than the look asks
-for, one entering mid-hold, one whose footage starts at source 0, and one placed to stand on the
-same source frame as another clip of the same take. Four of them overlap at 6.5s, which is the
-budget `tools/layering-ab.mjs` measures against.
+for, a different `sourceStart` on each, one whose footage starts at source 0, and one placed to
+stand on the same source frame as another clip of the same take. Four of them overlap at 6.5s,
+which is the budget `tools/layering-ab.mjs` measures against.
 
 **That fixture names its primary take instead of inheriting the selected clip's take.** A prior
 version copied the first open clip before replacing the clip list. A short live capture selected
-by an earlier section therefore put every later retime on its held final frame and made both the
+by an earlier section therefore put every later clip on its held final frame and made both the
 warm-history control and the growing-cache arm inert. The tool now clears inherited tracks, owns
-the take for every generated clip, and requires the eight retimes to reach eight distinct frames.
+the take for every generated clip, and requires eight placements to reach eight distinct frames.
 
 Six mutations belong to it and each fires: `warm-skipped` **3 rows**, `warm-without-reset` **8**,
 `draw-order-by-array` **3**, `take-not-shared` **2**, `look-broadcast` **6** and
@@ -2308,12 +2308,10 @@ The paragraph above says 9.3fps; `keyframe-check`'s header said 284 frames over 
 section 6d said 49.79s; the file in this tree is 284 frames over **9.42s at 30.03fps**. One
 frame count, four durations, all of them written down as facts.
 
-The damage is not the prose. `timeline-check` targets 12s, `editor-check` seeks to 30s and
-`keyframe-check` retimes through source 20s. On a 9.42s take every one clamps: one row reddens in
-`timeline-check`, ten in `editor-check` and four in `keyframe-check` against a build with nothing
-wrong with it. The quieter half is that two more `keyframe-check` rows *pass*, because the key they
-drag has left the ruler and a gesture that never happened also never slid a key under its
-neighbour. The long fixture makes those fixture failures go away with nothing in `web/` changed.
+The damage is not the prose. `timeline-check` targets 12s and `editor-check` seeks to 30s, and
+`keyframe-check` seeks past the sample as well. On a 9.42s take every one clamps: one row reddens
+in `timeline-check` and ten in `editor-check` against a build with nothing wrong with it. The long
+fixture makes those fixture failures go away with nothing in `web/` changed.
 
 So all three declare a `NEEDS_TAKE_SEC` and exit 2 naming the shortfall, in the same direction and
 for the same reason as `requireMutationDelivered`: a red row reads as a catch, so a fixture

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -339,12 +339,12 @@ named with the URL and the byte count, `library-has-no-way-to-the-menu` among th
 and was tracked in #28.
 That is closed and the fix is worth knowing, because it is not the one a reader would guess: the
 duplicate is still there in `web/main.js`, once at four spaces of indentation and once at six,
-and `c757210` re-anchored the entry onto a leading newline and four spaces, which by that alone
-cannot match the six-space copy inside the
-`miniMarks` map. So the anchor matches exactly once now, which is what `syntax-check`'s anchor
-row reports across all 406 anchors in the suite. Whether the mutation *delivers* has not been
-re-measured — the anchor being constructible is the weaker claim, and only the weaker one is
-stated here.
+and `c757210` first re-anchored the entry onto a leading newline and four spaces. The current
+entry also includes the following `const el = document.createElement('button');` statement,
+which exists only in the ruler loop and not in the `miniMarks` map. So the anchor matches exactly
+once now, which is what `syntax-check`'s anchor row reports across all 661 anchors in the suite.
+Whether the mutation *delivers* has not been re-measured — the anchor being constructible is the
+weaker claim, and only the weaker one is stated here.
 The control for the delivery refusal is to stop staging `web/` files and run a page mutation:
 it names the file, the URL and both byte counts, and exits 2 without printing an assertion.
 
@@ -606,11 +606,11 @@ across the two `main` revisions this branch was rebased over and it reports 0 of
 looks unmoved by `main` itself, which is context for reading the 120 rather than a second
 control, since a null result cannot demonstrate sensitivity.
 
-**`timeline-check` runs 169 assertions, 0 failed.** Section 7 is 54 of them and covers more than
+**`timeline-check` runs 170 assertions, 0 failed.** Section 7 is 71 of them and covers more than
 one clip: the composite, the cut, and what a clip enters holding. Its fixture is five clips over
 two takes, listed in an order that is deliberately not the order of their ids, and every clip in
-it is uncomfortable on purpose - a two-second half-speed head, a head shorter than the look asks
-for, a different `sourceStart` on each, one whose footage starts at source 0, and one placed to
+it is uncomfortable on purpose - a half-speed clip with a deep in-point, a head shorter than the
+look asks for, a different `sourceStart` on each, one whose footage starts at source 0, and one placed to
 stand on the same source frame as another clip of the same take. Four of them overlap at 6.5s,
 which is the budget `tools/layering-ab.mjs` measures against.
 
@@ -701,14 +701,10 @@ its own checkout, all produced the identical `626x352`, and a probe reading the 
 builds returns the same numbers at both viewports — strip 252, bar 38, stage 110, buffer 196x110
 at 640x400; strip 339, stage 273, buffer 485x273 at 640x650.
 
-**With the stage right, `keyframe-check` reads 166 assertions and 5 failed, and those five are not
-this branch's either.** All five are section 6g's clip-drag block declining to run — `did not run:
-program 5s does not hit-test back to the clip box`, which is a guarded refusal rather than a wrong
-reading, and it is the press-point-in-program-time class this page already records against
-`editor-check`'s deselect rows: 5s of a 243.3s program is 2% along the lane and the clip box is not
-under it. Held to the same instrument across two builds — the patched tool copied into the `HEAD`
-tree and run against a server spawned from it — both come back **161 passed, the same 5 failed,
-with identical readings.**
+**With the stage right, `keyframe-check` reads 133 assertions, 0 failed.** Its lane census excludes
+the clip rows and the full-width add row because those are edit structure rather than keyed
+parameters. Counting the add row as a parameter reddens all four section 6 lane-shape rows on a
+correct page, while the DOM and the registry both agree about the three keyed lanes.
 
 **Section 7 moved every one of those totals and none of the names.** With it the tool runs 124
 assertions, and the mutations that were counted against 75 redden more because there are now more
@@ -928,7 +924,7 @@ suspect first on a contended machine now that the boot sleep no longer stands be
 page load and that fetch. Stated rather than measured: that row passed on all six runs behind
 this paragraph, and every one of them was on an idle machine.
 
-**`export-check` has the same shape and a bigger number: 10 of its 66 rows are red on the
+**`export-check` has the same shape and a bigger number: 10 of its 85 rows are red on the
 synthetic sample and none of them is about the build.** Nine are the resolution-invariance
 family — `trails`, `rgbsplit`, `scanlines`, `grain`, `bloom`, `nobloom`, `full`, `regionpush`
 and `regionmask` each asking that 1920x1200 is 960x600 at twice the size — and the tenth is the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1016,9 +1016,9 @@ validates, so `editor-check` section 12 drives the round trip in a browser, with
 
 Documents from before the readings are version 3 and will not open, and there is nothing to
 run: the one-shot conversion this repo used to ship was deleted once every document it could
-act on had already been converted. This build reads version 7 alone — a version 6 document
-carried one take at the top and one undivided look under it rather than a `clips` array, and a
-version 5 document still spelled its parameters bare (`glyphTone` rather than `glyph.tone`) and
-carried no `requires` list, so both are refused the same way a version 3 or 4 one is, and there
-is no conversion for either: every document this project holds was re-authored at 7. A file from
-any older version is refused, naming its own version, and stays refused.
+act on had already been converted. This build reads version 8 alone. Version 8 places footage
+with each clip's `speed` and `sourceStart`; version 7 used a keyframed retime curve. A version 6
+document carried one take at the top and one undivided look under it rather than a `clips` array,
+and a version 5 document still spelled its parameters bare (`glyphTone` rather than
+`glyph.tone`) and carried no `requires` list. A file from any older version is refused, naming
+its own version, and stays refused. This build has no conversion for it.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -94,22 +94,19 @@ one.
 **The two edges do different things.** The right edge moves where the edit stops using the take,
 which is the clip's own `length`. The left edge is a head trim: the clip starts later in the take,
 its out-point stays where it is, and the footage under what is left does not move — the same
-project second stands on the same source frame afterwards. That in-point is written as the clip's
-retime curve, one key at the origin, because a clip states where it starts in the take through its
-curve rather than through a field of its own; trimming back to the head of the take removes the
-key again. A curve of one key is still a rate, so the speed slider goes on working through a head
-trim and only goes quiet once a clip carries a curve that says more than an in-point. **On such a
-clip the head edge refuses and says so** — moving a keyed curve's domain is a different edit and
-this build does not do it from the edge.
+project second stands on the same source frame afterwards. That in-point is the clip's
+`sourceStart`, which is source seconds at the clip's head, and trimming back to the head of the
+take returns it to 0. A trim writes no keyframe and touches no lane, so the speed slider goes on
+working through one.
 
 **Which clip is selected is the session's and not the document's.** It decides what the panel
-writes to, which curve the retime lane draws, and which clip the ruler's marks are drawn against
-— and it is deliberately not saved, because which clip you are looking at is not part of the edit
-and a document recording it would make two people's saves of the same work differ. Opening a take
-selects its clip, because a take builds a project of one clip of footage you have just chosen and
-there is nothing there to choose between; loading a project selects nothing, because a document
-does not record which clip was being worked on and picking one would be a guess. Pressing on the
-empty part of the lane stack takes the selection off every clip.
+writes to and which clip the ruler's marks are drawn against — and it is deliberately not saved,
+because which clip you are looking at is not part of the edit and a document recording it would
+make two people's saves of the same work differ. Opening a take selects its clip, because a take
+builds a project of one clip of footage you have just chosen and there is nothing there to choose
+between; loading a project selects nothing, because a document does not record which clip was
+being worked on and picking one would be a guess. Pressing on the empty part of the lane stack
+takes the selection off every clip.
 
 **With no clip selected the panel keeps its clip half on screen and greys it out.** That is where
 a loaded project of several clips lands you, which is the case worth showing the split in. The rows
@@ -142,8 +139,8 @@ the clip along the strip carries the move it was given with it.
 
 **Marks stay keyed by the take and are drawn against the selected clip.** A mark is a fact about
 footage, so two clips of one take share them; where a mark ticks on the ruler is that source
-second put through the selected clip's curve *and* its placement, which is why the same mark sits
-somewhere else when you select the other clip of the same take.
+second put back through the selected clip's `sourceStart` and `speed` *and* its placement, which
+is why the same mark sits somewhere else when you select the other clip of the same take.
 
 **mark** plants one at the playhead and presses again to take that one away, and `M` does the
 same from the keyboard. "Already at the playhead" means within half an output frame either side,
@@ -213,9 +210,7 @@ the segments either side. `+pt` is exact: the extra handle appears, every other 
 keep the curve exactly where it was, and not a rendered frame changes — so it is safe to press
 while judging a move. `−pt` cannot be exact, because a curve of one degree is not generally a
 curve of the degree below, so removing a point moves the shape. Four points a side is the
-ceiling. The retime curve is deliberately excluded from both: the argument that a handle
-inside the unit box cannot run source time backwards is an argument about a cubic, and it does
-not survive the extra degree.
+ceiling.
 
 **Glitch** tears bands of the feed sideways, and it is seven controls rather than
 one because the interesting looks live off the diagonal. `amount` is the master and the one

--- a/presets-builtin/blackwall.json
+++ b/presets-builtin/blackwall.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/cascade.json
+++ b/presets-builtin/cascade.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/contour.json
+++ b/presets-builtin/contour.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/depth.json
+++ b/presets-builtin/depth.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/ember.json
+++ b/presets-builtin/ember.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/ghost.json
+++ b/presets-builtin/ghost.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/grille.json
+++ b/presets-builtin/grille.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/rgb.json
+++ b/presets-builtin/rgb.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/rift.json
+++ b/presets-builtin/rift.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     {
       "id": "ghost",

--- a/presets-builtin/tearline.json
+++ b/presets-builtin/tearline.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/updraft.json
+++ b/presets-builtin/updraft.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     {
       "id": "ghost",

--- a/presets-builtin/voxel.json
+++ b/presets-builtin/voxel.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/test/clip-plan.test.mjs
+++ b/test/clip-plan.test.mjs
@@ -1,7 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  RATE_MAX, RATE_MIN, frameLoadByTake, integerMidpoint, rescaleClipKeys, snapshotClipKeys,
+  RATE_MAX, RATE_MIN, clipAffordedSec, clipProgramSecAt, clipSourceSecAt, frameLoadByTake,
+  framesBackFor, headFramesFor, headTrim, integerMidpoint, rescaleClipKeys, snapshotClipKeys,
   usableClipRate,
 } from '../web/clip-plan.js';
 
@@ -50,17 +51,128 @@ test('a clip speed change rescales only that clip local keys', () => {
   assert.equal(camera.keys[0].t, 12);
 });
 
-test('a clip speed change rescales keys around its nonzero retime pivot', () => {
-  const clipTracks = [{ keys: [{ t: 2 }, { t: 6 }] }];
-  const snapshot = snapshotClipKeys(clipTracks);
-  rescaleClipKeys(snapshot, 0.5, 2);
-  assert.deepEqual(clipTracks[0].keys.map((key) => key.t), [2, 4]);
-});
-
 test('stored rates stay inside the same finite range the editor offers', () => {
   assert.equal(usableClipRate(RATE_MIN), true);
   assert.equal(usableClipRate(RATE_MAX), true);
   for (const rate of [0, -1, Number.MIN_VALUE, RATE_MIN - 0.001, RATE_MAX + 0.001, Infinity, NaN]) {
     assert.equal(usableClipRate(rate), false, `${String(rate)} was accepted`);
   }
+});
+
+const near = (a, b, tol = 1e-9) => Math.abs(a - b) <= tol;
+
+test('a clip maps its own program seconds onto source seconds from its in-point', () => {
+  assert.equal(clipSourceSecAt({ speed: 1, sourceStart: 0 }, 3), 3);
+  assert.equal(clipSourceSecAt({ speed: 2, sourceStart: 0 }, 3), 6);
+  assert.equal(clipSourceSecAt({ speed: 0.5, sourceStart: 4 }, 6), 7);
+});
+
+test('clipProgramSecAt inverts clipSourceSecAt at every speed and in-point', () => {
+  for (const timing of [
+    { speed: 1, sourceStart: 0 }, { speed: 2, sourceStart: 4 }, { speed: 0.25, sourceStart: 9.5 },
+  ]) {
+    for (const localSec of [0, 0.7, 3, 12.25]) {
+      const source = clipSourceSecAt(timing, localSec);
+      assert.ok(near(clipProgramSecAt(timing, source), localSec),
+        `${localSec}s of ${JSON.stringify(timing)} came back as ${clipProgramSecAt(timing, source)}s`);
+    }
+  }
+});
+
+test('what a clip affords is the footage past its in-point, never a negative length', () => {
+  assert.equal(clipAffordedSec({ speed: 2, sourceStart: 0 }, 12), 6);
+  assert.equal(clipAffordedSec({ speed: 0.5, sourceStart: 0 }, 12), 24);
+  assert.equal(clipAffordedSec({ speed: 1, sourceStart: 4 }, 12), 8);
+  // An in-point past the end of the footage affords nothing rather than running backwards.
+  assert.equal(clipAffordedSec({ speed: 1, sourceStart: 20 }, 12), 0);
+});
+
+test('a head trim moves the in-point later and leaves the footage under the body where it was', () => {
+  const clip = { start: 0, sourceStart: 0, speed: 1 };
+  const at = 20;
+  const before = clipSourceSecAt(clip, at - clip.start);
+  const trimmed = { ...clip, ...headTrim(clip, 5, 30, 0.2) };
+  assert.ok(near(trimmed.start, 5));
+  assert.ok(near(trimmed.sourceStart, 5));
+  assert.ok(near(clipSourceSecAt(trimmed, at - trimmed.start), before),
+    'the source second under a fixed program position moved');
+  assert.ok(near(trimmed.trim, 25), 'the out-point held');
+});
+
+test('a head trim at double speed advances the in-point by twice what the head moved', () => {
+  const clip = { start: 0, sourceStart: 0, speed: 2 };
+  const at = 20;
+  const before = clipSourceSecAt(clip, at - clip.start);
+  const trimmed = { ...clip, ...headTrim(clip, 5, 30, 0.2) };
+  assert.ok(near(trimmed.sourceStart, 10));
+  assert.ok(near(clipSourceSecAt(trimmed, at - trimmed.start), before));
+});
+
+test('a head trim stops at program zero and at the head of the take', () => {
+  // Program zero: a clip at the head of the edit cannot be dragged before it.
+  const atZero = headTrim({ start: 0, sourceStart: 0, speed: 1 }, -9, 30, 0.2);
+  assert.equal(atZero.start, 0);
+  assert.equal(atZero.sourceStart, 0);
+  // The head of the take: a clip placed later can come back only as far as its footage reaches.
+  const takeFloor = headTrim({ start: 10, sourceStart: 4, speed: 2 }, 0, 30, 0.2);
+  assert.ok(near(takeFloor.start, 8), `stopped at ${takeFloor.start}s rather than 8s`);
+  assert.equal(takeFloor.sourceStart, 0, 'the in-point landed near zero rather than on it');
+});
+
+test('a head trim cannot cross its own out-point, and leaves a clip still wide enough to grab', () => {
+  const trimmed = headTrim({ start: 0, sourceStart: 0, speed: 1 }, 99, 30, 0.2);
+  assert.ok(near(trimmed.start, 29.8));
+  assert.ok(near(trimmed.trim, 0.2));
+});
+
+test('a trim and a trim back to the head of the take return the in-point to exactly zero', () => {
+  const clip = { start: 0, sourceStart: 0, speed: 1.5 };
+  const trimmed = { ...clip, ...headTrim(clip, 6, 40, 0.2) };
+  assert.ok(trimmed.sourceStart > 0);
+  const back = headTrim(trimmed, -3, 40, 0.2);
+  assert.equal(back.sourceStart, 0, 'the in-point kept a rounding residue');
+  assert.equal(back.start, 0);
+});
+
+test('a trim back to the head of the take lands on zero at every speed, not near it', () => {
+  // The in-point a clip carries need not have been written at the speed it now runs at: the
+  // slider moves a trimmed clip, and a document arrives holding both fields. So the subtraction
+  // that walks the head back to the take does not cancel exactly, and either sign is a defect -
+  // a positive residue is a clip the surface calls trimmed, and a negative one is refused at the
+  // document door.
+  for (const speed of [0.1, 0.15, 0.3, 0.35, 0.7, 0.9, 1.1, 1.3, 1.7, 2.3, 3.3, 0.33, 1.23]) {
+    for (const sourceStart of [0.1, 0.3, 0.7, 1.3, 2.9, 5.7, 7.796909871244635, 9.1, 12.7]) {
+      for (const pad of [0, 3]) {
+        // Placed so the head of the take is reachable: a clip whose take floor sits before
+        // program zero stops at zero with footage still in front of its in-point, and the
+        // in-point it keeps there is a reading rather than a residue.
+        const start = sourceStart / speed + pad;
+        const back = headTrim({ start, sourceStart, speed }, -99, start + 40, 0.2);
+        assert.equal(back.sourceStart, 0,
+          `speed ${speed}, in-point ${sourceStart}s, start ${start}s left ${back.sourceStart}`);
+      }
+    }
+  }
+});
+
+test('the frames a surface span reaches back over count the span, not the ceiling', () => {
+  assert.deepEqual(framesBackFor(2, 0.5, 30, 600), { frames: 8, covered: true });
+  assert.deepEqual(framesBackFor(0.5, 0.5, 30, 600), { frames: 30, covered: true });
+  assert.deepEqual(framesBackFor(1, 2, 30, 600), { frames: 60, covered: true });
+  // The tolerance the walk it replaces carried: 0.1 + 0.2 is 0.30000000000000004 in binary.
+  assert.deepEqual(framesBackFor(1, 0.1 + 0.2, 30, 600), { frames: 9, covered: true });
+  // A span the ceiling cannot cover answers the ceiling and says so.
+  assert.deepEqual(framesBackFor(0.1, 2.1, 30, 618), { frames: 618, covered: false });
+  assert.deepEqual(framesBackFor(1, 0, 30, 600), { frames: 0, covered: true });
+  assert.deepEqual(framesBackFor(1, -1, 30, 600), { frames: 0, covered: true });
+});
+
+test('the frames before its in-point a clip still reaches footage over stop at the take head', () => {
+  assert.equal(headFramesFor(1, 2, 30, 600), 60);
+  assert.equal(headFramesFor(2, 2, 30, 600), 30);
+  assert.equal(headFramesFor(0.5, 2, 30, 600), 120);
+  // An untrimmed clip reaches back over nothing: there is no footage before its in-point.
+  assert.equal(headFramesFor(1, 0, 30, 600), 0);
+  // Bounded by the window it is asked for rather than by the footage alone.
+  assert.equal(headFramesFor(1, 100, 30, 12), 12);
 });

--- a/test/clip-plan.test.mjs
+++ b/test/clip-plan.test.mjs
@@ -125,6 +125,19 @@ test('a head trim cannot cross its own out-point, and leaves a clip still wide e
   assert.ok(near(trimmed.trim, 0.2));
 });
 
+test('a head trim cannot move an extended clip past the end of its footage', () => {
+  const trimmed = headTrim(
+    { start: 0, sourceStart: 0, speed: 1 },
+    15,
+    20,
+    0.2,
+    10,
+  );
+  assert.ok(near(trimmed.start, 9.8));
+  assert.ok(near(trimmed.sourceStart, 9.8));
+  assert.ok(near(trimmed.trim, 10.2));
+});
+
 test('a trim and a trim back to the head of the take return the in-point to exactly zero', () => {
   const clip = { start: 0, sourceStart: 0, speed: 1.5 };
   const trimmed = { ...clip, ...headTrim(clip, 6, 40, 0.2) };

--- a/test/curve.test.mjs
+++ b/test/curve.test.mjs
@@ -6,8 +6,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   EASE_OUT_LINEAR, EASE_IN_LINEAR, SEGMENT_POINT_CEILING, easeAt, easeParam, elevate,
-  keyBefore, HOLD_ENDS, EXTEND_ENDS, scalarAt, scalarSlopeAt, stepAt, hermite, tangentAt,
-  foldRefusal, foldFreeX, retimeSourceSecAt, retimeProgramSecAt,
+  keyBefore, HOLD_ENDS, scalarAt, stepAt, hermite, tangentAt, foldRefusal, foldFreeX,
 } from '../web/curve.js';
 
 /** A key as the tracks build one: a time, a value, and the two handles around it. */
@@ -128,17 +127,15 @@ test('scalarAt interpolates monotonically between two rising keys', () => {
   }
 });
 
-test('HOLD_ENDS holds the outer values and EXTEND_ENDS keeps the slope going', () => {
+test('a query outside the track holds the outer values rather than extending the slope', () => {
   const keys = [key(1, 10), key(2, 20)];
   assert.ok(near(scalarAt(keys, -5, HOLD_ENDS), 10));
   assert.ok(near(scalarAt(keys, 99, HOLD_ENDS), 20));
-  assert.ok(scalarAt(keys, 0, EXTEND_ENDS) < 10, 'extending back should fall below the first key');
-  assert.ok(scalarAt(keys, 3, EXTEND_ENDS) > 20, 'extending on should rise past the last key');
 });
 
 test('a single key answers with its value everywhere, and no keys answers 0', () => {
   assert.equal(scalarAt([key(4, 7)], 0, HOLD_ENDS), 7);
-  assert.equal(scalarAt([key(4, 7)], 99, EXTEND_ENDS), 7);
+  assert.equal(scalarAt([key(4, 7)], 99, HOLD_ENDS), 7);
   assert.equal(scalarAt([], 0, HOLD_ENDS), 0);
 });
 
@@ -155,12 +152,6 @@ test('stepAt holds the earlier value across a segment and never interpolates', (
   assert.equal(stepAt(keys, 0.99), 0);
   assert.equal(stepAt(keys, 1), 1);
   assert.equal(stepAt(keys, -1), 0, 'before the first key it holds the first value');
-});
-
-test('scalarSlopeAt is positive while rising, negative while falling, flat when level', () => {
-  assert.ok(scalarSlopeAt([key(0, 0), key(1, 10)], 0.5) > 0);
-  assert.ok(scalarSlopeAt([key(0, 10), key(1, 0)], 0.5) < 0);
-  assert.ok(near(scalarSlopeAt([key(0, 4), key(1, 4)], 0.5), 0, 1e-6));
 });
 
 test('hermite lands on its endpoints, so a segment meets the keys it spans', () => {
@@ -284,57 +275,4 @@ test('foldFreeX holds the line a drag cannot: no sequence of clamped moves folds
       }
     }
   }
-});
-
-
-// The retime curve, which the editor evaluates against a clip it is rendering and the projects
-// page evaluates against a document it has only read. Both call these, so the cases below are
-// the ones a rendered frame never visits: no keys at all, one key, and a query past both ends.
-
-test('a retime with no keys is its rate, and the inverse undoes it', () => {
-  const curve = { rate: 2, keys: [] };
-  assert.equal(retimeSourceSecAt(curve, 0), 0);
-  assert.equal(retimeSourceSecAt(curve, 3), 6);
-  assert.equal(retimeProgramSecAt(curve, 6), 3);
-});
-
-test('a retime with one key is a line of slope `rate` through it, not a hold', () => {
-  const curve = { rate: 0.5, keys: [key(4, 10)] };
-  assert.equal(retimeSourceSecAt(curve, 4), 10);
-  assert.equal(retimeSourceSecAt(curve, 6), 11);
-  // Before the key as well as after it: a clip trimmed at the head has its one key inside its
-  // own span, so the program seconds before it are footage rather than nothing.
-  assert.equal(retimeSourceSecAt(curve, 2), 9);
-  assert.equal(retimeProgramSecAt(curve, 11), 6);
-});
-
-test('a retime past its last key keeps going, so a take\'s tail stays reachable', () => {
-  const curve = { rate: 1, keys: [key(0, 0), key(2, 4)] };
-  assert.equal(retimeSourceSecAt(curve, 1), 2);
-  // EXTEND_ENDS and not HOLD_ENDS: holding would freeze the program at the last key.
-  assert.ok(near(retimeSourceSecAt(curve, 4), 8, 1e-6));
-  assert.ok(near(retimeSourceSecAt(curve, -1), -2, 1e-6));
-});
-
-test('retimeProgramSecAt inverts retimeSourceSecAt across a keyed, eased curve', () => {
-  const curve = {
-    rate: 1,
-    keys: [
-      { t: 0, value: 0, easeOut: [[0.9, 0.1]], easeIn: [[2 / 3, 2 / 3]] },
-      { t: 3, value: 9, easeOut: [[1 / 3, 1 / 3]], easeIn: [[0.1, 0.9]] },
-      key(6, 12),
-    ],
-  };
-  for (const programSec of [0.2, 1, 1.5, 2.9, 3, 3.1, 4, 5.5, 6]) {
-    const source = retimeSourceSecAt(curve, programSec);
-    assert.ok(near(retimeProgramSecAt(curve, source), programSec, 1e-6),
-      `${programSec}s maps to ${source}s of source and back to ${retimeProgramSecAt(curve, source)}s`);
-  }
-});
-
-test('a clip with no trim runs for what its curve affords, which is the inverse at the take end', () => {
-  // What `serialiseProjectBody` writes for any clip nobody trimmed is `length: null`, so this
-  // is the arithmetic the projects page runs to find where such a clip stops.
-  assert.equal(retimeProgramSecAt({ rate: 2, keys: [] }, 12), 6);
-  assert.equal(retimeProgramSecAt({ rate: 0.5, keys: [] }, 12), 24);
 });

--- a/tools/boot-check.mjs
+++ b/tools/boot-check.mjs
@@ -87,8 +87,8 @@ const MUTATIONS = {
   'panel-does-not-follow-the-selection': {
     file: 'web/main.js',
     edits: [[
-      '  paintClipPanel();\n  paintGizmo();\n  // The retime binding',
-      '  paintGizmo();\n  // The retime binding',
+      '  paintClipPanel();\n  paintGizmo();\n  // The ruler\'s mapping',
+      '  paintGizmo();\n  // The ruler\'s mapping',
     ]],
     fails: 'the pre-fix build: the panel written by value writes alone, so selecting a clip '
       + 'leaves every clip-scope control showing the clip selected before it. Reddens the two '

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -107,31 +107,15 @@ const MUTATIONS = {
   'head-trim-slides-the-footage': {
     file: 'web/main.js',
     edits: [[
-      '  const sourceAtHead = held + (start - clip.start) * rate;',
-      '  const sourceAtHead = held;',
+      '  const sourceDuration = clip.source.streaming ? Infinity : clip.source.duration;\n'
+        + '  Object.assign(clip, headTrim(clip, wantStart, holdEnd, MIN_CLIP_SEC, sourceDuration));',
+      '  const priorStart = clip.start;\n'
+        + '  const sourceDuration = clip.source.streaming ? Infinity : clip.source.duration;\n'
+        + '  Object.assign(clip, headTrim(clip, wantStart, holdEnd, MIN_CLIP_SEC, sourceDuration));\n'
+        + '  if (clip.start > priorStart) clip.sourceStart += 0.25;',
     ]],
     fails: 'a head trim that moves the clip and lets the footage travel with it, which is a slip '
       + 'and not a trim',
-  },
-
-  'head-trim-drops-single-key-offset': {
-    file: 'web/main.js',
-    edits: [[
-      '    key.value = sourceAtHead + key.t * rate;',
-      '    key.value = sourceAtHead;',
-    ]],
-    fails: 'a head trim writing the source-at-head value directly onto a single retime key away '
-      + 'from zero. The offset-key footage row reddens alone',
-  },
-
-  // The head edge takes a keyed curve's clip anyway, silently, which is the shape this refusal
-  // exists to avoid. Must redden the two refusal rows of 22.
-  'head-trim-ignores-the-curve': {
-    file: 'web/main.js',
-    edits: [["    if (side === 'head' && clip.retime.keys.length > 1) {",
-             '    if (false) {']],
-    fails: 'the head edge taking a keyed clip anyway and silently, which is the shape the '
-      + 'refusal exists to avoid',
   },
 
   // A clip lands at the head of the edit rather than under the playhead. Must redden 'it lands
@@ -311,16 +295,16 @@ const MUTATIONS = {
       + 'project row reddens on a capped tick set instead of one sized to the viewport',
   },
 
-  // A mark is drawn through its clip's curve and not through where that clip sits.
+  // A mark is drawn through the clip-local map and not through where that clip sits.
   // Must redden both mark rows of 22 and nothing else there.
   'marks-ignore-the-placement': {
     file: 'web/main.js',
     edits: [[
       'const programSecOfSource = (sourceSec) => selectedClip.start\n'
-      + '  + selectedClip.retime.programSecAt(sourceSec);',
-      'const programSecOfSource = (sourceSec) => selectedClip.retime.programSecAt(sourceSec);',
+      + '  + clipProgramSecAt(selectedClip, sourceSec);',
+      'const programSecOfSource = (sourceSec) => clipProgramSecAt(selectedClip, sourceSec);',
     ]],
-    fails: 'a mark drawn through its clip\'s curve and not through where that clip sits, so two '
+    fails: 'a mark drawn through its clip-local map and not through where that clip sits, so two '
       + 'clips of one take draw their marks on top of each other',
   },
 
@@ -349,7 +333,7 @@ const MUTATIONS = {
   },
 
   // Selecting a row moves the strip's idea of the selection and not the page's.
-  // Must redden 'the panel and the retime binding follow it' and the mark rows with it.
+  // Must redden 'the panel and speed binding follow it' and the mark rows with it.
   'select-row-does-not-select-the-clip': {
     file: 'web/main.js',
     edits: [['  clipRow = clip;\n  selectClip(clip);',
@@ -559,7 +543,6 @@ const MUTATIONS = {
     edits: [
       ['    refuseFolds(owner, ready);\n', ''],
       ["  refuseFolds('track camera', camera);\n", ''],
-      ["    refuseFolds('the retime curve', keys);\n", ''],
     ],
     fails: 'that check: whole-curve monotonicity asked once per segment with both handles in '
       + 'hand. The per-side ordering rule it replaced refused the legal crossed polygons '
@@ -1477,16 +1460,6 @@ const MUTATIONS = {
     ]],
   },
 
-  'rate-keys-ignore-retime-pivot': {
-    file: 'web/main.js',
-    edits: [[
-      '  rescaleClipKeys(was.keys, k, was.pivot);',
-      '  rescaleClipKeys(was.keys, k, 0);',
-    ]],
-    fails: 'the nonzero-pivot row in section 4: the look key lands at local 3s/source 7s instead '
-      + 'of local 4s/source 9s',
-  },
-
   'rate-window-stays-fractional': {
     file: 'web/main.js',
     edits: [[
@@ -1684,7 +1657,7 @@ const MUTATIONS = {
       '  if (dur !== null) {\n'
       + '    clipIn = Math.max(0, Math.min(clipIn, dur));\n'
       + '    // `null` still means "to the end", which is a different statement from a number that\n'
-      + '    // happens to equal the duration: "whole clip" has to survive a retime that lengthens\n'
+      + '    // happens to equal the duration: "whole clip" has to survive a speed change that lengthens\n'
       + '    // the program, and a duration written in here would freeze it at today\'s length.\n'
       + '    if (clipOut !== null) clipOut = Math.max(clipIn, Math.min(clipOut, dur));\n'
       + '  }\n',
@@ -1845,8 +1818,10 @@ const MUTATIONS = {
   'pose-handle-overshoots': {
     file: 'web/main.js',
     edits: [[
-      "    if (row.owner === 'retime' || !KINDS[row.kind].overshoots) h[1] = Math.min(1, Math.max(0, h[1]));",
-      "    if (row.owner === 'retime') h[1] = Math.min(1, Math.max(0, h[1]));",
+      "    if (KINDS[row.kind].overshoots) h[1] = Math.min(2, Math.max(-1, h[1]));\n"
+        + '    else h[1] = Math.min(1, Math.max(0, h[1]));',
+      "    if (KINDS[row.kind].overshoots || row.kind === 'pose') h[1] = Math.min(2, Math.max(-1, h[1]));\n"
+        + '    else h[1] = Math.min(1, Math.max(0, h[1]));',
     ]],
     fails: 'a pose handle leaving the unit box, which sends the camera past the pose it was '
       + 'keyed at',
@@ -1964,16 +1939,6 @@ const MUTATIONS = {
     fails: 'the quintic dropped to a cubic, whose rate still reaches zero at the key - so every '
       + 'velocity row stays green and only the degree is gone with the acceleration claim '
       + 'resting on it',
-  },
-
-  'points-reach-the-retime': {
-    file: 'web/main.js',
-    edits: [[
-      "  if (!state || selection.owner === 'retime') return [];",
-      '  if (!state) return [];',
-    ]],
-    fails: 'and the point controls offered on the retime, whose unit-box monotonicity proof is a '
-      + 'proof about a cubic and nothing else',
   },
 
   'ease-preset-ignored': {
@@ -2122,7 +2087,7 @@ const DRIVER_RULES = [
     key: 'keyframe',
     what: 'a keyframe toggle',
     by: 'keyframe-check, and section 5 here deletes what it creates',
-    match: (row) => row.kf && row.id !== 'tRateKey',
+    match: (row) => row.kf,
   },
   {
     key: 'recorder',
@@ -2296,13 +2261,12 @@ const DRIVER_IDS = {
   tCamView: 'section 1 - looks through the program camera and reads the orbit back',
   effectRackOpen: 'section 1 - opens the installed-effect search, adds every effect, and removes one',
   menuWholeClip: 'section 3 - clears the range through both its menu command and keyboard shortcut',
-  tRateKey: 'section 5 - plants and removes a retime key',
   // `tFps` is deliberately not here: it moved into Project settings with the rate itself, so
   // the `shelldialogs` rule covers it and section 1 drives it.
   tMark: 'library-check writes a mark and reads the sidecar back',
   tDeleteKey: 'section 5 - removes the selected key',
   tAddPoint: 'section 5 - grows a segment\'s degree and reads the curve back unmoved',
-  tDropPoint: 'section 5 - shrinks it again, and both are read dead on the retime',
+  tDropPoint: 'section 5 - shrinks it again',
   tPrevKey: 'section 18 - walks the selected track and reads which key the playhead landed on',
   tNextKey: 'section 18 - walks the selected track and reads which key the playhead landed on',
   tPreset: 'library-check applies a preset and compares the look',
@@ -4010,7 +3974,7 @@ try {
   // This block runs at the head of the section rather than at its tail, and the placement is
   // load-bearing: at the tail it left section 5's ease-handle drag dead on a page whose state was
   // byte-identical to a passing run's.
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await settle();
   await page.evaluate("document.getElementById('tRate').focus()");
   await page.evaluate('__kinect.timeline.transport().play()');
@@ -4019,7 +3983,7 @@ try {
     playing: __kinect.timeline.transport().playing,
     depth: __kinect.keyframes.undo.depth(),
     seeks: __kinect.timeline.counters.seeks,
-    rate: __kinect.timeline.retime.rate,
+    rate: __kinect.timeline.read().speed,
   }))()`);
   await page.evaluate(`(() => {
     const el = document.getElementById('tRate');
@@ -4051,7 +4015,7 @@ try {
     playing: __kinect.timeline.transport().playing,
     depth: __kinect.keyframes.undo.depth(),
     seeks: __kinect.timeline.counters.seeks,
-    rate: __kinect.timeline.retime.rate,
+    rate: __kinect.timeline.read().speed,
   }))()`);
   check(heldBefore.playing && heldAfter.rate > heldBefore.rate,
     'a held arrow key moves the speed, so the two counters below are counting a gesture that happened',
@@ -4071,11 +4035,11 @@ try {
   // the source to go back, which reddens the page-errors row at the end of the file.
   await focusStage();
   await page.evaluate('__kinect.timeline.transport().pause()');
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await page.evaluate('__kinect.timeline.transport().seek(0)');
   await settle();
 
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await settle();
   await page.evaluate('__kinect.timeline.transport().play()');
   await new Promise((r) => setTimeout(r, 300));
@@ -4104,7 +4068,7 @@ try {
     '  and a navigation arriving inside its pre-roll keeps it stopped, rather than the resume starting it again',
     `playing ${runningBefore} -> ${afterNav}`);
   await page.evaluate('__kinect.timeline.transport().pause()');
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await settle();
 
 
@@ -4117,14 +4081,14 @@ try {
       el.dispatchEvent(new Event('change'));
     })()`);
     await settle();
-    const landed = await page.evaluate('__kinect.timeline.retime.rate');
+    const landed = await page.evaluate('__kinect.timeline.read().speed');
     check(near(landed, rate, 1e-6), `  the slider went to ${rate}x when it was asked for ${rate}x`,
       `landed at ${landed}x`);
     return landed;
   };
 
   const rateArm = async (parkAt, to) => {
-    await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+    await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
     await driveRate(1);
     await page.evaluate(`__kinect.timeline.transport().seek(${parkAt})`);
     await settle();
@@ -4196,7 +4160,7 @@ try {
   };
   const strip = () => page.evaluate(`(${STRIP})()`);
 
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await page.evaluate(`__kinect.keyframes.setTracks({ bloom: [ { t: 2, value: 0.2 }, { t: 6, value: 0.9 } ] })`);
   await page.evaluate(`(() => {
     const body = __kinect.library.serialiseProjectBody();
@@ -4275,40 +4239,8 @@ try {
   check(undone.clipKeys === at120.clipKeys && undone.clipKeyTimes === at120.clipKeyTimes,
     "  and the selected clip's keys", `${at120.clipKeyTimes} -> ${undone.clipKeyTimes}`);
 
-  const pivoted = await page.evaluate(`(async () => {
-    const k = globalThis.__kinect;
-    const original = k.library.serialiseProjectBody();
-    const selected = k.editor.clipSelection();
-    k.keyframes.setRetime({ rate: 1, keys: [{ t: 2, value: 5 }] });
-    k.keyframes.setTracks({ pointSize: [{ t: 6, value: 12 }] });
-    await k.timeline.transport().seek(4);
-    await k.timeline.settled();
-    return { original, selected };
-  })()`);
-  await driveRate(2);
-  const pivotResult = await page.evaluate(`(() => {
-    const k = globalThis.__kinect;
-    const clip = k.library.serialiseProjectBody().clips
-      .find((candidate) => candidate.id === k.editor.clipSelection());
-    const key = clip.tracks.pointSize[0];
-    return {
-      keyTime: key.t,
-      sourceAtKey: k.timeline.retime.sourceSecAt(key.t),
-      pivot: k.timeline.retime.keys[0].t,
-    };
-  })()`);
-  check(near(pivotResult.pivot, 2, 1e-9) && near(pivotResult.keyTime, 4, 1e-9)
-      && near(pivotResult.sourceAtKey, 9, 1e-9),
-    'a speed change rescales clip-local keys around a nonzero retime pivot and keeps their source association',
-    `pivot ${pivotResult.pivot}s, key ${pivotResult.keyTime}s at source ${pivotResult.sourceAtKey}s`);
-  await page.evaluate(({ original, selected }) => {
-    __kinect.library.restoreProject(original);
-    __kinect.editor.selectClipRow(selected);
-  }, pivoted);
-  await settle();
-
   // The detent at 1.00x, the one rate that has to be reachable exactly rather than approximately:
-  // `slopeAt` reports it to the audio gate, and a take playing at 0.9995 reads as retimed.
+  // the audio gate reads it too, and a take playing at 0.9995 is not normal speed.
   const atSlider = async (offset) => {
     await page.evaluate(`(() => {
       const el = document.getElementById('tRate');
@@ -4317,7 +4249,7 @@ try {
       el.dispatchEvent(new Event('change'));
     })()`);
     await settle();
-    return page.evaluate('__kinect.timeline.retime.rate');
+    return page.evaluate('__kinect.timeline.read().speed');
   };
   // Driven by pixel as well as by value, because a detent is a hit target: the band was stated as
   // +/-3% of rate, which on a travel spanning a factor of 40 is 0.74px each side of the 92px
@@ -4370,26 +4302,26 @@ try {
   // and the first small input in the same neighbourhood came through the band and
   // returned exactly 1.00.
   const nudged = await page.evaluate(`(async () => {
-    __kinect.keyframes.setRetime({ rate: 1.02, keys: [] });
+    (__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1.02));
     await __kinect.timeline.settled();
     const el = document.getElementById('tRate');
-    const loaded = { rate: __kinect.timeline.retime.rate, value: Number(el.value) };
+    const loaded = { rate: __kinect.timeline.read().speed, value: Number(el.value) };
     el.focus();
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     el.value = String(loaded.value + 0.001);
     el.dispatchEvent(new Event('input', { bubbles: true }));
     await __kinect.timeline.settled();
-    const nudge = __kinect.timeline.retime.rate;
+    const nudge = __kinect.timeline.read().speed;
     // Out of the band and back in, which is a gesture that aimed at 1.00x rather than one
     // that started next to it - the snap has to still happen there or the band is gone.
     el.value = String(__kinect.editor.rateSlider.toValue(1.5));
     el.dispatchEvent(new Event('input', { bubbles: true }));
     await __kinect.timeline.settled();
-    const away = __kinect.timeline.retime.rate;
+    const away = __kinect.timeline.read().speed;
     el.value = String(__kinect.editor.rateSlider.toValue(1.005));
     el.dispatchEvent(new Event('input', { bubbles: true }));
     await __kinect.timeline.settled();
-    const returned = __kinect.timeline.retime.rate;
+    const returned = __kinect.timeline.read().speed;
     el.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true }));
     el.blur();
     await __kinect.timeline.settled();
@@ -4406,7 +4338,7 @@ try {
   check(nudged.returned === 1,
     '  and coming back into it from outside still snaps, which is what the band is for',
     `landed at ${nudged.returned}x`);
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await settle();
 
   await page.evaluate('__kinect.timeline.counters.seeks = 0');
@@ -4419,7 +4351,7 @@ try {
   const seeks = await page.evaluate('__kinect.timeline.counters.seeks');
   check(seeks <= 2, 'twenty slider steps cost one accurate seek, not twenty', `${seeks} seeks`);
 
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await page.evaluate(`__kinect.keyframes.setTracks({ bloom: [
     { t: 1, value: 0.2 }, { t: 5, value: 0.9 }, { t: 9, value: 0.3 } ] })`);
   await settle();
@@ -4440,7 +4372,7 @@ try {
   // A gesture lasts as long as a finger or a key is down, which is long enough for a load started
   // before it to land in the middle of it.
   const snap = () => page.evaluate(`(() => ({
-    rate: __kinect.timeline.retime.rate,
+    rate: __kinect.timeline.read().speed,
     depth: __kinect.keyframes.undo.depth(),
     lanes: JSON.stringify(__kinect.keyframes.lanes()),
     range: JSON.stringify(__kinect.editor.clipRange()),
@@ -4450,7 +4382,7 @@ try {
   }))()`);
 
   const heldGesture = async ({ interrupt }) => {
-    await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+    await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
     await page.evaluate(`(() => {
       const body = __kinect.library.serialiseProjectBody();
       const clip = body.clips.find((entry) => entry.id === __kinect.editor.clipSelection());
@@ -4461,7 +4393,7 @@ try {
     await page.evaluate('__kinect.editor.setClipRange(0, null)');
     await page.evaluate('__kinect.keyframes.undo.commit()');
     await driveRate(2);
-    const committed = await page.evaluate('__kinect.timeline.retime.rate');
+    const committed = await page.evaluate('__kinect.timeline.read().speed');
     await page.evaluate('__kinect.timeline.transport().seek(2)');
     await settle();
     await page.evaluate('__kinect.timeline.transport().play()');
@@ -4475,12 +4407,12 @@ try {
       el.dispatchEvent(new Event('input'));
     })()`);
     await settle();
-    const held = await page.evaluate('__kinect.timeline.retime.rate');
+    const held = await page.evaluate('__kinect.timeline.read().speed');
     if (interrupt) {
       await page.evaluate('__kinect.keyframes.undo.pop()');
       await settle();
     }
-    const afterInterrupt = await page.evaluate('__kinect.timeline.retime.rate');
+    const afterInterrupt = await page.evaluate('__kinect.timeline.read().speed');
     const before = await snap();
     if (interrupt === 'then-more-input') {
       await page.evaluate(`(() => {
@@ -4541,7 +4473,7 @@ try {
 
   await focusStage();
   await page.evaluate('__kinect.timeline.transport().pause()');
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await page.evaluate('__kinect.keyframes.setTracks({})');
   await page.evaluate(`(() => {
     const body = __kinect.library.serialiseProjectBody();
@@ -4590,26 +4522,6 @@ try {
   await page.mouse.click(dbl.x + dbl.width / 2, dbl.y + dbl.height / 2);
   await settle();
   check(await keyCount('bloom') === 2, 'and a double click on a key removes it', `${await keyCount('bloom')} keys left`);
-
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [
-    { t: 0, value: 0 }, { t: 10, value: 8 }, { t: 20, value: 20 } ] })`);
-  await settle();
-  await page.evaluate(`__kinect.editor.select('retime', 0)`);
-  await settle();
-  await page.keyboard.press('Delete');
-  await settle();
-  const retimeKeys = () => page.evaluate('__kinect.timeline.retime.keys.length');
-  check(await retimeKeys() === 3, 'the retime origin will not delete while keys follow it',
-    `${await retimeKeys()} keys, note "${(await text('#tNote')).trim().slice(0, 60)}"`);
-  check((await text('#tNote')).trim().length > 10, 'and it says why rather than doing nothing quietly');
-  await page.evaluate(`__kinect.editor.select('retime', 2)`);
-  await page.keyboard.press('Delete');
-  await settle();
-  await page.evaluate(`__kinect.editor.select('retime', 1)`);
-  await page.keyboard.press('Delete');
-  await settle();
-  check(await retimeKeys() === 0, 'and the curve empties once the last one after it has gone',
-    `${await retimeKeys()} keys`);
 
   const EXPECTED = {
     linear: { out: [[1 / 3, 1 / 3]], in: [[2 / 3, 2 / 3]] },
@@ -4814,25 +4726,6 @@ try {
   check(JSON.stringify(pairFirst.easeOut) === glideOut && JSON.stringify(pairLast.easeIn) === glideIn,
     'on a two-key move `ends` shapes both ends of the one segment there is',
     `first-out ${JSON.stringify(pairFirst.easeOut)}, last-in ${JSON.stringify(pairLast.easeIn)}`);
-
-  // `assertMonotonic` argues that a handle anywhere in the unit box cannot run source time
-  // backwards, and that argument is about a cubic - a quintic with ordinates
-  // 0,1,0,1,0,1 oscillates.
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [
-    { t: 0, value: 0 }, { t: 6, value: 4 }, { t: 12, value: 11 } ] })`);
-  await page.evaluate(`__kinect.editor.select('retime', 1)`);
-  await settle();
-  const retimePoints = await page.evaluate(`(() => {
-    const add = document.getElementById('tAddPoint').disabled;
-    const drop = document.getElementById('tDropPoint').disabled;
-    const smooth = document.querySelector('#tEase button[data-ease=smooth]').disabled;
-    return { add, drop, smooth };
-  })()`);
-  check(retimePoints.add && retimePoints.drop && !retimePoints.smooth,
-    'both point controls are dead on a retime key while the ordinary presets stay live, '
-    + 'because the monotonicity proof the retime rests on is a proof about a cubic',
-    `add ${retimePoints.add ? 'dead' : 'LIVE'}, drop ${retimePoints.drop ? 'dead' : 'LIVE'}, `
-    + `smooth ${retimePoints.smooth ? 'DEAD' : 'live'}`);
 
   await plant({ bloom: [{ t: 1, value: 0.5 }, { t: 5, value: 0.5 }, { t: 9, value: 0.9 }] });
   await page.evaluate(`__kinect.editor.select('bloom', 0)`);
@@ -5136,7 +5029,7 @@ try {
     return res.json();
   })()`);
 
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await page.evaluate(`__kinect.keyframes.setTracks({ bloom: [{ t: 2, value: 0.2 }, { t: 6, value: 0.9 }] })`);
   await settle();
   // The far trim is read off the take rather than written down: `setClipInOut` holds a trim
@@ -5186,7 +5079,7 @@ try {
     el.dispatchEvent(new Event('input', { bubbles: true }));
   })()`);
   await settle();
-  const heldRate = await page.evaluate('__kinect.timeline.retime.rate');
+  const heldRate = await page.evaluate('__kinect.timeline.read().speed');
   const swapped = await pick('editor-check-near');
   check(near(swapped.in ?? -1, 2, 1e-3) && near(swapped.out ?? -1, 8, 1e-3),
     '  even while a speed gesture is held, and as the stored program times rather than rescaled',
@@ -5203,7 +5096,7 @@ try {
     '  and the gesture that continues keeps that project trim at its authored times',
     `${JSON.stringify(afterSwap)}, wanted in 2.0000 out 8.0000`);
 
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await settle();
   const pastDur = (await read()).duration;
   check(pastIn > pastDur,
@@ -5290,7 +5183,7 @@ try {
     el.dispatchEvent(new Event('change', { bubbles: true }));
   }).toString()})(${JSON.stringify(menuBefore)})`);
   await settle();
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await page.evaluate('__kinect.keyframes.setTracks({})');
   // And the trim, which nothing below resets: leaving it at the near deliverable's range
   // moved section 8's crop numbers, and those rows read as a rendering change rather than
@@ -5307,7 +5200,7 @@ try {
   await page.evaluate('__kinect.editor.setClipRange(0, null)');
   await page.evaluate('__kinect.setOutputSize("1920x1080")');
   await page.evaluate('__kinect.keyframes.setTracks({})');
-  await page.evaluate('__kinect.keyframes.setRetime({ rate: 1, keys: [] })');
+  await page.evaluate('(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))');
   await page.evaluate("__kinect.params.reset(__kinect.params.names('look'))");
   await page.evaluate('__kinect.sensorView()');
   await page.evaluate('__kinect.keyframes.chrome.set(false)');
@@ -6235,7 +6128,7 @@ try {
   check((await page.evaluate('__kinect.editor.shortcuts()')).includes(',/. pan it'),
     '  and the shortcut list says so too', await page.evaluate('__kinect.editor.shortcuts()'));
 
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await settle();
   const slowRate = await driveRate(0.1);
   await page.evaluate('__kinect.editor.view.set(0.5, 0.5)');
@@ -6256,7 +6149,7 @@ try {
   check(near(atBack.spanSec, atMin.spanSec, 1e-6),
     '  and comes back to exactly the window it started at, rather than to what the clamp left',
     `${atMin.spanSec.toFixed(6)}s -> ${atBack.spanSec.toFixed(6)}s`);
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await page.evaluate('__kinect.editor.view.fit()');
   await settle();
 
@@ -6293,7 +6186,7 @@ try {
   // boundary is a float and the playhead is a frame, so one that was exactly on `clipIn` can land
   // a fraction of a frame outside the rescaled one and `setClipInOut` buys a full accurate seek
   // for it on every `input`.
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await settle();
   await page.evaluate('__kinect.timeline.transport().seek(10)');
   await settle();
@@ -6322,7 +6215,7 @@ try {
     '  and twelve slider steps from there still cost one accurate seek, not one per step',
     `${boundarySeeks} seeks`);
   await page.evaluate('__kinect.editor.setClipRange(0, null)');
-  await page.evaluate(`__kinect.keyframes.setRetime({ rate: 1, keys: [] })`);
+  await page.evaluate(`(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))`);
   await settle();
 
   // A wheel notch is not three pixels, and on Firefox that is what it reports: `deltaMode` is
@@ -7428,7 +7321,7 @@ try {
       { id: 'em1', sourceMs: 3000, label: 'second' },
       { id: 'em2', sourceMs: 5000, label: 'third' },
     ];
-    await page.evaluate('__kinect.keyframes.setRetime({ rate: 1, keys: [] })');
+    await page.evaluate('(__kinect.keyframes.setSourceStart(0), __kinect.keyframes.setSpeed(1))');
     await page.evaluate(`(() => {
       const el = document.getElementById('tRate');
       el.value = String(__kinect.editor.rateSlider.toValue(${RATE}));
@@ -7444,10 +7337,10 @@ try {
     const geometry = await page.evaluate(`(() => {
       const total = __kinect.editor.view.window().duration;
       return {
-        rate: __kinect.timeline.retime.rate,
+        rate: __kinect.timeline.read().speed,
         total,
         program: ${JSON.stringify(MARKS)}.map((m) => Math.max(0, Math.min(total,
-          __kinect.timeline.retime.programSecAt(m.sourceMs / 1000)))),
+          __kinect.editor.markProgramSec(m.sourceMs / 1000)))),
         source: ${JSON.stringify(MARKS)}.map((m) => m.sourceMs / 1000),
         ticks: __kinect.library.markTicks().length,
       };
@@ -7472,7 +7365,7 @@ try {
       `playhead ${pressed.toFixed(3)}s against the tick's ${geometry.program[1].toFixed(3)}s`
       + ` (the source second is ${geometry.source[1].toFixed(3)}s)`);
     check(!near(pressed, geometry.source[1], TOL),
-      'and not on the mark\'s own source second, which is where the retime would be undone',
+      'and not on the mark\'s own source second, which would ignore its clip timing',
       `${pressed.toFixed(3)}s against ${geometry.source[1].toFixed(3)}s`);
 
     await page.evaluate('__kinect.timeline.transport().seek(0)');
@@ -7546,7 +7439,7 @@ try {
     const trim = await page.evaluate(`(() => {
       const window0 = __kinect.editor.view.window();
       const total = window0.duration;
-      const at = (s) => Math.max(0, Math.min(total, __kinect.timeline.retime.programSecAt(s)));
+      const at = (s) => Math.max(0, Math.min(total, __kinect.editor.markProgramSec(s)));
       const outside = at(2);
       const inside = at(8);
       const inAt = (outside + inside) / 2;
@@ -9744,7 +9637,8 @@ try {
       const k = globalThis.__kinect;
       return {
         clips: k.timeline.clips().map((c) => ({ id: c.id, take: c.take && c.take.id,
-          start: c.start, end: c.end, length: c.length, selected: c.selected })),
+          start: c.start, end: c.end, trim: c.trim, length: c.length,
+          speed: c.speed, sourceStart: c.sourceStart, selected: c.selected })),
         selection: k.editor.clipSelection(),
         rows: k.keyframes.lanes().map((l) => l.owner),
         boxes: [...document.querySelectorAll('.tclip')].length,
@@ -9757,8 +9651,8 @@ try {
 
     let one = await read();
     console.log(`  the stack: ${one.rows.join(', ')}`);
-    check(one.rows[0] === 'clips' && one.rows.includes('clip:c1'),
-      'the lane stack opens with a clip bar and a row for the clip that is open',
+    check(one.rows[0] === `clip:${one.clips[0].id}` && one.rows.includes('clip-add'),
+      'the lane stack opens with the clip that is open and the full-width add row beneath it',
       one.rows.slice(0, 3).join(', '));
     check(one.boxes === one.clips.length,
       'and one box is drawn per clip', `${one.boxes} boxes for ${one.clips.length} clips`);
@@ -10414,7 +10308,7 @@ try {
     // pass on the defect it exists to catch.
     check(picked.clips[0].selected === true && picked.clips[1].selected === false
       && two.clips.find((c) => c.selected)?.id !== picked.clips.find((c) => c.selected)?.id,
-    'and the panel and the retime binding move with it, so the selection is one fact rather than two',
+    'and the panel and the speed binding move with it, so the selection is one fact rather than two',
     `${two.clips.find((c) => c.selected)?.id} then `
       + picked.clips.map((c) => `${c.id}:${c.selected}`).join(' '));
 
@@ -10449,10 +10343,10 @@ try {
       + `drawn at ${marked.ticks.map((t) => t.left.toFixed(2)).join(', ')}%`);
     check(marked.start > 0.5,
       'the selected clip is placed away from the head of the edit, which is what makes the two '
-      + 'rows below a claim about placement rather than about a curve',
+      + 'rows below a claim about placement rather than about source timing',
       `${marked.start.toFixed(3)}s`);
     check(near(marked.program, marked.start + MARK_SOURCE_MS / 1000, 0.05),
-      'a mark ticks at the selected clip\'s placement plus its curve, because a mark is a fact '
+      'a mark ticks at the selected clip\'s placement plus its source timing, because a mark is a fact '
       + 'about footage and which clip of it the ruler is drawing is the selection',
       `${marked.program.toFixed(3)}s against ${(marked.start + MARK_SOURCE_MS / 1000).toFixed(3)}s`);
     // Against the placement and the source second rather than against `markProgramSec`: a build
@@ -10460,11 +10354,11 @@ try {
     // the row would pass on the defect it exists to catch.
     const wantLeft = ((marked.start + MARK_SOURCE_MS / 1000) / marked.duration) * 100;
     check(marked.ticks.length === 1 && near(marked.ticks[0].left, wantLeft, 0.5),
-      'and the tick is drawn where that says, rather than where the curve alone would put it',
+      'and the tick is drawn where that says, rather than where the source second alone would put it',
       `${marked.ticks[0]?.left.toFixed(2)}% against ${wantLeft.toFixed(2)}%`);
 
     // Both write gestures at a program second before this placed clip. The sidecar stores source
-    // time, so extrapolating the retime curve here would write a negative time the take has never
+    // time, so extrapolating the clip timing here would write a negative time the take has never
     // contained. The route returns the submitted list and keeps the real sidecar untouched.
     const markWrites = [];
     const markPattern = '**/capture/*/marks';
@@ -10644,121 +10538,208 @@ try {
         'it needs a second take so the selected take can change while the first take writes');
     }
 
+    console.log('\n[22b] the handles that move a clip, and the half of a preset that is shared');
 
-    // The head, which moves the clip's in-point and must not move its footage.
-    const bed = await page.locator('#tBed').boundingBox();
-    const insideBody = () => page.evaluate(`(() => {
-      const k = globalThis.__kinect;
-      const c = k.timeline.clips().find((x) => x.selected);
-      // A source time sampled inside what will still be the body after the trim, so the row is
-      // about the mapping holding rather than about a position that left the clip.
-      const at = c.start + c.length - 0.5;
-      return { id: c.id, start: c.start, end: c.end, length: c.length,
-        keys: k.timeline.retime.keys.map((key) => [key.t, key.value]),
-        rateDisabled: document.getElementById('tRate').disabled,
-        at, sourceSec: k.timeline.retime.sourceSecAt(at - c.start) };
-    })()`);
+    // Stage one ordinary clip with no keys. Head trims must change timing fields, not grow a
+    // hidden timing lane or key that the current document format does not have.
     await page.mouse.click((await boxAt(1)).x, (await boxAt(1)).y);
     await settle();
-    const beforeHead = await insideBody();
-    {
-      const r = (await boxAt(1)).r;
-      await page.mouse.move(r.x + 3, r.y + r.height / 2);
-      await page.mouse.down();
-      for (let i = 1; i <= 6; i++) {
-        await page.mouse.move(r.x + 3 + (bed.width * 0.04 * i) / 6, r.y + r.height / 2);
-      }
-      await page.mouse.up();
-      await settle();
-    }
-    const afterHead = await insideBody();
-    console.log(`  head trim: ${beforeHead.start.toFixed(3)}s -> ${afterHead.start.toFixed(3)}s, `
-      + `out-point ${beforeHead.end.toFixed(3)} -> ${afterHead.end.toFixed(3)}, `
-      + `curve ${JSON.stringify(afterHead.keys)}, source time at ${afterHead.at.toFixed(2)}s `
-      + `${beforeHead.sourceSec.toFixed(4)}s -> ${afterHead.sourceSec.toFixed(4)}s`);
-    check(afterHead.start > beforeHead.start + 0.2,
-      'dragging a clip\'s head edge moves its in-point later in the edit',
-      `${beforeHead.start.toFixed(3)}s to ${afterHead.start.toFixed(3)}s`);
-    check(near(afterHead.end, beforeHead.end, 1e-6),
-      'and leaves its out-point where it was, so a head trim shortens the clip rather than moving it',
-      `${beforeHead.end.toFixed(4)} against ${afterHead.end.toFixed(4)}`);
-    check(near(afterHead.sourceSec, beforeHead.sourceSec, 1e-9),
-      'and the footage under what is left holds still, which is what makes it a trim rather than '
-      + 'a slip: the same project second stands on the same source time',
-      `source ${beforeHead.sourceSec.toFixed(4)}s against ${afterHead.sourceSec.toFixed(4)}s `
-      + `at ${afterHead.at.toFixed(2)}s`);
-    check(afterHead.keys.length === 1 && afterHead.keys[0][0] === 0 && afterHead.keys[0][1] > 0,
-      'the in-point is written as the curve\'s single key at the origin, because a clip states '
-      + 'where it starts in the take through its curve rather than through a field of its own',
-      JSON.stringify(afterHead.keys));
-    check(afterHead.rateDisabled === false,
-      'and the speed slider still answers, because a curve of one key is still a rate',
-      `disabled ${afterHead.rateDisabled}`);
-
-    await page.evaluate(`globalThis.__kinect.keyframes.setRetime({
-      rate: 1.25, keys: [{ t: 2, value: 5 }],
-    })`);
-    await settle();
-    const beforeOffsetHead = await insideBody();
-    {
-      const r = (await boxAt(1)).r;
-      await page.mouse.move(r.x + 3, r.y + r.height / 2);
-      await page.mouse.down();
-      await page.mouse.move(r.x + 3 + bed.width * 0.04, r.y + r.height / 2);
-      await page.mouse.up();
-      await settle();
-    }
-    const afterOffsetHead = await insideBody();
-    check(afterOffsetHead.start > beforeOffsetHead.start + 0.2
-      && afterOffsetHead.keys.length === 1 && afterOffsetHead.keys[0][0] === 2
-      && near(afterOffsetHead.sourceSec, beforeOffsetHead.sourceSec, 1e-9),
-    'a head trim preserves the offset of an imported single retime key and holds the remaining footage still',
-    `start ${beforeOffsetHead.start.toFixed(3)} -> ${afterOffsetHead.start.toFixed(3)}, `
-      + `key ${JSON.stringify(beforeOffsetHead.keys)} -> ${JSON.stringify(afterOffsetHead.keys)}, `
-      + `source ${beforeOffsetHead.sourceSec.toFixed(4)}s -> ${afterOffsetHead.sourceSec.toFixed(4)}s`);
-
-    // Keep the two edge handles apart. The two trims above can leave this clip at the minimum
-    // length, where a real pointer cannot distinguish the head from the tail.
-    const refusalLength = await page.evaluate(`(() => {
+    const TRIM_PROBE = '__editor-check-pointer-trim__';
+    const timingFixture = await page.evaluate(`(() => {
       const k = globalThis.__kinect;
       const body = k.library.serialiseProjectBody();
+      body.look.tracks = {};
+      body.composition.camera = [];
+      for (const clip of body.clips) clip.tracks = {};
       const clip = body.clips.find((candidate) => candidate.id === k.editor.clipSelection());
-      clip.length = Math.max(4, clip.length ?? 0);
+      clip.length = 8;
+      clip.speed = 1;
+      clip.sourceStart = 0;
       k.library.restoreProject(body);
       k.editor.selectClipRow(clip.id);
-      return k.timeline.clips().find((candidate) => candidate.id === clip.id).length;
+      k.editor.view.fit();
+      k.keyframes.undo.begin();
+      return clip.id;
     })()`);
-    check(refusalLength >= 4,
-      'the keyed-curve refusal arm gives the head and tail separate pointer targets',
-      `${refusalLength.toFixed(3)}s of clip`);
-
-    // The same edge on a clip whose curve says more than an in-point.
-    await page.evaluate(`globalThis.__kinect.keyframes.setRetime({ rate: 1, keys: [
-      { t: 0, value: 2 }, { t: 4, value: 6 } ] })`);
     await settle();
-    const beforeRefusal = await insideBody();
-    {
+
+    const bed = await page.locator('#tBed').boundingBox();
+    const selectedTiming = () => page.evaluate(() => {
+      const k = globalThis.__kinect;
+      const c = k.timeline.clips().find((candidate) => candidate.selected);
+      return {
+        id: c.id,
+        start: c.start,
+        end: c.end,
+        trim: c.trim,
+        length: c.length,
+        speed: c.speed,
+        sourceStart: c.sourceStart,
+        keys: document.querySelectorAll('#tLanes .tkey').length,
+        rateKey: document.getElementById('tRateKey') !== null,
+        rateDisabled: document.getElementById('tRate').disabled,
+        undo: k.keyframes.undo.depth(),
+      };
+    });
+    const sourceAt = async (programSec) => {
+      await page.evaluate((at) => __kinect.timeline.transport().seek(at), programSec);
+      await settle();
+      return page.evaluate('__kinect.timeline.read().sourceSec');
+    };
+    const dragSelected = async (side, delta, destination = null) => {
       const r = (await boxAt(1)).r;
-      await page.mouse.move(r.x + 3, r.y + r.height / 2);
+      const x = side === 'head' ? r.x + 3
+        : side === 'tail' ? r.x + r.width - 3 : r.x + r.width / 2;
+      const y = r.y + r.height / 2;
+      await page.mouse.move(x, y);
       await page.mouse.down();
-      await page.mouse.move(r.x + 3 + bed.width * 0.04, r.y + r.height / 2);
+      await page.mouse.move(destination ?? x + delta, y, { steps: 8 });
       await page.mouse.up();
       await settle();
-    }
-    const afterRefusal = await insideBody();
-    const refusal = await page.evaluate("document.getElementById('tNote').textContent");
-    console.log(`  head trim on a keyed curve: "${refusal}"`);
-    check(near(afterRefusal.start, beforeRefusal.start, 1e-9),
-      'the head edge of a clip carrying a retime curve moves nothing',
-      `${beforeRefusal.start.toFixed(4)} against ${afterRefusal.start.toFixed(4)}`);
-    check(/retime curve/.test(refusal) && /head/.test(refusal),
-      'and says why rather than being an edge that silently does nothing on some clips',
-      refusal);
-    check(afterRefusal.rateDisabled === true,
-      'and that clip\'s speed slider has gone quiet, because a curve of two keys is not a rate',
-      `disabled ${afterRefusal.rateDisabled}`);
-    await page.evaluate('globalThis.__kinect.keyframes.setRetime({ rate: 1, keys: [] })');
+    };
+
+    const beforeHead = await selectedTiming();
+    const fixedBodyPosition = beforeHead.start + beforeHead.length - 0.5;
+    const beforeHeadSource = await sourceAt(fixedBodyPosition);
+    await dragSelected('head', bed.width * 0.04);
+    const afterHead = await selectedTiming();
+    const afterHeadSource = await sourceAt(fixedBodyPosition);
+    console.log(`  head trim on ${timingFixture}: ${beforeHead.start.toFixed(3)}s -> `
+      + `${afterHead.start.toFixed(3)}s, in-point ${beforeHead.sourceStart.toFixed(3)}s -> `
+      + `${afterHead.sourceStart.toFixed(3)}s, fixed source ${beforeHeadSource.toFixed(4)}s -> `
+      + `${afterHeadSource.toFixed(4)}s`);
+    check(afterHead.start > beforeHead.start + 0.2 && afterHead.sourceStart > beforeHead.sourceStart,
+      'dragging a clip\'s head later moves both its project in-point and its source in-point',
+      `start ${beforeHead.start.toFixed(3)}s -> ${afterHead.start.toFixed(3)}s, source `
+        + `${beforeHead.sourceStart.toFixed(3)}s -> ${afterHead.sourceStart.toFixed(3)}s`);
+    check(near(afterHead.end, beforeHead.end, 1e-6)
+      && afterHead.length < beforeHead.length - 0.2,
+    'and leaves its out-point where it was, so the head shortens the clip rather than moving it',
+    `end ${beforeHead.end.toFixed(4)}s -> ${afterHead.end.toFixed(4)}s, length `
+      + `${beforeHead.length.toFixed(4)}s -> ${afterHead.length.toFixed(4)}s`);
+    check(near(afterHeadSource, beforeHeadSource, 1e-9),
+      'and the footage under what is left holds still, which is what makes it a trim rather than '
+        + 'a slip: the same project second stands on the same source time',
+      `source ${beforeHeadSource.toFixed(4)}s against ${afterHeadSource.toFixed(4)}s `
+        + `at ${fixedBodyPosition.toFixed(2)}s`);
+    check(beforeHead.keys === 0 && afterHead.keys === 0 && !afterHead.rateKey,
+      'and the trim creates no timing key in the strip and no removed speed-key control in the DOM',
+      `${beforeHead.keys} keys before, ${afterHead.keys} after, speed-key control ${afterHead.rateKey}`);
+    check(afterHead.rateDisabled === false,
+      'while the speed slider still answers on the trimmed clip',
+      `disabled ${afterHead.rateDisabled}`);
+
+    const draggedTiming = {
+      start: afterHead.start,
+      trim: afterHead.trim,
+      length: afterHead.length,
+      speed: afterHead.speed,
+      sourceStart: afterHead.sourceStart,
+    };
+    await page.evaluate(`(async () => {
+      const k = __kinect;
+      const res = await __ecWrite('/projects/${TRIM_PROBE}', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(k.library.serialiseProjectBody()),
+      });
+      if (!res.ok) throw new Error('the pointer-trim project could not be saved: ' + res.status);
+      await k.library.loadProject('${TRIM_PROBE}');
+      await k.timeline.settled();
+    })()`);
     await settle();
+    const reloadedDrag = await page.evaluate((id) => {
+      const clip = __kinect.timeline.clips().find((candidate) => candidate.id === id);
+      return { start: clip.start, trim: clip.trim, length: clip.length,
+        speed: clip.speed, sourceStart: clip.sourceStart };
+    }, timingFixture);
+    check(['start', 'trim', 'length', 'speed', 'sourceStart']
+      .every((name) => near(reloadedDrag[name], draggedTiming[name], 1e-9)),
+    'saving and loading the project preserves the timing produced by the pointer head trim',
+    `${JSON.stringify(draggedTiming)} -> ${JSON.stringify(reloadedDrag)}`);
+    await page.evaluate((id) => __kinect.editor.selectClipRow(id), timingFixture);
+    await settle();
+
+    const anchorAt = afterHead.start + Math.min(2, afterHead.length / 2);
+    await page.evaluate((at) => __kinect.timeline.transport().seek(at), anchorAt);
+    await settle();
+    const beforeSpeed = await page.evaluate('__kinect.timeline.read()');
+    await driveRate(1.5);
+    const afterSpeed = await page.evaluate('__kinect.timeline.read()');
+    const speedAnchorDrift = Math.abs(afterSpeed.sourceSec - beforeSpeed.sourceSec);
+    const speedAnchorBound = afterSpeed.speed / (2 * afterSpeed.outputFps);
+    check(speedAnchorDrift <= speedAnchorBound + 1e-9
+      && near(afterSpeed.sourceStart, beforeSpeed.sourceStart, 1e-9)
+      && Math.abs(afterSpeed.programSec - beforeSpeed.programSec) > 0.1,
+    'changing speed on the trimmed clip holds the source frame to the nearest output frame by '
+      + 'moving the playhead, not its in-point',
+    `source ${beforeSpeed.sourceSec.toFixed(4)}s -> ${afterSpeed.sourceSec.toFixed(4)}s, `
+      + `program ${beforeSpeed.programSec.toFixed(4)}s -> ${afterSpeed.programSec.toFixed(4)}s, `
+      + `in-point ${beforeSpeed.sourceStart.toFixed(4)}s -> ${afterSpeed.sourceStart.toFixed(4)}s, `
+      + `drift ${(speedAnchorDrift * 1000).toFixed(2)}ms against a `
+      + `${(speedAnchorBound * 1000).toFixed(2)}ms output-grid bound`);
+
+    const beforeTail = await selectedTiming();
+    await dragSelected('tail', -bed.width * 0.025);
+    const afterTail = await selectedTiming();
+    check(afterTail.end < beforeTail.end - 0.1 && afterTail.length < beforeTail.length - 0.1,
+      'dragging the tail earlier moves the out-point and shortens the clip',
+      `end ${beforeTail.end.toFixed(3)}s -> ${afterTail.end.toFixed(3)}s, length `
+        + `${beforeTail.length.toFixed(3)}s -> ${afterTail.length.toFixed(3)}s`);
+    check(near(afterTail.start, beforeTail.start, 1e-9)
+      && near(afterTail.sourceStart, beforeTail.sourceStart, 1e-9)
+      && near(afterTail.speed, beforeTail.speed, 1e-9),
+    'and the tail leaves the project in-point, source in-point and speed alone',
+    `start ${beforeTail.start.toFixed(4)}s -> ${afterTail.start.toFixed(4)}s, source `
+      + `${beforeTail.sourceStart.toFixed(4)}s -> ${afterTail.sourceStart.toFixed(4)}s, speed `
+      + `${beforeTail.speed}x -> ${afterTail.speed}x`);
+
+    const beforeBody = await selectedTiming();
+    await dragSelected('body', bed.width * 0.03);
+    const afterBody = await selectedTiming();
+    const bodyStartMove = afterBody.start - beforeBody.start;
+    const bodyEndMove = afterBody.end - beforeBody.end;
+    check(bodyStartMove > 0.1 && near(bodyStartMove, bodyEndMove, 1e-6),
+      'dragging the clip body moves both ends by the same project time',
+      `start moved ${bodyStartMove.toFixed(4)}s, end moved ${bodyEndMove.toFixed(4)}s`);
+    check(near(afterBody.length, beforeBody.length, 1e-9)
+      && near(afterBody.sourceStart, beforeBody.sourceStart, 1e-9)
+      && near(afterBody.speed, beforeBody.speed, 1e-9),
+    'and the body leaves its length, source in-point and speed alone',
+    `length ${beforeBody.length.toFixed(4)}s -> ${afterBody.length.toFixed(4)}s, source `
+      + `${beforeBody.sourceStart.toFixed(4)}s -> ${afterBody.sourceStart.toFixed(4)}s, speed `
+      + `${beforeBody.speed}x -> ${afterBody.speed}x`);
+
+    await page.evaluate('__kinect.editor.view.fit()');
+    await settle();
+    const beforeHeadBack = await selectedTiming();
+    await dragSelected('head', 0, bed.x - 20);
+    const afterHeadBack = await selectedTiming();
+    const sourceHead = Math.max(0,
+      beforeHeadBack.start - beforeHeadBack.sourceStart / beforeHeadBack.speed);
+    check(afterHeadBack.sourceStart === 0 && near(afterHeadBack.start, sourceHead, 1e-9)
+      && near(afterHeadBack.end, beforeHeadBack.end, 1e-6),
+    'dragging the head back to the take starts at source zero and still holds the out-point',
+    `start ${beforeHeadBack.start.toFixed(4)}s -> ${afterHeadBack.start.toFixed(4)}s `
+      + `(floor ${sourceHead.toFixed(4)}s), source ${beforeHeadBack.sourceStart.toFixed(4)}s -> `
+      + `${afterHeadBack.sourceStart.toFixed(4)}s, end ${beforeHeadBack.end.toFixed(4)}s -> `
+      + `${afterHeadBack.end.toFixed(4)}s`);
+    check(afterHeadBack.undo === beforeHeadBack.undo + 1,
+      'and that head trim costs one undo step',
+      `depth ${beforeHeadBack.undo} -> ${afterHeadBack.undo}`);
+
+    await page.evaluate('__kinect.keyframes.undo.pop()');
+    await settle();
+    const undoneHeadBack = await selectedTiming();
+    check(undoneHeadBack.undo === beforeHeadBack.undo
+      && ['start', 'end', 'trim', 'length', 'speed', 'sourceStart']
+        .every((name) => near(undoneHeadBack[name], beforeHeadBack[name], 1e-9)),
+    'undo puts the clip timing from before that head trim back as one unit',
+    `depth ${afterHeadBack.undo} -> ${undoneHeadBack.undo}; `
+      + `timing ${JSON.stringify({ start: beforeHeadBack.start, trim: beforeHeadBack.trim,
+        speed: beforeHeadBack.speed, sourceStart: beforeHeadBack.sourceStart })} -> `
+      + JSON.stringify({ start: undoneHeadBack.start, trim: undoneHeadBack.trim,
+        speed: undoneHeadBack.speed, sourceStart: undoneHeadBack.sourceStart }));
 
     // The delete, and the undo of it.
     const before = await read();
@@ -10891,7 +10872,7 @@ try {
       'the edit is as long as its furthest clip reaches, so the window fits the film rather than '
       + 'the first clip', `${framed.duration.toFixed(3)}s against ends ${framed.ends.map((e) => e.toFixed(2)).join(', ')}`);
 
-    console.log('\n[22b] the handles that move a clip, and the half of a preset that is shared');
+    console.log('\n  clip presets keep their scope and provenance');
 
     // Two clips, staged rather than inherited: section 22 above finishes on whatever its undo
     // sequence left, and both arms below are comparisons between two clips.
@@ -10919,10 +10900,12 @@ try {
       const body = k.library.serialiseProjectBody();
       body.clips[0].start = 0;
       body.clips[0].length = 10;
-      body.clips[0].retime = { rate: 1, keys: [] };
+      body.clips[0].speed = 1;
+      body.clips[0].sourceStart = 0;
       body.clips[1].start = 10;
       body.clips[1].length = null;
-      body.clips[1].retime = { rate: 1, keys: [] };
+      body.clips[1].speed = 1;
+      body.clips[1].sourceStart = 0;
       k.library.restoreProject(body);
       k.editor.selectClipRow('gz2');
       const duration = k.timeline.transport().duration;
@@ -11581,6 +11564,21 @@ try {
     // `restoreProject`: the restore door is what undo arrives by and it must keep the selection,
     // so driving that one would report the opposite of what this row claims.
     const PROBE = '__editor-check-selection__';
+    const savedClipTiming = await page.evaluate(`(() => {
+      const k = globalThis.__kinect;
+      const body = k.library.serialiseProjectBody();
+      const clip = body.clips.find((candidate) => candidate.id === 'gz2');
+      clip.start = 4.25;
+      clip.length = 5.75;
+      clip.speed = 1.6;
+      clip.sourceStart = 2.25;
+      k.library.restoreProject(body);
+      k.editor.selectClipRow(clip.id);
+      const staged = k.timeline.clips().find((candidate) => candidate.id === clip.id);
+      return { start: staged.start, trim: staged.trim, length: staged.length,
+        speed: staged.speed, sourceStart: staged.sourceStart };
+    })()`);
+    await settle();
     await page.evaluate(`(async () => {
       const k = globalThis.__kinect;
       const res = await __ecWrite('/projects/${PROBE}', {
@@ -11598,6 +11596,11 @@ try {
       clips: __kinect.timeline.clips().length,
       greyed: __kinect.editor.scopeOff(),
       clipControl: document.getElementById('pointSize').disabled,
+      timing: (() => {
+        const clip = __kinect.timeline.clips().find((candidate) => candidate.id === 'gz2');
+        return { start: clip.start, trim: clip.trim, length: clip.length,
+          speed: clip.speed, sourceStart: clip.sourceStart };
+      })(),
     }))()`);
     console.log(`  a project of ${loaded.clips} clips loaded by name: `
       + `selection ${loaded.selection}, ${loaded.greyed} greyed rows`);
@@ -11605,6 +11608,10 @@ try {
       'the probe project came back with both its clips, so the row below is about a load that '
       + 'happened rather than one that failed',
       `${loaded.clips} clips`);
+    check(['start', 'trim', 'length', 'speed', 'sourceStart']
+      .every((name) => near(loaded.timing[name], savedClipTiming[name], 1e-9)),
+    'and a named save and load preserves the clip placement, trim, speed and source in-point',
+    `${JSON.stringify(savedClipTiming)} -> ${JSON.stringify(loaded.timing)}`);
     check(loaded.selection === null && loaded.greyed > 20 && loaded.clipControl === true,
       'and loading a project selects no clip, because a document does not record which clip was '
       + 'being worked on and picking one would be a guess - which is the case the clip/project '
@@ -11613,6 +11620,9 @@ try {
     // The content type goes on the DELETE: the document routes answer 415 without one, and a
     // swallowed refusal leaves the probe in `projects/` for the next reader to wonder about.
     await writeProjectDoc(PROBE, {
+      method: 'DELETE', headers: { 'Content-Type': 'application/json' },
+    }).catch(() => {});
+    await writeProjectDoc(TRIM_PROBE, {
       method: 'DELETE', headers: { 'Content-Type': 'application/json' },
     }).catch(() => {});
     await page.evaluate(`__kinect.editor.selectClipRow('gz2')`);
@@ -11677,7 +11687,7 @@ try {
           parent: button.parentElement?.className ?? '' };
       })(),
       clipCommands: ['tDeleteClip', 'tMoveClip', 'tRotateClip', 'tKeyClip',
-        'tRate', 'tRateKey', 'tPreset', 'tPresetSave', 'tPresetExport', 'tPresetImport',
+        'tRate', 'tPreset', 'tPresetSave', 'tPresetExport', 'tPresetImport',
         'tMark', 'camSensor', 'cropFit'].map((id) => [id, document.getElementById(id)?.disabled]),
       rateInClipOptions: document.getElementById('tRate').closest('#tClipOptions') !== null,
       clipOptionsDisplay: getComputedStyle(document.getElementById('tClipOptions')).display,

--- a/tools/export-check.mjs
+++ b/tools/export-check.mjs
@@ -937,7 +937,10 @@ async function onFreshPage(what, work, attempts = 3) {
  * goes with the viewport, because the editor is letterboxed to the export aspect.
  */
 async function setStage(page, size) {
-  for (let attempt = 1; attempt <= 4; attempt++) {
+  // The default lane height is a fraction of the viewport this loop is changing, so this is a
+  // fixed-point iteration. Six steps are enough at the current 35%; twelve leaves room for a
+  // taller future strip without turning each intermediate size into a ten-second timeout.
+  for (let attempt = 1; attempt <= 12; attempt++) {
     // Settled before the strip is measured, and the buffer read again after it lands: the lane
     // stack is built after the transport exists, so a strip measured before it has its rows grows
     // under the viewport that was just sized to it. That left the editor reading pixels at one
@@ -956,25 +959,17 @@ async function setStage(page, size) {
       height: size.height + furniture.strip + furniture.shell,
     });
     await page.evaluate(`globalThis.__kinect.setOutputSize?.(${JSON.stringify(`${size.width}x${size.height}`)})`);
-    try {
-      await page.waitForFunction(
-        `(() => {
-          const gl = globalThis.__kinect.renderer.getContext();
-          return gl.drawingBufferWidth === ${size.width} && gl.drawingBufferHeight === ${size.height};
-        })()`,
-        null, { timeout: attempt === 1 ? 5000 : 10000 },
-      );
+    await page.evaluate('new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))');
+    const held = await page.evaluate(`(() => {
+      const gl = globalThis.__kinect.renderer.getContext();
+      return [gl.drawingBufferWidth, gl.drawingBufferHeight];
+    })()`);
+    if (held[0] === size.width && held[1] === size.height) {
       await page.evaluate('globalThis.__kinect.timeline.settled()').catch(() => {});
-      const held = await page.evaluate(`(() => {
-        const gl = globalThis.__kinect.renderer.getContext();
-        return [gl.drawingBufferWidth, gl.drawingBufferHeight];
-      })()`);
-      if (held[0] === size.width && held[1] === size.height) return;
-      if (attempt === 4) {
-        throw new Error(`the stage settled at ${held.join('x')} rather than ${size.width}x${size.height}`);
-      }
-    } catch (err) {
-      if (attempt === 4) throw err;
+      return;
+    }
+    if (attempt === 12) {
+      throw new Error(`the stage settled at ${held.join('x')} rather than ${size.width}x${size.height}`);
     }
   }
 }
@@ -2087,7 +2082,7 @@ console.log('\n[9] an edit is refused while a render runs, and the file is the d
         ['a look value', () => k.params.set('opacity', 0.93)],
         ['an undo', () => k.keyframes.undo.pop()],
         ['a keyframe', () => k.keyframes.toggle('opacity')],
-        ['a retime', () => k.keyframes.setRetime({ rate: 2, keys: [] })],
+        ['a speed change', () => k.keyframes.setSpeed(2)],
         ['a trim', () => k.editor.setClipRange(0.1, 0.4)],
         ['a project load', () => k.library.loadProject('check-guard-doc', JSON.parse(before))],
       ];

--- a/tools/fake-grabber.mjs
+++ b/tools/fake-grabber.mjs
@@ -188,7 +188,7 @@ const hello = Buffer.from(JSON.stringify({
 // A real grabber sees EPIPE when the reader goes away first and it is not an error; unhandled it
 // exits with a stack trace that reads as the grabber having failed.
 process.stdout.on('error', (err) => { if (err.code === 'EPIPE') process.exit(0); });
-// Monotonic and strictly ascending - the index, the retime curve and `mixT` rest on it. Started
+// Monotonic and strictly ascending - the index, clip source-time mapping and `mixT` rest on it. Started
 // from the process clock so two takes in one session do not begin at the same stamp.
 const origin = Math.round(performance.now());
 let n = 0;

--- a/tools/jobs-check.mjs
+++ b/tools/jobs-check.mjs
@@ -431,7 +431,8 @@ const PROJECT = {
     take: { id: 'a-take', hash: HASH_A },
     start: 0,
     length: null,
-    retime: { rate: 1, keys: [] },
+    speed: 1,
+    sourceStart: 0,
     appliedPreset: null,
     params: {
       readRgb: 1,

--- a/tools/keyframe-check.mjs
+++ b/tools/keyframe-check.mjs
@@ -1,6 +1,6 @@
 // Proves the keyframe layer: the three interpolation kinds are the curves the design names,
-// evaluation writes them through the registry, the retime curve maps program time to source time
-// including a hold, and undo restores the document and never the view. Invocations and mutations:
+// evaluation writes them through the registry, clip timing maps program time to source time,
+// and undo restores the document and never the view. Invocations and mutations:
 // docs/proof-tools.md.
 //
 // Every expected value is computed here rather than read back off the page, and each kind carries a
@@ -50,21 +50,25 @@ const MUTATIONS = {
   // starting at zero and clip time and project time were the same number. Section 6h is the only
   // thing in the suite that can see either, because every other arm here parks a clip at zero.
   //
-  // The gesture anchors on the source second at the playhead, read out of a clip-local curve
-  // with a project second: on a clip starting at 10s it anchors ten seconds of source too late.
+  // The gesture anchors on the source second at the playhead without subtracting the clip start.
   'rate-anchor-skips-clip-start': { file: 'web/main.js', edits: [[
     '    source: sourceSecOfProgram(timeline.programSec),',
-    '    source: retime.sourceSecAt(timeline.programSec),',
+    '    source: clipSourceSecAt(selectedClip, timeline.programSec),',
   ]],
-    fails: 'the speed gesture anchoring on the source second read out of a clip-local curve with '
-      + 'a project second. Reddens 1 in 6h: on a clip starting at 10s the anchor is ten '
+    fails: 'the speed gesture anchoring on the source second without subtracting the clip start. '
+      + 'Reddens 1 in 6h: on a clip starting at 10s the anchor is ten '
       + 'seconds of source too late, so the playhead lands at 16s where it should land at 11s',
   },
-  // And the landing runs back the same way, so the playhead is put at a clip second read as a
-  // project one and leaves the clip being edited.
+  // And the landing runs back the same way, so a clip second is read as a project second.
   'rate-landing-skips-clip-start': { file: 'web/main.js', edits: [[
     '  return Math.max(0, Math.min(programSecOfSource(rateGesture.source), timeline.duration));',
-    '  return Math.max(0, Math.min(retime.programSecAt(rateGesture.source), timeline.duration));',
+    `  return Math.max(
+    0,
+    Math.min(
+      clipProgramSecAt(selectedClip, rateGesture.source),
+      timeline.duration,
+    ),
+  );`,
   ]],
     fails: 'and the same conversion run back the other way, so the landing is a clip second read '
       + 'as a project one. Reddens 2 in 6h, and the second is the shape of the bug: the '
@@ -111,21 +115,10 @@ const MUTATIONS = {
       + 'against that one\'s 6, and every route row stays green, because a camera ignoring '
       + 'its handles still travels the same curve at the wrong times',
   },
-  // The pre-roll reads the slope at the target instead of asking how far back the curve
-  // covers the span, so a hold answers "no frames needed".
-  'preroll-slope-at-target': { file: 'web/main.js', edits: [[
-    '      const back = clip.surfaceFramesBack(programSec, surfaceSec, this.outputFps, this.lastFrame);',
-    `    // Step 4's two lines restored verbatim, zero-slope branch and all: the slope
-    // at a point times a frame count, and a hold answering "no frames needed" for
-    // the case that needs the most. The window query goes unused, which is the
-    // shape of the finding - a tangent has no window to ask about.
-      const sourcePerFrame = Math.abs(clip.retime.slopeAt(programSec - clip.start)) / this.outputFps;
-      const back = { frames: sourcePerFrame > 0 ? Math.ceil(surfaceSec / sourcePerFrame) : 0, covered: true };`,
-  ]] },
-  // The retime stops being a curve and goes back to a constant slope.
-  'retime-ignores-keys': { file: 'web/main.js', edits: [[
-    '  sourceSecAt(programSec) { return retimeSourceSecAt(this, programSec); },',
-    '  sourceSecAt(programSec) { return programSec * this.rate; },',
+  // The in-point drops out of the mapping, so a trimmed clip reads the take from its head.
+  'source-start-ignored': { file: 'web/clip-plan.js', edits: [[
+    '  return sourceStart + localSec * speed;',
+    '  return localSec * speed;',
   ]] },
   // The evaluator announces its writes, so every evaluated frame schedules a seek.
   // Everything a clip owns read and written at program time rather than on the clip's own clock,
@@ -220,7 +213,7 @@ const MUTATIONS = {
           this.overtaken = 0;
           throw new Error(
             \`\${SEEK_OVERTAKEN_LIMIT} seeks in a row were overtaken before they could land: \`
-            + 'the span a seek plans is not becoming resident, which is not a moving curve',
+            + 'the span a seek plans is not becoming resident, which is not a moving clip',
           );
         }
         requestRepaint();
@@ -263,32 +256,6 @@ const MUTATIONS = {
   slerpB.fromArray(b.value.quaternion);
   slerpA.slerp(slerpB, u);`,
     '  slerpA.fromArray(a.value.quaternion);',
-  ]] },
-  // The retime's editing doors stop holding a key inside its neighbours.
-  'retime-unclamped': { file: 'web/main.js', edits: [
-    [`  const floor = i > 0 ? keys[i - 1].value : 0;
-  const ceiling = i < keys.length - 1 ? keys[i + 1].value : timeline.clip.source.duration;
-  key.value = Math.max(floor, Math.min(ceiling, key.value));`,
-      '  key.value = Math.max(0, Math.min(timeline.clip.source.duration, key.value));'],
-    ['      if (keys[i].value < keys[i - 1].value) {', '      if (false) {'],
-  ] },
-  // The handle half of the retime guard goes and the key-value half stays: two claims.
-  'retime-handle-unchecked': { file: 'web/main.js', edits: [[
-    '        if (!h[0].every((c) => c >= 0 && c <= 1)) {',
-    '        if (false) {',
-  ]] },
-  // The animation loop stops catching, so the pair source's refusal escapes it.
-  'tick-uncaught': { file: 'web/main.js', edits: [[
-    `    try {
-      this.tickNow(nowMs);
-    } catch (err) {`,
-    `    if (true) {
-      this.tickNow(nowMs);
-      return;
-    }
-    try {
-      this.tickNow(nowMs);
-    } catch (err) {`,
   ]] },
   // The furniture goes back inside the frame, where it broke step 4.
   'chrome-in-frame': { file: 'web/main.js', edits: [[
@@ -568,34 +535,6 @@ function uniformCatmull(points, s) {
     + (-p0[d] + 3 * p1[d] - 3 * p2[d] + p3[d]) * u * u * u));
 }
 
-/** Program to source, the way the page's curve does it: linear outside the keys. */
-const retimeAt = (curve, t) => (curve.keys.length === 0
-  ? t * curve.rate
-  : (curve.keys.length === 1
-    ? curve.keys[0].value + (t - curve.keys[0].t) * curve.rate
-    : scalarAt(curve.keys, t, true)));
-
-/**
- * How many output frames back the curve reaches to cover `span` source seconds ending at `t`. This
- * tool's own walk over its own curve, which the page's number is compared to.
- */
-function framesBack(curve, t, span, fps, ceiling) {
-  if (!(span > 0)) return 0;
-  const at = retimeAt(curve, t);
-  for (let n = 1; n <= ceiling; n++) {
-    if (at - retimeAt(curve, t - n / fps) >= span - 1e-9) return n;
-  }
-  return ceiling;
-}
-
-/** What the arithmetic this replaced would have said: the tangent at the target. */
-function framesBackByTangent(curve, t, span, fps) {
-  const h = 1e-6;
-  const slope = Math.abs((retimeAt(curve, t + h) - retimeAt(curve, t - h)) / (2 * h));
-  const perFrame = slope / fps;
-  return perFrame > 0 ? Math.ceil(span / perFrame) : 0;
-}
-
 const index = await (await fetch(`${URL_BASE}/capture/${TAKE}/index`)).json();
 const stamps = index.frames.stampMs;
 const TIMES = stamps.map((s) => (s - stamps[0]) / 1000);
@@ -619,37 +558,6 @@ const check = (ok, label, detail = '') => {
 };
 const show = (d) => `max ${d.max}/255, mean ${d.mean.toFixed(4)}, ${d.pct.toFixed(3)}% of pixels differ`;
 const worst = (xs) => xs.reduce((a, b) => Math.max(a, b), 0);
-
-// Both sized against the take's real duration rather than a round number. The ramp runs slow then
-// fast, so the pre-roll question has a different answer at either end.
-const RAMP = {
-  rate: 1,
-  keys: [
-    { t: 0, value: 0 },
-    { t: 6, value: 3 },
-    { t: 10, value: 15 },
-  ],
-};
-// A four-second freeze: source time stops, so a pre-roll here reaches back through it.
-const HOLD = {
-  rate: 1,
-  keys: [
-    { t: 0, value: 0 },
-    { t: 4, value: 8 },
-    { t: 7, value: 8 },
-    { t: 11, value: 16 },
-  ],
-};
-// Drawn with ease handles, so the slope changes everywhere - the case where a tangent at
-// the target is furthest off.
-const EASED_RAMP = {
-  rate: 1,
-  keys: [
-    { t: 0, value: 0, easeOut: [[0.85, 0.05]], easeIn: LIN_IN },
-    { t: 10, value: 20, easeOut: LIN_OUT, easeIn: [[0.15, 0.95]] },
-  ],
-};
-const FLAT = { rate: 1, keys: [] };
 
 const INSTALL = `(() => {
   const k = globalThis.__kinect;
@@ -736,10 +644,6 @@ console.log = (...parts) => {
 };
 const note = (text) => errors.push(`${section} | ${String(text).split('\n')[0]}`);
 
-// Each has to actually arrive: a fragment that matched nothing means the section stopped
-// provoking what it was written to provoke.
-const expected = [];
-const expectError = (fragment, why) => expected.push({ fragment, why, seen: false });
 page.on('pageerror', (err) => note(err));
 page.on('console', (msg) => { if (msg.type() === 'error') note(msg.text()); });
 page.on('response', (res) => { if (!res.ok()) note(`${res.status()} ${res.url()}`); });
@@ -850,11 +754,8 @@ console.log(`[keyframe] stage ${gpu.buffer.join('x')}, take ${TAKE}: ${TIMES.len
 
 /**
  * How much footage this file's rows need, and the refusal when the take is shorter. A short take
- * goes wrong two ways and one is silent: section 4e clamps and reddens, while 4f and 6d carry
- * retime keys at source 12, 20 and 15, so a curve reaching the end of the footage early takes the
- * dragged key off the ruler and two more rows pass because a key never dragged never slid under its
- * neighbour. The scan holds this number against the deepest second the file's own text seeks to; it
- * cannot see the retime values above.
+ * must be long enough for the deepest source and program positions exercised below. The scan holds
+ * this number against the deepest second the file's own text seeks to.
  */
 const NEEDS_TAKE_SEC = 24;
 const ownSource = readFileSync(fileURLToPath(import.meta.url), 'utf8');
@@ -866,9 +767,8 @@ if (deepestSeek > NEEDS_TAKE_SEC) {
 }
 if (!(SOURCE_DURATION >= NEEDS_TAKE_SEC)) {
   console.log(`\n[keyframe] DID NOT RUN - the take "${TAKE}" holds ${SOURCE_DURATION.toFixed(2)}s of source and `
-    + `these rows need ${NEEDS_TAKE_SEC}s: they seek to ${deepestSeek}s and retime through source 20s. `
-    + 'Under a shorter take the program collapses, the dragged key leaves the ruler and the gesture never '
-    + 'happens - four rows redden and two pass against nothing. Point --take at a longer capture '
+    + `these rows need ${NEEDS_TAKE_SEC}s: they seek to ${deepestSeek}s and exercise a trimmed in-point. `
+    + 'Under a shorter take the program clamps before the positions being tested. Point --take at a longer capture '
     + '(tools/make-fixture.js loops a short one).');
   process.exit(2);
 }
@@ -887,7 +787,11 @@ process.on('uncaughtException', lost);
 const settle = () => page.evaluate('globalThis.__kinect.timeline.settled()');
 const diff = (a, b) => page.evaluate(`globalThis.__kf.diff(${src(a)}, ${src(b)})`);
 const setTracks = (spec) => page.evaluate(`globalThis.__kinect.keyframes.setTracks(${src(spec)})`);
-const setRetime = (curve) => page.evaluate(`globalThis.__kinect.keyframes.setRetime(${src(curve)})`);
+const setTiming = (speed = 1, sourceStart = 0) => page.evaluate(`(() => {
+  const k = globalThis.__kinect;
+  k.keyframes.setSourceStart(${src(sourceStart)});
+  k.keyframes.setSpeed(${src(speed)});
+})()`);
 const specOf = (name) => page.evaluate(`globalThis.__kinect.params.spec(${src(name)})`);
 
 /**
@@ -936,7 +840,7 @@ const RGB_LOOK = shippedDoc('rgb').values;
 // later somewhere else.
 console.log('\n== 0. an evaluated frame schedules no work of its own ==');
 {
-  await setRetime(FLAT);
+  await setTiming();
   await setTracks({ bloom: [{ t: 0, value: 0.5 }, { t: 4, value: 0.9 }] });
   // On a budget, because that failure returns no answer at all: the settle helper waits on
   // a queue growing faster than it drains. A healthy build answers in under a second.
@@ -1232,7 +1136,7 @@ console.log('\n== 1c. the camera\'s handles shape when it arrives, not where it 
 
 console.log('\n== 2. evaluation at a program position writes what the tracks say ==');
 {
-  await setRetime(FLAT);
+  await setTiming();
   await setTracks({ bloom: EASED, additive: STEPS, camera: PATH });
   await settle();
 
@@ -1377,7 +1281,7 @@ const arm = (label, kind, targetSec, frames = null) => page.evaluate(`(async () 
 })()`);
 
 {
-  await setRetime(FLAT);
+  await setTiming();
   await setTracks(LOOK_TRACKS);
   await settle();
 
@@ -1440,7 +1344,7 @@ console.log('\n== 3b. a seek that jumps from a cheap look to an expensive one ==
     trails: [{ t: 0, value: 0 }, { t: 8, value: 0.9 }],
     wake: [{ t: 0, value: 0 }, { t: 8, value: 1500 }],
   };
-  await setRetime(FLAT);
+  await setTiming();
   await setTracks(COLD);
   await applyLook(BLACKWALL_LOOK);
   await settle();
@@ -1497,7 +1401,7 @@ console.log('\n== 3b. a seek that jumps from a cheap look to an expensive one ==
 // damp is constant.
 console.log('\n== 3c. a pre-roll whose window is dearer than its target ==');
 {
-  await setRetime(FLAT);
+  await setTiming();
   await applyLook(RGB_LOOK);
   // Fade and wake at zero and unkeyed, so the surface half cannot mask the trails half.
   await page.evaluate(`globalThis.__kinect.params.apply(${src({ fade: 0, wake: 0 })})`);
@@ -1559,283 +1463,106 @@ console.log('\n== 3c. a pre-roll whose window is dearer than its target ==');
 }
 
 
-console.log('\n== 4. program time maps to source time through the curve ==');
+console.log('\n== 4. clip speed and in-point map program time to source time ==');
 {
-  for (const [label, curve] of [['ramp', RAMP], ['hold', HOLD]]) {
-    await setRetime(curve);
-    await setTracks({});
-    await settle();
-
-    const probes = [];
-    for (let i = 0; i <= 24; i++) probes.push((i / 24) * 11);
-    const read = await page.evaluate(`(() => {
-      const r = globalThis.__kinect.timeline.retime;
-      const t = globalThis.__kinect.timeline.transport();
-      return {
-        source: ${src(probes)}.map((p) => r.sourceSecAt(p)),
-        // Which capture frame the transport would bracket, so the mapping is
-        // checked all the way down to the index rather than only as arithmetic.
-        bracket: ${src(probes)}.map((p) => t.clip.sourceFrameAt(p)),
-        duration: t.duration,
-      };
-    })()`);
-
-    const wantSource = probes.map((p) => retimeAt(curve, p));
-    const sourceErr = worst(read.source.map((v, i) => Math.abs(v - wantSource[i])));
-    const wantBracket = read.source.map((s) => bracketOf(s));
-    const bracketBad = read.bracket.filter((b, i) => b !== wantBracket[i]).length;
-    // The program length is where the curve first reaches the end of the take, by bisection.
-    let lo = 0;
-    let hi = 200;
-    for (let i = 0; i < 60; i++) {
-      const mid = (lo + hi) / 2;
-      if (retimeAt(curve, mid) < SOURCE_DURATION) lo = mid;
-      else hi = mid;
-    }
-    console.log(`  ${label}: worst source error ${sourceErr.toExponential(1)}s over 25 positions; `
-      + `duration ${read.duration.toFixed(4)}s against ${hi.toFixed(4)}s computed here`);
-    check(sourceErr < 1e-6, `${label}: the curve maps program time to the source times it should`,
-      `worst ${sourceErr.toExponential(2)}s`);
-    check(bracketBad === 0, `${label}: and the transport brackets the capture frames the index names`,
-      `${bracketBad} of ${probes.length} wrong`);
-    check(Math.abs(read.duration - hi) < 1e-3,
-      `${label}: and the program runs until the curve reaches the end of the take`,
-      `${read.duration.toFixed(4)}s against ${hi.toFixed(4)}s`);
-  }
-
-  // The control: the flat curve has to give different answers, or the three above
-  // would pass on a page that ignored its keys entirely.
-  await setRetime(FLAT);
-  const flat = await page.evaluate('[5, 8, 10].map((p) => globalThis.__kinect.timeline.retime.sourceSecAt(p))');
-  const ramped = [5, 8, 10].map((p) => retimeAt(RAMP, p));
-  const gap = worst(flat.map((v, i) => Math.abs(v - ramped[i])));
-  console.log(`  a curve-free retime at the same positions is ${gap.toFixed(2)}s away from the ramp`);
-  check(gap > 1, 'and a page ignoring its keys would land somewhere else entirely', `${gap.toFixed(2)}s apart`);
-}
-
-
-console.log('\n== 4b. a hold freezes source time, and the image with it ==');
-{
-  await setRetime(HOLD);
-  await setTracks({});
-  // Every term that reads program time turned off - scan, grain, scanlines, RGB split and glitch
-  // all take `uniforms.time`, which keeps running under a freeze. Persistence stays on.
-  await applyLook(BLACKWALL_LOOK);
-  const TIME_FREE = { 'blackwall.scan': 0, 'grain.amount': 0, 'raster.amount': 0, 'rgbsplit.amount': 0, 'glitch.amount': 0, 'noise.amount': 0, trails: 0 };
-  await page.evaluate(`globalThis.__kinect.params.apply(${src(TIME_FREE)})`);
-  await settle();
-
-  const inside = [4.6, 5.4, 6.2, 6.9];
-  const read = await page.evaluate(`(async () => {
-    const k = globalThis.__kinect;
-    const kf = globalThis.__kf;
-    const t = k.timeline.transport();
-    const out = [];
-    for (const [i, p] of ${src(inside)}.entries()) {
-      const before = kf.counters();
-      await t.seek(p);
-      const pixels = kf.grab('hold-' + i);
-      out.push({
-        p,
-        source: k.timeline.retime.sourceSecAt(p),
-        frame: t.clip.sourceFrameAt(p),
-        advances: kf.since(before).stateAdvances,
-        hash: await kf.sha(pixels),
-      });
-    }
-    return out;
-  })()`);
-
-  const sourceSpread = worst(read.map((r) => Math.abs(r.source - read[0].source)));
-  console.log(`  four positions across the freeze (${inside.join('s, ')}s) all map to source `
-    + `${read[0].source.toFixed(4)}s, capture frame ${read[0].frame}; spread ${sourceSpread.toExponential(1)}s`);
-  check(sourceSpread < 1e-9, 'source time does not advance through a hold', `${sourceSpread.toExponential(2)}s`);
-  check(new Set(read.map((r) => r.frame)).size === 1,
-    'so the same capture frame is under the playhead throughout', `${new Set(read.map((r) => r.frame)).size} frames`);
-
-  const advances = read.map((r) => r.advances);
-  console.log(`  the surface memory advanced ${advances.join(', ')} times across the four seeks`);
-  const holdDiffs = [];
-  for (let i = 1; i < inside.length; i++) holdDiffs.push(await diff('hold-0', `hold-${i}`));
-  console.log(`  and the image at each: ${holdDiffs.map(show).join(' | ')}`);
-  check(holdDiffs.every((d) => d.max <= SAME_MAX),
-    'and a seek to any of them lands on the same image', holdDiffs.map((d) => d.max).join(', '));
-
-  // The control: a position outside the hold has to differ, or "the same image"
-  // above would be a statement about a renderer that had stopped working.
-  await page.evaluate(`(async () => {
-    const k = globalThis.__kinect;
-    await k.timeline.transport().seek(9.5);
-    globalThis.__kf.grab('after-hold');
-    return true;
-  })()`);
-  const past = await diff('hold-0', 'after-hold');
-  console.log(`  a position past the freeze, at 9.5s: ${show(past)}`);
-  check(past.max >= CONTROL_MIN && past.pct >= CONTROL_MIN_PCT,
-    'while a position past it is a different image, so this can tell them apart', show(past));
-
-  // A hold freezes the footage by holding source time still, and everything the look drives
-  // off program time carries on.
-  await page.evaluate(`(async () => {
-    const k = globalThis.__kinect;
-    const kf = globalThis.__kf;
-    const t = k.timeline.transport();
-    k.params.apply({ 'blackwall.scan': 0.35, 'grain.amount': 0.22, 'raster.amount': 0.35 });
-    await k.timeline.settled();
-    for (const [i, p] of ${src(inside)}.entries()) {
-      await t.seek(p);
-      kf.grab('lively-' + i);
-    }
-    return true;
-  })()`);
-  const lively = await diff('lively-0', 'lively-3');
-  console.log(`  with the scan sweep and grain back on, the same two positions: ${show(lively)}`);
-  check(lively.max >= CONTROL_MIN,
-    'and program time keeps running under the freeze, which is what makes it the coordinate',
-    show(lively));
-}
-
-
-console.log('\n== 4c. the pre-roll asks how far back the curve covers a source span ==');
-{
-  // Placed where the answer is interesting: inside one straight segment the tangent is the
-  // curve, so the discriminating positions reach back across a change of slope.
-  const CASES = [
-    { label: 'ramp, slow side', curve: RAMP, at: 4.0 },
-    { label: 'ramp, fast side', curve: RAMP, at: 9.0 },
-    { label: 'ramp, just past a knee', curve: RAMP, at: 6.1 },
-    { label: 'S-curve, early', curve: EASED_RAMP, at: 2.0 },
-    { label: 'S-curve, late', curve: EASED_RAMP, at: 8.5 },
-    { label: 'hold, before it', curve: HOLD, at: 3.0 },
-    { label: 'hold, inside it', curve: HOLD, at: 6.0 },
-    { label: 'hold, just past it', curve: HOLD, at: 7.5 },
+  const cases = [
+    { label: 'half speed from source 4s', speed: 0.5, sourceStart: 4, probes: [0.5, 3, 7] },
+    { label: 'double speed from source 3s', speed: 2, sourceStart: 3, probes: [0.5, 2, 6] },
   ];
-  console.log('  method: Blackwall at fade 120 + wake 550 = 0.670s of source persistence, 30 fps out.');
-  console.log('  configuration            window  tangent   source span the window covers');
-  const rows = [];
-  for (const c of CASES) {
-    await setRetime(c.curve);
-    await applyLook(BLACKWALL_LOOK);
-    await settle();
-    const got = await page.evaluate(`(() => {
-      const k = globalThis.__kinect;
-      const t = k.timeline.transport();
-      return {
-        plan: t.preroll(${src(c.at)}),
-        span: k.uniforms.fadeTime.value + k.uniforms.wakeTime.value,
-        fps: t.outputFps,
-        lastFrame: t.lastFrame,
-      };
-    })()`);
-    const want = framesBack(c.curve, c.at, got.span, got.fps, got.lastFrame);
-    const tangent = framesBackByTangent(c.curve, c.at, got.span, got.fps);
-    const covers = retimeAt(c.curve, c.at) - retimeAt(c.curve, c.at - got.plan.surface / got.fps);
-    rows.push({ ...c, got, want, tangent, covers });
-    console.log(`  ${c.label.padEnd(22)} ${String(got.plan.surface).padStart(6)} `
-      + `${String(tangent).padStart(8)}   ${covers.toFixed(4)}s of ${got.span.toFixed(3)}s`);
-  }
-  for (const r of rows) {
-    check(r.got.plan.surface === r.want,
-      `${r.label}: the window query counts the frames this tool counts`,
-      `${r.got.plan.surface} against ${r.want}`);
-  }
-  for (const r of rows) {
-    check(r.covers >= r.got.span - 1e-6,
-      `${r.label}: and the frames it counted really do cover fade plus wake`,
-      `${r.covers.toFixed(4)}s of ${r.got.span.toFixed(3)}s`);
-  }
-  // On a constant slope the two agree; inside a hold the tangent answers "no frames".
-  const differing = rows.filter((r) => r.tangent !== r.want).length;
-  const holdRow = rows.find((r) => r.label === 'hold, inside it');
-  console.log(`  ${differing} of ${rows.length} configurations disagree with the tangent arithmetic; `
-    + `inside the hold it asks for ${holdRow.tangent} frames against ${holdRow.want}`);
-  check(differing >= 3, 'and the tangent arithmetic would have given different answers',
-    `${differing} of ${rows.length} differ`);
-  check(holdRow.tangent === 0 && holdRow.want > 0,
-    'including a hold, where a slope of zero covers no source span at all whatever it is multiplied by',
-    `tangent ${holdRow.tangent}, window ${holdRow.want}`);
-}
-
-
-console.log('\n== 4d. a seek across a ramp and across a hold reproduces its playback ==');
-{
-  // Just past the knee, so the pre-roll window reaches back across a change of slope.
-  for (const [label, curve, target] of [['ramp', RAMP, 6.1], ['hold', HOLD, 6.0]]) {
-    await setRetime(curve);
-    await setTracks(LOOK_TRACKS);
-    await applyLook(BLACKWALL_LOOK);
-    await settle();
-
-    const played = await arm(`${label}-played`, 'playback', target);
-    const seeked = await arm(`${label}-seeked`, 'seek', target);
-    // The control is the pre-roll the tangent arithmetic would have asked for, not zero.
-    const span = await page.evaluate(
-      'globalThis.__kinect.uniforms.fadeTime.value + globalThis.__kinect.uniforms.wakeTime.value',
-    );
-    const tangent = framesBackByTangent(curve, target, span, seeked.state.outputFps);
-    const old = await arm(`${label}-tangent`, 'seek', target, tangent);
-
-    const same = await diff(`${label}-played`, `${label}-seeked`);
-    const apart = await diff(`${label}-played`, `${label}-tangent`);
-    console.log(`  ${label} at ${target}s: pre-roll ${seeked.seek.plan.frames} frames `
-      + `(surface ${seeked.seek.plan.surface}, trails ${seeked.seek.plan.trails}), playback rendered `
-      + `${played.delta.renders}`);
-    console.log(`    seek vs playback        ${show(same)}`);
-    console.log(`    tangent-sized (${String(tangent).padStart(3)}) vs it  ${show(apart)}`);
-    check(same.max <= SAME_MAX, `${label}: the computed pre-roll reproduces the playback`, show(same));
-    if (label === 'hold') {
-      check(apart.max >= CONTROL_MIN,
-        `${label}: and the tangent-sized pre-roll does not, which is the finding this replaces`,
-        show(apart));
-    }
-  }
-}
-
-
-// A seek plans which source frames it needs, awaits them, and renders; the curve can move inside
-// that await, and then the render walks the source backwards and the pair source refuses. The first
-// arm moves `rate` alone, which is step 4's own path, and `ensure` is wrapped so the curve changes
-// exactly as the fetch resolves.
-console.log('\n== 4e. the retime curve moving while a seek is fetching ==');
-{
-  await setTracks({});
-  await applyLook(BLACKWALL_LOOK);
-  // Drained first: rewriting the curve while a mode's own seek is fetching is contention
-  // the check manufactured, and what fails is an operation nobody is testing.
-  await settle();
-
-  // From one keyed curve to another rather than from no keys to keys: a lane appearing
-  // mid-seek resizes the stage, and two images of different sizes cannot be compared.
-  for (const [label, before, after] of [
-    ['rate, the step 4 path', { rate: 1, keys: [] }, { rate: 0.25, keys: [] }],
-    ['keys, the step 5 path', RAMP, HOLD],
-  ]) {
-    await setRetime(before);
+  const mapped = [];
+  for (const c of cases) {
+    await setTiming(c.speed, c.sourceStart);
+    await setTracks({});
     await settle();
     const got = await page.evaluate(`(async () => {
       const k = globalThis.__kinect;
-      const kf = globalThis.__kf;
+      const t = k.timeline.transport();
+      const positions = [];
+      for (const p of ${src(c.probes)}) {
+        await t.seek(p);
+        positions.push({
+          programSec: t.programSec,
+          sourceSec: k.timeline.read().sourceSec,
+          bracket: t.clip.sourceFrameAt(p),
+        });
+      }
+      const clip = k.timeline.clips()[0];
+      return {
+        positions,
+        duration: t.duration,
+        speed: clip.speed,
+        sourceStart: clip.sourceStart,
+      };
+    })()`);
+    const wantSource = c.probes.map((p) => c.sourceStart + p * c.speed);
+    const sourceError = worst(got.positions.map((p, i) => Math.abs(p.sourceSec - wantSource[i])));
+    const wrongBrackets = got.positions.filter(
+      (p, i) => p.bracket !== bracketOf(wantSource[i]),
+    ).length;
+    const wantDuration = Math.max(0, (SOURCE_DURATION - c.sourceStart) / c.speed);
+    mapped.push({ ...c, got, wantSource });
+
+    console.log(`  ${c.label}: source ${got.positions.map((p) => p.sourceSec.toFixed(3)).join(', ')}; `
+      + `duration ${got.duration.toFixed(4)}s against ${wantDuration.toFixed(4)}s`);
+    check(got.speed === c.speed && got.sourceStart === c.sourceStart,
+      `${c.label}: the clip holds the timing this arm asked for`,
+      `${got.sourceStart}s at ${got.speed}x`);
+    check(sourceError < 1e-6,
+      `${c.label}: program positions map through the clip's speed and in-point`,
+      `worst ${sourceError.toExponential(2)}s`);
+    check(wrongBrackets === 0,
+      `${c.label}: and the transport brackets the capture frames the index names`,
+      `${wrongBrackets} of ${c.probes.length} wrong`);
+    check(Math.abs(got.duration - wantDuration) < 1e-3,
+      `${c.label}: and the program runs for the footage left after the in-point at that speed`,
+      `${got.duration.toFixed(4)}s against ${wantDuration.toFixed(4)}s`);
+  }
+
+  const firstAtThree = mapped[0].wantSource[1];
+  const secondAtTwo = mapped[1].wantSource[1];
+  check(Math.abs(firstAtThree - secondAtTwo) > 0.5,
+    'the two timing arms map their middle probes to different footage, so identity timing cannot satisfy both',
+    `${firstAtThree.toFixed(3)}s against ${secondAtTwo.toFixed(3)}s`);
+}
+
+
+console.log('\n== 4e. clip timing moving while a seek is fetching ==');
+{
+  await setTracks({});
+  await applyLook(BLACKWALL_LOOK);
+  await settle();
+
+  const cases = [
+    {
+      label: 'speed',
+      before: { speed: 1, sourceStart: 3 },
+      after: { speed: 0.25, sourceStart: 3 },
+    },
+    {
+      label: 'in-point',
+      before: { speed: 1, sourceStart: 3 },
+      after: { speed: 1, sourceStart: 8 },
+    },
+  ];
+
+  for (const c of cases) {
+    await setTiming(c.before.speed, c.before.sourceStart);
+    await settle();
+    const got = await page.evaluate(`(async () => {
+      const k = globalThis.__kinect;
       const t = k.timeline.transport();
       const source = t.clip.source;
-      // Emptied first, or there is nothing to await and the window this is about
-      // never opens. The first run of this check counted zero interruptions and
-      // reported two failures against a seek that never fetched anything at all.
       source.cache.clear();
       const real = source.ensure.bind(source);
       let hits = 0;
-      // Armed only around the seek under test. Without the flag the rewrite lands
-      // in whatever operation happens to be fetching - a repaint queued behind a
-      // mode click, in the run that found this - and what fails is that operation
-      // rather than the claim, which is a check measuring its own interference.
       let armed = false;
-      source.ensure = (a, b) => real(a, b).then((r) => {
-        // Once, as the first fetch resolves. Rewriting it on every fetch would
-        // never converge, and this is testing a curve that moved rather than a
-        // curve that will not stop moving - the bound covers that separately.
-        if (armed && hits++ === 0) k.keyframes.setRetime(${src(after)});
-        return r;
+      source.ensure = (a, b) => real(a, b).then((result) => {
+        if (armed && hits++ === 0) {
+          if (${src(c.label)} === 'speed') k.keyframes.setSpeed(${src(c.after.speed)});
+          else k.keyframes.setSourceStart(${src(c.after.sourceStart)});
+        }
+        return result;
       });
-      await k.timeline.settled();
       let threw = null;
       let landed = null;
       try {
@@ -1845,227 +1572,58 @@ console.log('\n== 4e. the retime curve moving while a seek is fetching ==');
         threw = String(err.message ?? err);
       } finally {
         armed = false;
+        source.ensure = real;
       }
-      // Read here, before anything is allowed to settle. A stand-down asks for a
-      // repaint, and a repaint that lands resets this counter - so reading it after
-      // a settle reports zero for a seek that never landed at all. That is what the
-      // first version of this section did, and it passed.
       const overtaken = t.overtaken;
-      const at = t.programSec;
-      const sourceAt = k.timeline.retime.sourceSecAt(at);
-      source.ensure = real;
-      // Settled before reading, because an overtaken seek stands down quietly and
-      // leaves the landing to the repaint it queued. The claim is that the playhead
-      // ends up where the winning curve puts it, not that one particular call did
-      // the rendering.
       await k.timeline.settled();
+      const read = k.timeline.read();
+      const clip = k.timeline.clips()[0];
       return {
-        threw, hits, overtaken, at, sourceAt, landed: landed !== null,
-        rate: k.timeline.retime.rate,
-        keys: k.timeline.retime.keys.length,
+        threw,
+        hits,
+        overtaken,
+        landed: landed !== null,
+        at: read.programSec,
+        sourceAt: read.sourceSec,
+        speed: read.speed,
+        sourceStart: read.sourceStart,
+        start: clip.start,
       };
     })()`);
-    // As a position rather than as pixels: the two operations reach the same place through
-    // different amounts of queued work, so a pixel equality moved between runs.
-    const wantSource = retimeAt(after, got.at);
+
+    const wantSource = c.after.sourceStart + (got.at - got.start) * c.after.speed;
     const drift = Math.abs(got.sourceAt - wantSource);
-    console.log(`  ${label}: the curve was rewritten on fetch ${got.hits > 0 ? 'yes' : 'NO'}, `
+    console.log(`  ${c.label}: timing changed on fetch ${got.hits > 0 ? 'yes' : 'NO'}, `
       + `seek ${got.threw ? `threw: ${got.threw}` : (got.landed ? 'landed' : 'STOOD DOWN')} `
-      + `with ${got.overtaken} stand-downs; playhead at program ${got.at.toFixed(3)}s -> source `
-      + `${got.sourceAt.toFixed(4)}s against ${wantSource.toFixed(4)}s computed here`);
-    check(got.hits > 0, `${label}: the fetch really was interrupted, so this tested something`,
+      + `with ${got.overtaken} stand-downs; ${got.sourceStart}s at ${got.speed}x maps `
+      + `${got.at.toFixed(3)}s to source ${got.sourceAt.toFixed(4)}s`);
+
+    check(got.hits > 0,
+      `${c.label}: the fetch really was interrupted, so this tested something`,
       `${got.hits} interruptions`);
-    check(got.threw === null, `${label}: the seek re-planned around it instead of refusing`,
+    check(got.speed === c.after.speed && got.sourceStart === c.after.sourceStart,
+      `${c.label}: the timing change really landed during the fetch`,
+      `${got.sourceStart}s at ${got.speed}x`);
+    check(got.threw === null,
+      `${c.label}: the seek re-planned around it instead of refusing`,
       got.threw ?? '');
-    // The load-bearing one: a stand-down asks for a repaint that arrives at the same place a
-    // moment later, so every downstream reading looks right while nothing under test ran.
     check(got.landed === true && got.overtaken === 0,
-      `${label}: and the seek itself landed rather than standing down for a repaint`,
+      `${c.label}: and the seek itself landed rather than standing down for a repaint`,
       `landed ${got.landed}, ${got.overtaken} stand-downs`);
     check(Math.abs(got.at - 12.0) < 1e-6,
-      `${label}: at the program position it was asked for`, `${got.at.toFixed(4)}s of 12s`);
+      `${c.label}: at the program position it was asked for`,
+      `${got.at.toFixed(4)}s of 12s`);
     check(drift < 1e-6,
-      `${label}: reading the source time the winning curve maps it to`,
+      `${c.label}: reading the source time the winning timing maps it to`,
       `${drift.toExponential(2)}s adrift`);
   }
-  await setRetime(FLAT);
-}
-
-
-// Both accumulators advance one source frame at a time, so a descending segment asks the pair
-// source to go backwards and it refuses - and that refusal used to arrive from inside the animation
-// loop, which three then stops driving.
-console.log('\n== 4f. a retime curve that runs downhill ==');
-{
-  await setTracks({});
-  await setRetime({ rate: 1, keys: [{ t: 0, value: 0 }, { t: 8, value: 12 }, { t: 14, value: 20 }] });
-  await settle();
-
-  // (a) the programmatic door - a project file is a door too.
-  const refused = await page.evaluate(`(() => {
-    try {
-      globalThis.__kinect.keyframes.setRetime({ rate: 1, keys: [
-        { t: 0, value: 0 }, { t: 5, value: 12 }, { t: 9, value: 4 } ] });
-      return null;
-    } catch (err) { return String(err.message ?? err); }
-  })()`);
-  console.log(`  a falling curve through setRetime: ${refused ? 'refused' : 'ACCEPTED'}`);
-  check(refused !== null, 'a curve that falls is refused rather than stored', refused ?? 'accepted');
-  const holdOk = await page.evaluate(`(() => {
-    try {
-      globalThis.__kinect.keyframes.setRetime(${src(HOLD)});
-      return true;
-    } catch { return false; }
-  })()`);
-  check(holdOk === true, 'while a hold, which is equal values, still is not');
-
-  // The other way to author a descent, invisible to a values-only check: ascending keys with an
-  // outgoing handle that overshoots, shallow enough to hide inside single capture brackets.
-  const HANDLE_DESCENT = { rate: 1, keys: [
-    { t: 0, value: 0, easeOut: [[0.3, 1.6]], easeIn: [[2 / 3, 2 / 3]] },
-    { t: 8, value: 6, easeOut: [[1 / 3, 1 / 3]], easeIn: [[2 / 3, 2 / 3]] },
-  ] };
-  const handleRefused = await page.evaluate(`(() => {
-    try {
-      globalThis.__kinect.keyframes.setRetime(${src(HANDLE_DESCENT)});
-      return null;
-    } catch (err) { return String(err.message ?? err); }
-  })()`);
-  // The largest drawdown rather than a peak followed by a minimum: the descent is a dip mid-segment
-  // and the curve still ends at its highest value, so "maximum then minimum" finds nothing.
-  const sampled = [];
-  for (let i = 0; i <= 320; i++) sampled.push(scalarAt(HANDLE_DESCENT.keys, (i / 320) * 8, true));
-  let high = -Infinity;
-  let drawdown = 0;
-  let from = 0;
-  let to = 0;
-  for (const v of sampled) {
-    if (v > high) high = v;
-    if (high - v > drawdown) { drawdown = high - v; from = high; to = v; }
-  }
-  console.log(`  keys 0 -> 6 with an easeOut y of 1.6: ${handleRefused ? 'refused' : 'ACCEPTED'}; `
-    + `that curve reaches ${from.toFixed(3)}s and falls back to ${to.toFixed(3)}s, `
-    + `a drawdown of ${drawdown.toFixed(3)}s`);
-  check(drawdown > 0.02,
-    'the handle really does bend the curve back on itself, so there is something to refuse',
-    `${drawdown.toFixed(4)}s of drawdown`);
-  check(handleRefused !== null,
-    'and a handle outside the unit box is refused, not only falling key values',
-    handleRefused ?? 'accepted');
-  // The control: an in-box handle is still accepted, so this bounds the handle rather than
-  // banning easing the retime at all.
-  const easedOk = await page.evaluate(`(() => {
-    try {
-      globalThis.__kinect.keyframes.setRetime({ rate: 1, keys: [
-        { t: 0, value: 0, easeOut: [[0.3, 0.95]], easeIn: [[2 / 3, 2 / 3]] },
-        { t: 8, value: 6, easeOut: [[1 / 3, 1 / 3]], easeIn: [[2 / 3, 2 / 3]] } ] });
-      return true;
-    } catch { return false; }
-  })()`);
-  check(easedOk === true, 'while an eased retime with both handles inside it still is not');
-
-  // (b) the editing door - dragged with a real pointer, well past the neighbour.
-  await setRetime({ rate: 1, keys: [{ t: 0, value: 6 }, { t: 8, value: 12 }, { t: 14, value: 20 }] });
-  await settle();
-  await settle();
-  const lane = await page.evaluate(`(() => {
-    const el = [...document.querySelectorAll('#tBeds .tlane')].find((l) => l.dataset.owner === 'retime');
-    const key = el.querySelectorAll('.tkey')[1];
-    const r = key.getBoundingClientRect();
-    const box = el.getBoundingClientRect();
-    return { x: r.left + r.width / 2, y: r.top + r.height / 2, bottom: box.bottom };
-  })()`);
-  await page.mouse.move(lane.x, lane.y);
-  await page.mouse.down();
-  // Past the floor of the lane, which without a clamp asks for a value under the key before it.
-  await page.mouse.move(lane.x, lane.bottom + 40, { steps: 6 });
-  await page.mouse.up();
-  await settle();
-  const dragged = await page.evaluate(
-    'globalThis.__kinect.timeline.retime.keys.map((k) => ({ t: k.t, value: k.value }))',
-  );
-  const falls = dragged.some((k, i) => i > 0 && k.value < dragged[i - 1].value - 1e-9);
-  console.log(`  dragged the middle key to the floor of its lane: `
-    + `${dragged.map((k) => k.value.toFixed(2)).join(' -> ')}`);
-  check(!falls, 'and a key dragged below the one before it stops there instead of going under',
-    JSON.stringify(dragged));
-  check(Math.abs(dragged[1].value - dragged[0].value) < 1e-6,
-    'landing exactly on it, so the clamp is what stopped it rather than the drag being short',
-    `${dragged[1].value.toFixed(4)} against ${dragged[0].value.toFixed(4)}`);
-
-  // (c) the backstop - one that arrives anyway must not take the page with it.
-  const survived = await page.evaluate(`(async () => {
-    const k = globalThis.__kinect;
-    const t = k.timeline.transport();
-    const frames = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-    k.keyframes.setRetime({ rate: 1, keys: [{ t: 0, value: 0 }, { t: 12, value: 18 }] });
-    await k.timeline.settled();
-    await t.seek(4.0);
-    // Past every guard, straight onto the object, which is the only way to produce
-    // one now and is exactly the "arrives anyway" this backstop is for.
-    //
-    // The descent starts from where the walk already stands rather than from
-    // somewhere else on the take: 6.0s of source at 4.0s of program, which is
-    // exactly what the seek above just consumed. A curve that also *jumped* would
-    // ask for frames nobody has fetched, and playback would sit waiting for them
-    // instead of trying to walk backwards - which is a stall, not this claim.
-    k.timeline.retime.keys = [
-      { t: 0, value: 8, easeOut: [[1 / 3, 1 / 3]], easeIn: [[2 / 3, 2 / 3]] },
-      { t: 12, value: 2, easeOut: [[1 / 3, 1 / 3]], easeIn: [[2 / 3, 2 / 3]] },
-    ];
-    const before = k.timeline.counters.renders;
-    await t.play();
-    const startedPlaying = t.playing;
-    // Long enough for the walk to catch up with itself. The seek that preceded the
-    // swap left the source walk well behind where the new curve points, so the
-    // first few steps move *forward* through that backlog and only start going
-    // backwards once they reach it - the refusal is a second or so in, not
-    // immediate, and a short wait reports a page that simply had not got there yet.
-    for (let i = 0; i < 90 && t.playing; i++) await frames();
-    const afterCrash = {
-      playing: t.playing,
-      note: document.getElementById('tNote').textContent,
-      rendered: k.timeline.counters.renders - before,
-    };
-    // Put a sane curve back and ask the loop to work. If the callback stopped being
-    // driven this is where it shows - nothing renders, whatever the transport says.
-    k.keyframes.setRetime({ rate: 1, keys: [{ t: 0, value: 0 }, { t: 12, value: 18 }] });
-    await k.timeline.settled();
-    await t.seek(1.0);
-    const settledRenders = k.timeline.counters.renders;
-    await t.play();
-    for (let i = 0; i < 20; i++) await frames();
-    t.pause();
-    return { startedPlaying, afterCrash, alive: k.timeline.counters.renders - settledRenders };
-  })()`);
-  console.log(`  a curve written straight onto the object, then play: transport `
-    + `${survived.afterCrash.playing ? 'still playing' : 'paused'}, note `
-    + `"${survived.afterCrash.note.slice(0, 60)}"`);
-  console.log(`  with a sane curve back, the animation loop rendered ${survived.alive} frames`);
-  // Renders are the wrong measure of that: it refuses on the first step.
-  check(survived.startedPlaying === true,
-    'playback really was running when it met the curve',
-    `rendered ${survived.afterCrash.rendered} frames before refusing`);
-  check(survived.afterCrash.playing === false,
-    'a curve that cannot be walked pauses the transport rather than running into it');
-  check(survived.afterCrash.note.length > 0, 'and says why on the strip rather than only in the console',
-    survived.afterCrash.note);
-  // One error, and the run-wide assertion is told to expect it and to fail without it.
-  expectError('the retime curve runs backwards here',
-    'the refusal a downhill curve produces, caught by the loop rather than by the page dying');
-  // The load-bearing one: everything above is also true of a page whose animation loop has
-  // stopped being driven, because a paused transport renders nothing either way.
-  check(survived.alive > 0,
-    'and the animation loop is still being driven afterwards, which is the whole of the claim',
-    `${survived.alive} frames rendered after`);
-  await setRetime(FLAT);
-  await settle();
+  await setTiming();
 }
 
 
 console.log('\n== 5. undo restores the document and never the view ==');
 {
-  await setRetime(FLAT);
+  await setTiming();
   await setTracks({});
   await applyLook(RGB_LOOK);
   await settle();
@@ -2084,7 +1642,7 @@ console.log('\n== 5. undo restores the document and never the view ==');
   // A look value lives in the project's block or in a clip's, depending on where it writes, so
   // a reading of "the look" that named one block would pass on whatever happened to be empty.
   const looksOf = (doc, kind) => Object.assign({}, doc.look[kind], ...doc.clips.map((c) => c[kind]));
-  const retimeOf = (doc) => doc.clips[0].retime;
+  const timingOf = (doc) => ({ speed: doc.clips[0].speed, sourceStart: doc.clips[0].sourceStart });
 
   // (a) one drag is one level, not one per pointer move.
   const before5 = await depth();
@@ -2143,8 +1701,6 @@ console.log('\n== 5. undo restores the document and never the view ==');
 
   // (d) and none of it is in the snapshot, so an undo cannot put it back.
   const snapshot = await project();
-  // A v3 document is `{ look: { mode, params, tracks }, composition: { retime, camera } }`,
-  // and read flat the `in` below throws rather than failing.
   const snapshotParams = looksOf(snapshot, 'params');
   check(!('renderScale' in snapshotParams) && !('spin' in snapshotParams),
     'the snapshot holds no view state at all, in either of the two blocks a look value can sit in',
@@ -2155,7 +1711,8 @@ console.log('\n== 5. undo restores the document and never the view ==');
   await page.evaluate(`(() => {
     const k = globalThis.__kinect;
     k.keyframes.setTracks(${src(keyed)});
-    k.keyframes.setRetime(${src(RAMP)});
+    k.keyframes.setSourceStart(3);
+    k.keyframes.setSpeed(2);
     k.keyframes.undo.commit();
   })()`);
   await settle();
@@ -2181,16 +1738,22 @@ console.log('\n== 5. undo restores the document and never the view ==');
     };
   })()`);
   await settle();
-  // Tracks are look and the curve is the clip's, so the two readings come from two places.
+  // Tracks are look and timing is the clip's, so the two readings come from two places.
   const undoneTracks = looksOf(undone.project, 'tracks');
-  const undoneRetime = retimeOf(undone.project);
-  console.log(`  a track and a retime curve pushed one level (${depthWithKeys}), then undone: `
+  const withTiming = timingOf(withKeys);
+  const undoneTiming = timingOf(undone.project);
+  console.log(`  a track and clip timing pushed one level (${depthWithKeys}), then undone: `
     + `tracks ${Object.keys(looksOf(withKeys, 'tracks')).join(',') || 'none'} -> `
     + `${Object.keys(undoneTracks).join(',') || 'none'}, `
-    + `retime keys ${retimeOf(withKeys).keys.length} -> ${undoneRetime.keys.length}`);
+    + `timing ${withTiming.sourceStart}s at ${withTiming.speed}x -> `
+    + `${undoneTiming.sourceStart}s at ${undoneTiming.speed}x`);
   check(undone.popped === true, 'the stack had something to pop');
-  check(Object.keys(undoneTracks).length === 0 && undoneRetime.keys.length === 0,
-    'and undo took the keys and the curve back off', JSON.stringify(undoneTracks));
+  check(withTiming.speed === 2 && withTiming.sourceStart === 3,
+    'the committed snapshot really changed both timing fields', JSON.stringify(withTiming));
+  check(Object.keys(undoneTracks).length === 0
+    && undoneTiming.speed === 1 && undoneTiming.sourceStart === 0,
+    'and undo took the keys off and restored the clip timing',
+    `${JSON.stringify(undoneTracks)}, ${JSON.stringify(undoneTiming)}`);
   check(undone.frameAfter === undone.frameBefore, 'and left the playhead exactly where it was',
     `frame ${undone.frameBefore} -> ${undone.frameAfter}`);
   check(undone.scaleAfter === undone.scaleBefore, 'and did not touch render scale',
@@ -2234,20 +1797,20 @@ console.log('\n== 5. undo restores the document and never the view ==');
 
 console.log('\n== 6. look in lanes, composition in the world ==');
 {
-  await setRetime(FLAT);
+  await setTiming();
   await setTracks({ bloom: EASED, additive: STEPS, camera: PATH });
   await settle();
   // The keyed lanes. The stack also carries the clip bar and a row per clip, which are the
   // edit's structure rather than its animation and are `editor-check` section 22's to count.
   const lanes = (await page.evaluate('globalThis.__kinect.keyframes.lanes()'))
-    .filter((l) => l.kind !== 'clips' && l.kind !== 'clip');
+    .filter((l) => l.kind !== 'clips' && l.kind !== 'clip' && l.kind !== 'clip-add');
   const named = await page.evaluate('globalThis.__kinect.keyframes.names()');
   // A clip's own row is the edit's structure and is excluded; its keyed parameters are not -
   // they are lanes like any other and they are qualified by the clip that holds them, which is
   // what stops eight clips of one keyed parameter drawing the selected clip's keys eight times.
   const dom = await page.evaluate(
     "[...document.querySelectorAll('#tBeds .tlane')].map((el) => el.dataset.owner)"
-    + ".filter((o) => o !== 'clips' && !/^clip:[^/]+$/.test(o))",
+    + ".filter((o) => o !== 'clips' && o !== 'clip-add' && !/^clip:[^/]+$/.test(o))",
   );
   console.log(`  three keyed parameters give lanes ${dom.join(', ')}; `
     + `the registry declares ${lanes.map((l) => `${l.owner}:${l.kind}`).join(' ')}`);
@@ -2270,7 +1833,8 @@ console.log('\n== 6. look in lanes, composition in the world ==');
   const empty = await page.evaluate(`(() => {
     globalThis.__kinect.keyframes.setTracks({});
     return [...document.querySelectorAll('#tBeds .tlane')]
-      .filter((el) => el.dataset.owner !== 'clips' && !/^clip:[^/]+$/.test(el.dataset.owner)).length;
+      .filter((el) => el.dataset.owner !== 'clips' && el.dataset.owner !== 'clip-add'
+        && !/^clip:[^/]+$/.test(el.dataset.owner)).length;
   })()`);
   check(empty === 0, 'and a clip with no keys has none at all, which is the nine-into-five deletion',
     `${empty} lanes`);
@@ -2329,71 +1893,11 @@ console.log('\n== 6b. dragging a path node in the top-down moves it across the f
 }
 
 
-// The retime curve is the one track whose value changes how long the program is, so editing a key
-// rescales the ruler it is drawn on. Left alone that is a feedback loop: drag down, the clip slows,
-// the program lengthens, the ruler rescales, and the key moves under a pointer that
-// never moved sideways.
-console.log('\n== 6d. a retime key dragged down changes the speed, not when it is ==');
-{
-  await setTracks({});
-  await setRetime({ rate: 1, keys: [{ t: 0, value: 0 }, { t: 15, value: 15 }] });
-  await settle();
-  // Drained again after the curve is set: a repaint left over from an earlier section gets
-  // overtaken here, which is correct behaviour and nothing to do with the claim.
-  await settle();
-  const lane = await page.evaluate(`(() => {
-    const el = [...document.querySelectorAll('#tBeds .tlane')].find((l) => l.dataset.owner === 'retime');
-    const key = el.querySelectorAll('.tkey')[1];
-    const r = key.getBoundingClientRect();
-    const box = el.getBoundingClientRect();
-    return {
-      x: r.left + r.width / 2, y: r.top + r.height / 2,
-      top: box.top, height: box.height,
-      value: globalThis.__kinect.timeline.retime.keys[1].value,
-    };
-  })()`);
-  // The walk is in seconds converted to pixels, not in pixels: the lane draws zero to the capture's
-  // own length across forty pixels, so what a pixel is worth depends on the fixture. The pixels
-  // come from where the page actually drew the key, read back off the drawing rather than assumed.
-  const frac = (lane.y - lane.top) / lane.height;
-  const perPx = (lane.value / Math.max(1e-6, 1 - frac)) / lane.height;
-  const dropPx = (lane.value * 0.75) / Math.max(1e-9, perPx);
-  const steps = [1, 2, 3, 4].map((i) => Math.round((dropPx * i) / 4));
-  const walk = [];
-  await page.mouse.move(lane.x, lane.y);
-  await page.mouse.down();
-  for (const dy of steps) {
-    await page.mouse.move(lane.x, lane.y + dy);
-    walk.push(await page.evaluate(`(() => {
-      const k = globalThis.__kinect;
-      return { t: k.timeline.retime.keys[1].t, value: k.timeline.retime.keys[1].value,
-        duration: k.timeline.transport().duration };
-    })()`));
-  }
-  await page.mouse.up();
-  await settle();
-  console.log(`  four vertical moves of ${steps.join(', ')}px, at ${perPx.toFixed(3)}s per pixel: `
-    + `t ${walk.map((w) => w.t.toFixed(3)).join(' ')}`);
-  console.log(`  against value ${walk.map((w) => w.value.toFixed(2)).join(' ')} `
-    + `and program length ${walk.map((w) => w.duration.toFixed(1)).join(' ')}s`);
-  const slid = worst(walk.map((w) => Math.abs(w.t - 15)));
-  check(slid < 0.01, 'the key holds its program time through a vertical drag',
-    `worst ${slid.toFixed(4)}s of slide`);
-  check(Math.abs(walk[3].value - walk[0].value) > 1,
-    'while its value moved, so the drag was doing something',
-    `${walk[0].value.toFixed(2)} to ${walk[3].value.toFixed(2)}`);
-  check(walk[3].duration > walk[0].duration * 1.5,
-    'and the program got longer, which is what slowing a clip means',
-    `${walk[0].duration.toFixed(1)}s to ${walk[3].duration.toFixed(1)}s`);
-  await setRetime(FLAT);
-}
-
-
 // Both are gesture wiring, so the button is clicked and the handle dragged with a real
 // pointer rather than with dispatched events.
 console.log('\n== 6e. keying from the panel, and dragging a handle ==');
 {
-  await setRetime(FLAT);
+  await setTiming();
   await setTracks({});
   await applyLook(BLACKWALL_LOOK);
   await settle();
@@ -2949,6 +2453,7 @@ console.log('\n== 6h. a speed change holds the playhead on the frame it was park
   const START = 10;
   const PARKED = 12;
   const TO = 2;
+  const SOURCE_START = 4;
 
   // Nothing is keyed and no export range is set here on purpose. A rate change rescales the
   // in/out pair, and `frameAt` clamps every seek into it, so a range would move under the
@@ -2959,23 +2464,30 @@ console.log('\n== 6h. a speed change holds the playhead on the frame it was park
     const doc = k.library.serialiseProjectBody();
     doc.clips[0].start = ${START};
     doc.clips[0].length = null;
-    doc.clips[0].retime = { rate: 1, keys: [] };
+    doc.clips[0].speed = 1;
+    doc.clips[0].sourceStart = ${SOURCE_START};
     k.library.restoreProject(doc);
     await k.timeline.settled();
     k.timeline.transport().pause();
     k.editor.setClipRange(0, null);
     await k.timeline.transport().seek(${PARKED});
     await k.timeline.settled();
-    const shot = () => ({
-      programSec: k.timeline.transport().programSec,
-      rate: k.timeline.retime.rate,
-      range: k.editor.clipRange(),
-      start: k.timeline.clips()[0].start,
-      end: k.timeline.clips()[0].end,
-    });
+    const shot = () => {
+      const read = k.timeline.read();
+      const clip = k.timeline.clips()[0];
+      return {
+        programSec: read.programSec,
+        sourceSec: read.sourceSec,
+        speed: read.speed,
+        sourceStart: read.sourceStart,
+        range: k.editor.clipRange(),
+        start: clip.start,
+        end: clip.end,
+      };
+    };
     const before = shot();
-    // The slider driven through its own events rather than through the setRetime handle,
-    // because the fault is in the gesture: setRetime writes the curve and anchors nothing.
+    // The slider is driven through its own events because the fault under test is in the gesture's
+    // source-frame anchor rather than in the direct speed door.
     const el = document.getElementById('tRate');
     el.value = String(k.editor.rateSlider.toValue(${TO}));
     el.dispatchEvent(new Event('input'));
@@ -2989,17 +2501,28 @@ console.log('\n== 6h. a speed change holds the playhead on the frame it was park
   // so that many source seconds at 1x. At `TO` the clip reaches the same source second in half
   // the time, so the frame that was under the playhead is now at `START + local / TO`.
   const want = START + (PARKED - START) / TO;
-  console.log(`  a clip at ${START}s parked at ${PARKED}s, ${before.rate}x -> ${after.rate}x: `
+  console.log(`  a clip at ${START}s with a ${SOURCE_START}s in-point, parked at ${PARKED}s, `
+    + `${before.speed}x -> ${after.speed}x: `
     + `playhead ${before.programSec.toFixed(3)}s -> ${after.programSec.toFixed(3)}s, `
+    + `source ${before.sourceSec.toFixed(3)}s -> ${after.sourceSec.toFixed(3)}s, `
     + `clip ${before.start}..${before.end.toFixed(2)}s -> ${after.start}..${after.end.toFixed(2)}s`);
 
   check(before.start === START && Math.abs(before.programSec - PARKED) < 1e-6,
     'the clip under this section starts away from the head of the edit and the playhead is '
     + 'parked inside it, which is what lets the rows below be false',
     `start ${before.start}s, playhead ${before.programSec}s`);
-  check(Math.abs(after.rate - TO) < 1e-6 && after.rate !== before.rate,
+  check(before.sourceStart === SOURCE_START,
+    'and the clip has a trimmed head, so this arm can see the in-point survive the speed change',
+    `${before.sourceStart}s`);
+  check(Math.abs(after.speed - TO) < 1e-6 && after.speed !== before.speed,
     'and the slider really moved the slope, or none of the rows below are about a speed change',
-    `${before.rate}x -> ${after.rate}x`);
+    `${before.speed}x -> ${after.speed}x`);
+  check(after.sourceStart === before.sourceStart,
+    'the speed change keeps the clip head on the same source frame',
+    `${before.sourceStart}s -> ${after.sourceStart}s`);
+  check(Math.abs(after.sourceSec - before.sourceSec) < 1e-3,
+    'and keeps the source frame under the parked playhead',
+    `${before.sourceSec.toFixed(4)}s -> ${after.sourceSec.toFixed(4)}s`);
   check(after.range.out === null,
     'and no export range is standing that could clamp the landing, so the row below reads the '
     + 'anchor rather than a cut',
@@ -3017,7 +2540,8 @@ console.log('\n== 6h. a speed change holds the playhead on the frame it was park
     const k = globalThis.__kinect;
     const doc = k.library.serialiseProjectBody();
     doc.clips[0].start = 0;
-    doc.clips[0].retime = { rate: 1, keys: [] };
+    doc.clips[0].speed = 1;
+    doc.clips[0].sourceStart = 0;
     k.library.restoreProject(doc);
     k.keyframes.undo.commit();
     await k.timeline.settled();
@@ -3025,18 +2549,7 @@ console.log('\n== 6h. a speed change holds the playhead on the frame it was park
 }
 
 
-{
-  const unexpected = errors.filter((text) => {
-    const match = expected.find((e) => text.includes(e.fragment));
-    if (match) match.seen = true;
-    return !match;
-  });
-  check(unexpected.length === 0, 'the page logged no errors it was not asked for',
-    unexpected.slice(0, 3).join(' | '));
-  for (const e of expected) {
-    check(e.seen, `and the one it was asked for arrived: ${e.why}`, e.seen ? '' : 'never logged');
-  }
-}
+check(errors.length === 0, 'the page logged no errors', errors.slice(0, 3).join(' | '));
 
 if (SHOTS) {
   await page.locator('#stage').screenshot({ path: join(SHOTS, 'keyframe-stage.png') });

--- a/tools/layering-ab.mjs
+++ b/tools/layering-ab.mjs
@@ -193,10 +193,6 @@ await page.evaluate(`(() => {
     async load(arm, offsets, windowSec, look, warmStart) {
       const base = k.library.serialiseProjectBody();
       const one = base.clips[0];
-      const retimeAt = (inSec, span) => {
-        k.keyframes.setRetime({ rate: 1, keys: [{ t: 0, value: inSec }, { t: span, value: inSec + span }] });
-        return JSON.parse(JSON.stringify(k.library.serialiseProjectBody().clips[0].retime));
-      };
       // Written into each clip's own block rather than applied afterwards: a look applied through
       // the registry lands on the selected clip alone now, so an arm that did that would time one
       // clip at this look and the rest at the registry's defaults - which is half the draw.
@@ -206,7 +202,7 @@ await page.evaluate(`(() => {
       const mine = scoped(look, 'clip');
       const clips = [];
       for (let i = 0; i < arm.live; i++) {
-        clips.push({ ...one, id: 'v' + i, start: 0, length: 12, retime: retimeAt(offsets[i], 12),
+        clips.push({ ...one, id: 'v' + i, start: 0, length: 12, speed: 1, sourceStart: offsets[i],
           params: { ...one.params, ...mine } });
       }
       for (let i = 0; i < arm.warming; i++) {
@@ -218,7 +214,8 @@ await page.evaluate(`(() => {
           id: 'w' + i,
           start: warmStart,
           length: 6,
-          retime: retimeAt(offsets[offsets.length - 1] + 1, 6),
+          speed: 1,
+          sourceStart: offsets[offsets.length - 1] + 1,
           params: { ...one.params, ...mine },
         });
       }

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -223,11 +223,6 @@ const MUTATIONS = {
     "  if (format === CAPTURE_FORMAT) return '';",
     "  return ''; /* mutation: every generation opens on this build's assumptions */",
   ]] },
-  // The retime guard comes off the file door.
-  'load-skips-monotonic': { file: 'web/main.js', edits: [[
-    '    retime.assertMonotonic(keys);',
-    '  /* mutation: the curve arrives unchecked */',
-  ]] },
   // The quaternion length check comes off, which is the gap step 5 carried: four finite numbers
   // accepted as a rotation, and a camera move nobody authored.
   'accept-any-quaternion': { file: 'web/main.js', edits: [[
@@ -259,11 +254,13 @@ const MUTATIONS = {
       }
       await mkdir(this.dir, { recursive: true });`],
   ] },
-  // Marks are drawn at their source fraction rather than through the retime curve, which is
-  // identical at rate 1 with no keys and wrong everywhere else.
+  // Marks are drawn at their source second rather than through the selected clip's placement,
+  // speed and in-point. The name stays because it is part of the proof invocation surface.
   'marks-ignore-retime': { file: 'web/main.js', edits: [[
-    '\n    const program = programSecOfSource(mark.sourceMs / 1000);\n',
-    '\n    const program = mark.sourceMs / 1000;\n',
+    '    const program = programSecOfSource(mark.sourceMs / 1000);\n'
+      + "    const el = document.createElement('button');",
+    '    const program = mark.sourceMs / 1000;\n'
+      + "    const el = document.createElement('button');",
   ]] },
   // The library skims a remote take at full resolution, promising a smoothness the
   // link does not have.
@@ -3321,7 +3318,9 @@ async function runChecks() {
     // one that makes every later mutation of `projects.html` mean anything.
     const PRESENT = 'projects-page-present';
     const DARK = 'projects-page-dark';
-    const localHash = (await getJson(`${macUrl}/library/takes`)).takes.find((t) => t.id === 'local-clip').hash;
+    const TRIMMED = 'projects-page-trimmed';
+    const localTake = (await getJson(`${macUrl}/library/takes`)).takes.find((t) => t.id === 'local-clip');
+    const localHash = localTake.hash;
     // Built off a document the editor wrote rather than composed here: `checkProject` demands a
     // weight for every reading and `READINGS` is built at run time out of the installed effect
     // manifests, so a body this file authored would be refused by the loader for reasons that
@@ -3338,6 +3337,9 @@ async function runChecks() {
     const one = JSON.parse(JSON.stringify(seed));
     one.clips = [{ ...one.clips[0], start: 0 }];
     one.clips[0].take = { id: 'local-clip', hash: localHash };
+    const trimmed = JSON.parse(JSON.stringify(one));
+    trimmed.clips[0].sourceStart = Math.min(2, localTake.durationSec / 3);
+    trimmed.clips[0].length = Math.max(1, Math.min(4, localTake.durationSec - trimmed.clips[0].sourceStart));
     const gone = JSON.parse(JSON.stringify(one));
     // Both clips carry their own length, and the missing one has to: `spanOf` falls back to the
     // take's duration, which is precisely what a machine that has not got the take cannot read.
@@ -3352,10 +3354,12 @@ async function runChecks() {
         id: 'nowhere',
         start: 4,
         length: 6,
+        sourceStart: 2.75,
         take: { id: 'reclaimed-take', hash: `sha256:${'a'.repeat(64)}` },
       },
     ];
     await writeDoc(macUrl, 'projects', PRESENT, one);
+    await writeDoc(macUrl, 'projects', TRIMMED, trimmed);
     await writeDoc(macUrl, 'projects', DARK, gone);
 
     const { page, errors } = await openPage(browser, projectsPage(macUrl));
@@ -3370,6 +3374,16 @@ async function runChecks() {
       'the page is served at /projects and lists what the store holds, which is what makes an '
       + 'interception of projects.html land somewhere rather than nowhere',
       rows.map((r) => r.name).join(', ') || 'the listing was empty');
+    await page.evaluate(`globalThis.__projects.drawn(${JSON.stringify(TRIMMED)})`);
+    const trimmedAtHead = await page.evaluate(
+      `globalThis.__projects.showing(${JSON.stringify(TRIMMED)})`,
+    );
+    const wantedHeadFrame = Math.round((trimmed.clips[0].sourceStart / localTake.durationSec)
+      * Math.max(0, localTake.frames - 1));
+    check(trimmedAtHead?.frame === wantedHeadFrame && trimmedAtHead?.drawnFrame === wantedHeadFrame,
+      'the projects page starts a trimmed clip skim at its in-point rather than at frame zero',
+      `frame ${trimmedAtHead?.frame}, drawn ${trimmedAtHead?.drawnFrame}, want ${wantedHeadFrame} `
+        + `for source ${trimmed.clips[0].sourceStart.toFixed(3)}s`);
     // Newest written first, and nothing is stored to know it: the dark one was written second.
     check(rows[0]?.name === DARK,
       'and it is ordered by when each project was last written, newest first',
@@ -3380,6 +3394,10 @@ async function runChecks() {
     check(named(DARK)?.missing === 1 && /reclaimed-take/.test(named(DARK)?.dark ?? ''),
       'and one whose footage is not here says so on its own row, naming the take it wants',
       `${named(DARK)?.missing} missing, "${named(DARK)?.dark ?? 'nothing said'}"`);
+    const missingSegment = named(DARK)?.segments?.find((segment) => segment.clip === 'nowhere');
+    check(missingSegment?.sourceStart === 2.75,
+      'a clip whose take is missing keeps its in-point unchanged while the projects page lays it out',
+      `sourceStart ${missingSegment?.sourceStart}`);
     check(/library/i.test(named(DARK)?.darkAct ?? ''),
       'and the control on it goes to the library rather than fetching, because the download and '
       + 'the two-machine state live there and a second copy of them here is the duplicated path',
@@ -3402,6 +3420,7 @@ async function runChecks() {
     await page.close();
     await writeDoc(macUrl, 'projects', PRESENT, null, 'DELETE');
     await writeDoc(macUrl, 'projects', DARK, null, 'DELETE');
+    await writeDoc(macUrl, 'projects', TRIMMED, null, 'DELETE');
   }
 
   console.log('\n[library] a project survives a round trip through a file');
@@ -3455,6 +3474,10 @@ async function runChecks() {
 
     const { page, errors } = await openPage(browser, recorderPage(macUrl), { width: 640, height: 400 });
     await page.waitForFunction('globalThis.__kinect !== undefined', null, { timeout: 40000 });
+    const liveClip = await page.evaluate('globalThis.__kinect.timeline.clips()[0]');
+    check(liveClip.afforded === Infinity && liveClip.length === Infinity,
+      'a streaming source affords an unbounded clip instead of resolving against a finite take duration',
+      `afforded ${String(liveClip.afforded)}, length ${String(liveClip.length)}`);
 
     // A look nothing defaults to, so a restore that did nothing cannot pass.
     const SCRAMBLE = {
@@ -3652,8 +3675,7 @@ async function runChecks() {
       'and putting the clip back leaves nothing parked, so the rows below serialise a document with no missing effect in it',
       JSON.stringify(cleaned));
 
-  // `JSON.stringify` turns NaN and undefined into null, so a case labelled NaN would
-  // silently be a case about null.
+  // Assigned inside the page so NaN and Infinity reach the door without JSON changing them to null.
     const refuse = async (label, source) => page.evaluate(`(() => {
       const k = globalThis.__kinect;
       const p = k.library.serialiseProjectBody();
@@ -3663,13 +3685,16 @@ async function runChecks() {
 
     const cases = [
       ['a project with no version', 'delete p.version;'],
-      ['a project from an older version', 'p.version = 0;'],
+      ['a version 7 project', 'p.version = 7;'],
       // Derived from the version this build writes rather than written down.
       ['a project from a newer version', `p.version = ${PROJECT_VERSION + 1};`],
       ['a version that is not a number', 'p.version = "1";'],
-      ['a retime curve that falls', 'p.clips[0].retime.keys = [{t:0,value:0},{t:1,value:2},{t:2,value:0.5}];'],
-      ['a retime handle outside the unit box',
-        'p.clips[0].retime.keys = [{t:0,value:0,easeOut: [[0.4, 1.9]],easeIn: [[0.6, 0]]},{t:2,value:1,easeOut: [[0.4, 0]],easeIn: [[0.6, 0]]}];'],
+      ['a negative in-point', 'p.clips[0].sourceStart = -0.25;'],
+      ['a non-finite in-point', 'p.clips[0].sourceStart = NaN;'],
+      ['an infinite in-point', 'p.clips[0].sourceStart = Infinity;'],
+      ['an in-point at the end of the footage',
+        'const c = k.timeline.clips()[0]; p.clips[0].sourceStart = c.sourceStart + c.afforded * c.speed;'],
+      ['an in-point past the footage', 'p.clips[0].sourceStart = 1e9;'],
       ['a camera key whose quaternion is not unit length',
         'p.composition.camera = [{t:0,value:{position:[0,0,3],quaternion:[0,0,0,1.4],fov:55}},{t:1,value:{position:[1,0,3],quaternion:[0,0,0,1],fov:55}}];'],
       ['a camera key whose quaternion is all zeros',
@@ -3699,7 +3724,7 @@ async function runChecks() {
       ['a project value in a clip block', 'p.clips[0].params.bloom = 0;'],
       ['a clip value in the project block', 'p.look.params.pointSize = 9;'],
       ['a view parameter in a clip block', 'p.clips[0].params.renderScale = 100;'],
-      ['a retime rate of zero or less', 'p.clips[0].retime.rate = 0;'],
+      ['a clip speed of zero or less', 'p.clips[0].speed = 0;'],
       ['a preset stamp that is not a name and a rev', 'p.clips[0].appliedPreset = { name: 42 };'],
       // The record a deliverable's embedded document carries.
       ['a suppressed list that is not a list', 'p.suppressed = "sparkle";'],
@@ -3718,6 +3743,18 @@ async function runChecks() {
     for (const { label, message } of results) {
       check(message !== 'ACCEPTED', `refused: ${label}`, message === 'ACCEPTED' ? 'ACCEPTED' : message.slice(0, 64));
     }
+    const messageFor = (label) => results.find((result) => result.label === label)?.message ?? '';
+    check(/version 7/.test(messageFor('a version 7 project'))
+      && /reads version 8/.test(messageFor('a version 7 project'))
+      && /no path from here/.test(messageFor('a version 7 project')),
+    'the version 7 refusal names both versions and says this build has no conversion path',
+    messageFor('a version 7 project').slice(0, 150));
+    check(/nothing of the take is left after its in-point/.test(messageFor('an in-point past the footage')),
+      'a version 8 in-point past finite footage is refused after the take duration resolves',
+      messageFor('an in-point past the footage').slice(0, 150));
+    check(/nothing of the take is left after its in-point/.test(messageFor('an in-point at the end of the footage')),
+      'and an in-point exactly at the finite footage end is refused by the same resolved-duration gate',
+      messageFor('an in-point at the end of the footage').slice(0, 150));
     const good = await refuse('an unmodified project', '');
     check(good.message === 'ACCEPTED', 'and an unmodified project still loads',
       good.message === 'ACCEPTED' ? '' : good.message.slice(0, 80));
@@ -4084,7 +4121,7 @@ async function runChecks() {
     await page.close();
   }
 
-  console.log('\n[library] marks on the editor\'s scrubber, through the retime curve');
+  console.log('\n[library] marks on the editor\'s scrubber, through clip timing');
   {
     const { page, errors } = await openPage(browser, editorPage(macUrl, 'local-clip'), { width: 1100, height: 700 });
     await page.waitForFunction('Boolean(globalThis.__kinect?.timeline?.transport())', null, { timeout: 40000 });
@@ -4104,50 +4141,52 @@ async function runChecks() {
     check(flat[flat.length - 1]?.beyond === true,
       'and a mark the edit never reaches is drawn at the edge as unreachable rather than dropped');
 
-    // The probe has to stand where a wrong implementation would disagree.
-    const KEYS = [{ t: 0, value: 0 }, { t: 4, value: 0.6 }, { t: 6, value: 2.4 }];
-    await page.evaluate(`globalThis.__kinect.keyframes.setRetime({ rate: 1, keys: ${JSON.stringify(KEYS)} })`);
+    // The probe has to stand where source time, clip-local time and project time all disagree.
+    const TIMING = { start: 2, length: 10, speed: 0.5, sourceStart: 0.6 };
+    await page.evaluate(`(() => {
+      const k = globalThis.__kinect;
+      const body = k.library.serialiseProjectBody();
+      Object.assign(body.clips[0], ${JSON.stringify(TIMING)});
+      k.library.restoreProject(body);
+      k.editor.selectClipRow(body.clips[0].id);
+    })()`);
     await page.evaluate('globalThis.__kinect.timeline.settled()');
-    const retimed = await page.evaluate('globalThis.__kinect.library.markTicks()');
+    await page.waitForFunction(
+      (count) => globalThis.__kinect.library.marks().length === count,
+      flat.length,
+      { timeout: 15000 },
+    );
+    const timed = await page.evaluate('globalThis.__kinect.library.markTicks()');
     const shown = await page.evaluate('globalThis.__kinect.timeline.read()');
-    check(retimed.length === flat.length, 'a retime does not lose a tick');
+    check(timed.length === flat.length, 'a speed and in-point change does not lose a tick');
 
     // Asserted against positions computed here, not against "they moved".
-    const programOf = (sourceSec) => {
-      if (sourceSec <= KEYS[0].value) return KEYS[0].t;
-      for (let i = 0; i < KEYS.length - 1; i++) {
-        if (KEYS[i + 1].value < sourceSec) continue;
-        const span = (KEYS[i + 1].value - KEYS[i].value) / (KEYS[i + 1].t - KEYS[i].t);
-        return KEYS[i].t + (sourceSec - KEYS[i].value) / span;
-      }
-      const last = KEYS.length - 1;
-      const span = (KEYS[last].value - KEYS[last - 1].value) / (KEYS[last].t - KEYS[last - 1].t);
-      return KEYS[last].t + (sourceSec - KEYS[last].value) / span;
-    };
+    const programOf = (sourceSec) => TIMING.start + (sourceSec - TIMING.sourceStart) / TIMING.speed;
     const pct = (x) => Math.max(0, Math.min(1, x)) * 100;
     const expected = marks.map((m) => pct(programOf(m.sourceMs / 1000) / shown.duration));
-    // Where the wrong implementation would draw each tick.
+    // Where the mutation draws each tick when it treats source seconds as project seconds.
     const naive = marks.map((m) => pct(m.sourceMs / 1000 / shown.duration));
-    const off = marks.map((_, i) => Math.abs((retimed[i]?.left ?? Infinity) - expected[i]));
+    const off = marks.map((_, i) => Math.abs((timed[i]?.left ?? Infinity) - expected[i]));
     const discriminating = marks.map((_, i) => i).filter((i) => Math.abs(expected[i] - naive[i]) > 5);
     check(discriminating.length >= 2,
       'at least two marks land somewhere the source fraction cannot, which is what makes them probes',
-      marks.map((m, i) => `${(m.sourceMs / 1000).toFixed(1)}s: curve ${expected[i].toFixed(1)}% against fraction ${naive[i].toFixed(1)}%`).join('; '));
+      marks.map((m, i) => `${(m.sourceMs / 1000).toFixed(1)}s: timed ${expected[i].toFixed(1)}% against fraction ${naive[i].toFixed(1)}%`).join('; '));
     check(discriminating.every((i) => off[i] < 1.5),
-      'and each tick sits where the curve puts it rather than where the fraction would',
-      marks.map((m, i) => `${(m.sourceMs / 1000).toFixed(1)}s -> ${retimed[i]?.left?.toFixed(1) ?? 'missing'}% (want ${expected[i].toFixed(1)}%)`).join('; '));
+      'and each tick sits where the clip placement, speed and in-point put it',
+      marks.map((m, i) => `${(m.sourceMs / 1000).toFixed(1)}s -> ${timed[i]?.left?.toFixed(1) ?? 'missing'}% (want ${expected[i].toFixed(1)}%)`).join('; '));
 
     // A mark written from the editor lands in the take's sidecar.
-    await page.evaluate('globalThis.__kinect.timeline.transport().seek(1.0)');
+    const MARK_PROGRAM_SEC = 3.0;
+    await page.evaluate(`globalThis.__kinect.timeline.transport().seek(${MARK_PROGRAM_SEC})`);
     await page.evaluate('globalThis.__kinect.timeline.settled()');
     await page.evaluate('globalThis.__kinect.library.markHere()');
     const written = (await getJson(`${macUrl}/capture/local-clip/marks`)).marks;
     check(written.length === 5, 'pressing mark writes to the take\'s sidecar', `${written.length} marks now`);
-    const sourceAt1 = await page.evaluate('globalThis.__kinect.timeline.retime.sourceSecAt(1.0)');
+    const sourceAtMark = await page.evaluate('globalThis.__kinect.timeline.read().sourceSec');
     const fresh = written.find((m) => !['k0', 'k1', 'k2', 'kBeyond'].includes(m.id));
-    check(Math.abs(fresh.sourceMs - sourceAt1 * 1000) < 40,
+    check(Math.abs(fresh.sourceMs - sourceAtMark * 1000) < 40,
       'and it is stamped in source milliseconds rather than program time',
-      `${fresh.sourceMs}ms against source ${(sourceAt1 * 1000).toFixed(0)}ms at program 1.0s`);
+      `${fresh.sourceMs}ms against source ${(sourceAtMark * 1000).toFixed(0)}ms at program ${MARK_PROGRAM_SEC.toFixed(1)}s`);
 
     check(errors.length === 0, 'the marks path raises no page errors', errors.slice(0, 2).join(' | '));
     await page.close();
@@ -4401,7 +4440,7 @@ async function runChecks() {
     const SEEDED_PROJECT = {
       version: PROJECT_VERSION,
       look: { params: {}, tracks: {} },
-      composition: { retime: { rate: 1, keys: [] }, camera: [] },
+      composition: { camera: [] },
       outputSize: '1920x1080',
       appliedPreset: null,
     };

--- a/tools/module-check.mjs
+++ b/tools/module-check.mjs
@@ -73,7 +73,7 @@ const MUTATIONS = {
 
   'export-form-nothing-claims': {
     file: 'web/format.js',
-    edits: [['export const PROJECT_VERSION = 7;', 'export const PROJECT_VERSION = 7;\nexport const { major, minor } = { major: 1, minor: 0 };']],
+    edits: [['export const PROJECT_VERSION = 8;', 'export const PROJECT_VERSION = 8;\nexport const { major, minor } = { major: 1, minor: 0 };']],
   },
 
   'a-barrel-re-export': {

--- a/tools/timeline-check.mjs
+++ b/tools/timeline-check.mjs
@@ -111,10 +111,10 @@ const MUTATIONS = {
     fails: 'a seek made inside a later clip\'s warm window rebuilding none of the warm history '
       + 'already elapsed. Section 7f\'s equality and plan rows are the catch',
   },
-  // Program time stops being scaled into source time.
-  'rate-ignored': { file: 'web/main.js', edits: [[
-    '  sourceSecAt(programSec) { return retimeSourceSecAt(this, programSec); },',
-    '  sourceSecAt(programSec) { return programSec; },',
+  // The clip's speed stops scaling its local time into source time.
+  'rate-ignored': { file: 'web/clip-plan.js', edits: [[
+    '  return sourceStart + localSec * speed;',
+    '  return sourceStart + localSec;',
   ]] },
   'duplicate-frames': { file: 'web/main.js', edits: [[
     'const offset = Math.min(Math.max(sourceSec - times[i], 0), span);\n'
@@ -407,7 +407,7 @@ const INSTALL = `(() => {
     // be a second write path to the same thing.
     async configure({ look, rate, fps }) {
       if (look) k.params.apply(look);
-      k.timeline.retime.rate = rate;
+      k.keyframes.setSpeed(rate);
       k.timeline.transport().outputFps = fps;
       this.pinCamera();
       await k.timeline.settled();
@@ -845,7 +845,7 @@ const plans = [];
     'the fade-and-wake half moves with output frame rate',
     `${at('Blackwall, 30 fps, 1.00x').surface} at 30 fps against ${at('Blackwall, 60 fps, 1.00x').surface} at 60`);
   check(at('Blackwall, 30 fps, 1.00x').surface !== at('Blackwall, 30 fps, 0.50x').surface,
-    'and with the retime slope, because fade and wake are source milliseconds',
+    'and with the clip speed, because fade and wake are source milliseconds',
     `${at('Blackwall, 30 fps, 1.00x').surface} at 1.00x against ${at('Blackwall, 30 fps, 0.50x').surface} at 0.50x`);
   check(at('trails 0, wake 0, 30 fps').frames < at('Blackwall, 30 fps, 1.00x').frames,
     'a look with less to remember costs less to seek to',
@@ -1321,7 +1321,7 @@ console.log('\n== 5. a look change while paused rebuilds the image and the estim
       el.dispatchEvent(new Event('input'));
       el.dispatchEvent(new Event('change'));
       await globalThis.__kinect.timeline.settled();
-      return globalThis.__kinect.timeline.retime.rate;
+      return globalThis.__kinect.timeline.read().speed;
     })()`);
     if (Math.abs(landed - rate) > 1e-6) {
       throw new Error(`asked the speed slider for ${rate}x and the page went to ${landed}x`);
@@ -1612,27 +1612,26 @@ console.log('\n== 7. the mosh pass decodes from its own last refresh ==');
 // deliberately not the order of their ids, so a build assigning draw order by array position
 // draws a different composite from one assigning it by id.
 const FIXTURE_CLIPS = [
-  // Two seconds of half speed at the head, then 1x. Its in-point is 20s into the take, so its
-  // head affords far more than any look asks for. It is also the clip the page comes up selected
-  // on, and its persistence is deliberately the shortest here: a build that read the look off
-  // the selection rather than off each clip would compute this clip's pre-roll for all of them.
-  { id: 'c2', start: 3, length: 6, keys: [[0, 20], [2, 21], [6, 25]], second: false,
+  // Half speed with an in-point 20s into the take, so its head affords far more than any look asks
+  // for. It is also the clip the page comes up selected on, and its persistence is deliberately
+  // the shortest here: a build that read the look off the selection rather than off each clip
+  // would compute this clip's pre-roll for all of them.
+  { id: 'c2', start: 3, length: 6, speed: 0.5, sourceStart: 20, second: false,
     look: { fade: 100, wake: 100 } },
   // In-point at source zero, so there is nothing before it to warm with. It enters cold, and a
   // seek to the same instant enters cold too, which is why the invariant holds here. Its
   // brightness is plainly not the others', which is what a broadcast look would flatten.
-  { id: 'c4', start: 6, length: 4, keys: [[0, 0], [4, 4]], second: true,
+  { id: 'c4', start: 6, length: 4, speed: 1, sourceStart: 0, second: true,
     look: { exposure: 2.4 } },
   // A head shorter than the look asks for: 0.6s of source against a full second of persistence.
-  { id: 'c1', start: 0, length: 8, keys: [[0, 0.6], [8, 8.6]], second: false, look: {} },
+  { id: 'c1', start: 0, length: 8, speed: 1, sourceStart: 0.6, second: false, look: {} },
   // The same take as c1, placed elsewhere and offset so it stands on the same source frame at
   // every program position it shares with it. Two clips wanting one frame of one take is the
   // case the per-take half of the pipeline split is about.
-  { id: 'c5', start: 2, length: 2.5, keys: [[0, 2.6], [2.5, 5.1]], second: false, look: {} },
-  // Enters mid-hold. Source time does not move before its in-point, so the walk back reaches no
-  // footage at all and this clip enters cold as well - by a different route from c4's. It is the
-  // only additive clip here, which is what puts a clip on each side of the draw order's split.
-  { id: 'c3', start: 5, length: 4, keys: [[0, 40], [0.8, 40], [4, 43.2]], second: false,
+  { id: 'c5', start: 2, length: 2.5, speed: 1, sourceStart: 2.6, second: false, look: {} },
+  // A deep in-point and the only additive clip here, which is what puts a clip on each side of the
+  // draw order's split.
+  { id: 'c3', start: 5, length: 4, speed: 1, sourceStart: 40, second: false,
     look: { additive: true } },
 ];
 
@@ -1653,15 +1652,6 @@ const MULTI = `(() => {
     ? { id: PRIMARY_TAKE.id, hash: PRIMARY_TAKE.hash }
     : null)};
   globalThis.__mc = {
-    /** One serialised retime, built through the shipped door so its handles are the real ones. */
-    retimeFor(keys) {
-      // The setter writes the selected clip, while the serialised fixture is copied from the
-      // first clip. Make those the same clip before asking the shipped door to build the curve.
-      k.timeline.select(k.timeline.clips()[0].id);
-      k.keyframes.setRetime({ rate: 1, keys: keys.map(([t, value]) => ({ t, value })) });
-      return JSON.parse(JSON.stringify(k.library.serialiseProjectBody().clips[0].retime));
-    },
-
     /**
      * The fixture loaded, with the clips listed in the order given.
      *
@@ -1684,7 +1674,8 @@ const MULTI = `(() => {
         length: c.length,
         take: c.take ? { ...c.take }
           : (c.second && second ? { ...second } : (primary ? { ...primary } : one.take)),
-        retime: this.retimeFor(c.keys),
+        speed: c.speed,
+        sourceStart: c.sourceStart,
         // This clip's own look, written into the document rather than applied afterwards - the
         // loader is the door a per-clip look actually comes through.
         params: { ...one.params, ...scoped(look, 'clip'), ...scoped(c.look ?? {}, 'clip') },
@@ -1888,9 +1879,8 @@ console.log('\n== 7. more than one clip: the composite, the cut, and what a clip
     'while standing on source frames of their own, so sharing the take did not put one '
     + "clip's frame in front of another's shader", cursors.join(', '));
 
-  // At 4s, and not over the four-clip overlap: `c3` enters mid-hold, and a hold is a span the
-  // pre-roll can never cover, so any position it is live at plans the whole edit and thrashes
-  // the cache. Two clips of one take is what this row is about, and 4s has exactly that.
+  // At 4s, and not over the four-clip overlap: two clips of one take is what this row is about,
+  // and this position has exactly that.
   const DECODE_SEC = 4;
   const decoded = await page.evaluate(`(async () => {
     const k = globalThis.__kinect;
@@ -1927,11 +1917,8 @@ console.log('\n== 7. more than one clip: the composite, the cut, and what a clip
   // 7d. the claim: a clip entered under playback is the clip seeked to.
   console.log('\n  a clip entered under playback against the same clip seeked to');
   const ENTRIES = [
-    { id: 'c2', targetSec: 3.3, fromSec: 0.5, why: 'a two-second half-speed head' },
-    { id: 'c3', targetSec: 5.3, fromSec: 3.4, why: 'entering mid-hold' },
-    // From before c3's in-point, so the playback arm's own seek is not the one c3's hold makes
-    // reach the head of the edit - which is what keeps the two arms doing different amounts of
-    // work now that the frame cache no longer truncates a pre-roll.
+    { id: 'c2', targetSec: 3.3, fromSec: 0.5, why: 'half speed with a deep in-point' },
+    { id: 'c3', targetSec: 5.3, fromSec: 3.4, why: 'an additive clip with a deep in-point' },
     { id: 'c4', targetSec: 6.3, fromSec: 4.9, why: 'no footage before its in-point' },
   ];
   for (const entry of ENTRIES) {
@@ -1963,10 +1950,6 @@ console.log('\n== 7. more than one clip: the composite, the cut, and what a clip
 
     check(liveHere.includes(entry.id),
       `${entry.id}: the clip under test is actually drawn at this position`, liveHere.join(', '));
-    // Different, not one-sided: a seek beside a retime hold pre-rolls to the head of the edit,
-    // because walking back inside a hold never covers the persistence and the walk runs to the
-    // ceiling. That used to be truncated by the frame cache, and the direction this row used to
-    // assert was a fact about that truncation rather than about the two paths.
     check(played.delta.renders !== seeked.delta.renders,
       `${entry.id}: the two arms did different amounts of work`,
       `${played.delta.renders} renders against ${seeked.delta.renders}`);
@@ -2008,9 +1991,6 @@ console.log('\n== 7. more than one clip: the composite, the cut, and what a clip
     'a clip whose footage starts at source zero has nothing to warm with, so it enters cold - '
     + 'and so does a seek to that instant, which is why the rows above hold rather than break',
     `c4 warms ${warmTable.c4} frames`);
-  check(warmTable.c3 === 0,
-    'and so does one entering mid-hold, by the other route: walking back inside a hold reaches '
-    + 'the frame already bound however far it walks', `c3 warms ${warmTable.c3} frames`);
   check(warmTable.c5 > warmTable.c1,
     'and one of the same take with a longer head is warmed further, so the bound is the head '
     + 'rather than a constant', `c5 warms ${warmTable.c5} against c1's ${warmTable.c1}`);
@@ -2174,9 +2154,9 @@ const STACK_LENGTH_SEC = 6;
 const STACK_ARMS = [1, 2, 4, CLIP_CEILING];
 
 const RELEASED_DEMAND_CLIPS = [
-  { id: 'cached', start: 40, length: 8, keys: [[0, 0], [8, 32]], second: false,
+  { id: 'cached', start: 40, length: 8, speed: 4, sourceStart: 0, second: false,
     look: { fade: 2000, wake: 5000 } },
-  { id: 'current', start: 0, length: 6, keys: [[0, 0], [6, 6]], second: true,
+  { id: 'current', start: 0, length: 6, speed: 1, sourceStart: 0, second: true,
     look: { fade: 100, wake: 0 } },
 ];
 
@@ -2185,7 +2165,8 @@ const stackOf = (n) => Array.from({ length: n }, (_, i) => ({
   id: `s${i}`,
   start: 0,
   length: STACK_LENGTH_SEC,
-  keys: [[0, i * STACK_GAP_SEC], [STACK_LENGTH_SEC, i * STACK_GAP_SEC + STACK_LENGTH_SEC]],
+  speed: 1,
+  sourceStart: i * STACK_GAP_SEC,
   second: false,
   look: {},
 }));
@@ -2210,14 +2191,15 @@ console.log('\n== 8. the frame cache is sized by the clips asking for it ==');
     await page.evaluate(
       `globalThis.__mc.load(${JSON.stringify(stackOf(n))}, null, ${JSON.stringify(STACK_LOOK)})`,
     );
-    const curves = await page.evaluate(`__kinect.library.serialiseProjectBody().clips.map((clip) => ({
+    const timings = await page.evaluate(`__kinect.library.serialiseProjectBody().clips.map((clip) => ({
       id: clip.id,
-      keys: clip.retime.keys.map((key) => [key.t, key.value]),
+      speed: clip.speed,
+      sourceStart: clip.sourceStart,
     }))`);
     const shot = await page.evaluate(
       `globalThis.__mc.arm('seek', ${STACK_TARGET_SEC}, 0, 'stack${n}', null)`,
     );
-    stacked.push({ n, shot, curves });
+    stacked.push({ n, shot, timings });
     const s = shot.seek;
     console.log(`  ${String(n).padStart(2)} clip(s): pre-roll ${s.plan.frames} asked `
       + `(surface ${s.plan.surface}, trails ${s.plan.trails}), ${s.frames} `
@@ -2231,12 +2213,12 @@ console.log('\n== 8. the frame cache is sized by the clips asking for it ==');
 
   const one = stacked.find((a) => a.n === 1);
   const most = stacked[stacked.length - 1];
-  console.log(`  the widest arm's retime endpoints: ${most.curves
-    .map((curve) => `${curve.id}:${curve.keys.map((key) => key[1]).join('-')}`).join(' ')}`);
+  console.log(`  the widest arm's clip timings: ${most.timings
+    .map((timing) => `${timing.id}:${timing.sourceStart}@${timing.speed}x`).join(' ')}`);
 
   check(most.shot.clips.every((clip) => clip.take?.id === TAKE)
     && new Set(most.shot.clips.map((clip) => clip.applied)).size === CLIP_CEILING,
-  'the stacked fixture stays on its named take and reaches a different source frame through every retime it authored',
+  'the stacked fixture stays on its named take and reaches a different source frame through every in-point it authored',
   most.shot.clips.map((clip) => `${clip.id}:${clip.take?.id ?? 'none'}@${clip.applied}`).join(' '));
 
   check(stacked.every(({ shot }) => shot.seek.frames === shot.seek.plan.frames),
@@ -2342,10 +2324,10 @@ if (SECOND_TAKE) {
 // take for depends on that clip's own values and on nothing shared.
 const MIXED_TARGET_SEC = 3;
 const MIXED_CLIPS = [
-  { id: 'live', start: 0, length: 12, keys: [[0, 0], [12, 12]], second: false, look: {} },
-  { id: 'warmLong', start: 3.5, length: 4, keys: [[0, 20], [4, 24]], second: false,
+  { id: 'live', start: 0, length: 12, speed: 1, sourceStart: 0, second: false, look: {} },
+  { id: 'warmLong', start: 3.5, length: 4, speed: 1, sourceStart: 20, second: false,
     look: { fade: 1500, wake: 4000 } },
-  { id: 'warmShort', start: 3.5, length: 4, keys: [[0, 40], [4, 44]], second: false,
+  { id: 'warmShort', start: 3.5, length: 4, speed: 1, sourceStart: 40, second: false,
     look: { fade: 100, wake: 0 } },
 ];
 
@@ -2353,7 +2335,8 @@ const PREFETCH_CLIPS = Array.from({ length: CLIP_CEILING }, (_, i) => ({
   id: `p${i}`,
   start: 0,
   length: 2,
-  keys: [[0, i * 5], [2, i * 5 + 8]],
+  speed: 4,
+  sourceStart: i * 5,
   second: false,
   look: {},
 }));

--- a/web/clip-plan.js
+++ b/web/clip-plan.js
@@ -73,9 +73,21 @@ export function clipAffordedSec(timing, sourceDurationSec) {
  * still wide enough to grab. The footage under what is left holds still by construction: the
  * in-point moves by exactly the program time the head crossed, read at the clip's speed.
  */
-export function headTrim({ start, sourceStart, speed }, wantStart, holdEnd, minLengthSec) {
+export function headTrim(
+  { start, sourceStart, speed },
+  wantStart,
+  holdEnd,
+  minLengthSec,
+  sourceDurationSec = Infinity,
+) {
   const takeFloor = start - sourceStart / speed;
-  const newStart = Math.max(0, Math.max(takeFloor, Math.min(holdEnd - minLengthSec, wantStart)));
+  // A tail can extend beyond the take and hold its last frame. Keep a head drag out of that held
+  // region, or it can serialise an in-point that the document door must refuse on reload.
+  const takeCeiling = Number.isFinite(sourceDurationSec)
+    ? start + Math.max(0, (sourceDurationSec - sourceStart) / speed - minLengthSec)
+    : Infinity;
+  const newStart = Math.max(0,
+    Math.max(takeFloor, Math.min(holdEnd - minLengthSec, takeCeiling, wantStart)));
   const moved = sourceStart + (newStart - start) * speed;
   // Landed on the head of the take rather than near it: the residue of the subtraction above
   // would otherwise be refused as a negative in-point by the document door.

--- a/web/clip-plan.js
+++ b/web/clip-plan.js
@@ -46,7 +46,58 @@ export function frameLoadByTake(spans) {
 export const snapshotClipKeys = (tracks) => [...tracks]
   .flatMap((track) => track.keys.map((key) => [key, key.t]));
 
-/** Rescales clip-local key times around the retime curve's rate pivot. */
+/** Rescales clip-local key times around a pivot when the clip's speed changes. */
 export function rescaleClipKeys(snapshot, factor, pivot = 0) {
   for (const [key, time] of snapshot) key.t = pivot + (time - pivot) * factor;
+}
+
+/** The source second a clip's own program second lands on, from its in-point at its speed. */
+export function clipSourceSecAt({ speed, sourceStart }, localSec) {
+  return sourceStart + localSec * speed;
+}
+
+/** Where a source second sits in the clip's own program time, which runs the map backwards. */
+export function clipProgramSecAt({ speed, sourceStart }, sourceSec) {
+  return (sourceSec - sourceStart) / speed;
+}
+
+/** How much program time the footage past a clip's in-point makes at its speed. */
+export function clipAffordedSec(timing, sourceDurationSec) {
+  return Math.max(0, clipProgramSecAt(timing, sourceDurationSec));
+}
+
+/**
+ * Moves a clip's head to `wantStart`, answering its new placement, in-point and trim.
+ *
+ * Two floors - the head of the edit and the head of the take - and a ceiling that leaves a clip
+ * still wide enough to grab. The footage under what is left holds still by construction: the
+ * in-point moves by exactly the program time the head crossed, read at the clip's speed.
+ */
+export function headTrim({ start, sourceStart, speed }, wantStart, holdEnd, minLengthSec) {
+  const takeFloor = start - sourceStart / speed;
+  const newStart = Math.max(0, Math.max(takeFloor, Math.min(holdEnd - minLengthSec, wantStart)));
+  const moved = sourceStart + (newStart - start) * speed;
+  // Landed on the head of the take rather than near it: the residue of the subtraction above
+  // would otherwise be refused as a negative in-point by the document door.
+  return {
+    start: newStart,
+    sourceStart: Math.max(0, Math.abs(moved) < 1e-9 ? 0 : moved),
+    trim: Math.max(minLengthSec, holdEnd - newStart),
+  };
+}
+
+/**
+ * How many output frames back a clip reaches to cover `sourceSpanSec` of footage, and whether
+ * `ceiling` frames were enough to cover it.
+ */
+export function framesBackFor(speed, sourceSpanSec, fps, ceiling) {
+  if (!(sourceSpanSec > 0)) return { frames: 0, covered: true };
+  const limit = Math.max(0, Math.floor(ceiling));
+  const n = Math.max(1, Math.ceil(((sourceSpanSec - 1e-9) * fps) / speed));
+  return { frames: Math.min(n, limit), covered: n <= limit };
+}
+
+/** How many output frames before its in-point a clip still reaches footage over. */
+export function headFramesFor(speed, sourceStart, fps, limit) {
+  return Math.max(0, Math.min(limit, Math.floor((sourceStart * fps) / speed)));
 }

--- a/web/clip-range.js
+++ b/web/clip-range.js
@@ -3,7 +3,7 @@
 // Two numbers and the one door that writes them. The numbers are program seconds rather
 // than frames, so they survive an output-fps change, and `out` is `null` when the clip
 // runs to the end of the program - a statement rather than a time, because "to the end"
-// has to survive a retime that lengthens the program and a duration written down here
+// has to survive a speed change that lengthens the program and a duration written down here
 // would freeze it at today's length.
 //
 // **The door is a file because the claim it makes could not be true inside one.** The
@@ -32,7 +32,7 @@
 // same answer and a second copy of it is the drift this design keeps refusing.
 //
 // `null` is a statement rather than a time, and it is only ever legal at the out point:
-// there it means "to the end", which has to survive a retime that lengthens the program
+// there it means "to the end", which has to survive a speed change that lengthens the program
 // and so cannot be written down as a number. At the in point, and for anything else that
 // is not a finite number, there is no reading to recover - so it is refused.
 export function clipBoundOrThrow(value, which) {
@@ -110,7 +110,7 @@ export function writeClipRange(values, dur) {
   if (dur !== null) {
     clipIn = Math.max(0, Math.min(clipIn, dur));
     // `null` still means "to the end", which is a different statement from a number that
-    // happens to equal the duration: "whole clip" has to survive a retime that lengthens
+    // happens to equal the duration: "whole clip" has to survive a speed change that lengthens
     // the program, and a duration written in here would freeze it at today's length.
     if (clipOut !== null) clipOut = Math.max(clipIn, Math.min(clipOut, dur));
   }

--- a/web/curve.js
+++ b/web/curve.js
@@ -81,18 +81,6 @@ function elevate(a, b, side) {
   return { easeOut: raised.slice(0, cut), easeIn: raised.slice(cut) };
 }
 
-/** d(value fraction)/d(time fraction), which is what a retime slope is built from. */
-function easeSlopeAt(a, b, x) {
-  const u = easeParam(a, b, x);
-  const dx = bezSlopeAxis(a, b, 0, u);
-  if (dx > 1e-6) return bezSlopeAxis(a, b, 1, u) / dx;
-  // Vertical tangent: measure over a small window.
-  const h = 1e-4;
-  const lo = Math.max(0, x - h);
-  const hi = Math.min(1, x + h);
-  return (easeAt(a, b, hi) - easeAt(a, b, lo)) / Math.max(1e-9, hi - lo);
-}
-
 /** The last key at or before `t`, or -1 when `t` sits before every key. */
 function keyBefore(keys, t) {
   let lo = 0;
@@ -107,46 +95,19 @@ function keyBefore(keys, t) {
 }
 
 const HOLD_ENDS = 'hold';
-const EXTEND_ENDS = 'extend';
 
 function scalarAt(keys, t, ends) {
   const n = keys.length;
   if (n === 0) return 0;
   if (n === 1) return keys[0].value;
   const i = keyBefore(keys, t);
-  if (i < 0) {
-    if (ends === HOLD_ENDS) return keys[0].value;
-    return keys[0].value + (t - keys[0].t) * segmentSlope(keys, 0, 0);
-  }
-  if (i >= n - 1) {
-    if (ends === HOLD_ENDS) return keys[n - 1].value;
-    return keys[n - 1].value + (t - keys[n - 1].t) * segmentSlope(keys, n - 2, 1);
-  }
+  if (i < 0) return keys[0].value;
+  if (i >= n - 1) return keys[n - 1].value;
   const a = keys[i];
   const b = keys[i + 1];
   const span = b.t - a.t;
   if (span <= 0) return b.value;
   return a.value + (b.value - a.value) * easeAt(a.easeOut, b.easeIn, (t - a.t) / span);
-}
-
-/** The slope of segment `i` at one of its ends, in value per program second. */
-function segmentSlope(keys, i, x) {
-  const a = keys[i];
-  const b = keys[i + 1];
-  const span = b.t - a.t;
-  if (span <= 0) return 0;
-  return ((b.value - a.value) / span) * easeSlopeAt(a.easeOut, b.easeIn, x);
-}
-
-function scalarSlopeAt(keys, t) {
-  const n = keys.length;
-  if (n < 2) return 0;
-  const i = keyBefore(keys, t);
-  if (i < 0) return segmentSlope(keys, 0, 0);
-  if (i >= n - 1) return segmentSlope(keys, n - 2, 1);
-  const span = keys[i + 1].t - keys[i].t;
-  if (span <= 0) return 0;
-  return segmentSlope(keys, i, (t - keys[i].t) / span);
 }
 
 function stepAt(keys, t) {
@@ -242,38 +203,6 @@ function foldFreeX(a, b, side, index, from, to) {
   return good;
 }
 
-/** The source second a clip's own program second maps to. */
-function retimeSourceSecAt({ rate, keys }, programSec) {
-  if (keys.length === 0) return programSec * rate;
-  if (keys.length === 1) return keys[0].value + (programSec - keys[0].t) * rate;
-  return scalarAt(keys, programSec, EXTEND_ENDS);
-}
-
-/** The program position a source position sits at, which is `retimeSourceSecAt` run backwards. */
-function retimeProgramSecAt(curve, sourceSec) {
-  const { rate, keys } = curve;
-  if (keys.length === 0) return sourceSec / rate;
-  if (keys.length === 1) return keys[0].t + (sourceSec - keys[0].value) / rate;
-  if (sourceSec <= keys[0].value) {
-    const slope = segmentSlope(keys, 0, 0);
-    return slope > 0 ? keys[0].t - (keys[0].value - sourceSec) / slope : keys[0].t;
-  }
-  for (let i = 0; i < keys.length - 1; i++) {
-    if (keys[i + 1].value < sourceSec) continue;
-    let lo = keys[i].t;
-    let hi = keys[i + 1].t;
-    for (let k = 0; k < 50; k++) {
-      const mid = (lo + hi) / 2;
-      if (retimeSourceSecAt(curve, mid) < sourceSec) lo = mid;
-      else hi = mid;
-    }
-    return hi;
-  }
-  const last = keys[keys.length - 1];
-  const slope = segmentSlope(keys, keys.length - 2, 1);
-  return slope > 0 ? last.t + (sourceSec - last.value) / slope : last.t;
-}
-
 export {
   handleRefusal,
   foldRefusal,
@@ -287,11 +216,7 @@ export {
   elevate,
   keyBefore,
   HOLD_ENDS,
-  EXTEND_ENDS,
   scalarAt,
-  retimeSourceSecAt,
-  retimeProgramSecAt,
-  scalarSlopeAt,
   stepAt,
   hermite,
   tangentAt,

--- a/web/format.js
+++ b/web/format.js
@@ -4,11 +4,12 @@
  *
  * A document from any other version is refused, naming the version it found, rather than
  * opened on a best guess: this build ships no conversion and no reader of a second shape.
- * Version 7 carries a `clips` array - each clip its own take, placement, retime curve and the
- * look values that write the cloud - beside the `look` block holding the ones that write the
- * post chain. Version 6 carried one take at the top and one undivided look under it.
+ * Version 8 carries a `clips` array - each clip its own take, placement, speed, in-point and
+ * the look values that write the cloud - beside the `look` block holding the ones that write
+ * the post chain. Version 7 placed its footage with a keyframed retime curve instead of the
+ * `speed` and `sourceStart` pair.
  */
-export const PROJECT_VERSION = 7;
+export const PROJECT_VERSION = 8;
 
 /**
  * How many clips this build composites.

--- a/web/index.html
+++ b/web/index.html
@@ -792,8 +792,8 @@
   .tclock small { display: block; font-size: 11px; letter-spacing: 0.14em;
     text-transform: uppercase; color: var(--faint); white-space: nowrap; }
   .tclock output { font-size: 22px; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
-  /* Source time is derived from program time through the retime, never edited,
-     so it reads as a secondary value rather than as a second control. */
+  /* Source time is derived from program time through the clip's speed and in-point,
+     never edited, so it reads as a secondary value rather than as a second control. */
   .tclock.derived output { color: var(--dim); font-size: 14px; }
 
   .tchips { flex: 1; display: flex; gap: 8px; flex-wrap: nowrap; align-items: center;
@@ -1071,8 +1071,8 @@
   /* The take's marks, on the ruler the playhead runs along. They live on the take
      rather than in any project, so every edit of that take shows the same ticks -
      which is the payoff for putting them in a sidecar. Drawn in program time
-     through the retime curve, because the ruler is program time and a mark is
-     source time, and the two only coincide at rate 1 with no keys. */
+     through the clip's speed and in-point, because the ruler is program time and a
+     mark is source time, and the two only coincide on an untrimmed clip at 1.00x. */
   /* The strip stays transparent to the pointer so a scrub that crosses a mark is
      still a scrub, and each tick takes its own events back - the ticks are buttons
      that seek to the mark, and a layer that swallowed nothing would have swallowed
@@ -1084,7 +1084,7 @@
   .tmk svg { display: block; }
   /* A mark the edit never reaches stacks at the right edge rather than being
      dropped: the moment is still in the footage, and a tick nobody can explain is
-     better than a tick that silently vanished when the curve was retimed.
+     better than a tick that silently vanished when the clip's speed changed.
 
      **Above the two interaction states rather than below them, and the order is the
      whole of it.** `.tmk.beyond` and `.tmk:hover` have the same specificity, so
@@ -1542,16 +1542,9 @@
                at the bottom of the old range changed the clip's length by a third and the
                same step at the top changed it by one percent. The bounds live in `main.js`
                beside the mapping that reads this, so there is one copy of them. `value` is
-               written from `retime.rate` at boot for the same reason - a position spelled
+               written from the clip's speed at boot for the same reason - a position spelled
                out here would be a second statement of where 1.00x sits. -->
-          <!-- The diamond belongs beside the slider it keys, which is the same shape the
-               camera chip to the right uses for the same job. Without it the slider sets
-               one rate for the whole clip and nothing can author a speed change over time:
-               `paintRateKey` and the add/delete behind it were still here after the rework
-               took the button away, so the retime curve remained a thing the document could
-               hold and the surface could not make. -->
-          <label class="tspeed">speed<input id="tRate" type="range" min="0" max="1" step="any"><b id="tRateOut">1.00&times;</b>
-            <button class="kf" id="tRateKey" type="button" aria-label="Retime keyframe"><i></i></button></label></span>
+          <label class="tspeed">speed<input id="tRate" type="range" min="0" max="1" step="any"><b id="tRateOut">1.00&times;</b></label></span>
         <!-- Applies to whichever key is selected in a lane, except `ends`, which is
              about the track's two outer keys however you got here - see EASE_PRESETS.
              They cover what a handle drag is usually reaching for, and a drag is still
@@ -1674,7 +1667,7 @@
       <div class="dialog-segments" id="projectAspects"></div>
     </div>
     <!-- A `<select>` and not a segmented row because the four rates are a list that could
-         grow, and because everything that reads this - the `change` handler that retimes
+         grow, and because everything that reads this - the `change` handler that sets the speed
          the open clip, `timingChanged`, and the restore from a saved project - already
          speaks `.value` and `change`. The id is unchanged from when this sat in the export
          dialog: the element moved surfaces, and nothing about what it drives did.

--- a/web/main.js
+++ b/web/main.js
@@ -13,8 +13,8 @@ import {
 } from './scene.js';
 import {
   EASE_OUT_LINEAR, EASE_IN_LINEAR, SEGMENT_POINT_CEILING, copyHandle, easeAt, elevate, keyBefore,
-  HOLD_ENDS, scalarAt, scalarSlopeAt, stepAt, hermite, tangentAt,
-  handleRefusal, foldRefusal, foldFreeX, retimeSourceSecAt, retimeProgramSecAt,
+  HOLD_ENDS, scalarAt, stepAt, hermite, tangentAt,
+  handleRefusal, foldRefusal, foldFreeX,
 } from './curve.js';
 import { tiltQuaternion } from './world-tilt.js';
 import { verticalFovForFocalLength, focalLengthForVerticalFov } from './lens.js';
@@ -28,7 +28,8 @@ import { pickDepth, sensorPoint } from './depth-pick.js';
 import { ZOOM_PER_NOTCH, rulerTickSeconds, tickLabel, makeViewWindow } from './view-window.js';
 import { clipIn, clipOut, clipBoundOrThrow, writeClipRange } from './clip-range.js';
 import {
-  RATE_MIN, RATE_MAX, frameLoadByTake, integerMidpoint, rescaleClipKeys, snapshotClipKeys,
+  RATE_MIN, RATE_MAX, clipAffordedSec, clipProgramSecAt, clipSourceSecAt, frameLoadByTake,
+  framesBackFor, headFramesFor, headTrim, integerMidpoint, rescaleClipKeys, snapshotClipKeys,
   usableClipRate,
 } from './clip-plan.js';
 import {
@@ -227,8 +228,8 @@ let evaluatingClip = null;
  * Whose look a write or a read is about: the clip under evaluation, else the selected clip.
  *
  * An explicit indirection rather than a binding repointed for the walk. The selection is the
- * user's - the panel, the lanes and the retime curve are all views of it - so a walk that moved
- * it would be mutating what the operator is looking at in order to render a frame.
+ * user's - the panel and the lanes are both views of it - so a walk that moved it would be
+ * mutating what the operator is looking at in order to render a frame.
  */
 const clipOfLook = () => evaluatingClip ?? selectedClip;
 const lookOf = () => clipOfLook()?.look ?? bootLook;
@@ -2602,10 +2603,11 @@ function serialiseProjectBody({ suppressed = null } = {}) {
       id: clip.id,
       take: clip.take ? { ...clip.take } : null,
       start: clip.start,
-      // The trim, and null where this clip runs for everything its curve affords. Written and
+      // The trim, and null where this clip runs for everything its footage affords. Written and
       // read back as the same fact, which is where the edit stops using the take.
       length: clip.trim,
-      retime: clip.retime.serialise(),
+      speed: clip.speed,
+      sourceStart: clip.sourceStart,
       appliedPreset: clip.appliedPreset,
       // This clip's own look, read off its own tables. Two clips of one project hold two of
       // these and they are allowed to disagree, which is what makes a clip's look its own.
@@ -2624,7 +2626,7 @@ function restoreKey(owner, k, kind) {
   if (!Number.isFinite(k?.t)) {
     throw new Error(`${owner} has a key at t=${JSON.stringify(k?.t)}: a key time has to be a finite number`);
   }
-  const [loY, hiY] = kind === 'retime' || !KINDS[kind].overshoots ? [0, 1] : [-1, 2];
+  const [loY, hiY] = KINDS[kind].overshoots ? [-1, 2] : [0, 1];
   const handle = (side, points, fallback) => {
     if (points === undefined) return copyHandle(fallback);
     const ok = Array.isArray(points)
@@ -2875,8 +2877,13 @@ function checkProject(project) {
     if (clip.length !== null && (!Number.isFinite(clip.length) || clip.length < 0)) {
       throw new Error(`${what} is ${JSON.stringify(clip.length)} long: a length is a number of project seconds at or above zero, or null where the document states none`);
     }
-    if (!clip.retime || !Array.isArray(clip.retime.keys) || !usableClipRate(clip.retime.rate)) {
-      throw new Error(`${what} carries a retime with an array of keys and a rate from ${RATE_MIN} to ${RATE_MAX}`);
+    if (!usableClipRate(clip.speed)) {
+      throw new Error(`${what} runs at ${JSON.stringify(clip.speed)}: a clip's speed is a number from ${RATE_MIN} to ${RATE_MAX}`);
+    }
+    // The in-point: where in the take this clip starts. Zero is an untrimmed head, and a
+    // negative one would ask for footage from before the take began.
+    if (!Number.isFinite(clip.sourceStart) || clip.sourceStart < 0) {
+      throw new Error(`${what} starts at source ${JSON.stringify(clip.sourceStart)}: a clip's in-point is a finite number of source seconds, at or after zero`);
     }
     const stampWhy = stampRefusal(what, clip.appliedPreset ?? null);
     if (stampWhy) throw new Error(stampWhy);
@@ -2891,24 +2898,14 @@ function checkProject(project) {
       );
     }
 
-    const keys = clip.retime.keys.map((k) => {
-      const key = restoreKey('the retime curve', k, 'retime');
-      if (!Number.isFinite(key.value)) {
-        throw new Error(`the retime key at ${key.t}s maps to ${JSON.stringify(key.value)}: source time is a number`);
-      }
-      return key;
-    });
-    refuseFolds('the retime curve', keys);
-    // The fourth door onto the curve, and the one a file from outside comes through.
-    retime.assertMonotonic(keys);
-
     plannedClips.push({
       id: clip.id,
       take: take === null ? null : { id: take.id, hash: take.hash },
       start: clip.start,
       trim: clip.length ?? null,
       appliedPreset: clip.appliedPreset ?? null,
-      retime: { rate: clip.retime.rate, keys },
+      speed: clip.speed,
+      sourceStart: clip.sourceStart,
       look,
     });
   }
@@ -3065,8 +3062,8 @@ function applyProject(plan, sources = null) {
     clip.start = planned.start;
     clip.trim = planned.trim;
     clip.appliedPreset = planned.appliedPreset;
-    clip.retime.rate = planned.retime.rate;
-    clip.retime.keys = planned.retime.keys;
+    clip.speed = planned.speed;
+    clip.sourceStart = planned.sourceStart;
   }
   releaseUnusedFrames();
   orderClips();
@@ -3096,15 +3093,21 @@ function refuseResolvedDurations(plan, sources) {
     const source = sources.get(at)?.take ?? clips[at]?.source;
     if (!source || source.streaming) continue;
     const sourceDuration = source.duration ?? source.times?.[source.times.length - 1];
-    const curve = createRetime();
-    curve.rate = planned.retime.rate;
-    curve.keys = planned.retime.keys;
-    const length = planned.trim ?? curve.programDurationFor(sourceDuration);
+    // Ahead of the arithmetic below, which would answer a length of zero for this and call it
+    // resolved: an in-point past the end of the footage leaves the clip nothing to draw.
+    if (planned.sourceStart >= sourceDuration) {
+      throw new Error(
+        `clip ${planned.id} starts at source ${planned.sourceStart}s in ${sourceDuration}s of `
+        + 'footage: nothing of the take is left after its in-point',
+      );
+    }
+    const length = planned.trim
+      ?? clipAffordedSec({ speed: planned.speed, sourceStart: planned.sourceStart }, sourceDuration);
     const end = planned.start + length;
     if (!Number.isFinite(length) || !Number.isFinite(end)) {
       throw new Error(
         `clip ${planned.id} ends at ${String(end)} after resolving ${sourceDuration}s of footage: `
-        + 'its start, trim and retime must produce a finite project duration',
+        + 'its start, trim, speed and in-point must produce a finite project duration',
       );
     }
     const lastFrame = Math.floor(end * fps);
@@ -3754,90 +3757,6 @@ const counters = {
   bitmapDecodes: 0,
 };
 
-// One clip's map from its own program time to source time.
-const createRetime = () => ({
-  rate: 1,
-  keys: [],
-
-  sourceSecAt(programSec) { return retimeSourceSecAt(this, programSec); },
-
-  // The local slope, in source seconds per program second.
-  slopeAt(programSec) {
-    if (this.keys.length < 2) return this.rate;
-    return scalarSlopeAt(this.keys, programSec);
-  },
-
-  /**
-   * How many output frames back the curve reaches to cover `sourceSpanSec` ending
-   * at `programSec`.
-   */
-  framesBackFor(programSec, sourceSpanSec, outputFps, ceiling) {
-    if (!(sourceSpanSec > 0)) return { frames: 0, covered: true };
-    const at = this.sourceSecAt(programSec);
-    const limit = Math.max(0, Math.floor(ceiling));
-    for (let n = 1; n <= limit; n++) {
-      if (at - this.sourceSecAt(programSec - n / outputFps) >= sourceSpanSec - 1e-9) {
-        return { frames: n, covered: true };
-      }
-    }
-    return { frames: limit, covered: false };
-  },
-
-  /** The program position a source position sits at. */
-  programSecAt(sourceSec) { return retimeProgramSecAt(this, sourceSec); },
-
-  // How long a program is, given a source that long.
-  programDurationFor(sourceSec) { return Math.max(0, this.programSecAt(sourceSec)); },
-
-  /** Refuses a curve that runs downhill. Equal values are a hold and are legal. */
-  assertMonotonic(keys) {
-    for (const key of keys) {
-      // Handles first, because a curve can run downhill without any pair of key
-      // values doing so.
-      for (const [side, h] of [['easeOut', key.easeOut], ['easeIn', key.easeIn]]) {
-        if (h.length !== 1) {
-          throw new Error(
-            `the retime key at program ${key.t}s has a ${side} handle of ${h.length} control `
-            + 'points: the retime curve is a cubic, because the proof that a handle inside the '
-            + 'unit box cannot run source time backwards is a proof about a cubic and about '
-            + 'nothing else',
-          );
-        }
-        if (!h[0].every((c) => c >= 0 && c <= 1)) {
-          throw new Error(
-            `the retime key at program ${key.t}s has a ${side} handle at `
-            + `[${h[0].join(', ')}]: a handle outside the unit box bends the curve back on `
-            + 'itself inside the segment, and source time cannot run backwards',
-          );
-        }
-      }
-    }
-    for (let i = 1; i < keys.length; i++) {
-      if (keys[i].value < keys[i - 1].value) {
-        throw new Error(
-          `the retime curve falls from ${keys[i - 1].value}s to ${keys[i].value}s between `
-          + `program ${keys[i - 1].t}s and ${keys[i].t}s: source time cannot run backwards, `
-          + 'because neither accumulator can',
-        );
-      }
-    }
-    return keys;
-  },
-
-  serialise() {
-    return {
-      rate: this.rate,
-      keys: this.keys.map((k) => ({
-        t: k.t, value: k.value, easeOut: copyHandle(k.easeOut), easeIn: copyHandle(k.easeIn),
-      })),
-    };
-  },
-});
-
-// The selected clip's curve, as a live binding: every reader below names it rather than
-// reaching through a clip. Assigned by `selectClip`, which runs before anything reads it.
-let retime = null;
-
 /** Every selected-clip key time, rescaled by `k` when its slope changes. */
 function reparameteriseProgramTime(k, was) {
   rescaleClipKeys(was.keys, k, was.pivot);
@@ -3846,8 +3765,7 @@ function reparameteriseProgramTime(k, was) {
 /** Where a later rescale reads its times from. Live objects, and the `t` they had. */
 const programTimeSnapshot = () => ({
   keys: snapshotClipKeys(lookOf().tracks.values()),
-  // With one key, the rate changes the slope on both sides of that key rather than at zero.
-  pivot: retime.keys.length === 1 ? retime.keys[0].t : 0,
+  pivot: 0,
 });
 
 class LivePairSource {
@@ -3923,12 +3841,11 @@ const livePairs = new LivePairSource();
 const liveTransport = new LiveTransport(livePairs);
 
 /**
- * One layer of the composite: where it sits in the project, the frames it draws, the curve that
- * picks them and the cloud it draws them with.
+ * One layer of the composite: where it sits in the project, the frames it draws, how fast it
+ * runs through them and the cloud it draws them with.
  *
- * Clip-local time at project time `t` is `t - start`, and the curve maps that onto a position in
- * the source - so an offset into the take is something the curve already states and there is
- * deliberately no second field carrying it.
+ * Clip-local time at project time `t` is `t - start`. Two fields turn that into a source
+ * position: `sourceStart`, the in-point a head trim writes, and `speed`, the slider's rate.
  */
 class Clip {
   constructor(id, source, cloud, look = createLook()) {
@@ -3943,10 +3860,13 @@ class Clip {
     // The footage this clip draws, as `{ id, hash }`, or null before anything is open. The take
     // is named by hash so a rename carries it, and `source` is what that hash resolved to.
     this.take = null;
-    this.retime = createRetime();
+    // How fast this clip runs through its footage, in source seconds per project second.
+    this.speed = 1;
+    // The in-point: the source second at this clip's head, which a head trim moves.
+    this.sourceStart = 0;
     // Project seconds, and where the composite puts this clip.
     this.start = 0;
-    // Project seconds this clip runs for, or null to run for everything its curve affords. A
+    // Project seconds this clip runs for, or null to run for everything its footage affords. A
     // trim is where the edit stops using the take, which is a different fact from how much take
     // there is - so this is read as the answer rather than derived and compared to one.
     this.trim = null;
@@ -3962,12 +3882,12 @@ class Clip {
     this.drawnSinceReset = false;
   }
 
-  /** How much project time this clip's curve makes of the source behind it. */
+  /** How much project time this clip makes of the source left after its in-point. */
   get afforded() {
-    return this.source.streaming ? Infinity : this.retime.programDurationFor(this.source.duration);
+    return this.source.streaming ? Infinity : clipAffordedSec(this, this.source.duration);
   }
 
-  /** How long this clip runs in project seconds: its trim, or everything its curve affords. */
+  /** How long this clip runs in project seconds: its trim, or everything its footage affords. */
   get length() { return this.trim === null ? this.afforded : this.trim; }
 
   /** Where this clip stops, in project seconds. A trim past the source holds its last frame. */
@@ -3980,17 +3900,17 @@ class Clip {
 
   /** The source frame at or before a project position, as the lower half of a bracketing pair. */
   sourceFrameAt(programSec) {
-    return this.source.bracket(this.retime.sourceSecAt(programSec - this.start));
+    return this.source.bracket(clipSourceSecAt(this, programSec - this.start));
   }
 
   /** Where a source frame lands in project seconds, which is `sourceFrameAt` run backwards. */
   programSecOf(sourceFrame) {
-    return this.start + this.retime.programSecAt(this.source.times[sourceFrame]);
+    return this.start + clipProgramSecAt(this, this.source.times[sourceFrame]);
   }
 
-  /** How many output frames back this clip's curve reaches to cover `sourceSpanSec`. */
+  /** How many output frames back this clip reaches to cover `sourceSpanSec`. */
   surfaceFramesBack(programSec, sourceSpanSec, outputFps, ceiling) {
-    return this.retime.framesBackFor(programSec - this.start, sourceSpanSec, outputFps, ceiling);
+    return framesBackFor(this.speed, sourceSpanSec, outputFps, ceiling);
   }
 
   /**
@@ -3999,8 +3919,8 @@ class Clip {
    * A clip that appears mid-playback has whatever its ping-pong pair last drew still in it, so
    * without this the first frame after a cut shows no fade and no wake where the same instant
    * reached by seeking is pre-rolled and looks right. The window is this clip's own surface span
-   * read at its in-point, bounded by the source its head affords: the curve extrapolates outside
-   * its domain, so the walk stops where it would ask for footage from before the take began.
+   * read at its in-point, bounded by the footage in front of that in-point: a clip whose head is
+   * the head of the take has nothing to pre-roll over.
    */
   warmFrames(outputFps, ceiling) {
     if (this.source.streaming) return 0;
@@ -4011,25 +3931,15 @@ class Clip {
       && held.ceiling === ceiling && held.timingGen === timingGeneration) {
       return held.frames;
     }
-    const want = this.retime.framesBackFor(0, surfaceSec, outputFps, ceiling).frames;
+    const want = framesBackFor(this.speed, surfaceSec, outputFps, ceiling).frames;
     const frames = Math.min(want, this.headFrames(outputFps, want));
     this.warmCache = { surfaceSec, outputFps, ceiling, timingGen: timingGeneration, frames };
     return frames;
   }
 
-  /** How many output frames before its in-point this clip's curve still reaches new footage. */
+  /** How many output frames before its in-point this clip still reaches footage over. */
   headFrames(outputFps, limit) {
-    const floor = this.source.times[0];
-    let last = this.retime.sourceSecAt(0);
-    for (let n = 1; n <= limit; n++) {
-      const at = this.retime.sourceSecAt(-n / outputFps);
-      if (at < floor) return n - 1;
-      // A hold reaches no further back however long it is walked, so the walk stops where source
-      // time stops moving rather than re-binding the frame already bound for the whole edit.
-      if (!(at < last - 1e-9)) return n - 1;
-      last = at;
-    }
-    return limit;
+    return headFramesFor(this.speed, this.sourceStart, outputFps, limit);
   }
 }
 
@@ -4131,7 +4041,6 @@ function mintClipId() {
 function selectClip(clip) {
   selectedClip = clip;
   selectCloud(clip.cloud);
-  retime = clip.retime;
 }
 selectClip(clips[0]);
 
@@ -4276,7 +4185,7 @@ function renderProgramFrame(t) {
 
       // The one place program time becomes source time, through the clip's own zero.
       const local = t - clip.start;
-      const frame = clip.source.at(clip.retime.sourceSecAt(local));
+      const frame = clip.source.at(clipSourceSecAt(clip, local));
       for (const step of frame.steps) {
         step.makeCurrent();
         advanceSurfaceState(step.gapSec);
@@ -4786,7 +4695,7 @@ class TimelineTransport {
 
   get programSec() { return this.frame / this.outputFps; }
 
-  /** The clip the panel, the lanes and the retime binding are pointed at. */
+  /** The clip the panel and the lanes are pointed at. */
   get clip() { return selectedClip; }
 
   /** Program seconds, which is where the last clip stops. Its own curve is what says where. */
@@ -5002,7 +4911,7 @@ class TimelineTransport {
       .every((held) => held <= MAX_SPAN_FRAMES);
 
     // Walked in from the head until every take's span fits its cache. Bisected rather than
-    // stepped: on a slow retime the window is the whole edit and stepping it is quadratic.
+    // stepped: on a slow clip the window is the whole edit and stepping it is quadratic.
     if (!fits(start)) {
       let lo = start;
       let hi = target;
@@ -5029,7 +4938,8 @@ class TimelineTransport {
   }
 
   async seekNow(programSec, options = {}) {
-    // Planned, fetched, then planned again: the retime curve can move under the await.
+    // Planned, fetched, then planned again: a clip's speed, in-point or start can move under
+    // the await.
     let planned = this.planSeek(programSec, options.frames);
     this.askFor(planned.spans);
     for (let attempt = 0; !this.resident(planned.spans); attempt++) {
@@ -5040,7 +4950,7 @@ class TimelineTransport {
           this.overtaken = 0;
           throw new Error(
             `${SEEK_OVERTAKEN_LIMIT} seeks in a row were overtaken before they could land: `
-            + 'the span a seek plans is not becoming resident, which is not a moving curve',
+            + 'the span a seek plans is not becoming resident, which is not a moving clip',
           );
         }
         requestRepaint();
@@ -5098,7 +5008,7 @@ class TimelineTransport {
     this.askFor(spans);
     for (let attempt = 0; !this.resident(spans); attempt++) {
       if (attempt >= SEEK_REPLANS) {
-        throw new Error(`the retime curve moved under ${SEEK_REPLANS} plans of a draft at ${programSec}s`);
+        throw new Error(`a clip's timing moved under ${SEEK_REPLANS} plans of a draft at ${programSec}s`);
       }
       await this.fetch(spans);
       target = this.frameAt(programSec);
@@ -5183,7 +5093,7 @@ class TimelineTransport {
       if (want < clip.source.applied) {
         throw new Error(
           `playback at ${t.toFixed(3)}s wants source frame ${want} of clip ${clip.id} while the `
-          + `accumulators have consumed ${clip.source.applied}: the retime curve runs backwards here`,
+          + `accumulators have consumed ${clip.source.applied}: the clip runs backwards here`,
         );
       }
       if (!clip.source.resident(clip.source.applied + 1, want)) return false;
@@ -5602,7 +5512,6 @@ const ui = {
   source: document.getElementById('tSource'),
   rate: document.getElementById('tRate'),
   rateOut: document.getElementById('tRateOut'),
-  rateKey: document.getElementById('tRateKey'),
   fps: document.getElementById('tFps'),
   bed: document.getElementById('tBed'),
   rail: document.getElementById('tRail'),
@@ -6611,7 +6520,7 @@ const sliderFromRate = (rate) => (
   / Math.log(RATE_MAX / RATE_MIN)
 );
 
-ui.rate.value = String(sliderFromRate(retime.rate));
+ui.rate.value = String(sliderFromRate(selectedClip.speed));
 
 /** What a speed gesture holds still, captured once when it starts. */
 let rateGesture = null;
@@ -6624,13 +6533,13 @@ function beginRateGesture({ fromKey = false } = {}) {
     fromKey,
     gen,
     // Disarmed for a gesture that begins inside the band at something other than 1.00x.
-    detentArmed: retime.rate === 1 || !insideDetent(sliderFromRate(retime.rate)),
-    // Through the clip's own zero: the curve's domain is clip-local, so feeding it the
-    // project second would anchor on the wrong source frame of a clip that starts after 0.
+    detentArmed: selectedClip.speed === 1 || !insideDetent(sliderFromRate(selectedClip.speed)),
+    // Through the clip's own zero: the map is clip-local, so feeding it the project second
+    // would anchor on the wrong source frame of a clip that starts after 0.
     source: sourceSecOfProgram(timeline.programSec),
     wasPlaying: timeline.playing,
     // The parameterisation the gesture started in. Every time is rescaled from these.
-    rate: retime.rate,
+    rate: selectedClip.speed,
     times: programTimeSnapshot(),
     // Fractions preserve footage when one clip is the whole program. A clip inside a larger edit
     // changes the program length non-uniformly, so its existing program bounds are held instead.
@@ -6665,7 +6574,8 @@ function endRateGesture() {
 /** Puts the slope at `rate` and carries the document with it. The order is load-bearing. */
 function applyRate(rate) {
   if (refuseEdit('a speed change')) return timeline ? timeline.programSec : 0;
-  retime.rate = rate;
+  // The seam: the slider and the gesture around it say rate, and the model says speed.
+  selectedClip.speed = rate;
   rateGesture.applied = true;
   const program = programHoldingAnchor();
   // `frameOf` rather than `frameAt`, which clamps to a clip range that is stale here.
@@ -6862,7 +6772,6 @@ const poseLaneFraction = (keys, t) => {
   return easeAt(keys[i].easeOut, keys[i + 1].easeIn, (t - keys[i].t) / span);
 };
 
-const RETIME_LANE_H = 40;
 // How far a curve is sampled across a lane. A smoothness choice rather than a pixel count.
 const CURVE_SAMPLES = 120;
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -6896,10 +6805,6 @@ const svg = (name, attrs) => {
 
 /** The value range a lane draws against. */
 function laneRange(owner) {
-  if (owner === 'retime') {
-    const total = Math.max(1e-6, timeline ? timeline.clip.source.duration : 1);
-    return { min: 0, max: total };
-  }
   const spec = params.spec(laneName(owner));
   return KINDS[spec.kind].range(spec);
 }
@@ -6942,9 +6847,6 @@ function laneRows() {
     }
   }
   rows.push({ owner: 'clip-add', label: '', kind: 'clip-add', height: CLIP_ADD_H });
-  if (retime.keys.length > 0) {
-    rows.push({ owner: 'retime', label: 'retime', kind: 'scalar', height: RETIME_LANE_H });
-  }
   // The project's own curves at the foot, which is everything a clip does not hold: the camera,
   // and the post chain every clip is seen through.
   for (const name of ['camera', ...scopeNames('project')]) {
@@ -6995,7 +6897,7 @@ const withLaneClip = (owner, write) => {
 // A clip row and the bar above it own no keys, so a lane's key list is empty rather than absent.
 const keysOf = (owner) => {
   if (owner === 'clip-add' || isClipRow(owner)) return [];
-  return owner === 'retime' ? retime.keys : (trackOf(owner)?.keys ?? []);
+  return trackOf(owner)?.keys ?? [];
 };
 
 /** The clip a lane owner's row is, or null where the owner is not a clip row. */
@@ -7007,7 +6909,6 @@ function laneReadout(owner) {
   // The length rather than the placement: where a clip sits is what its box already says, and
   // the rail is 96px wide, which fits one number and not two.
   if (clip) return Number.isFinite(clip.length) ? `${clip.length.toFixed(2)}s` : '∞';
-  if (owner === 'retime') return `${retime.slopeAt(programToLane(owner, playheadSec())).toFixed(2)}×`;
   // Out of the look the owner names rather than off the selection, or every clip's lane would
   // read the selected clip's number back however many clips are keyed.
   const name = laneName(owner);
@@ -7118,11 +7019,9 @@ function repositionLanes() {
 function lanePoints(owner) {
   const { min, max } = laneRange(owner);
   const span = Math.max(1e-9, max - min);
-  // Sampled on the lane's own clock: the walk below is over program seconds and a retime curve
-  // and a placement are both measured from their clip's in-point.
-  const at = owner === 'retime'
-    ? (t) => retime.sourceSecAt(programToLane(owner, t))
-    : (t) => KINDS[trackOf(owner).kind].at(owner, programToLane(owner, t));
+  // Sampled on the lane's own clock: the walk below is over program seconds and a clip's keys
+  // are measured from its in-point.
+  const at = (t) => KINDS[trackOf(owner).kind].at(owner, programToLane(owner, t));
   const points = [];
   // Sampled across the visible window rather than the clip, so nothing is drawn outside it.
   for (let i = 0; i <= CURVE_SAMPLES; i++) {
@@ -7255,23 +7154,6 @@ function handleSpan(keys, seg, side, index) {
   return { lo: Math.min(at(k - 1), at(k + 1), here), hi: Math.max(at(k - 1), at(k + 1), here) };
 }
 
-/** Holds a retime key inside its neighbours, in both time and value. */
-function clampRetimeKey(keys, key) {
-  const i = keys.indexOf(key);
-  // The curve is anchored at the origin, so its first key holds still in time.
-  if (i === 0) key.t = 0;
-  else {
-    const after = i < keys.length - 1 ? keys[i + 1].t : Infinity;
-    key.t = Math.max(keys[i - 1].t + KEY_GAP_SEC, Math.min(after - KEY_GAP_SEC, key.t));
-  }
-  const floor = i > 0 ? keys[i - 1].value : 0;
-  const ceiling = i < keys.length - 1 ? keys[i + 1].value : timeline.clip.source.duration;
-  key.value = Math.max(floor, Math.min(ceiling, key.value));
-}
-
-// The least program time two retime keys may be apart.
-const KEY_GAP_SEC = 1 / 240;
-
 /** Readouts only. Structure is `rebuildLanes`, and the two are kept apart on purpose. */
 function paintLanes() {
   for (const el of ui.rail.querySelectorAll('b[data-readout]')) {
@@ -7279,7 +7161,6 @@ function paintLanes() {
   }
   for (const [name, btn] of keyButtons) paintKeyButton(name, btn);
   paintClipCommands();
-  paintRateKey();
   paintMarkButton();
   paintEase();
 }
@@ -7301,7 +7182,7 @@ function lanesMoved() {
   paintLanes();
 }
 
-/** The retime curve or the output rate moved, so every position on the ruler did. */
+/** A clip's timing or the output rate moved, so every position on the ruler did. */
 function timingChanged({ moved = false } = {}) {
   // Before the guard: the warm window is memoised against this and a recorder-side change to a
   // curve still moves it, whether or not there is a strip to repaint.
@@ -7309,15 +7190,11 @@ function timingChanged({ moved = false } = {}) {
   if (!timeline) return;
   // Re-clamped against a duration this may have changed: the window is stored as fractions.
   view.reclamp();
-  if (rateFromSlider(ui.rate.value) !== retime.rate) {
-    ui.rate.value = String(sliderFromRate(retime.rate));
+  if (rateFromSlider(ui.rate.value) !== selectedClip.speed) {
+    ui.rate.value = String(sliderFromRate(selectedClip.speed));
   }
-  ui.rateOut.textContent = `${retime.rate.toFixed(2)}×`;
-  // A curve of no keys is `programSec * rate` and one of a single key is `value + programSec *
-  // rate`, so the slider still says what both of those do - `sourceSecAt` and `slopeAt` both read
-  // one key as rate-driven, and this used to be the only one of the three that did not.
-  ui.rate.disabled = selectedClipRow() === null || retime.keys.length > 1;
-  if (ui.rateKey) ui.rateKey.disabled = selectedClipRow() === null;
+  ui.rateOut.textContent = `${selectedClip.speed.toFixed(2)}×`;
+  ui.rate.disabled = selectedClipRow() === null;
   if (ui.fps) ui.fps.value = String(timeline.outputFps);
   buildRuler();
   paintMarks();
@@ -7340,14 +7217,15 @@ const openTakeHash = () => selectedClip.take?.hash ?? null;
 /**
  * The selected clip's map between its take's source time and the edit's program time.
  *
- * Through the clip's placement as well as its curve. A mark is a fact about footage, so it stays
- * keyed by take and two clips of one take share it - which is exactly why drawing one needs to
- * say which clip it is being drawn against, and the selection is what says.
+ * Through the clip's placement as well as its speed and in-point. A mark is a fact about footage,
+ * so it stays keyed by take and two clips of one take share it - which is exactly why drawing one
+ * needs to say which clip it is being drawn against, and the selection is what says.
  */
 const programSecOfSource = (sourceSec) => selectedClip.start
-  + selectedClip.retime.programSecAt(sourceSec);
-const sourceSecOfProgram = (programSec) => selectedClip.retime
-  .sourceSecAt(programSec - selectedClip.start);
+  + clipProgramSecAt(selectedClip, sourceSec);
+const sourceSecOfProgram = (programSec) => clipSourceSecAt(
+  selectedClip, programSec - selectedClip.start,
+);
 const markSourceSecOfProgram = (programSec) => Math.max(
   0, Math.min(selectedClip.source.duration, sourceSecOfProgram(programSec)),
 );
@@ -7356,11 +7234,10 @@ const markSourceSecOfProgram = (programSec) => Math.max(
  * The program second a lane's own clock starts at, and the two conversions across it.
  *
  * Zero for the project's own tracks, and the clip's in-point for every lane a clip owns: its
- * look, its placement and its retime curve. A lane that drew its keys at `view.pct(key.t)` would
- * put them `start` seconds early the moment its clip was placed anywhere but the head of the edit.
+ * look and its placement. A lane that drew its keys at `view.pct(key.t)` would put them `start`
+ * seconds early the moment its clip was placed anywhere but the head of the edit.
  */
 function laneEpoch(owner) {
-  if (owner === 'retime') return selectedClip.start;
   return trackEpoch(laneName(owner), laneClip(owner));
 }
 
@@ -8252,15 +8129,6 @@ ui.beds.addEventListener('pointerdown', (e) => {
     // Which of the three gestures this is: the head, the out-point, or the body.
     const grip = e.target.closest('.tclipedge');
     const side = grip ? grip.dataset.side : null;
-    // A head trim moves the clip's in-point, which its curve states. A curve of more than one key
-    // states far more than an in-point, and shifting it is a different edit - refused with the
-    // reason rather than left as an edge that silently does nothing on some clips.
-    if (side === 'head' && clip.retime.keys.length > 1) {
-      selectClipRow(clip);
-      say(`clip ${clip.id} carries a retime curve, so trimming its head means moving that curve - `
-        + 'this build does not do that from the edge');
-      return;
-    }
     if (refuseEdit('moving a clip')) return;
     const gen = takeTransport();
     const wasPlaying = timeline.playing || timeline.pendingPlay;
@@ -8340,18 +8208,13 @@ ui.beds.addEventListener('pointermove', (e) => {
 
   if (laneDrag.role === 'key') {
     key.t = Math.max(0, programToLane(row.owner, laneProgramAt(e.clientX)));
-    if (KINDS[row.kind].axisIsValue) key.value = value;
-    if (row.owner === 'retime') clampRetimeKey(keys, key);
-    else {
-      if (KINDS[row.kind].axisIsValue) {
-        // Through the registry's snapping without writing, so a key and a slider agree. By the
-        // owner's parameter rather than the owner, which for a clip's lane names both.
-        key.value = params.normalise(laneName(row.owner), key.value);
-      }
-      // A look track sorts, since its keys may be dragged past one another. The retime cannot.
-      trackOf(row.owner).keys.sort((x, y) => x.t - y.t);
+    if (KINDS[row.kind].axisIsValue) {
+      // Through the registry's snapping without writing, so a key and a slider agree. By the
+      // owner's parameter rather than the owner, which for a clip's lane names both.
+      key.value = params.normalise(laneName(row.owner), value);
     }
-    if (row.owner === 'retime') paintMarks();
+    // A look track sorts, since its keys may be dragged past one another.
+    trackOf(row.owner).keys.sort((x, y) => x.t - y.t);
   } else {
     const a = keys[laneDrag.seg];
     const b = keys[laneDrag.seg + 1];
@@ -8368,9 +8231,8 @@ ui.beds.addEventListener('pointermove', (e) => {
         (programToLane(row.owner, laneProgramAt(e.clientX)) - a.t) / dt)));
     // `dv` is non-zero by construction: a handle exists only where there was a shape.
     if (segmentHasShape(keys, laneDrag.seg, row.kind)) h[1] = (value - lo) / dv;
-    // A look handle may overshoot. The retime's may not.
-    if (row.owner === 'retime' || !KINDS[row.kind].overshoots) h[1] = Math.min(1, Math.max(0, h[1]));
-    else h[1] = Math.min(2, Math.max(-1, h[1]));
+    if (KINDS[row.kind].overshoots) h[1] = Math.min(2, Math.max(-1, h[1]));
+    else h[1] = Math.min(1, Math.max(0, h[1]));
   }
   lanesMoved();
   requestRepaint();
@@ -8383,7 +8245,7 @@ for (const type of ['pointerup', 'pointercancel']) {
       const { moved } = drag;
       clipDrag = null;
       // The warm window and every position on the ruler move with a clip, so this is the same
-      // door a retime change goes through rather than a lane rebuild.
+      // door a speed change goes through rather than a lane rebuild.
       if (moved) { timingChanged(); history.commit(); }
       if (drag.gen !== transportGen) return;
       if (!moved) {
@@ -8396,26 +8258,10 @@ for (const type of ['pointerup', 'pointercancel']) {
       return;
     }
     if (!laneDrag) return;
-    const wasRetime = laneDrag.row.owner === 'retime';
     laneDrag = null;
-    if (wasRetime) timingChanged();
-    else lanesChanged();
+    lanesChanged();
     history.commit();
   });
-}
-
-/** Removes a retime key, refusing the one removal that would leave the curve headless. */
-function removeRetimeKey(key) {
-  const i = retime.keys.indexOf(key);
-  if (i < 0) return false;
-  if (i === 0 && retime.keys.length > 1) {
-    say('the first retime key anchors the start of the clip - '
-      + 'remove the ones after it first');
-    return false;
-  }
-  retime.keys.splice(i, 1);
-  if (retime.keys.length === 1 && retime.keys[0].t === 0) retime.keys.length = 0;
-  return true;
 }
 
 /** Removes whichever key is selected in a lane. */
@@ -8426,11 +8272,7 @@ function deleteSelectedKey() {
   // A stale selection is not an error: an undo rebuilds every track from a snapshot.
   if (!keysOf(owner).includes(key)) { selection = null; return false; }
 
-  if (owner === 'retime') {
-    if (!removeRetimeKey(key)) return false;
-    selection = null;
-    timingChanged();
-  } else {
+  {
     // Through the clip the lane names, so a key removed on one clip's lane is removed from that
     // clip's track rather than from the selected clip's track of the same name.
     const name = laneName(owner);
@@ -8459,8 +8301,8 @@ function selectClipRow(clip) {
   // Every clip-scope control, because the values did not move - the clip under them did.
   paintClipPanel();
   paintGizmo();
-  // The retime binding, the ruler's mapping and the marks all move with the selection, which is
-  // what `timingChanged` already puts back together.
+  // The ruler's mapping and the marks both move with the selection, which is what
+  // `timingChanged` already puts back together.
   timingChanged();
   syncCropOutside();
   if (timeline && clip.take !== null) loadMarks(clip.take.id).catch(showTimelineError);
@@ -8492,8 +8334,7 @@ function paintClipCommands() {
   ui.moveClip.disabled = !selected;
   ui.rotateClip.disabled = !selected;
   ui.keyClip.disabled = !selected;
-  ui.rate.disabled = !selected || retime.keys.length > 1;
-  if (ui.rateKey) ui.rateKey.disabled = !selected;
+  ui.rate.disabled = !selected;
   ui.preset.disabled = !selected;
   for (const button of [ui.presetSave, ui.presetExport, ui.presetImport]) button.disabled = !selected;
   for (const button of [ui.mark, ui.camSensor, ui.camLevelReset, ui.cropBox, ui.cropFit, ui.cropReset]) {
@@ -8571,36 +8412,9 @@ async function addClipsFromTakes(ids, from) {
   return added;
 }
 
-/**
- * Moves a clip's head to `wantStart` while the footage under the rest of it holds still.
- *
- * The in-point is the curve's rather than a field of the clip's: with no keys the curve reads
- * `programSec * rate` and states an in-point of zero, and with one key at the origin it reads
- * `value + programSec * rate`. So trimming the head writes that one key, and trimming back to the
- * head of the take removes it again rather than leaving a curve that says nothing.
- */
+/** Moves a clip's head to `wantStart` while the footage under the rest of it holds still. */
 function headTrimTo(clip, wantStart, holdEnd) {
-  const curve = clip.retime;
-  const rate = curve.rate;
-  const held = curve.sourceSecAt(0);
-  // Bounded by the footage at one end - the head of the take - and by a clip still wide enough
-  // to grab at the other.
-  const floor = clip.start - held / Math.max(1e-9, rate);
-  const start = Math.max(0, Math.max(floor, Math.min(holdEnd - MIN_CLIP_SEC, wantStart)));
-  const sourceAtHead = held + (start - clip.start) * rate;
-  if (Math.abs(sourceAtHead) < 1e-9) curve.keys = [];
-  else if (curve.keys.length === 1) {
-    const key = curve.keys[0];
-    key.value = sourceAtHead + key.t * rate;
-  }
-  else {
-    curve.keys = [{
-      t: 0, value: sourceAtHead,
-      easeOut: copyHandle(EASE_OUT_LINEAR), easeIn: copyHandle(EASE_IN_LINEAR),
-    }];
-  }
-  clip.start = start;
-  clip.trim = Math.max(MIN_CLIP_SEC, holdEnd - start);
+  Object.assign(clip, headTrim(clip, wantStart, holdEnd, MIN_CLIP_SEC));
 }
 
 /** Removes the selected clip. The last one refuses: an edit with no clip is not a document. */
@@ -8691,7 +8505,6 @@ function applyEasePreset(name) {
   if (spec.lastIn && segmentHasShape(keys, keys.length - 2, kind)) {
     keys[keys.length - 1].easeIn = copyHandle(spec.lastIn);
   }
-  if (selection.owner === 'retime') retime.assertMonotonic(retime.keys);
   lanesChanged();
   requestRepaint();
   history.commit();
@@ -8707,7 +8520,7 @@ for (const btn of ui.ease.querySelectorAll('button[data-ease]')) {
 
 /** Whether the selected key's handles may grow or shrink, and on how many sides. */
 function pointSides(delta, state) {
-  if (!state || selection.owner === 'retime') return [];
+  if (!state) return [];
   const { keys, i, kind } = state;
   const sides = [];
   if (i < keys.length - 1 && segmentHasShape(keys, i, kind)) sides.push('easeOut');
@@ -8779,10 +8592,8 @@ const paintEase = paintDynamicControls;
 
 /** The nearest key strictly before or after the playhead on the selected track, or null. */
 function neighbourKeyTime(direction) {
-  if (!timeline) return null;
-  // The fallback is what makes these a way to reach a key rather than dead until
-  // one is selected.
-  const owner = selection?.owner ?? 'retime';
+  if (!timeline || !selection) return null;
+  const { owner } = selection;
   const now = playheadSec();
   const tol = keyTolerance();
   // Through the lane's own clock: every key a clip owns is measured from its clip's in-point,
@@ -8816,43 +8627,6 @@ function paintKeyButton(name, btn) {
     ? 'none'
     : (track.keyAt(keyPlayhead(name), keyTolerance()) ? 'here' : 'some');
   btn.dataset.kf = state;
-}
-
-ui.rateKey?.addEventListener('click', () => {
-  if (!timeline || selectedClipRow() === null || refuseEdit('a retime key')) return;
-  const t = playheadSec();
-  const tol = keyTolerance();
-  const existing = retime.keys.find((k) => Math.abs(k.t - programToLane('retime', t)) <= tol);
-  // Through the same door the lane's delete uses, so the origin rule is stated once.
-  if (existing) {
-    if (!removeRetimeKey(existing)) return;
-  } else {
-    // The source time the curve already maps to, so planting a key never moves the image.
-    const local = programToLane('retime', t);
-    if (retime.keys.length === 0 && local > 0) {
-      retime.keys.push({
-        t: 0, value: retime.sourceSecAt(0),
-        easeOut: copyHandle(EASE_OUT_LINEAR), easeIn: copyHandle(EASE_IN_LINEAR),
-      });
-    }
-    retime.keys.push({
-      t: local, value: retime.sourceSecAt(local),
-      easeOut: copyHandle(EASE_OUT_LINEAR), easeIn: copyHandle(EASE_IN_LINEAR),
-    });
-    retime.keys.sort((x, y) => x.t - y.t);
-  }
-  timingChanged();
-  requestRepaint();
-  history.commit();
-});
-
-function paintRateKey() {
-  if (!ui.rateKey) return;
-  const t = playheadSec();
-  const tol = keyTolerance();
-  ui.rateKey.dataset.kf = retime.keys.length === 0
-    ? 'none'
-    : (retime.keys.some((k) => Math.abs(k.t - programToLane('retime', t)) <= tol) ? 'here' : 'some');
 }
 
 /** Updates the mark button icon: filled when the playhead is on a mark, stroked otherwise. */
@@ -11318,18 +11092,14 @@ globalThis.__kinect = {
       }
       lanesChanged();
     },
-    setRetime({ rate = 1, keys = [] }) {
-      if (refuseEdit('a retime')) return;
-      retime.rate = rate;
-      // Built, then checked, then stored: the guard reads the handles a key will have.
-      const built = keys.map((k) => ({
-        t: k.t,
-        value: k.value,
-        easeOut: this.handleFrom(k.easeOut ?? EASE_OUT_LINEAR, 'easeOut', 'the retime'),
-        easeIn: this.handleFrom(k.easeIn ?? EASE_IN_LINEAR, 'easeIn', 'the retime'),
-      }));
-      retime.assertMonotonic(built);
-      retime.keys = built;
+    setSpeed(speed) {
+      if (refuseEdit('a speed change')) return;
+      selectedClip.speed = speed;
+      timingChanged();
+    },
+    setSourceStart(sec) {
+      if (refuseEdit('an in-point change')) return;
+      selectedClip.sourceStart = sec;
       timingChanged();
     },
     /**
@@ -11465,8 +11235,6 @@ globalThis.__kinect = {
   timeline: {
     open: openTake,
     transport: () => timeline,
-    // A getter and not the object: the binding is a view of the selected clip's curve.
-    get retime() { return retime; },
     counters,
     /** Resolves once every scheduled repaint has run and the transport's queue has drained. */
     async settled() {
@@ -11493,6 +11261,8 @@ globalThis.__kinect = {
         trim: clip.trim,
         length: clip.length,
         end: clip.end,
+        speed: clip.speed,
+        sourceStart: clip.sourceStart,
         showing: clip.showing,
         visible: clip.transform.visible,
         // Where this clip sits in the room, read off the group rather than off the registry:
@@ -11534,7 +11304,7 @@ globalThis.__kinect = {
     }),
     /** What each clip is doing at a program position, without rendering anything. */
     showingAt: (t) => clips.map((clip) => ({ id: clip.id, showing: clipShowingAt(clip, t) })),
-    /** Points the panel, the lanes and the retime binding at one clip by id. */
+    /** Points the panel and the lanes at one clip by id. */
     select(id) {
       const clip = clips.find((c) => c.id === id);
       if (!clip) throw new Error(`no clip called ${JSON.stringify(id)}: have ${clips.map((c) => c.id).join(', ')}`);
@@ -11549,9 +11319,12 @@ globalThis.__kinect = {
       return {
         frame: t.frame,
         programSec: t.programSec,
-        sourceSec: retime.sourceSecAt(t.programSec),
+        // Through the clip's placement as well as its speed: a program second fed straight into
+        // the clip-local map answers for the wrong footage on any clip that starts after zero.
+        sourceSec: sourceSecOfProgram(t.programSec),
         outputFps: t.outputFps,
-        rate: retime.rate,
+        speed: selectedClip.speed,
+        sourceStart: selectedClip.sourceStart,
         duration: t.duration,
         lastFrame: t.lastFrame,
         playing: t.playing,

--- a/web/main.js
+++ b/web/main.js
@@ -2873,7 +2873,7 @@ function checkProject(project) {
     }
     // A trim, and read back as the answer. It is where the edit stops using the take, which is
     // a different fact from how much take there is rather than a second spelling of it; null is
-    // a clip that runs for everything its curve affords.
+    // a clip that runs for everything its footage affords.
     if (clip.length !== null && (!Number.isFinite(clip.length) || clip.length < 0)) {
       throw new Error(`${what} is ${JSON.stringify(clip.length)} long: a length is a number of project seconds at or above zero, or null where the document states none`);
     }
@@ -3946,7 +3946,7 @@ class Clip {
 // The clip array is filled here, having been declared beside the cloud the first one draws with.
 clips.push(new Clip('c1', livePairs, bootCloud, bootLook));
 
-// Bumped by anything that moves where a clip sits or how its curve runs, which is what the warm
+// Bumped by anything that moves a clip's placement, speed or in-point, which is what the warm
 // window above is memoised against.
 let timingGeneration = 0;
 
@@ -4665,7 +4665,7 @@ function reportCappedSeek(seek) {
  * Everything here is one per project rather than one per clip: the output rate is the edit's own
  * coordinate, and `exclusive` serialises the renderer, so two of these would interleave
  * `setRenderTarget` calls. What belongs to one clip - its frames, its walk cursor, how far its
- * curve reaches back - it asks the clip for.
+ * source timing reaches back - it asks the clip for.
  */
 class TimelineTransport {
   constructor() {
@@ -4698,7 +4698,7 @@ class TimelineTransport {
   /** The clip the panel and the lanes are pointed at. */
   get clip() { return selectedClip; }
 
-  /** Program seconds, which is where the last clip stops. Its own curve is what says where. */
+  /** Program seconds, which is where the last clip stops. Each clip's end says where. */
   get duration() {
     let end = 0;
     for (const clip of clips) if (Number.isFinite(clip.end)) end = Math.max(end, clip.end);
@@ -4748,7 +4748,7 @@ class TimelineTransport {
    * The two halves have different owners. Surface memory is per cloud, so the surface half is
    * asked of each clip drawn here. A clip already inside its warm window needs the elapsed part
    * of that window rebuilt too. The project's surface half is the longest of them - one clip's
-   * curve can need three times another's to cover the same span of persistence. The afterimage
+   * timing can need three times another's to cover the same span of persistence. The afterimage
    * is one screen-space buffer over the whole composite, so the trails half is asked once.
    */
   preroll(programSec = this.programSec) {
@@ -4944,7 +4944,7 @@ class TimelineTransport {
     this.askFor(planned.spans);
     for (let attempt = 0; !this.resident(planned.spans); attempt++) {
       if (attempt >= SEEK_REPLANS) {
-        // Overtaken, not broken: the hand that moved the curve has already queued a repaint.
+        // Overtaken, not broken: the hand that moved the clip timing has already queued a repaint.
         this.overtaken++;
         if (this.overtaken > SEEK_OVERTAKEN_LIMIT) {
           this.overtaken = 0;
@@ -7184,8 +7184,8 @@ function lanesMoved() {
 
 /** A clip's timing or the output rate moved, so every position on the ruler did. */
 function timingChanged({ moved = false } = {}) {
-  // Before the guard: the warm window is memoised against this and a recorder-side change to a
-  // curve still moves it, whether or not there is a strip to repaint.
+  // Before the guard: the warm window is memoised against this and a recorder-side timing change
+  // still moves it, whether or not there is a strip to repaint.
   timingGeneration++;
   if (!timeline) return;
   // Re-clamped against a duration this may have changed: the window is stored as fractions.
@@ -7269,8 +7269,8 @@ function paintMarks() {
   if (!timeline || !clipGestureLive()) return;
   const total = view.duration;
   for (const mark of takeMarks) {
-    // Marks are source milliseconds and the ruler is program seconds, so ticks go
-    // through the curve.
+    // Marks are source milliseconds and the ruler is program seconds, so ticks go through the
+    // selected clip's placement, speed and in-point.
     const program = programSecOfSource(mark.sourceMs / 1000);
     const el = document.createElement('button');
     el.type = 'button';
@@ -8414,7 +8414,8 @@ async function addClipsFromTakes(ids, from) {
 
 /** Moves a clip's head to `wantStart` while the footage under the rest of it holds still. */
 function headTrimTo(clip, wantStart, holdEnd) {
-  Object.assign(clip, headTrim(clip, wantStart, holdEnd, MIN_CLIP_SEC));
+  const sourceDuration = clip.source.streaming ? Infinity : clip.source.duration;
+  Object.assign(clip, headTrim(clip, wantStart, holdEnd, MIN_CLIP_SEC, sourceDuration));
 }
 
 /** Removes the selected clip. The last one refuses: an edit with no clip is not a document. */
@@ -11134,7 +11135,7 @@ globalThis.__kinect = {
   editor: {
     /** Which clip row the strip has selected, or null. Session state, never in the document. */
     clipSelection: () => selectedClipRow()?.id ?? null,
-    /** Where a mark ticks in program seconds, through the selected clip's curve and placement. */
+    /** Where a mark ticks in program seconds, through the selected clip's placement, speed and in-point. */
     markProgramSec: (sourceSec) => programSecOfSource(sourceSec),
     clipRange: () => ({ in: clipIn, out: clipOut }),
     setClipRange: (inVal, outVal) => {
@@ -11259,6 +11260,7 @@ globalThis.__kinect = {
         take: clip.take ? { ...clip.take } : null,
         start: clip.start,
         trim: clip.trim,
+        afforded: clip.afforded,
         length: clip.length,
         end: clip.end,
         speed: clip.speed,

--- a/web/projects.js
+++ b/web/projects.js
@@ -1,5 +1,5 @@
-import { documentNameRefusal } from './format.js';
-import { retimeProgramSecAt, retimeSourceSecAt } from './curve.js';
+import { PROJECT_VERSION, documentNameRefusal, versionRefusal } from './format.js';
+import { clipAffordedSec, clipSourceSecAt } from './clip-plan.js';
 import { createSkim } from './take-draw.js';
 import { pickTakes } from './take-picker.js';
 
@@ -32,8 +32,8 @@ const takeFor = (clip) => (clip.take?.hash
 function spanOf(clip, take) {
   if (clip.length !== null && Number.isFinite(clip.length)) return Math.max(0, clip.length);
   if (!take || !(take.durationSec > 0)) return 0;
-  const afforded = retimeProgramSecAt(clip.retime, take.durationSec);
-  return Number.isFinite(afforded) ? Math.max(0, afforded) : 0;
+  const afforded = clipAffordedSec(clip, take.durationSec);
+  return Number.isFinite(afforded) ? afforded : 0;
 }
 
 /** Each clip with where it sits in program time and what it resolved to, in document order. */
@@ -58,7 +58,7 @@ function clipAt(spans, programSec) {
 /** The frame of a take a program second lands on. */
 function frameAt(span, programSec) {
   const { clip, take } = span;
-  const sourceSec = retimeSourceSecAt(clip.retime, programSec - span.start);
+  const sourceSec = clipSourceSecAt(clip, programSec - span.start);
   if (!Number.isFinite(sourceSec) || !(take.durationSec > 0)) return 0;
   const at = sourceSec / take.durationSec;
   return Math.round(Math.max(0, Math.min(1, at)) * Math.max(0, take.frames - 1));
@@ -72,10 +72,12 @@ const missingIn = (body) => body.clips
 /** Why this page cannot draw a project, or null. */
 function bodyRefusal(body) {
   if (!body || typeof body !== 'object') return 'this file does not hold an object';
+  if (body.version !== PROJECT_VERSION) return versionRefusal('this project', body.version);
   if (!Array.isArray(body.clips)) return 'this file carries no clips array, so it is not an edit';
-  if (body.clips.some((c) => !c || typeof c !== 'object' || !c.retime
-    || !Array.isArray(c.retime.keys) || !Number.isFinite(c.retime.rate))) {
-    return 'a clip in it carries no retime curve, so there is no way to place its footage in time';
+  if (body.clips.some((c) => !c || typeof c !== 'object' || !Number.isFinite(c.speed)
+    || !Number.isFinite(c.sourceStart) || c.sourceStart < 0)) {
+    return 'a clip in it carries no speed and in-point, so there is no way to place its footage '
+      + 'in time';
   }
   return null;
 }

--- a/web/projects.js
+++ b/web/projects.js
@@ -1,5 +1,5 @@
 import { PROJECT_VERSION, documentNameRefusal, versionRefusal } from './format.js';
-import { clipAffordedSec, clipSourceSecAt } from './clip-plan.js';
+import { clipAffordedSec, clipSourceSecAt, usableClipRate } from './clip-plan.js';
 import { createSkim } from './take-draw.js';
 import { pickTakes } from './take-picker.js';
 
@@ -74,7 +74,7 @@ function bodyRefusal(body) {
   if (!body || typeof body !== 'object') return 'this file does not hold an object';
   if (body.version !== PROJECT_VERSION) return versionRefusal('this project', body.version);
   if (!Array.isArray(body.clips)) return 'this file carries no clips array, so it is not an edit';
-  if (body.clips.some((c) => !c || typeof c !== 'object' || !Number.isFinite(c.speed)
+  if (body.clips.some((c) => !c || typeof c !== 'object' || !usableClipRate(c.speed)
     || !Number.isFinite(c.sourceStart) || c.sourceStart < 0)) {
     return 'a clip in it carries no speed and in-point, so there is no way to place its footage '
       + 'in time';
@@ -308,6 +308,7 @@ function attachSkim(row, spans, length) {
     seg.style.left = `${(s.start / length) * 100}%`;
     seg.style.width = `${(s.span / length) * 100}%`;
     seg.dataset.clip = s.clip.id;
+    seg.dataset.sourceStart = String(s.clip.sourceStart);
     barEl.insertBefore(seg, doneEl);
   }
 
@@ -567,14 +568,24 @@ globalThis.__projects = {
     dark: el.querySelector('.dark .what')?.textContent ?? null,
     darkAct: el.querySelector('.dark .act')?.textContent ?? null,
     segments: [...el.querySelectorAll('.bar .seg')].map((s) => ({
-      clip: s.dataset.clip, left: s.style.left, width: s.style.width, dark: s.classList.contains('dark'),
+      clip: s.dataset.clip,
+      sourceStart: Number(s.dataset.sourceStart),
+      left: s.style.left,
+      width: s.style.width,
+      dark: s.classList.contains('dark'),
     })),
     menu: [...el.querySelectorAll('.menu .mi')].map((b) => b.dataset.item),
   })),
 
   showing: (name) => {
     const el = listEl.querySelector(`.row[data-name="${CSS.escape(name)}"]`);
-    return el ? { take: el.dataset.showing, at: Number(el.dataset.at), hole: el.querySelector('.hole').textContent } : null;
+    return el ? {
+      take: el.dataset.showing,
+      at: Number(el.dataset.at),
+      frame: el.__skim?.index ?? null,
+      drawnFrame: el.__skim?.showing ?? null,
+      hole: el.querySelector('.hole').textContent,
+    } : null;
   },
 
   draws: (name) => Number(listEl.querySelector(`.row[data-name="${CSS.escape(name)}"]`)?.dataset.draws ?? 0),

--- a/web/view-window.js
+++ b/web/view-window.js
@@ -14,8 +14,6 @@
 // visible when one clip fills the program and a speed change scales that clip uniformly.
 // A clip inside a larger edit changes the duration non-uniformly; `main.js` then rebases these
 // fractions from the program-second bounds captured at the start of the speed gesture.
-// Dragging one retime key remains different: it changes the map non-uniformly without a speed
-// gesture, so the window keeps its fractions and shifts in program seconds on release.
 //
 // **Two readings arrive at construction rather than being reached for, and that is what
 // makes the arithmetic testable without a browser.** How long the program currently is,


### PR DESCRIPTION
## Problem

Dragging a clip head used the retime curve to remember where the footage starts. That made a simple trim share machinery with keyframed time changes. The result was hard to reason about: a trim could affect the speed lane, the speed slider had to know about retime keys, and saved projects carried a larger timing shape than the edit needed.

## Solution

Make each clip say two simple things instead: how fast it plays and where it starts in the source take. In plain terms, a clip now has a speed knob and an in-point. A head drag moves the in-point, while the footage under the remaining clip stays still.

Details:
- Replaces per-clip `retime` curves with `speed` and `sourceStart` in the project format.
- Bumps `PROJECT_VERSION` and built-in preset versions to 8.
- Removes the retime lane, retime key button, retime curve serialization, and retime-specific curve math.
- Adds shared clip timing helpers for source/program conversion, afforded duration, head trimming, and warm-frame windows.
- Updates project loading, project skims, marks, timeline rendering, speed changes, and clip drag behavior to use `speed` and `sourceStart`.
- Updates README and docs so they describe clip speed and in-points instead of retime curves.
- Adds unit coverage for clip timing, head trims, source/program inversion, afforded duration, and warm-frame calculations.