### PR TITLE
Use Shift for flight, look, and lens control

### DIFF
--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -1299,6 +1299,35 @@ rules and reddens the 520px and collapsed-panel rows. These are separate mutatio
 single broken sidebar could otherwise redden all three claims without saying which contract the
 instrument observed.
 
+**Section 24's eight controls each take one half of the fly out.** Holding a fly key translates
+the camera and its orbit pivot by the same vector out of `advanceNavigation`, and that is four
+claims rather than one, so each control removes exactly one of them and the section says which row
+answers it.
+
+- **`fly-leaves-the-pivot`** drops the `controls.target` half of the translation. The camera still
+  flies and the row about the view direction stays green; what changes is that the orbit's radius
+  grows instead of the standpoint moving, so a drag afterwards swings the cloud across the frame.
+- **`fly-up-is-the-cameras-up`** swaps `web/fly.js`'s pole for the camera's own local Y. Those are
+  the same vector while the camera is level, which is why the E row poses it at `(0, 2, 0)` looking
+  down at the pivot first and asserts the pitch is real before it flies.
+- **`fly-moves-while-typing`** moves the keydown block above the typing guard, so a `w` in a
+  filename flies the camera while it is being typed.
+- **`fly-survives-blur`** removes the listener that releases every held key when the page loses
+  focus. A key released outside the page never arrives, so the camera then flies until something
+  else stops it.
+- **`fly-ignores-the-program-camera`** takes `controls.enabled` out of the gate, which is the
+  program camera, a gizmo drag, a node drag and the crop drag in one term.
+- **`fly-never-settles`** removes the `orbitSettling` the release arms, so a flight ends on the
+  draft-quality frame the hold was redrawing rather than on an accurate seek.
+- **`fly-rehomes-reset`** calls `saveState()` after the translation. It is `pick-rehomes-reset`'s
+  defect through a second door: Reset stops going anywhere known, which on the Pi's collapsed panel
+  is the only way back.
+- **`fly-ignores-shift`** freezes the multiplier at one.
+
+**Two of the eight plant in `web/fly.js` and the rest in `web/main.js`**, which is the split the
+module exists for. The pole and the multiplier are arithmetic `test/fly.test.mjs` states in
+longhand under bare node, and what is left for a browser to answer is whether the page uses them.
+
 **Whole clip is driven through both user paths.** Section 3 narrows the trim, selects
 **Output > Whole clip**, narrows it again, and presses Option-X. Both must restore
 `{ in: 0, out: null }`; `whole-clip-does-nothing` leaves the history write in place while removing

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -1299,10 +1299,9 @@ rules and reddens the 520px and collapsed-panel rows. These are separate mutatio
 single broken sidebar could otherwise redden all three claims without saying which contract the
 instrument observed.
 
-**Section 24's eight controls each take one half of the fly out.** Holding a fly key translates
-the camera and its orbit pivot by the same vector out of `advanceNavigation`, and that is four
-claims rather than one, so each control removes exactly one of them and the section says which row
-answers it.
+**Section 24's ten controls each break one fly contract.** Holding a fly key translates the camera
+and its orbit pivot by the same vector out of `advanceNavigation`. Each mutation names the exact
+row that must fail. Another red row cannot stand in for it.
 
 - **`fly-leaves-the-pivot`** drops the `controls.target` half of the translation. The camera still
   flies and the row about the view direction stays green; what changes is that the orbit's radius
@@ -1317,6 +1316,10 @@ answers it.
   else stops it.
 - **`fly-ignores-the-program-camera`** takes `controls.enabled` out of the gate, which is the
   program camera, a gizmo drag, a node drag and the crop drag in one term.
+- **`fly-redraws-cancelled-keys`** treats a non-empty held-key set as movement even when opposite
+  keys cancel. The camera stays in place, but the parked loop keeps rebuilding the same frame.
+- **`fly-reuses-old-clock`** removes the event-side clock reset. A release and new press between
+  animation frames then inherit the old hold's time and jump by the stall cap on the first frame.
 - **`fly-never-settles`** removes the `orbitSettling` the release arms, so a flight ends on the
   draft-quality frame the hold was redrawing rather than on an accurate seek.
 - **`fly-rehomes-reset`** calls `saveState()` after the translation. It is `pick-rehomes-reset`'s
@@ -1324,7 +1327,7 @@ answers it.
   is the only way back.
 - **`fly-ignores-shift`** freezes the multiplier at one.
 
-**Two of the eight plant in `web/fly.js` and the rest in `web/main.js`**, which is the split the
+**Two of the ten plant in `web/fly.js` and the rest in `web/main.js`**, which is the split the
 module exists for. The pole and the multiplier are arithmetic `test/fly.test.mjs` states in
 longhand under bare node, and what is left for a browser to answer is whether the page uses them.
 

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -1299,9 +1299,9 @@ rules and reddens the 520px and collapsed-panel rows. These are separate mutatio
 single broken sidebar could otherwise redden all three claims without saying which contract the
 instrument observed.
 
-**Section 24's ten controls each break one fly contract.** Holding a fly key translates the camera
-and its orbit pivot by the same vector out of `advanceNavigation`. Each mutation names the exact
-row that must fail. Another red row cannot stand in for it.
+**Section 24 covers flight, look drags, the lens wheel and control focus.** Shift enables flight
+at one speed. Each mutation names the exact row that must fail. Another red row cannot stand in
+for it.
 
 - **`fly-leaves-the-pivot`** drops the `controls.target` half of the translation. The camera still
   flies and the row about the view direction stays green; what changes is that the orbit's radius
@@ -1311,6 +1311,7 @@ row that must fail. Another red row cannot stand in for it.
   down at the pivot first and asserts the pitch is real before it flies.
 - **`fly-moves-while-typing`** moves the keydown block above the typing guard, so a `w` in a
   filename flies the camera while it is being typed.
+- **`fly-survives-text-focus`** keeps an existing flight hold after a text field gains focus.
 - **`fly-survives-blur`** removes the listener that releases every held key when the page loses
   focus. A key released outside the page never arrives, so the camera then flies until something
   else stops it.
@@ -1325,11 +1326,33 @@ row that must fail. Another red row cannot stand in for it.
 - **`fly-rehomes-reset`** calls `saveState()` after the translation. It is `pick-rehomes-reset`'s
   defect through a second door: Reset stops going anywhere known, which on the Pi's collapsed panel
   is the only way back.
-- **`fly-ignores-shift`** freezes the multiplier at one.
+- **`fly-ignores-the-shift-gate`** allows an unmodified key to fly.
+- **`fly-takes-the-key-only-with-shift`** prevents flight when Shift arrives after W.
+- **`fly-stops-during-a-look`** stops translation while the pointer turns the camera.
+- **`typing-guard-takes-every-control`** makes a focused slider swallow flight shortcuts.
+- **`typing-guard-takes-adjustment-keys`** takes arrow keys away from a focused slider.
+- **`look-orbits-the-camera`** moves the camera instead of turning it in place.
+- **`look-shrinks-the-pivot`** changes the orbit radius during a look drag.
+- **`look-ignores-the-lens`** uses a fixed turn rate instead of the camera's field of view.
+- **`look-drags-backwards`** reverses horizontal look; **`look-pitches-backwards`** reverses pitch.
+- **`look-tips-past-the-pole`** removes the pitch limit. Each pole is reached in one pointer move.
+- **`look-never-settles`** omits the accurate seek after the pointer is released.
+- **`look-survives-blur`**, **`look-survives-capture-loss`** and
+  **`look-survives-camera-switch`** each leave a drag active after its owner has changed.
+- **`lens-wheel-reads-only-the-vertical`** ignores horizontal wheel input.
+- **`lens-wheel-ignores-the-band`** removes the 8–300mm lens limits.
+- **`showlens-reads-the-raw-number`** compares unrounded focal lengths with the displayed limits,
+  so a lens at 8mm can read as outside the range after conversion through field of view.
 
-**Two of the ten plant in `web/fly.js` and the rest in `web/main.js`**, which is the split the
-module exists for. The pole and the multiplier are arithmetic `test/fly.test.mjs` states in
-longhand under bare node, and what is left for a browser to answer is whether the page uses them.
+The arithmetic mutations target `web/fly.js`; the event and rendering mutations target
+`web/main.js`. The unit tests cover the arithmetic, and the browser rows verify its use by the
+page. Pole drags start inside the stage and can finish outside it through pointer capture.
+The slider row opens the Camera tab before focusing the lens control.
+Section 21 also drives flight, look and horizontal wheel input on the recorder, then runs the
+same drag-interruption checks as the editor. These checks use the fake grabber or the server's
+existing stream; they do not prove physical sensor behavior.
+The capture-loss check sends a stationary pointer event after releasing capture, so the browser
+delivers its pending `lostpointercapture` event before the state is read.
 
 **Whole clip is driven through both user paths.** Section 3 narrows the trim, selects
 **Output > Whole clip**, narrows it again, and presses Option-X. Both must restore

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -54,7 +54,11 @@ halves, and [SECURITY.md](../SECURITY.md) has the threat model.
 
 ## Viewer and timeline controls
 
-Drag to orbit, scroll to zoom, right-drag to pan, `H` hides the panel.
+Drag to orbit, scroll to zoom, right-drag to pan, `H` hides the panel. `W` `A` `S` `D` fly the
+camera, `Q` and `E` take it down and up, and holding shift makes all six three times faster.
+`W` follows the view direction and `Q`/`E` the room's vertical, so a pitched camera still
+climbs straight up. Flying carries the orbit pivot with the camera, so a drag afterwards
+still turns about the same subject rather than about where you set off from.
 
 **The orbit turns about whatever you pressed on.** A left press reads the depth under the
 pointer and moves the pivot along the view axis to that range, so orbiting a subject four metres
@@ -68,9 +72,8 @@ on the smear the eye is aimed at.
 
 The ruler shows a *window* of the clip, because a fifteen-minute take across one screen puts
 a keyframe against gradations forty times coarser than the thing being placed. Scroll to
-zoom about the pointer, `+`/`-` about the playhead, `,`/`.` to pan, `F` to fit the clip, `Z`
-to frame the trim. The overview underneath is always the whole clip: drag its box to pan, click
-to go there.
+zoom about the pointer, `+`/`-` about the playhead, `,`/`.` to pan, `F` to fit the clip. The
+overview underneath is always the whole clip: drag its box to pan, click to go there.
 
 Press `I` and `O` to set the trim at the playhead. Choose **Output > Whole clip**, or press
 Option-X, to restore `{ in: 0, out: null }`. The null end means the range continues to the end

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -54,12 +54,27 @@ halves, and [SECURITY.md](../SECURITY.md) has the threat model.
 
 ## Viewer and timeline controls
 
-Drag to orbit, scroll to zoom, right-drag to pan, `H` hides the panel. `W` `A` `S` `D` fly the
-camera, `Q` and `E` take it down and up, and holding shift makes all six three times faster.
-`W` follows the view direction. `Q`/`E` follow the current navigation vertical: the levelled
-room in the normal view and the sensor's vertical in Sensor view. Flying carries the orbit pivot
-with the camera, so a drag afterwards still turns about the same subject rather than about where
-you set off from.
+Drag to orbit, scroll to zoom, right-drag to pan, `H` hides the panel. **Shift is the free
+camera's modifier.** Hold it and `W` `A` `S` `D` fly the camera, `Q` and `E` take it down and up,
+a left-drag turns the camera in place, and the wheel changes the lens. Without shift the six keys
+do nothing at all. `W` follows the view direction. `Q`/`E` follow the current navigation vertical:
+the levelled room in the normal view and the sensor's vertical in Sensor view. Flying carries the
+orbit pivot with the camera, so a drag afterwards still turns about the same subject rather than
+about where you set off from.
+
+**A focused text field keeps the whole keyboard.** Gaining text focus also stops any flight keys
+already held. Sliders, dropdowns and other non-text inputs
+keep the arrows, space, enter, home, end and the page keys, so a focused slider still
+nudges with the arrows while `Shift-W` still flies and `cmd-z` still undoes. Editor shortcuts take
+priority over dropdown letter type-ahead.
+
+**Shift-drag turns the view the way you drag it**, which is the opposite of an orbit: drag right
+and the view turns right, so the scene sweeps left. The camera does not move, and the orbit pivot
+rides a sphere around it at the distance it already had - so letting go of shift orbits whatever
+you are now looking at. A drag the height of the stage turns the view by exactly one field of
+view. A longer lens therefore turns through a smaller angle for the same drag. The view stops just
+short of straight up and straight down rather than tipping over. Releasing or cancelling the
+pointer, losing focus or pointer capture, hiding the page, and changing cameras end the look drag.
 
 **The orbit turns about whatever you pressed on.** A left press reads the depth under the
 pointer and moves the pivot along the view axis to that range, so orbiting a subject four metres
@@ -166,6 +181,9 @@ reason the orbit does the same there: the program camera's lens is what its keys
 follows the playhead through a keyed move rather than taking a new value. The row offers 8mm to
 300mm and says which way it ran out past either end — the angle
 itself is never clamped, because the sensor's intrinsics have to be free to imply anything.
+Shift and the wheel over the stage move the same lens, and that gesture is bounded by those two
+numbers rather than only measured against them: a wheel has no value to type, so it stops where
+the band does.
 `verticalFovForFocalLength` and `focalLengthForVerticalFov` in
 [`web/lens.js`](../web/lens.js) are the conversion, and it is the same arithmetic either way
 round.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -56,9 +56,10 @@ halves, and [SECURITY.md](../SECURITY.md) has the threat model.
 
 Drag to orbit, scroll to zoom, right-drag to pan, `H` hides the panel. `W` `A` `S` `D` fly the
 camera, `Q` and `E` take it down and up, and holding shift makes all six three times faster.
-`W` follows the view direction and `Q`/`E` the room's vertical, so a pitched camera still
-climbs straight up. Flying carries the orbit pivot with the camera, so a drag afterwards
-still turns about the same subject rather than about where you set off from.
+`W` follows the view direction. `Q`/`E` follow the current navigation vertical: the levelled
+room in the normal view and the sensor's vertical in Sensor view. Flying carries the orbit pivot
+with the camera, so a drag afterwards still turns about the same subject rather than about where
+you set off from.
 
 **The orbit turns about whatever you pressed on.** A left press reads the depth under the
 pointer and moves the pivot along the view axis to that range, so orbiting a subject four metres

--- a/test/fly.test.mjs
+++ b/test/fly.test.mjs
@@ -1,12 +1,15 @@
-// The fly keys' directions and one frame's displacement, called directly. The rows that matter
-// are the two a browser cannot separate: Q and E climb the pole they are handed rather than the
-// camera's own vertical, and a frame that arrives after a stall moves the cap and not the gap.
+// The fly keys' directions, one frame's displacement, and where a look drag puts the pivot,
+// called directly. The rows that matter are the ones a browser cannot separate: Q and E climb
+// the pole they are handed rather than the camera's own vertical, a frame that arrives after a
+// stall moves the cap and not the gap, and the look turns the view the way the drag went rather
+// than the way an orbit of the same pixels would.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import * as THREE from 'three';
 import {
-  FLY_SPEED_MPS, FLY_FAST, FLY_STALL_S, isFlyKey, flyDirection, flyStep,
+  FLY_SPEED_MPS, FLY_STALL_S, LOOK_POLE_EPS,
+  isFlyKey, flyDirection, flyStep, lookOffset,
 } from '../web/fly.js';
 
 const UP = new THREE.Vector3(0, 1, 0);
@@ -14,8 +17,8 @@ const held = (...codes) => new Set(codes);
 const dir = (codes, quaternion = new THREE.Quaternion()) => (
   flyDirection(codes, quaternion, UP, new THREE.Vector3()).toArray()
 );
-const step = (codes, fast, dt, quaternion = new THREE.Quaternion(), up = UP) => (
-  flyStep(codes, fast, dt, quaternion, up, new THREE.Vector3())
+const step = (codes, dt, quaternion = new THREE.Quaternion(), up = UP) => (
+  flyStep(codes, dt, quaternion, up, new THREE.Vector3())
 );
 
 const near = (a, b, tol = 1e-12) => Math.abs(a - b) <= tol;
@@ -25,6 +28,17 @@ const nearAll = (got, want, tol = 1e-12) => got.every((v, i) => near(v, want[i],
 const pitched = (deg) => new THREE.Quaternion().setFromAxisAngle(
   new THREE.Vector3(1, 0, 0), THREE.MathUtils.degToRad(-deg),
 );
+
+// A camera at the origin looking two metres down -Z, which is the offset the look drag turns.
+const LOOK_HEIGHT = 1000;
+// The lens the rows below drag at, unless they are the ones about the lens mattering.
+const LOOK_FOV = 90;
+const offsetOf = (...xyz) => new THREE.Vector3(...xyz);
+const look = (offset, dx, dy, up = UP, fov = LOOK_FOV, height = LOOK_HEIGHT) => (
+  lookOffset(offset, up, dx, dy, fov, height, new THREE.Vector3())
+);
+/** The camera's right axis for an offset and a pole, which is the axis the pitch turns about. */
+const rightOf = (offset, up) => new THREE.Vector3().crossVectors(offset, up).normalize();
 
 test('the six keys are fly keys and nothing else is', () => {
   for (const code of ['KeyW', 'KeyA', 'KeyS', 'KeyD', 'KeyQ', 'KeyE']) {
@@ -79,41 +93,138 @@ test('the target is the caller\'s object, written in place and handed back', () 
   assert.equal(flyDirection(held('KeyW'), new THREE.Quaternion(), UP, out), out);
   assert.ok(nearAll(out.toArray(), [0, 0, -1]), `${out.toArray()}`);
   const moved = new THREE.Vector3();
-  assert.equal(flyStep(held('KeyW'), false, 0.05, new THREE.Quaternion(), UP, moved), moved);
+  assert.equal(flyStep(held('KeyW'), 0.05, new THREE.Quaternion(), UP, moved), moved);
+  const turned = new THREE.Vector3();
+  assert.equal(lookOffset(offsetOf(0, 0, -2), UP, 10, 10, LOOK_FOV, LOOK_HEIGHT, turned), turned);
+  assert.ok(turned.length() > 0, `${turned.toArray()}`);
 });
 
 test('a frame moves direction x speed x dt, and the first frame of a hold moves nothing', () => {
   // `nearAll` and not a deep equal: a direction of -1 scaled by zero is -0, which is the same
   // displacement and a different value.
-  assert.ok(nearAll(step(held('KeyW'), false, 0).toArray(), [0, 0, 0]), 'dt 0 moved something');
-  assert.ok(nearAll(step(held(), false, 0.05).toArray(), [0, 0, 0]), 'nothing held moved something');
-  const tenth = step(held('KeyW'), false, 0.05);
+  assert.ok(nearAll(step(held('KeyW'), 0).toArray(), [0, 0, 0]), 'dt 0 moved something');
+  assert.ok(nearAll(step(held(), 0.05).toArray(), [0, 0, 0]), 'nothing held moved something');
+  const tenth = step(held('KeyW'), 0.05);
   assert.ok(near(tenth.length(), 0.05 * FLY_SPEED_MPS), `${tenth.length()} m over 50 ms`);
   assert.ok(nearAll(tenth.toArray(), [0, 0, -0.05 * FLY_SPEED_MPS]), `${tenth.toArray()}`);
   // A negative delta is a clock that went backwards, which moves nothing rather than backwards.
-  assert.ok(nearAll(step(held('KeyW'), false, -1).toArray(), [0, 0, 0]),
-    `a negative delta moved ${step(held('KeyW'), false, -1).toArray()}`);
+  assert.ok(nearAll(step(held('KeyW'), -1).toArray(), [0, 0, 0]),
+    `a negative delta moved ${step(held('KeyW'), -1).toArray()}`);
 });
 
 test('a frame after a stall moves the cap and not the gap', () => {
-  const stalled = step(held('KeyW'), false, 5);
+  const stalled = step(held('KeyW'), 5);
   assert.ok(near(stalled.length(), FLY_STALL_S * FLY_SPEED_MPS),
     `${stalled.length()} m over a 5 s gap, where the cap allows ${FLY_STALL_S * FLY_SPEED_MPS}`);
   assert.ok(stalled.length() < 0.2, `${stalled.length()} m is a teleport`);
   // The cap is a cap and not a floor: a frame inside it keeps its own length.
-  const inside = step(held('KeyW'), false, FLY_STALL_S / 2);
+  const inside = step(held('KeyW'), FLY_STALL_S / 2);
   assert.ok(near(inside.length(), (FLY_STALL_S / 2) * FLY_SPEED_MPS), `${inside.length()}`);
 });
 
-test('shift multiplies the distance and leaves the direction alone', () => {
-  const slow = step(held('KeyW'), false, 0.05);
-  const fast = step(held('KeyW'), true, 0.05);
-  assert.ok(near(fast.length(), slow.length() * FLY_FAST),
-    `${fast.length()} against ${slow.length()} x ${FLY_FAST}`);
-  assert.ok(near(fast.length(), 0.05 * FLY_SPEED_MPS * FLY_FAST), `${fast.length()}`);
-  assert.ok(nearAll(fast.clone().normalize().toArray(), slow.clone().normalize().toArray()),
-    `${fast.toArray()} against ${slow.toArray()}`);
-  // And it multiplies the capped frame too, rather than the cap swallowing it.
-  assert.ok(near(step(held('KeyW'), true, 5).length(), FLY_STALL_S * FLY_SPEED_MPS * FLY_FAST),
-    `${step(held('KeyW'), true, 5).length()}`);
+test('dragging right turns the view right, which is the opposite of orbiting the same pixels', () => {
+  const from = offsetOf(0, 0, -2);
+  const right = rightOf(from, UP);
+  assert.ok(nearAll(right.toArray(), [1, 0, 0]), `the right axis is ${right.toArray()}`);
+  const turned = look(from, 100, 0);
+  // The whole point of the change: the pivot swings towards the camera's right, which puts the
+  // scene to the left of where it was. An orbit of the same 100 pixels swings the camera the
+  // other way and sweeps the scene right.
+  assert.ok(turned.dot(right) > 0,
+    `dragging right put the pivot at ${turned.toArray()}, which dots the right axis at ${turned.dot(right)}`);
+  assert.ok(look(from, -100, 0).dot(right) < 0, `dragging left went ${look(from, -100, 0).toArray()}`);
+});
+
+test('a drag the height of the viewport turns exactly one field of view, at any lens', () => {
+  const from = offsetOf(0, 0, -2);
+  // Both a wide view and a long lens must scale the angle by the same fraction of stage height.
+  for (const fov of [90, 4]) {
+    const whole = look(from, LOOK_HEIGHT, 0, UP, fov);
+    assert.ok(near(whole.angleTo(from), THREE.MathUtils.degToRad(fov), 1e-12),
+      `a full-height drag at ${fov} degrees turned ${THREE.MathUtils.radToDeg(whole.angleTo(from))}`);
+    // And a quarter of the screen is a quarter of the angle, so the rate holds across the drag.
+    const quarter = look(from, LOOK_HEIGHT / 4, 0, UP, fov);
+    assert.ok(near(quarter.angleTo(from), THREE.MathUtils.degToRad(fov) / 4, 1e-12),
+      `a quarter-height drag at ${fov} degrees turned ${THREE.MathUtils.radToDeg(quarter.angleTo(from))}`);
+  }
+  // The control: the same pixels at the two lenses turn the view by different amounts, so a
+  // build with a rate of its own would satisfy the shape of the rows above and fail here.
+  const wide = look(from, 200, 0, UP, 90).angleTo(from);
+  const long = look(from, 200, 0, UP, 4).angleTo(from);
+  assert.ok(near(wide / long, 90 / 4, 1e-9), `200 pixels turned ${wide} wide and ${long} long`);
+});
+
+test('dragging down looks down, at the same radians per pixel as across', () => {
+  const from = offsetOf(0, 0, -2);
+  assert.ok(look(from, 0, 100).dot(UP) < from.dot(UP),
+    `dragging down put the pivot at ${look(from, 0, 100).toArray()}`);
+  assert.ok(look(from, 0, -100).dot(UP) > from.dot(UP),
+    `dragging up put the pivot at ${look(from, 0, -100).toArray()}`);
+  // The same rate on both axes, stated as the angle rather than as a vector: the same pixels
+  // down and across turn the view by the same amount, and that amount is the field of view over
+  // the viewport height.
+  const down = look(from, 0, 137);
+  const across = look(from, 137, 0);
+  assert.ok(near(down.angleTo(from), across.angleTo(from), 1e-12),
+    `${down.angleTo(from)} down against ${across.angleTo(from)} across`);
+  assert.ok(near(down.angleTo(from), (THREE.MathUtils.degToRad(LOOK_FOV) * 137) / LOOK_HEIGHT, 1e-12),
+    `137 pixels down turned ${THREE.MathUtils.radToDeg(down.angleTo(from))} degrees`);
+});
+
+test('the look is a rotation, so the orbit radius survives it and a zero drag changes nothing', () => {
+  const from = offsetOf(0.7, -1.3, -2.4);
+  for (const [dx, dy] of [[0, 0], [37, 0], [0, -91], [220, 140], [-4000, 3000]]) {
+    const turned = look(from, dx, dy);
+    assert.ok(near(turned.length(), from.length(), 1e-12),
+      `${dx},${dy} took the radius from ${from.length()} to ${turned.length()}`);
+  }
+  // Exactly nothing, not nearly nothing: a zero drag is a zero angle on both axes.
+  assert.deepEqual(look(from, 0, 0).toArray(), from.toArray());
+});
+
+test('a drag past the pole stops at it rather than flipping the view over it', () => {
+  const from = offsetOf(0, 0, -2);
+  const forward = from.clone().normalize();
+  for (const [dy, pole, name] of [[40 * LOOK_HEIGHT, -1, 'down'], [-40 * LOOK_HEIGHT, 1, 'up']]) {
+    const turned = look(from, 0, dy);
+    const polar = Math.acos(turned.dot(UP) / turned.length());
+    const wanted = pole < 0 ? Math.PI - LOOK_POLE_EPS : LOOK_POLE_EPS;
+    assert.ok(near(polar, wanted, 1e-9),
+      `dragging ${name} forty screens landed a polar angle of ${polar}, wanted ${wanted}`);
+    // Not flipped: a build that let the pitch run past the pole comes back facing the other way,
+    // so the horizontal part of the offset would have changed sign.
+    assert.ok(turned.dot(forward) > 0,
+      `dragging ${name} forty screens turned the view around: ${turned.toArray()}`);
+    assert.ok(near(turned.length(), from.length(), 1e-12), `${turned.length()}`);
+  }
+});
+
+test('the look follows the pole it was handed, which is a levelled room and not the world\'s +Y', () => {
+  const canted = new THREE.Vector3(0.3, 0.9, -0.2);
+  const pole = canted.clone().normalize();
+  // An offset square to that pole, so the drag starts on the room's own horizon.
+  const from = new THREE.Vector3(0, 0, -2).projectOnPlane(pole).setLength(2);
+  assert.ok(near(from.dot(pole), 0, 1e-12), `the offset is not square to the pole: ${from.dot(pole)}`);
+
+  // Across: a yaw about the pole leaves the height above the room's floor exactly alone.
+  const yawed = look(from, 130, 0, canted);
+  assert.ok(near(yawed.dot(pole), from.dot(pole), 1e-12),
+    `the yaw moved the pivot off the room's horizon by ${yawed.dot(pole) - from.dot(pole)}`);
+  // The control: the same yaw does move the height above the *world's* floor, so a build that
+  // ignored the pole and used +Y would pass the row above and answer somewhere else here.
+  assert.ok(Math.abs(yawed.y - from.y) > 0.1,
+    `the canted pole is indistinguishable from +Y here: ${yawed.y} against ${from.y}`);
+
+  // Down: the pitch stays in the plane the pole and the offset span, so it leaves that plane's
+  // normal alone. That normal is the right axis, which is the axis the pitch turns about.
+  const right = rightOf(from, canted);
+  const pitchedDown = look(from, 0, 90, canted);
+  assert.ok(near(pitchedDown.dot(right), 0, 1e-12),
+    `the pitch left the pole's plane by ${pitchedDown.dot(right)}`);
+  assert.ok(pitchedDown.dot(pole) < from.dot(pole),
+    `dragging down did not look down the room: ${pitchedDown.dot(pole)} against ${from.dot(pole)}`);
+  // And the clamp is against that pole too, so forty screens down stops at the room's floor.
+  const far = look(from, 0, 40 * LOOK_HEIGHT, canted);
+  assert.ok(near(Math.acos(far.dot(pole) / far.length()), Math.PI - LOOK_POLE_EPS, 1e-9),
+    `${Math.acos(far.dot(pole) / far.length())}`);
 });

--- a/test/fly.test.mjs
+++ b/test/fly.test.mjs
@@ -1,0 +1,119 @@
+// The fly keys' directions and one frame's displacement, called directly. The rows that matter
+// are the two a browser cannot separate: Q and E climb the pole they are handed rather than the
+// camera's own vertical, and a frame that arrives after a stall moves the cap and not the gap.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+import {
+  FLY_SPEED_MPS, FLY_FAST, FLY_STALL_S, isFlyKey, flyDirection, flyStep,
+} from '../web/fly.js';
+
+const UP = new THREE.Vector3(0, 1, 0);
+const held = (...codes) => new Set(codes);
+const dir = (codes, quaternion = new THREE.Quaternion()) => (
+  flyDirection(codes, quaternion, UP, new THREE.Vector3()).toArray()
+);
+const step = (codes, fast, dt, quaternion = new THREE.Quaternion(), up = UP) => (
+  flyStep(codes, fast, dt, quaternion, up, new THREE.Vector3())
+);
+
+const near = (a, b, tol = 1e-12) => Math.abs(a - b) <= tol;
+const nearAll = (got, want, tol = 1e-12) => got.every((v, i) => near(v, want[i], tol));
+
+/** Pitched down by `deg`, which is a rotation about the camera's local X. */
+const pitched = (deg) => new THREE.Quaternion().setFromAxisAngle(
+  new THREE.Vector3(1, 0, 0), THREE.MathUtils.degToRad(-deg),
+);
+
+test('the six keys are fly keys and nothing else is', () => {
+  for (const code of ['KeyW', 'KeyA', 'KeyS', 'KeyD', 'KeyQ', 'KeyE']) {
+    assert.equal(isFlyKey(code), true, code);
+  }
+  for (const code of ['KeyZ', 'KeyF', 'KeyR', 'ArrowUp', 'Space', 'ShiftLeft', 'w', '']) {
+    assert.equal(isFlyKey(code), false, code);
+  }
+});
+
+test('W is the view direction, S is its opposite, and D is the camera\'s local +X', () => {
+  assert.ok(nearAll(dir(held('KeyW')), [0, 0, -1]), `${dir(held('KeyW'))}`);
+  assert.ok(nearAll(dir(held('KeyS')), [0, 0, 1]), `${dir(held('KeyS'))}`);
+  assert.ok(nearAll(dir(held('KeyD')), [1, 0, 0]), `${dir(held('KeyD'))}`);
+  assert.ok(nearAll(dir(held('KeyA')), [-1, 0, 0]), `${dir(held('KeyA'))}`);
+  // Turned a quarter turn about the pole, so a camera-space direction is a different world one.
+  const yawed = new THREE.Quaternion().setFromAxisAngle(UP, Math.PI / 2);
+  assert.ok(nearAll(dir(held('KeyW'), yawed), [-1, 0, 0], 1e-9), `${dir(held('KeyW'), yawed)}`);
+  assert.ok(nearAll(dir(held('KeyD'), yawed), [0, 0, -1], 1e-9), `${dir(held('KeyD'), yawed)}`);
+});
+
+test('E is the pole it was handed and not the camera\'s own vertical, however the camera is aimed', () => {
+  const down = pitched(40);
+  // The control: at this pitch the camera's local Y is 40 degrees off the pole, so a build
+  // reading the camera's vertical answers somewhere else entirely.
+  const localY = new THREE.Vector3(0, 1, 0).applyQuaternion(down);
+  assert.ok(localY.dot(UP) < 0.8, `the camera is not pitched: local Y dots the pole at ${localY.dot(UP)}`);
+  assert.ok(nearAll(dir(held('KeyE'), down), [0, 1, 0], 1e-12), `${dir(held('KeyE'), down)}`);
+  assert.ok(nearAll(dir(held('KeyQ'), down), [0, -1, 0], 1e-12), `${dir(held('KeyQ'), down)}`);
+  // And a pole that is not the world's +Y is followed just as exactly, which is what levelling
+  // and the sensor view hand in.
+  const canted = new THREE.Vector3(0.3, 0.9, -0.2);
+  const want = canted.clone().normalize().toArray();
+  const got = flyDirection(held('KeyE'), down, canted, new THREE.Vector3()).toArray();
+  assert.ok(nearAll(got, want, 1e-12), `${got} against ${want}`);
+});
+
+test('opposite keys cancel and a diagonal stays one unit long', () => {
+  assert.deepEqual(dir(held('KeyW', 'KeyS')), [0, 0, 0]);
+  assert.deepEqual(dir(held('KeyA', 'KeyD')), [0, 0, 0]);
+  assert.deepEqual(dir(held('KeyQ', 'KeyE')), [0, 0, 0]);
+  assert.deepEqual(dir(held()), [0, 0, 0]);
+  const diagonal = dir(held('KeyW', 'KeyD'));
+  assert.ok(near(Math.hypot(...diagonal), 1), `${diagonal} is ${Math.hypot(...diagonal)} long`);
+  assert.ok(nearAll(diagonal, [Math.SQRT1_2, 0, -Math.SQRT1_2]), `${diagonal}`);
+  const corner = dir(held('KeyW', 'KeyD', 'KeyE'));
+  assert.ok(near(Math.hypot(...corner), 1), `${corner} is ${Math.hypot(...corner)} long`);
+});
+
+test('the target is the caller\'s object, written in place and handed back', () => {
+  const out = new THREE.Vector3(9, 9, 9);
+  assert.equal(flyDirection(held('KeyW'), new THREE.Quaternion(), UP, out), out);
+  assert.ok(nearAll(out.toArray(), [0, 0, -1]), `${out.toArray()}`);
+  const moved = new THREE.Vector3();
+  assert.equal(flyStep(held('KeyW'), false, 0.05, new THREE.Quaternion(), UP, moved), moved);
+});
+
+test('a frame moves direction x speed x dt, and the first frame of a hold moves nothing', () => {
+  // `nearAll` and not a deep equal: a direction of -1 scaled by zero is -0, which is the same
+  // displacement and a different value.
+  assert.ok(nearAll(step(held('KeyW'), false, 0).toArray(), [0, 0, 0]), 'dt 0 moved something');
+  assert.ok(nearAll(step(held(), false, 0.05).toArray(), [0, 0, 0]), 'nothing held moved something');
+  const tenth = step(held('KeyW'), false, 0.05);
+  assert.ok(near(tenth.length(), 0.05 * FLY_SPEED_MPS), `${tenth.length()} m over 50 ms`);
+  assert.ok(nearAll(tenth.toArray(), [0, 0, -0.05 * FLY_SPEED_MPS]), `${tenth.toArray()}`);
+  // A negative delta is a clock that went backwards, which moves nothing rather than backwards.
+  assert.ok(nearAll(step(held('KeyW'), false, -1).toArray(), [0, 0, 0]),
+    `a negative delta moved ${step(held('KeyW'), false, -1).toArray()}`);
+});
+
+test('a frame after a stall moves the cap and not the gap', () => {
+  const stalled = step(held('KeyW'), false, 5);
+  assert.ok(near(stalled.length(), FLY_STALL_S * FLY_SPEED_MPS),
+    `${stalled.length()} m over a 5 s gap, where the cap allows ${FLY_STALL_S * FLY_SPEED_MPS}`);
+  assert.ok(stalled.length() < 0.2, `${stalled.length()} m is a teleport`);
+  // The cap is a cap and not a floor: a frame inside it keeps its own length.
+  const inside = step(held('KeyW'), false, FLY_STALL_S / 2);
+  assert.ok(near(inside.length(), (FLY_STALL_S / 2) * FLY_SPEED_MPS), `${inside.length()}`);
+});
+
+test('shift multiplies the distance and leaves the direction alone', () => {
+  const slow = step(held('KeyW'), false, 0.05);
+  const fast = step(held('KeyW'), true, 0.05);
+  assert.ok(near(fast.length(), slow.length() * FLY_FAST),
+    `${fast.length()} against ${slow.length()} x ${FLY_FAST}`);
+  assert.ok(near(fast.length(), 0.05 * FLY_SPEED_MPS * FLY_FAST), `${fast.length()}`);
+  assert.ok(nearAll(fast.clone().normalize().toArray(), slow.clone().normalize().toArray()),
+    `${fast.toArray()} against ${slow.toArray()}`);
+  // And it multiplies the capped frame too, rather than the cap swallowing it.
+  assert.ok(near(step(held('KeyW'), true, 5).length(), FLY_STALL_S * FLY_SPEED_MPS * FLY_FAST),
+    `${step(held('KeyW'), true, 5).length()}`);
+});

--- a/test/view-window.test.mjs
+++ b/test/view-window.test.mjs
@@ -161,14 +161,6 @@ test('the window stays inside the clip however it is asked to move', () => {
   assert.equal(view.fit(), false, 'fitting an already-whole window reports that nothing moved');
 });
 
-test('framing a range leaves a margin, so the two markers are not on the very edges', () => {
-  const { view } = windowOver(100);
-  view.frame(40, 60);
-  assert.ok(view.startSec < 40 && view.endSec > 60, `${view.startSec}..${view.endSec}`);
-  view.frame(50, 50);
-  assert.ok(view.spanSec >= 2 * MIN_VIEW_SEC - 1e-9, `${view.spanSec}`);
-});
-
 test('a marker just outside the window is still drawn, because its corner is inside', () => {
   const { view } = windowOver(100);
   view.set(0.4, 0.6);

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -101,7 +101,7 @@ const MUTATIONS = {
     ]],
   },
 
-  // ---- section 24, the fly keys ----
+  // ---- section 24, flying, looking and the lens ----
   // The pivot left behind, so the flight changes the orbit's radius instead of the standpoint.
   'fly-leaves-the-pivot': {
     file: 'web/main.js',
@@ -128,27 +128,60 @@ const MUTATIONS = {
     mustFail: 'E climbs the room\'s vertical rather than the camera\'s, however the camera is aimed',
   },
 
-  // The fly read before the typing guard, so a name with a w in it flies the camera.
+  // The fly read before the typing guard, so a name with a w in it flies the camera while it is
+  // being typed. The shift gate travels with the block, or the row would redden about the gate.
   'fly-moves-while-typing': {
     file: 'web/main.js',
     edits: [
       [
         '  // The recorder\'s viewport orbits the same camera, so this sits above the clip guard below.\n'
-        + '  // A repeat is harmless: the set already holds the code.\n'
+        + '  // A repeat is harmless: the set already holds the code. The key is recorded whether or not\n'
+        + '  // shift is down, so pressing shift onto a key already held starts the flight rather than\n'
+        + '  // waiting for the key to be pressed again; shift is what *takes* the key, so without it the\n'
+        + '  // key goes on to whatever else is bound to it.\n'
         + '  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {\n'
-        + '    e.preventDefault();\n    changeFlyKeys(() => flyHeld.add(e.code));\n    return;\n  }\n',
+        + '    changeFlyKeys(() => flyHeld.add(e.code));\n'
+        + '    if (e.shiftKey) {\n      e.preventDefault();\n      return;\n    }\n  }\n',
         '',
       ],
       [
-        '  flyFast = e.shiftKey;\n  if (isTyping(e.target)) return;',
-        '  flyFast = e.shiftKey;\n'
+        '  changeFlyKeys(() => { flyShift = e.shiftKey; });\n'
+        + '  if (controlKeeps(e.target, e.key)) return;',
+        '  changeFlyKeys(() => { flyShift = e.shiftKey; });\n'
         + '  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {\n'
-        + '    e.preventDefault();\n    changeFlyKeys(() => flyHeld.add(e.code));\n    return;\n  }\n'
-        + '  if (isTyping(e.target)) return;',
+        + '    changeFlyKeys(() => flyHeld.add(e.code));\n'
+        + '    if (e.shiftKey) {\n      e.preventDefault();\n      return;\n    }\n  }\n'
+        + '  if (controlKeeps(e.target, e.key)) return;',
       ],
     ],
-    fails: 'a fly key does nothing while a control holds the keyboard',
-    mustFail: 'a fly key does nothing while a control holds the keyboard',
+    fails: 'a fly key does nothing while a text field holds the keyboard',
+    mustFail: 'a fly key does nothing while a text field holds the keyboard',
+  },
+
+  // The guard back to the tag name, which is the build that shipped: a focused slider swallowed
+  // every shortcut in the editor, so a lens nudged by hand left the keyboard dead until
+  // something else took the focus back.
+  'typing-guard-takes-every-control': {
+    file: 'web/main.js',
+    edits: [[
+      '  if (controlKeeps(e.target, e.key)) return;',
+      "  if (e.target instanceof HTMLElement\n"
+      + "    && ['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName)) return;",
+    ]],
+    fails: 'and a fly key still flies while a slider holds the keyboard, because a slider takes no text',
+    mustFail: 'and a fly key still flies while a slider holds the keyboard, because a slider takes no text',
+  },
+
+  'typing-guard-takes-adjustment-keys': {
+    file: 'web/main.js',
+    edits: [['  return SELF_OPERATING_KEYS.has(key);', '  return false;']],
+    mustFail: 'control: a focused slider still takes its own arrow key, which is what it is left holding',
+  },
+
+  'fly-survives-text-focus': {
+    file: 'web/main.js',
+    edits: [["document.addEventListener('focusin', (e) => { if (takesText(e.target)) clearFlyKeys(); });\n", '']],
+    mustFail: 'focusing a text field stops a flight already in progress',
   },
 
   // A key released outside the page never arrives, so without this the camera flies for ever.
@@ -159,15 +192,29 @@ const MUTATIONS = {
     mustFail: 'and losing the page releases the key, so a held fly key stops',
   },
 
-  // The half of the gate that is the program camera, a gizmo drag and a node drag at once.
+  // The half of the gate that is the program camera, a gizmo drag, a node drag and a crop drag at
+  // once. Both terms go, because `lookDrag` on its own still refuses under the program camera and
+  // the row would pass on a build with the gate gone.
   'fly-ignores-the-program-camera': {
     file: 'web/main.js',
     edits: [[
-      'const flying = () => flyInputActive() && controls.enabled && !exporting;',
+      'const flying = () => flyInputActive() && (controls.enabled || lookDrag !== null) && !exporting;',
       'const flying = () => flyInputActive() && !exporting;',
     ]],
     fails: 'and nothing flies under the program camera, whose pose is the document\'s',
     mustFail: 'and nothing flies under the program camera, whose pose is the document\'s',
+  },
+
+  // The other half: a look drag turns the orbit off, and it is the one reason for that which must
+  // not stop the flight. Without the term, flying while you turn is the one thing the mode is not.
+  'fly-stops-during-a-look': {
+    file: 'web/main.js',
+    edits: [[
+      'const flying = () => flyInputActive() && (controls.enabled || lookDrag !== null) && !exporting;',
+      'const flying = () => flyInputActive() && controls.enabled && !exporting;',
+    ]],
+    fails: 'and the flight carries on through a look drag, so you fly the way you are turning',
+    mustFail: 'and the flight carries on through a look drag, so you fly the way you are turning',
   },
 
   // Held keys can cancel exactly. They ask for no movement, so they must not keep the redraw
@@ -175,11 +222,39 @@ const MUTATIONS = {
   'fly-redraws-cancelled-keys': {
     file: 'web/main.js',
     edits: [[
-      'const flying = () => flyInputActive() && controls.enabled && !exporting;',
-      'const flying = () => flyHeld.size > 0 && controls.enabled && !exporting;',
+      '  flyShift && flyDirection(flyHeld, freeCamera.quaternion, freeCamera.up, flyMove).lengthSq() > 0\n',
+      '  flyShift && flyHeld.size > 0\n',
     ]],
     fails: 'opposite fly keys do not keep the redraw loop alive because their requested move is zero',
     mustFail: 'opposite fly keys do not keep the redraw loop alive because their requested move is zero',
+  },
+
+  // The gate itself. Without it the six keys fly bare, which is the whole of what the redesign
+  // took away and what the unshifted control below is for.
+  'fly-ignores-the-shift-gate': {
+    file: 'web/main.js',
+    edits: [[
+      '  flyShift && flyDirection(flyHeld, freeCamera.quaternion, freeCamera.up, flyMove).lengthSq() > 0',
+      '  flyDirection(flyHeld, freeCamera.quaternion, freeCamera.up, flyMove).lengthSq() > 0',
+    ]],
+    fails: 'control: an unshifted fly key moves nothing at all, which is the gate every row above is held by',
+    mustFail: 'control: an unshifted fly key moves nothing at all, which is the gate every row above is held by',
+  },
+
+  // The gate keyed on the keydown rather than on the shift state: the key is only recorded while
+  // shift is already down, so shift arriving onto a key already held finds an empty set.
+  'fly-takes-the-key-only-with-shift': {
+    file: 'web/main.js',
+    edits: [[
+      '  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {\n'
+      + '    changeFlyKeys(() => flyHeld.add(e.code));\n'
+      + '    if (e.shiftKey) {\n      e.preventDefault();\n      return;\n    }\n  }',
+      '  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {\n'
+      + '    if (e.shiftKey) {\n      changeFlyKeys(() => flyHeld.add(e.code));\n'
+      + '      e.preventDefault();\n      return;\n    }\n  }',
+    ]],
+    fails: 'and shift arriving onto a key already held starts the flight',
+    mustFail: 'and shift arriving onto a key already held starts the flight',
   },
 
   // A release and new press can both land between animation frames. Without the event-side reset,
@@ -211,14 +286,149 @@ const MUTATIONS = {
     mustFail: 'and Reset still goes home after a flight rather than to wherever the flight ended',
   },
 
-  'fly-ignores-shift': {
+  // The look written as an orbit about a pivot that happens to be near. The view turns by exactly
+  // the same angle and the radius survives, so position is the only reading that can see it.
+  'look-orbits-the-camera': {
+    file: 'web/main.js',
+    edits: [[
+      '  controls.target.copy(freeCamera.position).add(lookPivot);',
+      '  freeCamera.position.copy(controls.target).sub(lookPivot);',
+    ]],
+    fails: 'the camera stands still through a look, so what turns is the view and not the standpoint',
+    mustFail: 'the camera stands still through a look, so what turns is the view and not the standpoint',
+  },
+
+  // The pivot pulled in rather than rotated, so the turn is right and the orbit afterwards is not.
+  'look-shrinks-the-pivot': {
+    file: 'web/main.js',
+    edits: [[
+      '  controls.target.copy(freeCamera.position).add(lookPivot);',
+      '  controls.target.copy(freeCamera.position).addScaledVector(lookPivot, 0.5);',
+    ]],
+    fails: 'and the pivot rides a sphere about the camera, so the orbit radius survives the turn',
+    mustFail: 'and the pivot rides a sphere about the camera, so the orbit radius survives the turn',
+  },
+
+  // A rate of its own rather than the lens's, which is the figure this started out as. Right at
+  // the default lens and wrong everywhere else: at 300mm the frame is four degrees tall and six
+  // pixels of drag would sweep the picture out of view.
+  'look-ignores-the-lens': {
     file: 'web/fly.js',
     edits: [[
-      '  const speed = FLY_SPEED_MPS * (fast ? FLY_FAST : 1);',
-      '  const speed = FLY_SPEED_MPS;',
+      '  const perPixel = THREE.MathUtils.degToRad(fovDeg) / Math.max(1, heightPx);',
+      '  const perPixel = (2 * Math.PI) / Math.max(1, heightPx);',
     ]],
-    fails: 'holding shift flies faster, by about the three times it claims',
-    mustFail: 'holding shift flies faster, by about the three times it claims',
+    fails: '  and a quarter field of view turns a quarter as far for the same pixels',
+    mustFail: '  and a quarter field of view turns a quarter as far for the same pixels',
+  },
+
+  // The wheel read off the vertical alone. Chrome delivers shift plus a physical wheel as
+  // `deltaX`, so this is the gesture dead on a real mouse and live under every driver.
+  'lens-wheel-reads-only-the-vertical': {
+    file: 'web/main.js',
+    edits: [[
+      '  const pixels = Math.abs(delta.x) > Math.abs(delta.y) ? delta.x : delta.y;',
+      '  const pixels = delta.y;',
+    ]],
+    fails: 'and a wheel that reports its notch sideways moves the lens by the same amount, which is '
+      + 'the axis a real mouse sends under shift',
+    mustFail: 'and a wheel that reports its notch sideways moves the lens by the same amount, which is '
+      + 'the axis a real mouse sends under shift',
+  },
+
+  // The yaw the other way, which is an orbit's sign rather than a look's.
+  'look-drags-backwards': {
+    file: 'web/fly.js',
+    edits: [[
+      '  out.applyAxisAngle(lookPole, -dxPx * perPixel);',
+      '  out.applyAxisAngle(lookPole, dxPx * perPixel);',
+    ]],
+    fails: 'dragging right turns the view right, which puts the scene to the left of where it was',
+    mustFail: 'dragging right turns the view right, which puts the scene to the left of where it was',
+  },
+
+  // And the pitch the other way. A separate control because a build can get one axis right.
+  'look-pitches-backwards': {
+    file: 'web/fly.js',
+    edits: [[
+      '    Math.PI - LOOK_POLE_EPS, Math.max(LOOK_POLE_EPS, polar + dyPx * perPixel),',
+      '    Math.PI - LOOK_POLE_EPS, Math.max(LOOK_POLE_EPS, polar - dyPx * perPixel),',
+    ]],
+    fails: 'dragging down looks down, at the same radians per pixel as across',
+    mustFail: 'dragging down looks down, at the same radians per pixel as across',
+  },
+
+  // The clamp removed, so a drag past the pole rotates through it and comes back facing the
+  // other way. Driven as one pointer move, because a stepped drag on this build oscillates back
+  // towards the pole it went through and a row reading the end of it sees nothing wrong.
+  'look-tips-past-the-pole': {
+    file: 'web/fly.js',
+    edits: [[
+      '  const wanted = Math.min(\n'
+      + '    Math.PI - LOOK_POLE_EPS, Math.max(LOOK_POLE_EPS, polar + dyPx * perPixel),\n'
+      + '  );',
+      '  const wanted = polar + dyPx * perPixel;',
+    ]],
+    fails: 'and the pitch stops just short of either pole rather than tipping over it',
+    mustFail: 'and the pitch stops just short of either pole rather than tipping over it',
+  },
+
+  // The look's release never arms the accurate seek, so a turn ends on the draft frame the drag
+  // was redrawing. `fly-never-settles` through the second door the redesign opened.
+  'look-never-settles': {
+    file: 'web/main.js',
+    edits: [[
+      '  controls.enabled = viewCamera === freeCamera;\n  orbitSettling = true;\n}',
+      '  controls.enabled = viewCamera === freeCamera;\n}',
+    ]],
+    fails: 'and letting the pointer up lands the accurate frame',
+    mustFail: 'and letting the pointer up lands the accurate frame',
+  },
+
+  'look-survives-blur': {
+    file: 'web/main.js',
+    edits: [["addEventListener('blur', stopLookDrag);\n", '']],
+    mustFail: 'editor: blur ends a look drag and rejects its remaining input',
+  },
+  'look-survives-capture-loss': {
+    file: 'web/main.js',
+    edits: [["['pointerup', 'pointercancel', 'lostpointercapture']", "['pointerup', 'pointercancel']"]],
+    mustFail: 'editor: lostpointercapture ends a look drag and rejects its remaining input',
+  },
+  'look-survives-camera-switch': {
+    file: 'web/main.js',
+    edits: [['function setViewCamera(cam) {\n  stopLookDrag();', 'function setViewCamera(cam) {']],
+    mustFail: 'editor: program camera ends a look drag and rejects its remaining input',
+  },
+
+  // The wheel's clamp removed. A wheel has no value to type, so nothing else stops it: the band
+  // is what the gesture is bounded by rather than only measured against.
+  'lens-wheel-ignores-the-band': {
+    file: 'web/main.js',
+    edits: [[
+      '  freeCamera.fov = verticalFovForFocalLength(\n'
+      + '    Math.min(LENS_MAX_MM, Math.max(LENS_MIN_MM, mm)), aspect,\n'
+      + '  );',
+      '  freeCamera.fov = verticalFovForFocalLength(mm, aspect);',
+    ]],
+    fails: 'and the wheel stops at each end of the band, at a reading the row can hold',
+    mustFail: 'and the wheel stops at each end of the band, at a reading the row can hold',
+  },
+
+  // The band read off the raw number rather than off the figure the row prints. A lens the wheel
+  // clamped to exactly 8mm comes back through `fov` as 7.9999999999999982 at 16:9, so the row
+  // says it is wider than the band it is standing in.
+  'showlens-reads-the-raw-number': {
+    file: 'web/main.js',
+    edits: [[
+      '  const shown = Number(mm.toFixed(1));\n'
+      + '  if (shown < LENS_MIN_MM) ui.camLensOut.textContent = `wider than ${LENS_MIN_MM}mm`;\n'
+      + '  else if (shown > LENS_MAX_MM) ui.camLensOut.textContent = `longer than ${LENS_MAX_MM}mm`;',
+      '  if (mm < LENS_MIN_MM) ui.camLensOut.textContent = `wider than ${LENS_MIN_MM}mm`;\n'
+      + '  else if (mm > LENS_MAX_MM) ui.camLensOut.textContent = `longer than ${LENS_MAX_MM}mm`;',
+    ]],
+    fails: 'and the wheel stops at each end of the band, at a reading the row can hold',
+    mustFail: 'and the wheel stops at each end of the band, at a reading the row can hold',
   },
 
   // ---- section 22, the clip a person adds, selects and deletes ----
@@ -2638,6 +2848,97 @@ const focusStage = () => page.evaluate(`(() => {
   if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
   document.getElementById('stage')?.focus?.();
 })()`);
+
+async function proveRecorderNavigation(page) {
+  const pose = () => page.evaluate(() => {
+    const k = __kinect, c = k.freeCamera;
+    return { p: c.position.toArray(), t: k.controls.target.toArray(), fov: c.fov };
+  });
+  const distance = (a, b) => Math.hypot(...a.map((v, i) => v - b[i]));
+  await page.evaluate(() => { document.activeElement?.blur(); });
+  const before = await pose();
+  await page.keyboard.down('w');
+  await page.waitForTimeout(250);
+  const bare = await pose();
+  await page.keyboard.down('Shift');
+  await page.waitForTimeout(350);
+  await page.keyboard.up('w');
+  await page.keyboard.up('Shift');
+  const flown = await pose();
+  check(distance(before.p, bare.p) < 1e-6 && distance(bare.p, flown.p) > 0.1,
+    'recorder: Shift enables flight on a key already held',
+    `bare ${distance(before.p, bare.p)}, shifted ${distance(bare.p, flown.p)}`);
+  const box = await page.locator('#stage').boundingBox();
+  const x = box.x + box.width * 0.4, y = box.y + box.height * 0.5;
+  await page.keyboard.down('Shift');
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x + 100, y, { steps: 6 });
+  await page.mouse.up();
+  await page.keyboard.up('Shift');
+  await page.waitForTimeout(50);
+  const looked = await pose();
+  check(distance(flown.p, looked.p) < 1e-6 && distance(flown.t, looked.t) > 0.05,
+    'recorder: Shift-drag turns the view without moving the camera');
+  await page.keyboard.down('Shift');
+  await page.mouse.wheel(-100, 0);
+  await page.waitForTimeout(50);
+  await page.keyboard.up('Shift');
+  const wheeled = await pose();
+  check(wheeled.fov < looked.fov * 0.95 && distance(looked.p, wheeled.p) < 1e-6,
+    'recorder: a horizontal Shift-wheel changes the lens without dollying');
+  await proveLookInterruptions(page, 'recorder');
+}
+
+async function proveLookInterruptions(page, label) {
+  const pose = () => page.evaluate(() => {
+    const k = __kinect;
+    return { p: k.freeCamera.position.toArray(), t: k.controls.target.toArray(), enabled: k.controls.enabled };
+  });
+  const distance = (a, b) => Math.hypot(...a.map((v, i) => v - b[i]));
+  for (const reason of ['blur', 'pointercancel', 'lostpointercapture', 'program camera']) {
+    await page.evaluate(() => { document.activeElement?.blur(); __kinect.setViewCamera(__kinect.freeCamera); });
+    const box = await page.locator('#stage').boundingBox();
+    const x = box.x + box.width * 0.4, y = box.y + box.height * 0.5;
+    await page.evaluate(() => {
+      addEventListener('pointerdown', (e) => {
+        globalThis.__proofPointer = e.pointerId;
+      }, { capture: true, once: true });
+    });
+    await page.keyboard.down('Shift');
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 30, y, { steps: 3 });
+    const held = await pose();
+    check(!held.enabled, `${label}: ${reason} starts with a live look drag`);
+    await page.evaluate((reason) => {
+      const stage = document.getElementById('stage');
+      if (reason === 'blur') dispatchEvent(new Event('blur'));
+      else if (reason === 'program camera') __kinect.setViewCamera(__kinect.programCamera);
+      else if (reason === 'lostpointercapture') stage.releasePointerCapture(globalThis.__proofPointer);
+      else stage.dispatchEvent(new PointerEvent('pointercancel', { pointerId: globalThis.__proofPointer }));
+    }, reason);
+    // Capture loss is delivered before the next pointer event, which can outlive a timed wait.
+    if (reason === 'lostpointercapture') await page.mouse.move(x + 30, y);
+    await page.waitForTimeout(50);
+    const stopped = await pose();
+    await page.mouse.move(x + 80, y + 30, { steps: 3 });
+    if (reason === 'program camera') await page.keyboard.down('w');
+    await page.waitForTimeout(200);
+    const later = await pose();
+    if (reason === 'program camera') await page.keyboard.up('w');
+    await page.mouse.up();
+    await page.keyboard.up('Shift');
+    check(stopped.enabled === (reason !== 'program camera')
+      && distance(stopped.p, later.p) < 1e-6 && distance(stopped.t, later.t) < 1e-6,
+    `${label}: ${reason} ends a look drag and rejects its remaining input`,
+    `enabled ${stopped.enabled}, camera ${distance(stopped.p, later.p)}, pivot ${distance(stopped.t, later.t)}`);
+  }
+  await page.evaluate(() => {
+    __kinect.setViewCamera(__kinect.freeCamera);
+    document.getElementById('menuCameraReset').click();
+  });
+}
 
 try {
   await settle();
@@ -9598,6 +9899,8 @@ try {
             'and the dock\'s sensor lands the pose Framing\'s own sensor view lands',
             `dock ${sensorByDock.join(', ')} against panel ${sensorByPanel.join(', ')}`);
         }
+        await proveRecorderNavigation(recorder.page);
+        check(recErrors.length === 0, 'recorder navigation raises no page errors', recErrors.join(' | '));
       } finally {
         // Closed before the editor is put back, so the last gesture of this section goes to the
         // page section 22 inherits and nothing is left holding a socket on the shooting server.
@@ -9839,7 +10142,7 @@ try {
   }
 
   // -------------------------------------------------------------------------------------------
-  console.log('\n[24] the fly keys');
+  console.log('\n[24] flying, looking and the lens');
   {
     await page.evaluate('__kinect.timeline.transport().pause()');
     await page.evaluate('__kinect.timeline.transport().seek(4.0)');
@@ -9855,12 +10158,20 @@ try {
       k.controls.update(0);
       k.controls.enableDamping = damped;
       const c = k.freeCamera;
+      const V = c.position.constructor;
       return {
         p: c.position.toArray(),
         up: c.up.clone().normalize().toArray(),
-        fwd: c.getWorldDirection(new (c.position.constructor)()).toArray(),
+        fwd: c.getWorldDirection(new V()).toArray(),
         target: k.controls.target.toArray(),
         offset: k.controls.target.clone().sub(c.position).toArray(),
+        radius: k.controls.target.distanceTo(c.position),
+        fov: c.fov,
+        // The height the look divides the drag by, which is the renderer's own size and not the
+        // element's box: a row expecting a turn has to ask the number the code used.
+        stageH: k.renderer.getSize({ set(x, y) { this.x = x; this.y = y; return this; } }).y,
+        lens: document.getElementById('camLens').value,
+        lensOut: document.getElementById('camLensOut').textContent,
         redraws: k.timeline.counters.navigationRedraws,
         seeks: k.timeline.counters.seeks,
         autoRotate: k.controls.autoRotate,
@@ -9869,12 +10180,27 @@ try {
       };
     })()`);
 
+    const dot3 = (a, b) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+    const cross3 = (a, b) => [
+      a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0],
+    ];
+    const unit = (a) => { const l = Math.hypot(...a) || 1; return a.map((v) => v / l); };
+    const flat = (v, pole) => { const k = dot3(v, pole); return unit(v.map((x, i) => x - k * pole[i])); };
+    /** The signed angle from `a` to `b` about `pole`, which is what a yaw is and a pitch is not. */
+    const yawAbout = (a, b, pole) => {
+      const [x, y] = [flat(a, pole), flat(b, pole)];
+      return Math.atan2(dot3(cross3(x, y), pole), dot3(x, y));
+    };
+    /** How far off the pole a direction points, in radians. Grows as the view goes down. */
+    const polarTo = (v, pole) => Math.acos(Math.min(1, Math.max(-1, dot3(v, pole))));
+    const apart = (a, b) => Math.hypot(...a.map((v, i) => v - b[i]));
+
     /**
      * Hold `keys` for about `ms` and report what the camera did over it. `seeks` is read between
      * the last frame of the hold and the release, so the release's own seek can be told from a
-     * redraw that fell back to one.
+     * redraw that fell back to one. `shift` is not decoration: it is what takes the six keys.
      */
-    const fly = async (keys, { ms = 400, shift = false, focus = true } = {}) => {
+    const fly = async (keys, { ms = 400, shift = true, focus = true } = {}) => {
       if (focus) await focusStage();
       const before = await rest();
       const began = Date.now();
@@ -9891,6 +10217,46 @@ try {
       return { before, after, moved, elapsed, heldSeeks, length: Math.hypot(...moved) };
     };
 
+    const stage = await page.evaluate(`(() => {
+      const r = document.getElementById('stage').getBoundingClientRect();
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2, top: r.y, bottom: r.y + r.height };
+    })()`);
+
+    /**
+     * A drag across the stage, shifted or bare, and the poses either side of it.
+     * `steps` of 1 is one pointer move, which is what the pole rows need: a build with no clamp
+     * turns back towards the pole it went through, so a stepped drag past it ends up reading as
+     * though it had stopped there.
+     */
+    const drag = async (dxPx, dyPx, { shift = true, steps = 8, from = null } = {}) => {
+      const at = from ?? { x: stage.x - dxPx / 2, y: stage.y - dyPx / 2 };
+      const before = await rest();
+      if (shift) await page.keyboard.down('Shift');
+      await page.mouse.move(at.x, at.y);
+      await page.mouse.down();
+      await page.mouse.move(at.x + dxPx, at.y + dyPx, { steps });
+      await page.mouse.up();
+      if (shift) await page.keyboard.up('Shift');
+      await settle();
+      const after = await rest();
+      return { before, after, moved: apart(after.p, before.p) };
+    };
+
+    /**
+     * One wheel notch over the middle of the stage, shifted or bare. `axis` is not decoration:
+     * Chrome turns shift plus a physical wheel into `deltaX`, so the horizontal branch is the
+     * one a real mouse takes and rows driven on `deltaY` alone leave it untested.
+     */
+    const wheel = async (delta, { shift = true, axis = 'y' } = {}) => {
+      const before = await rest();
+      await page.mouse.move(stage.x, stage.y);
+      if (shift) await page.keyboard.down('Shift');
+      await page.mouse.wheel(axis === 'x' ? delta : 0, axis === 'x' ? 0 : delta);
+      if (shift) await page.keyboard.up('Shift');
+      await settle();
+      return { before, after: await rest() };
+    };
+
     const armed = await rest();
     // The trail is a precondition and not decoration: `redrawNow` falls back to a full seek while
     // one is up, which would take the seek pair below away without saying so.
@@ -9903,12 +10269,12 @@ try {
     const w = await fly(['w']);
     const along = w.moved.reduce((n, v, i) => n + v * w.before.fwd[i], 0);
     const across = Math.hypot(...w.moved.map((v, i) => v - along * w.before.fwd[i]));
-    note('holding W at a parked playhead',
+    note('holding shift and W at a parked playhead',
       `${w.length.toFixed(3)} m over ${w.elapsed.toFixed(2)}s held, `
       + `${w.after.redraws - w.before.redraws} navigation redraws, `
       + `${w.heldSeeks - w.before.seeks} seeks during the hold`);
     check(along > 0.1 && along < 0.8,
-      'holding W flies the camera along the view direction',
+      'holding shift and W flies the camera along the view direction',
       `${along.toFixed(3)} m along the way it was pointing, over ${w.elapsed.toFixed(2)}s held`);
     check(w.length > 0 && across < 0.05 * w.length,
       '  and next to nothing across it, so it flies the view rather than a world axis',
@@ -9933,7 +10299,38 @@ try {
       `${w.after.seeks - w.heldSeeks} seeks after the release, against `
       + `${w.heldSeeks - w.before.seeks} during the hold`);
 
+    // The falsification control for every row above: with the gate gone they all still pass, and
+    // only this one can see it. The key is still recorded while it is down, so an unshifted hold
+    // is a build that took the key and refused to move on it rather than one that never saw it.
+    const bare = await fly(['w'], { shift: false });
+    check(bare.length < 1e-6 && bare.after.redraws === bare.before.redraws,
+      'control: an unshifted fly key moves nothing at all, which is the gate every row above is held by',
+      `${bare.length.toExponential(2)} m and ${bare.after.redraws - bare.before.redraws} navigation `
+      + `redraws over ${bare.elapsed.toFixed(2)}s held`);
+
+    // Shift onto a key already down. A different failure from the gate: a build that reads shift
+    // on the keydown alone never records the key, so this hold has nothing to start.
     await focusStage();
+    const beforeLate = await rest();
+    await page.keyboard.down('w');
+    await new Promise((r) => setTimeout(r, 300));
+    const heldBare = await page.evaluate('__kinect.freeCamera.position.toArray()');
+    await page.keyboard.down('Shift');
+    await new Promise((r) => setTimeout(r, 350));
+    const heldShifted = await page.evaluate('__kinect.freeCamera.position.toArray()');
+    await page.keyboard.up('w');
+    await page.keyboard.up('Shift');
+    await settle();
+    check(apart(heldBare, beforeLate.p) < 1e-6,
+      'control: the key on its own flew nothing over the 300 ms before shift arrived',
+      `${apart(heldBare, beforeLate.p).toExponential(2)} m`);
+    check(apart(heldShifted, heldBare) > 0.1,
+      'and shift arriving onto a key already held starts the flight',
+      `${apart(heldShifted, heldBare).toFixed(3)} m over the 350 ms after shift went down`);
+
+    // Shifted, or the keys cancel for the second reason and the row passes on the gate instead.
+    await focusStage();
+    await page.keyboard.down('Shift');
     await page.keyboard.down('w');
     await page.keyboard.down('s');
     const cancelledBefore = await rest();
@@ -9941,42 +10338,44 @@ try {
     const cancelledAfter = await rest();
     await page.keyboard.up('s');
     await page.keyboard.up('w');
+    await page.keyboard.up('Shift');
     await settle();
-    const cancelledMove = Math.hypot(...cancelledAfter.p.map((v, i) => v - cancelledBefore.p[i]));
+    const cancelledMove = apart(cancelledAfter.p, cancelledBefore.p);
     const cancelledRedraws = cancelledAfter.redraws - cancelledBefore.redraws;
     check(cancelledMove < 1e-6 && cancelledRedraws <= 1,
       'opposite fly keys do not keep the redraw loop alive because their requested move is zero',
       `${cancelledMove.toExponential(2)} m and ${cancelledRedraws} navigation redraws over 300 ms`);
 
+    // Every synthetic event carries the shift, including the keyup: `flyShift` is written from
+    // `e.shiftKey` on both, so a release without it puts the gate down and the re-press flies
+    // nothing at all - which is the row passing for the opposite of its reason.
     await focusStage();
+    await page.keyboard.down('Shift');
     await page.keyboard.down('w');
     await new Promise((r) => setTimeout(r, 250));
     const restarted = await page.evaluate(`(async () => {
       const c = __kinect.freeCamera;
-      dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyW', key: 'w' }));
+      const shift = { code: 'KeyW', key: 'w', shiftKey: true };
+      dispatchEvent(new KeyboardEvent('keyup', shift));
       const until = performance.now() + 150;
       while (performance.now() < until) {}
       const before = c.position.toArray();
-      dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyW', key: 'w' }));
+      dispatchEvent(new KeyboardEvent('keydown', shift));
       await new Promise((resolve) => requestAnimationFrame(resolve));
-      const after = c.position.toArray();
-      dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyW', key: 'w' }));
-      return Math.hypot(...after.map((v, i) => v - before[i]));
+      const one = c.position.toArray();
+      for (let i = 0; i < 3; i++) await new Promise((resolve) => requestAnimationFrame(resolve));
+      const four = c.position.toArray();
+      dispatchEvent(new KeyboardEvent('keyup', shift));
+      const d = (a, b) => Math.hypot(...a.map((v, i) => v - b[i]));
+      return { first: d(one, before), overFour: d(four, before) };
     })()`);
     await page.keyboard.up('w');
+    await page.keyboard.up('Shift');
     await settle();
-    check(restarted < 0.03,
+    check(restarted.first < 0.03 && restarted.overFour > 0.002,
       'a new hold starts a new clock even when its release and press land between frames',
-      `${restarted.toFixed(4)} m on the first frame after a 150 ms gap`);
-
-    const fast = await fly(['w'], { shift: true });
-    const slowRate = w.length / w.elapsed;
-    const fastRate = fast.length / fast.elapsed;
-    check(slowRate > 0 && fastRate > 1.8 * slowRate,
-      'holding shift flies faster, by about the three times it claims',
-      `${fastRate.toFixed(3)} m per second held against ${slowRate.toFixed(3)}, `
-      + `a ratio of ${(fastRate / Math.max(slowRate, 1e-9)).toFixed(2)} over `
-      + `${fast.length.toFixed(3)} m and ${w.length.toFixed(3)} m`);
+      `${restarted.first.toFixed(4)} m on the first frame after a 150 ms gap, and `
+      + `${restarted.overFour.toFixed(4)} m over the four frames after it, so it did fly`);
 
     // Pitched hard down, which is the pose that tells the room's vertical from the camera's.
     const pitched = await page.evaluate(`(() => {
@@ -10008,21 +10407,71 @@ try {
     })()`);
     await settle();
 
-    // `tRate` and not a text field: the guard is on the tag name, so a slider with the keyboard
-    // is the same case as a name being typed into, and it needs no dialog opened over the stage.
-    await page.evaluate("document.getElementById('tRate').focus()");
-    const focused = await page.evaluate('document.activeElement && document.activeElement.id');
+    // The keyboard guard is two claims and not one: a text field keeps the whole keyboard, and
+    // every other control keeps only the keys it works itself. Both are driven, because the
+    // build that took every control's keyboard passed the first of them for years.
+    //
+    // The editor has no text field standing on the page, so this opens the one the export
+    // dialog carries and puts its value back afterwards - the refused key would otherwise be
+    // typed into the name a later section reads.
+    await focusStage();
+    const exportName = await page.evaluate('document.getElementById("tExportName").value');
+    const beforeTextFocus = await rest();
+    await page.keyboard.down('Shift');
+    await page.keyboard.down('w');
+    await page.waitForTimeout(150);
+    await page.locator('#outputMenuButton').click();
+    await page.locator('#menuExport').click();
+    await page.evaluate("document.getElementById('tExportName').focus()");
+    const atTextFocus = await rest();
+    await page.waitForTimeout(200);
+    const afterTextFocus = await rest();
+    await page.keyboard.up('w');
+    await page.keyboard.up('Shift');
+    check(apart(beforeTextFocus.p, atTextFocus.p) > 0.05,
+      'control: the camera was flying before the text field took focus');
+    check(apart(atTextFocus.p, afterTextFocus.p) < 1e-6,
+      'focusing a text field stops a flight already in progress',
+      `${apart(atTextFocus.p, afterTextFocus.p)} m while the filename held focus`);
+    const inText = await page.evaluate('document.activeElement && document.activeElement.id');
     const whileTyping = await fly(['w'], { focus: false });
-    check(focused === 'tRate',
-      'control: a panel control holds the keyboard, which is the case the typing guard is about',
-      `the focus is on ${JSON.stringify(focused)}`);
+    await page.evaluate(`(() => {
+      const el = document.getElementById('tExportName');
+      el.value = ${JSON.stringify(exportName)};
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      document.getElementById('exportDialog').close();
+    })()`);
+    await settle();
+    check(inText === 'tExportName',
+      'control: a text field holds the keyboard, which is the case the guard is about',
+      `the focus is on ${JSON.stringify(inText)}`);
     check(whileTyping.length < 1e-6,
-      'a fly key does nothing while a control holds the keyboard',
+      'a fly key does nothing while a text field holds the keyboard',
       `${whileTyping.length.toExponential(2)} m over ${whileTyping.elapsed.toFixed(2)}s held`);
+
+    // A slider is not a text field, so it keeps the arrows it works itself and nothing else.
+    // `camLens` rather than `tRate`: this section already puts the lens back on the way out,
+    // where a nudged clip speed would be an edit left behind in the document.
+    await page.locator('#panelTabCamera').click();
+    await page.locator('#camLens').focus();
+    const onSlider = await page.evaluate('document.activeElement && document.activeElement.id');
+    const nudgeFrom = await page.evaluate('document.getElementById("camLens").value');
+    await page.keyboard.press('ArrowRight');
+    const nudgeTo = await page.evaluate('document.getElementById("camLens").value');
+    const whileSliding = await fly(['w'], { focus: false });
+    check(onSlider === 'camLens' && Number(nudgeTo) > Number(nudgeFrom),
+      'control: a focused slider still takes its own arrow key, which is what it is left holding',
+      `the focus is on ${JSON.stringify(onSlider)} and the right arrow took it from `
+      + `${nudgeFrom} to ${nudgeTo}`);
+    check(whileSliding.length > 0.1,
+      'and a fly key still flies while a slider holds the keyboard, because a slider takes no text',
+      `${whileSliding.length.toFixed(3)} m over ${whileSliding.elapsed.toFixed(2)}s held, against `
+      + `${whileTyping.length.toExponential(2)} m with the text field focused`);
     await focusStage();
 
     // A key released outside the page never arrives, so the blur has to be the release.
     const beforeBlur = await rest();
+    await page.keyboard.down('Shift');
     await page.keyboard.down('w');
     await new Promise((r) => setTimeout(r, 250));
     const atBlur = await page.evaluate('__kinect.freeCamera.position.toArray()');
@@ -10032,9 +10481,10 @@ try {
     await new Promise((r) => setTimeout(r, 300));
     const laterAfterBlur = await page.evaluate('__kinect.freeCamera.position.toArray()');
     await page.keyboard.up('w');
+    await page.keyboard.up('Shift');
     await settle();
-    const flewBeforeBlur = Math.hypot(...atBlur.map((v, i) => v - beforeBlur.p[i]));
-    const flewAfterBlur = Math.hypot(...laterAfterBlur.map((v, i) => v - settledAfterBlur[i]));
+    const flewBeforeBlur = apart(atBlur, beforeBlur.p);
+    const flewAfterBlur = apart(laterAfterBlur, settledAfterBlur);
     check(flewBeforeBlur > 0.05,
       'control: the hold was flying when the window lost the page',
       `${flewBeforeBlur.toFixed(3)} m over the 250 ms before the blur`);
@@ -10048,19 +10498,21 @@ try {
       return { enabled: k.controls.enabled, p: k.freeCamera.position.toArray() };
     })()`);
     await focusStage();
+    await page.keyboard.down('Shift');
     await page.keyboard.down('w');
     await new Promise((r) => setTimeout(r, 400));
     const underProgram = await page.evaluate('__kinect.freeCamera.position.toArray()');
     // Released before the free camera comes back, or the restored gate flies it on the next frame.
     await page.keyboard.up('w');
+    await page.keyboard.up('Shift');
     await page.evaluate('__kinect.setViewCamera(__kinect.freeCamera)');
     await settle();
     check(onProgram.enabled === false,
       'control: the program camera turns the orbit off, which is the gate the fly reads',
       `controls.enabled is ${onProgram.enabled} under the program camera`);
-    check(Math.hypot(...underProgram.map((v, i) => v - onProgram.p[i])) < 1e-6,
+    check(apart(underProgram, onProgram.p) < 1e-6,
       'and nothing flies under the program camera, whose pose is the document\'s',
-      `${Math.hypot(...underProgram.map((v, i) => v - onProgram.p[i])).toExponential(2)} m over a 400 ms hold`);
+      `${apart(underProgram, onProgram.p).toExponential(2)} m over a 400 ms hold`);
 
     // Reset first, so "home" is a pose the camera is standing at rather than one it has left.
     await page.evaluate("document.getElementById('menuCameraReset').click()");
@@ -10079,6 +10531,247 @@ try {
       `${rehomed.p.map((v) => v.toFixed(4)).join(', ')} against a home of `
       + `${home.p.map((v) => v.toFixed(4)).join(', ')}`);
 
+    // ---- the look ----
+    // A look and an orbit of the same pixels turn the view by the same angle in the same
+    // direction, so the direction rows below cannot tell them apart and the standpoint is the
+    // only reading that can. That is why the position row is the first one here and why the
+    // plain-drag control at the end of the block is the one that gives it a scale.
+    const turned = await drag(100, 0);
+    const right0 = unit(cross3(turned.before.fwd, turned.before.up));
+    const yaw = yawAbout(turned.before.fwd, turned.after.fwd, turned.before.up);
+    // The rate is the lens: a drag the height of the stage turns exactly one field of view, so
+    // the angle a row expects is read off the camera rather than written down here. A baked
+    // figure would be a second copy of the rule and would break the day the default lens moves.
+    const perPixel = ((turned.before.fov * Math.PI) / 180) / turned.before.stageH;
+    const yawWanted = 100 * perPixel;
+    note('a 100 px shift-drag across a stage the renderer sizes',
+      `${turned.before.stageH} px tall at a ${turned.before.fov.toFixed(4)} degree field of view, `
+      + `so the turn asked for is ${((yawWanted * 180) / Math.PI).toFixed(3)} degrees; the view `
+      + `turned ${((-yaw * 180) / Math.PI).toFixed(3)} and the camera moved `
+      + `${turned.moved.toExponential(2)} m`);
+    check(turned.moved < 1e-6,
+      'the camera stands still through a look, so what turns is the view and not the standpoint',
+      `${turned.moved.toExponential(2)} m, against the metres a plain drag of the same pixels `
+      + 'moves it below');
+    check(dot3(turned.after.fwd, right0) > 0 && yaw < -1e-4,
+      'dragging right turns the view right, which puts the scene to the left of where it was',
+      `the view direction ended dotting the right axis at ${dot3(turned.after.fwd, right0).toFixed(4)}`);
+    check(Math.abs(Math.abs(yaw) - yawWanted) < 1e-3,
+      '  and a drag the height of the stage turns exactly one field of view',
+      `${((Math.abs(yaw) * 180) / Math.PI).toFixed(4)} degrees against `
+      + `${((yawWanted * 180) / Math.PI).toFixed(4)} asked for, at a `
+      + `${turned.before.fov.toFixed(4)} degree lens over ${turned.before.stageH} px`);
+    check(Math.abs(turned.after.radius - turned.before.radius) < 1e-6,
+      'and the pivot rides a sphere about the camera, so the orbit radius survives the turn',
+      `${turned.before.radius.toFixed(9)} m before, ${turned.after.radius.toFixed(9)} m after`);
+
+    const dipped = await drag(0, 60);
+    const pitch = polarTo(dipped.after.fwd, dipped.before.up)
+      - polarTo(dipped.before.fwd, dipped.before.up);
+    const pitchWanted = 60 * (((dipped.before.fov * Math.PI) / 180) / dipped.before.stageH);
+    check(pitch > 0 && Math.abs(pitch - pitchWanted) < 1e-3 && dipped.moved < 1e-6,
+      'dragging down looks down, at the same radians per pixel as across',
+      `${((pitch * 180) / Math.PI).toFixed(4)} degrees down against `
+      + `${((pitchWanted * 180) / Math.PI).toFixed(4)} asked for, with the camera `
+      + `${dipped.moved.toExponential(2)} m from where it stood`);
+
+    // The lens is the rate, so the same pixels at a long lens have to turn a smaller angle. The
+    // control for that rule: a build with a rate of its own passes both rows above and answers
+    // the same angle here.
+    const longLens = await page.evaluate(`(() => {
+      const k = __kinect, c = k.freeCamera;
+      const was = c.fov;
+      c.fov = was / 4;
+      c.updateProjectionMatrix();
+      return was;
+    })()`);
+    const dippedLong = await drag(0, 60);
+    const pitchLong = polarTo(dippedLong.after.fwd, dippedLong.before.up)
+      - polarTo(dippedLong.before.fwd, dippedLong.before.up);
+    await page.evaluate(`(() => {
+      const c = __kinect.freeCamera;
+      c.fov = ${longLens};
+      c.updateProjectionMatrix();
+    })()`);
+    await settle();
+    check(pitchLong > 0 && Math.abs(pitchLong * 4 - pitch) < 1e-3,
+      '  and a quarter field of view turns a quarter as far for the same pixels',
+      `${((pitchLong * 180) / Math.PI).toFixed(4)} degrees at `
+      + `${(longLens / 4).toFixed(4)} degrees of view against `
+      + `${((pitch * 180) / Math.PI).toFixed(4)} at ${longLens.toFixed(4)}`);
+
+    // Both poles in one row, and each reached in a single pointer move: a stepped drag on a
+    // build with no clamp turns back through the pole it went past and reads as though it had
+    // stopped there. The widest lens the wheel offers first, because the reach of a drag *is*
+    // the lens now - at the default 50 degrees a pixel is worth so little that 150 degrees of
+    // pitch would need a drag longer than the window is tall.
+    const poleLens = await page.evaluate('__kinect.freeCamera.fov');
+    await wheel(1200);
+    const poles = {};
+    for (const [name, sign] of [['down', 1], ['up', -1]]) {
+      await page.evaluate(`(() => {
+        const k = __kinect, c = k.freeCamera;
+        c.position.set(0, 1, 3);
+        k.controls.target.set(0, 1, 0);
+        k.controls.update(0);
+        c.updateMatrixWorld(true);
+      })()`);
+      await settle();
+      const level = await rest();
+      // 150 degrees of pitch onto a level view, so a build with no clamp ends up 60 degrees the
+      // other side of the pole - which reads -0.5 where the clamp reads -1.
+      const far = Math.round((150 / level.fov) * level.stageH);
+      const top = stage.top + 10;
+      const past = await drag(0, far * sign, {
+        steps: 1, from: { x: stage.x, y: sign > 0 ? top : stage.bottom - 10 },
+      });
+      poles[name] = {
+        at: dot3(past.after.fwd, level.up), far: far * sign, fov: level.fov,
+        asked: (far / level.stageH) * level.fov, from: dot3(level.fwd, level.up),
+      };
+    }
+    await page.evaluate(`(() => {
+      const c = __kinect.freeCamera;
+      c.fov = ${poleLens};
+      c.updateProjectionMatrix();
+    })()`);
+    await settle();
+    check(poles.down.at < -0.9999 && poles.up.at > 0.9999,
+      'and the pitch stops just short of either pole rather than tipping over it',
+      `${poles.down.far} px down at a ${poles.down.fov.toFixed(2)} degree lens asks for `
+      + `${poles.down.asked.toFixed(1)} degrees of pitch and landed the view direction at `
+      + `${poles.down.at.toFixed(6)} of the pole; ${poles.up.far} px up landed at `
+      + `${poles.up.at.toFixed(6)}, from ${poles.down.from.toFixed(4)} level - a build that ran `
+      + 'past either lands about -0.5 and 0.5');
+
+    await page.evaluate("document.getElementById('menuCameraReset').click()");
+    await settle();
+    const orbited = await drag(100, 0, { shift: false });
+    check(orbited.moved > 0.1,
+      'control: a plain drag still orbits, so the camera moves where a look leaves it standing',
+      `${orbited.moved.toFixed(4)} m, against ${turned.moved.toExponential(2)} m for the same `
+      + 'pixels with shift down');
+
+    // The draft-per-frame and one-seek-on-release pair the fly hold has, asked of the look.
+    await page.evaluate('__kinect.timeline.transport().seek(4.0)');
+    await settle();
+    const lookBefore = await rest();
+    await page.keyboard.down('Shift');
+    await page.mouse.move(stage.x - 50, stage.y);
+    await page.mouse.down();
+    await page.mouse.move(stage.x, stage.y, { steps: 5 });
+    await new Promise((r) => setTimeout(r, 200));
+    await page.mouse.move(stage.x + 50, stage.y, { steps: 5 });
+    const lookHeld = await page.evaluate(`(() => ({
+      redraws: __kinect.timeline.counters.navigationRedraws,
+      seeks: __kinect.timeline.counters.seeks,
+    }))()`);
+    await page.mouse.up();
+    await page.keyboard.up('Shift');
+    await settle();
+    const lookAfter = await rest();
+    check(lookHeld.redraws > lookBefore.redraws && lookHeld.seeks === lookBefore.seeks,
+      'a look redraws while the pointer is down and does not seek, so the seek below is the release',
+      `${lookHeld.redraws - lookBefore.redraws} navigation redraws and `
+      + `${lookHeld.seeks - lookBefore.seeks} seeks over the drag`);
+    check(lookAfter.seeks > lookHeld.seeks,
+      'and letting the pointer up lands the accurate frame',
+      `${lookAfter.seeks - lookHeld.seeks} seeks after the release`);
+
+    // Flight and look at once, which is the pair the gate change is about. Both readings are
+    // taken with the pointer still down: shift and W fly perfectly well either side of the drag,
+    // so a window that reaches past the release cannot see the term that keeps them together.
+    await focusStage();
+    await page.keyboard.down('Shift');
+    await page.keyboard.down('w');
+    await page.mouse.move(stage.x - 60, stage.y);
+    await page.mouse.down();
+    await new Promise((r) => setTimeout(r, 150));
+    const bothStart = await page.evaluate(`(() => {
+      const k = __kinect, c = k.freeCamera, V = c.position.constructor;
+      return {
+        p: c.position.toArray(), fwd: c.getWorldDirection(new V()).toArray(),
+        up: c.up.clone().normalize().toArray(), enabled: k.controls.enabled,
+      };
+    })()`);
+    await page.mouse.move(stage.x + 60, stage.y, { steps: 6 });
+    await new Promise((r) => setTimeout(r, 250));
+    const bothEnd = await page.evaluate(`(() => {
+      const k = __kinect, c = k.freeCamera, V = c.position.constructor;
+      return { p: c.position.toArray(), fwd: c.getWorldDirection(new V()).toArray() };
+    })()`);
+    await page.mouse.up();
+    await page.keyboard.up('w');
+    await page.keyboard.up('Shift');
+    await settle();
+    const bothFlew = apart(bothEnd.p, bothStart.p);
+    const bothTurned = Math.abs(yawAbout(bothStart.fwd, bothEnd.fwd, bothStart.up));
+    check(bothStart.enabled === false,
+      'control: a look drag turns the orbit off, which is the term the flight has to read past',
+      `controls.enabled is ${bothStart.enabled} with the look drag up`);
+    check(bothFlew > 0.1 && bothTurned > 0.01,
+      'and the flight carries on through a look drag, so you fly the way you are turning',
+      `${bothFlew.toFixed(3)} m flown and ${((bothTurned * 180) / Math.PI).toFixed(1)} degrees `
+      + 'turned between two readings taken with the pointer down');
+
+    // ---- the lens ----
+    const lensHome = await rest();
+    const zoomed = await wheel(-100);
+    check(zoomed.after.fov < zoomed.before.fov * 0.95
+      && apart(zoomed.after.p, zoomed.before.p) < 1e-9
+      && Math.abs(zoomed.after.radius - zoomed.before.radius) < 1e-9,
+      'shift and the wheel change the lens, and leave the camera where it is standing',
+      `${zoomed.before.lensOut} -> ${zoomed.after.lensOut}, fov ${zoomed.before.fov.toFixed(4)} -> `
+      + `${zoomed.after.fov.toFixed(4)}, camera ${apart(zoomed.after.p, zoomed.before.p).toExponential(2)} m `
+      + `and radius ${(zoomed.after.radius - zoomed.before.radius).toExponential(2)} m from where it was`);
+    const backAgain = await wheel(100);
+    check(Math.abs(backAgain.after.fov - zoomed.before.fov) < 1e-9,
+      '  and a notch back is the same lens again, so the gesture is a ratio and not a step',
+      `fov ${zoomed.before.fov.toFixed(9)} -> ${zoomed.after.fov.toFixed(9)} -> `
+      + `${backAgain.after.fov.toFixed(9)}`);
+
+    // Chrome turns shift plus a physical wheel into `deltaX`, so this is the branch a real mouse
+    // takes and the one no hand-drive here has ever reached.
+    const sideways = await wheel(-100, { axis: 'x' });
+    check(Math.abs(sideways.after.fov - zoomed.after.fov) < 1e-9,
+      'and a wheel that reports its notch sideways moves the lens by the same amount, which is '
+      + 'the axis a real mouse sends under shift',
+      `deltaX -100 left the fov at ${sideways.after.fov.toFixed(9)}, where deltaY -100 left it `
+      + `at ${zoomed.after.fov.toFixed(9)}, both from ${zoomed.before.fov.toFixed(9)}`);
+    await wheel(100, { axis: 'x' });
+
+    const dollied = await wheel(-100, { shift: false });
+    check(dollied.after.radius < dollied.before.radius * 0.99
+      && dollied.after.fov === dollied.before.fov,
+      'control: a plain wheel still dollies, and leaves the lens exactly where it was',
+      `radius ${dollied.before.radius.toFixed(5)} -> ${dollied.after.radius.toFixed(5)} m, `
+      + `fov ${dollied.before.fov} -> ${dollied.after.fov}, readout ${dollied.after.lensOut}`);
+
+    // From the 8mm clamp, -2600 asks for 395mm; -2400 only reaches 293mm.
+    const wide = await wheel(1200);
+    const long = await wheel(-2600);
+    check(wide.after.lensOut === '8.0mm' && long.after.lensOut === '300.0mm',
+      'and the wheel stops at each end of the band, at a reading the row can hold',
+      `${wide.after.lensOut} at the wide end and ${long.after.lensOut} at the long end, from `
+      + `${lensHome.lensOut}; the readings either end must be the band's own numbers rather than `
+      + 'the words for running past it');
+    note('the lens the clamps landed on',
+      `fov ${wide.after.fov.toFixed(4)} wide and ${long.after.fov.toFixed(4)} long, `
+      + `with the slider at ${wide.after.lens} and ${long.after.lens}`);
+
+    // The lens back where the section found it, exactly, and the row repainted through the
+    // control's own handler so the panel is not left showing the clamp.
+    await page.evaluate(`(() => {
+      const k = __kinect, c = k.freeCamera;
+      const el = document.getElementById('camLens');
+      el.value = ${JSON.stringify(lensHome.lens)};
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      c.fov = ${lensHome.fov};
+      c.updateProjectionMatrix();
+    })()`);
+    await page.evaluate("document.getElementById('menuCameraReset').click()");
+    await settle();
+
     await page.evaluate('__kinect.editor.setClipRange(4, 9)');
     await settle();
     await focusStage();
@@ -10095,11 +10788,11 @@ try {
     await page.evaluate('__kinect.editor.setClipRange(0, null)');
     await page.evaluate('__kinect.editor.view.fit()');
     // Nothing held on the way out, whatever a row above left behind.
+    await proveLookInterruptions(page, 'editor');
     await page.evaluate("dispatchEvent(new Event('blur'))");
     await settle();
   }
 
-  // -------------------------------------------------------------------------------------------
   console.log('\n[22] adding, selecting, moving and deleting a clip');
   {
     const library = await (await fetch(`${URL_BASE}/library/takes`)).json();
@@ -10122,8 +10815,8 @@ try {
 
     let one = await read();
     console.log(`  the stack: ${one.rows.join(', ')}`);
-    check(one.rows[0] === 'clips' && one.rows.includes('clip:c1'),
-      'the lane stack opens with a clip bar and a row for the clip that is open',
+    check(one.rows[0] === `clip:${one.clips[0].id}` && one.rows.includes('clip-add'),
+      'the lane stack opens with the clip row and offers a row to add another clip',
       one.rows.slice(0, 3).join(', '));
     check(one.boxes === one.clips.length,
       'and one box is drawn per clip', `${one.boxes} boxes for ${one.clips.length} clips`);

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -113,6 +113,7 @@ const MUTATIONS = {
       '  freeCamera.position.add(flyMove);',
     ]],
     fails: 'the pivot flies with it, so what moves is the standpoint and not the orbit\'s radius',
+    mustFail: 'the pivot flies with it, so what moves is the standpoint and not the orbit\'s radius',
   },
 
   // Q and E off the camera's own vertical rather than the room's, which is right only while the
@@ -124,6 +125,7 @@ const MUTATIONS = {
       '    if (push.pole) out.addScaledVector(flyAxis.set(0, 1, 0).applyQuaternion(quaternion), push.pole);',
     ]],
     fails: 'E climbs the room\'s vertical rather than the camera\'s, however the camera is aimed',
+    mustFail: 'E climbs the room\'s vertical rather than the camera\'s, however the camera is aimed',
   },
 
   // The fly read before the typing guard, so a name with a w in it flies the camera.
@@ -134,18 +136,19 @@ const MUTATIONS = {
         '  // The recorder\'s viewport orbits the same camera, so this sits above the clip guard below.\n'
         + '  // A repeat is harmless: the set already holds the code.\n'
         + '  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {\n'
-        + '    e.preventDefault();\n    flyHeld.add(e.code);\n    return;\n  }\n',
+        + '    e.preventDefault();\n    changeFlyKeys(() => flyHeld.add(e.code));\n    return;\n  }\n',
         '',
       ],
       [
         '  flyFast = e.shiftKey;\n  if (isTyping(e.target)) return;',
         '  flyFast = e.shiftKey;\n'
         + '  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {\n'
-        + '    e.preventDefault();\n    flyHeld.add(e.code);\n    return;\n  }\n'
+        + '    e.preventDefault();\n    changeFlyKeys(() => flyHeld.add(e.code));\n    return;\n  }\n'
         + '  if (isTyping(e.target)) return;',
       ],
     ],
     fails: 'a fly key does nothing while a control holds the keyboard',
+    mustFail: 'a fly key does nothing while a control holds the keyboard',
   },
 
   // A key released outside the page never arrives, so without this the camera flies for ever.
@@ -153,16 +156,39 @@ const MUTATIONS = {
     file: 'web/main.js',
     edits: [["addEventListener('blur', clearFlyKeys);\n", '']],
     fails: 'and losing the page releases the key, so a held fly key stops',
+    mustFail: 'and losing the page releases the key, so a held fly key stops',
   },
 
   // The half of the gate that is the program camera, a gizmo drag and a node drag at once.
   'fly-ignores-the-program-camera': {
     file: 'web/main.js',
     edits: [[
-      'const flying = () => flyHeld.size > 0 && controls.enabled && !exporting;',
-      'const flying = () => flyHeld.size > 0 && !exporting;',
+      'const flying = () => flyInputActive() && controls.enabled && !exporting;',
+      'const flying = () => flyInputActive() && !exporting;',
     ]],
     fails: 'and nothing flies under the program camera, whose pose is the document\'s',
+    mustFail: 'and nothing flies under the program camera, whose pose is the document\'s',
+  },
+
+  // Held keys can cancel exactly. They ask for no movement, so they must not keep the redraw
+  // loop alive merely because the set is non-empty.
+  'fly-redraws-cancelled-keys': {
+    file: 'web/main.js',
+    edits: [[
+      'const flying = () => flyInputActive() && controls.enabled && !exporting;',
+      'const flying = () => flyHeld.size > 0 && controls.enabled && !exporting;',
+    ]],
+    fails: 'opposite fly keys do not keep the redraw loop alive because their requested move is zero',
+    mustFail: 'opposite fly keys do not keep the redraw loop alive because their requested move is zero',
+  },
+
+  // A release and new press can both land between animation frames. Without the event-side reset,
+  // the new hold inherits the old hold's clock and takes the stall cap as its first step.
+  'fly-reuses-old-clock': {
+    file: 'web/main.js',
+    edits: [['  if (!wasActive || !flyInputActive()) flyLastAt = 0;\n', '']],
+    fails: 'a new hold starts a new clock even when its release and press land between frames',
+    mustFail: 'a new hold starts a new clock even when its release and press land between frames',
   },
 
   // The release never arms the accurate seek, so the flight ends on a draft-quality frame.
@@ -170,6 +196,7 @@ const MUTATIONS = {
     file: 'web/main.js',
     edits: [['  else if (flyWasHeld) orbitSettling = true;\n', '']],
     fails: 'and releasing the last key lands the accurate frame',
+    mustFail: 'and releasing the last key lands the accurate frame',
   },
 
   // Reset re-homed on wherever the flight ended, which is the same defect `pick-rehomes-reset`
@@ -181,6 +208,7 @@ const MUTATIONS = {
       '  controls.target.add(flyMove);\n  controls.saveState();\n}',
     ]],
     fails: 'and Reset still goes home after a flight rather than to wherever the flight ended',
+    mustFail: 'and Reset still goes home after a flight rather than to wherever the flight ended',
   },
 
   'fly-ignores-shift': {
@@ -190,6 +218,7 @@ const MUTATIONS = {
       '  const speed = FLY_SPEED_MPS;',
     ]],
     fails: 'holding shift flies faster, by about the three times it claims',
+    mustFail: 'holding shift flies faster, by about the three times it claims',
   },
 
   // ---- section 22, the clip a person adds, selects and deletes ----
@@ -9904,6 +9933,42 @@ try {
       `${w.after.seeks - w.heldSeeks} seeks after the release, against `
       + `${w.heldSeeks - w.before.seeks} during the hold`);
 
+    await focusStage();
+    await page.keyboard.down('w');
+    await page.keyboard.down('s');
+    const cancelledBefore = await rest();
+    await new Promise((r) => setTimeout(r, 300));
+    const cancelledAfter = await rest();
+    await page.keyboard.up('s');
+    await page.keyboard.up('w');
+    await settle();
+    const cancelledMove = Math.hypot(...cancelledAfter.p.map((v, i) => v - cancelledBefore.p[i]));
+    const cancelledRedraws = cancelledAfter.redraws - cancelledBefore.redraws;
+    check(cancelledMove < 1e-6 && cancelledRedraws <= 1,
+      'opposite fly keys do not keep the redraw loop alive because their requested move is zero',
+      `${cancelledMove.toExponential(2)} m and ${cancelledRedraws} navigation redraws over 300 ms`);
+
+    await focusStage();
+    await page.keyboard.down('w');
+    await new Promise((r) => setTimeout(r, 250));
+    const restarted = await page.evaluate(`(async () => {
+      const c = __kinect.freeCamera;
+      dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyW', key: 'w' }));
+      const until = performance.now() + 150;
+      while (performance.now() < until) {}
+      const before = c.position.toArray();
+      dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyW', key: 'w' }));
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      const after = c.position.toArray();
+      dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyW', key: 'w' }));
+      return Math.hypot(...after.map((v, i) => v - before[i]));
+    })()`);
+    await page.keyboard.up('w');
+    await settle();
+    check(restarted < 0.03,
+      'a new hold starts a new clock even when its release and press land between frames',
+      `${restarted.toFixed(4)} m on the first frame after a 150 ms gap`);
+
     const fast = await fly(['w'], { shift: true });
     const slowRate = w.length / w.elapsed;
     const fastRate = fast.length / fast.elapsed;
@@ -12239,11 +12304,21 @@ for (const label of standingGreen) {
 }
 
 if (MUTATE) {
+  const mustFail = MUTATIONS[MUTATE]?.mustFail;
   if (MUTATIONS[MUTATE]?.fails) console.log(`[editor] it should redden: ${MUTATIONS[MUTATE].fails}`);
   if (standingFired.length) {
     console.log(`[editor] ${standingFired.length} of those ${failures} are red on this tree either way, `
       + 'so they are not this mutation being caught:');
     for (const label of standingFired) console.log(`           ${label}`);
+  }
+  if (mustFail && !fired.includes(mustFail)) {
+    console.log(`[editor] NOT CAUGHT - ${MUTATE} left its required row green:`);
+    console.log(`           ${mustFail}`);
+    if (newlyFired.length) {
+      console.log(`[editor] ${newlyFired.length} other assertions fired, but none can stand in for that row:`);
+      for (const label of newlyFired) console.log(`           ${label}`);
+    }
+    process.exit(1);
   }
   if (newlyFired.length === 0) {
     console.log(`[editor] NOT CAUGHT - ${MUTATE} reddened nothing this tree was not already red on, `
@@ -12251,6 +12326,7 @@ if (MUTATE) {
     process.exit(1);
   }
   console.log(`[editor] caught ${MUTATE}, as required (${newlyFired.length} assertions fired beyond the standing set)`);
+  if (mustFail) console.log(`[editor] its required row fired: ${mustFail}`);
   for (const label of newlyFired) console.log(`           ${label}`);
   process.exit(1);
 }

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -101,6 +101,97 @@ const MUTATIONS = {
     ]],
   },
 
+  // ---- section 24, the fly keys ----
+  // The pivot left behind, so the flight changes the orbit's radius instead of the standpoint.
+  'fly-leaves-the-pivot': {
+    file: 'web/main.js',
+    edits: [[
+      '  freeCamera.position.add(flyMove);\n'
+      + '  // The pivot travels with the camera. `update()` rebuilds the position out of the target, so\n'
+      + '  // moving the camera alone would change the orbit\'s radius instead of where you are standing.\n'
+      + '  controls.target.add(flyMove);',
+      '  freeCamera.position.add(flyMove);',
+    ]],
+    fails: 'the pivot flies with it, so what moves is the standpoint and not the orbit\'s radius',
+  },
+
+  // Q and E off the camera's own vertical rather than the room's, which is right only while the
+  // camera is level and wrong the moment anything is being looked down at.
+  'fly-up-is-the-cameras-up': {
+    file: 'web/fly.js',
+    edits: [[
+      '    if (push.pole) out.addScaledVector(flyAxis.copy(up).normalize(), push.pole);',
+      '    if (push.pole) out.addScaledVector(flyAxis.set(0, 1, 0).applyQuaternion(quaternion), push.pole);',
+    ]],
+    fails: 'E climbs the room\'s vertical rather than the camera\'s, however the camera is aimed',
+  },
+
+  // The fly read before the typing guard, so a name with a w in it flies the camera.
+  'fly-moves-while-typing': {
+    file: 'web/main.js',
+    edits: [
+      [
+        '  // The recorder\'s viewport orbits the same camera, so this sits above the clip guard below.\n'
+        + '  // A repeat is harmless: the set already holds the code.\n'
+        + '  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {\n'
+        + '    e.preventDefault();\n    flyHeld.add(e.code);\n    return;\n  }\n',
+        '',
+      ],
+      [
+        '  flyFast = e.shiftKey;\n  if (isTyping(e.target)) return;',
+        '  flyFast = e.shiftKey;\n'
+        + '  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {\n'
+        + '    e.preventDefault();\n    flyHeld.add(e.code);\n    return;\n  }\n'
+        + '  if (isTyping(e.target)) return;',
+      ],
+    ],
+    fails: 'a fly key does nothing while a control holds the keyboard',
+  },
+
+  // A key released outside the page never arrives, so without this the camera flies for ever.
+  'fly-survives-blur': {
+    file: 'web/main.js',
+    edits: [["addEventListener('blur', clearFlyKeys);\n", '']],
+    fails: 'and losing the page releases the key, so a held fly key stops',
+  },
+
+  // The half of the gate that is the program camera, a gizmo drag and a node drag at once.
+  'fly-ignores-the-program-camera': {
+    file: 'web/main.js',
+    edits: [[
+      'const flying = () => flyHeld.size > 0 && controls.enabled && !exporting;',
+      'const flying = () => flyHeld.size > 0 && !exporting;',
+    ]],
+    fails: 'and nothing flies under the program camera, whose pose is the document\'s',
+  },
+
+  // The release never arms the accurate seek, so the flight ends on a draft-quality frame.
+  'fly-never-settles': {
+    file: 'web/main.js',
+    edits: [['  else if (flyWasHeld) orbitSettling = true;\n', '']],
+    fails: 'and releasing the last key lands the accurate frame',
+  },
+
+  // Reset re-homed on wherever the flight ended, which is the same defect `pick-rehomes-reset`
+  // plants through the pivot: the one control for getting un-lost stops going anywhere known.
+  'fly-rehomes-reset': {
+    file: 'web/main.js',
+    edits: [[
+      '  controls.target.add(flyMove);\n}',
+      '  controls.target.add(flyMove);\n  controls.saveState();\n}',
+    ]],
+    fails: 'and Reset still goes home after a flight rather than to wherever the flight ended',
+  },
+
+  'fly-ignores-shift': {
+    file: 'web/fly.js',
+    edits: [[
+      '  const speed = FLY_SPEED_MPS * (fast ? FLY_FAST : 1);',
+      '  const speed = FLY_SPEED_MPS;',
+    ]],
+    fails: 'holding shift flies faster, by about the three times it claims',
+  },
+
   // ---- section 22, the clip a person adds, selects and deletes ----
   // A head trim that moves the clip and lets the footage travel with it, which is a slip and not
   // a trim. Must redden 'the footage under what is left holds still', alone.
@@ -1413,7 +1504,7 @@ const MUTATIONS = {
     edits: [[
       '  if (!timeline || timeline.playing || exporting) {\n'
       + '    draftWanted = null;\n    orbitRedrawWanted = false;\n    orbitSettling = false;\n'
-      + '    gizmoWriteWanted = false;\n    return;\n  }',
+      + '    flyWasHeld = false;\n    gizmoWriteWanted = false;\n    return;\n  }',
       '  if (!timeline || timeline.playing || exporting) return;',
     ]],
   },
@@ -6355,22 +6446,6 @@ try {
   await settle();
   check((await page.evaluate('__kinect.editor.view.window()')).whole,
     'f fits the whole clip back on the ruler', JSON.stringify(await page.evaluate('__kinect.editor.view.window()')));
-  await page.evaluate('__kinect.timeline.transport().seek(4)');
-  await settle();
-  await focusStage();
-  await page.keyboard.press('i');
-  await page.evaluate('__kinect.timeline.transport().seek(9)');
-  await settle();
-  await page.keyboard.press('o');
-  await page.keyboard.press('z');
-  await settle();
-  const framed = await page.evaluate('__kinect.editor.view.window()');
-  check(framed.startSec < 4 && framed.endSec > 9 && framed.spanSec < framed.duration / 2,
-    'z frames the trimmed range, which is the window an edit is actually made in',
-    `${framed.startSec.toFixed(2)}s..${framed.endSec.toFixed(2)}s around in 4s / out 9s`);
-  await page.evaluate('__kinect.editor.setClipRange(0, null)');
-  await page.evaluate('__kinect.editor.view.fit()');
-  await settle();
 
   console.log('\n[11] the strip is bounded, and the splitter is what bounds it');
   const LANED = ['bloom', 'grain.amount', 'raster.amount', 'rgbsplit.amount', 'glitch.amount', 'trails', 'rim',
@@ -9732,6 +9807,231 @@ try {
       'and a modified left press leaves it alone, because OrbitControls uses that press to pan',
       `${modified.after.target.map((v) => v.toFixed(6)).join(', ')} against `
       + `${modified.before.target.map((v) => v.toFixed(6)).join(', ')}`);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  console.log('\n[24] the fly keys');
+  {
+    await page.evaluate('__kinect.timeline.transport().pause()');
+    await page.evaluate('__kinect.timeline.transport().seek(4.0)');
+    await settle();
+
+    // The damping residual is paid off before every reading, because an orbit still travelling
+    // reads here as flight - `docs/instruments.md`, "A settled flag that could not see the end
+    // of what it was settling".
+    const rest = () => page.evaluate(`(() => {
+      const k = __kinect;
+      const damped = k.controls.enableDamping;
+      k.controls.enableDamping = false;
+      k.controls.update(0);
+      k.controls.enableDamping = damped;
+      const c = k.freeCamera;
+      return {
+        p: c.position.toArray(),
+        up: c.up.clone().normalize().toArray(),
+        fwd: c.getWorldDirection(new (c.position.constructor)()).toArray(),
+        target: k.controls.target.toArray(),
+        offset: k.controls.target.clone().sub(c.position).toArray(),
+        redraws: k.timeline.counters.navigationRedraws,
+        seeks: k.timeline.counters.seeks,
+        autoRotate: k.controls.autoRotate,
+        enabled: k.controls.enabled,
+        free: k.viewCamera() === c,
+      };
+    })()`);
+
+    /**
+     * Hold `keys` for about `ms` and report what the camera did over it. `seeks` is read between
+     * the last frame of the hold and the release, so the release's own seek can be told from a
+     * redraw that fell back to one.
+     */
+    const fly = async (keys, { ms = 400, shift = false, focus = true } = {}) => {
+      if (focus) await focusStage();
+      const before = await rest();
+      const began = Date.now();
+      if (shift) await page.keyboard.down('Shift');
+      for (const key of keys) await page.keyboard.down(key);
+      await new Promise((r) => setTimeout(r, ms));
+      const heldSeeks = await page.evaluate('__kinect.timeline.counters.seeks');
+      for (const key of keys) await page.keyboard.up(key);
+      if (shift) await page.keyboard.up('Shift');
+      const elapsed = (Date.now() - began) / 1000;
+      await settle();
+      const after = await rest();
+      const moved = after.p.map((v, i) => v - before.p[i]);
+      return { before, after, moved, elapsed, heldSeeks, length: Math.hypot(...moved) };
+    };
+
+    const armed = await rest();
+    // The trail is a precondition and not decoration: `redrawNow` falls back to a full seek while
+    // one is up, which would take the seek pair below away without saying so.
+    const trails = await page.evaluate("__kinect.params.get('trails')");
+    check(armed.enabled && armed.free && armed.autoRotate === false && !(trails > 0),
+      'control: the free camera is navigated, its orbit is on, the turntable is off and no trail is up',
+      `enabled ${armed.enabled}, free camera ${armed.free}, autoRotate ${armed.autoRotate}, `
+      + `trails ${trails}`);
+
+    const w = await fly(['w']);
+    const along = w.moved.reduce((n, v, i) => n + v * w.before.fwd[i], 0);
+    const across = Math.hypot(...w.moved.map((v, i) => v - along * w.before.fwd[i]));
+    note('holding W at a parked playhead',
+      `${w.length.toFixed(3)} m over ${w.elapsed.toFixed(2)}s held, `
+      + `${w.after.redraws - w.before.redraws} navigation redraws, `
+      + `${w.heldSeeks - w.before.seeks} seeks during the hold`);
+    check(along > 0.1 && along < 0.8,
+      'holding W flies the camera along the view direction',
+      `${along.toFixed(3)} m along the way it was pointing, over ${w.elapsed.toFixed(2)}s held`);
+    check(w.length > 0 && across < 0.05 * w.length,
+      '  and next to nothing across it, so it flies the view rather than a world axis',
+      `${across.toFixed(4)} m across a ${w.length.toFixed(3)} m flight`);
+
+    const offsetDrift = Math.max(...w.after.offset.map((v, i) => Math.abs(v - w.before.offset[i])));
+    check(offsetDrift < 1e-4,
+      'the pivot flies with it, so what moves is the standpoint and not the orbit\'s radius',
+      `worst axis of target minus position moved ${offsetDrift.toExponential(2)} m over `
+      + `${w.length.toFixed(3)} m of flight`);
+
+    check(w.after.redraws > w.before.redraws,
+      'and the picture was redrawn while it flew, out of the animation loop',
+      `${w.after.redraws - w.before.redraws} navigation redraws over ${w.elapsed.toFixed(2)}s`);
+
+    check(w.heldSeeks === w.before.seeks,
+      'control: a flight redraws and does not seek, so the seek below is the release and not the hold',
+      `${w.heldSeeks - w.before.seeks} seeks over the hold, with trails at ${trails} - a trail or `
+      + 'a live datamosh turns every redraw into a seek and takes this pair away');
+    check(w.after.seeks > w.heldSeeks,
+      'and releasing the last key lands the accurate frame',
+      `${w.after.seeks - w.heldSeeks} seeks after the release, against `
+      + `${w.heldSeeks - w.before.seeks} during the hold`);
+
+    const fast = await fly(['w'], { shift: true });
+    const slowRate = w.length / w.elapsed;
+    const fastRate = fast.length / fast.elapsed;
+    check(slowRate > 0 && fastRate > 1.8 * slowRate,
+      'holding shift flies faster, by about the three times it claims',
+      `${fastRate.toFixed(3)} m per second held against ${slowRate.toFixed(3)}, `
+      + `a ratio of ${(fastRate / Math.max(slowRate, 1e-9)).toFixed(2)} over `
+      + `${fast.length.toFixed(3)} m and ${w.length.toFixed(3)} m`);
+
+    // Pitched hard down, which is the pose that tells the room's vertical from the camera's.
+    const pitched = await page.evaluate(`(() => {
+      const k = __kinect, c = k.freeCamera;
+      const was = { p: c.position.toArray(), t: k.controls.target.toArray() };
+      c.position.set(0, 2, 0);
+      k.controls.target.set(0, 0, -2.2);
+      k.controls.update(0);
+      c.updateMatrixWorld(true);
+      const localY = new (c.position.constructor)(0, 1, 0).applyQuaternion(c.quaternion);
+      return { was, pitch: localY.dot(c.up.clone().normalize()) };
+    })()`);
+    check(pitched.pitch < 0.9,
+      'control: the camera is pitched, so its own vertical is not the room\'s',
+      `the camera's local Y dots the pole at ${pitched.pitch.toFixed(3)}`);
+    const climbed = await fly(['e']);
+    const climb = climbed.moved.reduce((n, v, i) => n + v * climbed.before.up[i], 0)
+      / Math.max(climbed.length, 1e-9);
+    check(climbed.length > 0.05 && climb > 0.99,
+      'E climbs the room\'s vertical rather than the camera\'s, however the camera is aimed',
+      `${climbed.length.toFixed(3)} m, ${climb.toFixed(4)} of it along the pole`);
+    await page.evaluate(`(() => {
+      const k = __kinect, c = k.freeCamera;
+      const was = ${JSON.stringify(pitched.was)};
+      c.position.fromArray(was.p);
+      k.controls.target.fromArray(was.t);
+      k.controls.update(0);
+      c.updateMatrixWorld(true);
+    })()`);
+    await settle();
+
+    // `tRate` and not a text field: the guard is on the tag name, so a slider with the keyboard
+    // is the same case as a name being typed into, and it needs no dialog opened over the stage.
+    await page.evaluate("document.getElementById('tRate').focus()");
+    const focused = await page.evaluate('document.activeElement && document.activeElement.id');
+    const whileTyping = await fly(['w'], { focus: false });
+    check(focused === 'tRate',
+      'control: a panel control holds the keyboard, which is the case the typing guard is about',
+      `the focus is on ${JSON.stringify(focused)}`);
+    check(whileTyping.length < 1e-6,
+      'a fly key does nothing while a control holds the keyboard',
+      `${whileTyping.length.toExponential(2)} m over ${whileTyping.elapsed.toFixed(2)}s held`);
+    await focusStage();
+
+    // A key released outside the page never arrives, so the blur has to be the release.
+    const beforeBlur = await rest();
+    await page.keyboard.down('w');
+    await new Promise((r) => setTimeout(r, 250));
+    const atBlur = await page.evaluate('__kinect.freeCamera.position.toArray()');
+    await page.evaluate("dispatchEvent(new Event('blur'))");
+    await new Promise((r) => setTimeout(r, 300));
+    const settledAfterBlur = await page.evaluate('__kinect.freeCamera.position.toArray()');
+    await new Promise((r) => setTimeout(r, 300));
+    const laterAfterBlur = await page.evaluate('__kinect.freeCamera.position.toArray()');
+    await page.keyboard.up('w');
+    await settle();
+    const flewBeforeBlur = Math.hypot(...atBlur.map((v, i) => v - beforeBlur.p[i]));
+    const flewAfterBlur = Math.hypot(...laterAfterBlur.map((v, i) => v - settledAfterBlur[i]));
+    check(flewBeforeBlur > 0.05,
+      'control: the hold was flying when the window lost the page',
+      `${flewBeforeBlur.toFixed(3)} m over the 250 ms before the blur`);
+    check(flewAfterBlur < 0.01,
+      'and losing the page releases the key, so a held fly key stops',
+      `${flewAfterBlur.toFixed(4)} m over the 300 ms after the blur had settled`);
+
+    const onProgram = await page.evaluate(`(() => {
+      const k = __kinect;
+      k.setViewCamera(k.programCamera);
+      return { enabled: k.controls.enabled, p: k.freeCamera.position.toArray() };
+    })()`);
+    await focusStage();
+    await page.keyboard.down('w');
+    await new Promise((r) => setTimeout(r, 400));
+    const underProgram = await page.evaluate('__kinect.freeCamera.position.toArray()');
+    // Released before the free camera comes back, or the restored gate flies it on the next frame.
+    await page.keyboard.up('w');
+    await page.evaluate('__kinect.setViewCamera(__kinect.freeCamera)');
+    await settle();
+    check(onProgram.enabled === false,
+      'control: the program camera turns the orbit off, which is the gate the fly reads',
+      `controls.enabled is ${onProgram.enabled} under the program camera`);
+    check(Math.hypot(...underProgram.map((v, i) => v - onProgram.p[i])) < 1e-6,
+      'and nothing flies under the program camera, whose pose is the document\'s',
+      `${Math.hypot(...underProgram.map((v, i) => v - onProgram.p[i])).toExponential(2)} m over a 400 ms hold`);
+
+    // Reset first, so "home" is a pose the camera is standing at rather than one it has left.
+    await page.evaluate("document.getElementById('menuCameraReset').click()");
+    await settle();
+    const home = await rest();
+    const flownFromHome = await fly(['w']);
+    await page.evaluate("document.getElementById('menuCameraReset').click()");
+    await settle();
+    const rehomed = await rest();
+    check(flownFromHome.length > 0.1,
+      'control: the camera flew away from home before Reset was pressed',
+      `${flownFromHome.length.toFixed(3)} m`);
+    check(rehomed.p.every((v, i) => Math.abs(v - home.p[i]) < 1e-6)
+      && rehomed.target.every((v, i) => Math.abs(v - home.target[i]) < 1e-6),
+      'and Reset still goes home after a flight rather than to wherever the flight ended',
+      `${rehomed.p.map((v) => v.toFixed(4)).join(', ')} against a home of `
+      + `${home.p.map((v) => v.toFixed(4)).join(', ')}`);
+
+    await page.evaluate('__kinect.editor.setClipRange(4, 9)');
+    await settle();
+    await focusStage();
+    const ruledBefore = await page.evaluate('__kinect.editor.view.window()');
+    await page.keyboard.press('z');
+    await settle();
+    const ruledAfter = await page.evaluate('__kinect.editor.view.window()');
+    check(await page.evaluate('typeof __kinect.editor.view.frame') === 'undefined',
+      'the ruler has no framing call left for a key to reach',
+      `view.frame is ${await page.evaluate('typeof __kinect.editor.view.frame')}`);
+    check(JSON.stringify(ruledBefore) === JSON.stringify(ruledAfter),
+      'and z leaves the ruler alone, with a trim set that it would have framed',
+      `${JSON.stringify(ruledAfter)} with the trim at 4s..9s`);
+    await page.evaluate('__kinect.editor.setClipRange(0, null)');
+    await page.evaluate('__kinect.editor.view.fit()');
+    // Nothing held on the way out, whatever a row above left behind.
+    await page.evaluate("dispatchEvent(new Event('blur'))");
+    await settle();
   }
 
   // -------------------------------------------------------------------------------------------

--- a/web/fly.js
+++ b/web/fly.js
@@ -1,0 +1,55 @@
+// Where the six fly keys point the camera, and how far one frame of holding them moves it.
+//
+// Outside `main.js` so a node test can state the directions in longhand: the pole Q and E climb
+// is the caller's, not the camera's own vertical, and that is the part a browser cannot see.
+
+import * as THREE from 'three';
+
+export const FLY_SPEED_MPS = 1;
+export const FLY_FAST = 3;
+export const FLY_STALL_S = 0.1;
+
+// Which way each key pushes. The first four are camera-space and turn with the view; the last
+// two take the pole the caller passes, so they climb the room rather than the picture.
+const FLY_KEYS = new Map([
+  ['KeyW', { local: [0, 0, -1] }],
+  ['KeyS', { local: [0, 0, 1] }],
+  ['KeyA', { local: [-1, 0, 0] }],
+  ['KeyD', { local: [1, 0, 0] }],
+  ['KeyE', { pole: 1 }],
+  ['KeyQ', { pole: -1 }],
+]);
+
+const flyAxis = new THREE.Vector3();
+
+/** Whether a key code is one of the six fly keys. */
+function isFlyKey(code) {
+  return FLY_KEYS.has(code);
+}
+
+/**
+ * Where the held key codes point: a unit vector in world space, or zero. Written into `out`
+ * and returned, so the caller decides what object carries it.
+ */
+function flyDirection(held, quaternion, up, out) {
+  out.set(0, 0, 0);
+  for (const [code, push] of FLY_KEYS) {
+    if (!held.has(code)) continue;
+    if (push.pole) out.addScaledVector(flyAxis.copy(up).normalize(), push.pole);
+    else out.add(flyAxis.fromArray(push.local).applyQuaternion(quaternion));
+  }
+  // Normalised, so a diagonal is no faster than one key and W against S is nothing at all.
+  return out.lengthSq() < 1e-12 ? out.set(0, 0, 0) : out.normalize();
+}
+
+/**
+ * One frame's displacement into `out`: direction x speed x the elapsed seconds, shift tripling
+ * it. The cap is why a stalled tab does not teleport the camera on the frame it comes back.
+ */
+function flyStep(held, fast, dtSec, quaternion, up, out) {
+  flyDirection(held, quaternion, up, out);
+  const speed = FLY_SPEED_MPS * (fast ? FLY_FAST : 1);
+  return out.multiplyScalar(speed * Math.min(Math.max(dtSec, 0), FLY_STALL_S));
+}
+
+export { isFlyKey, flyDirection, flyStep };

--- a/web/fly.js
+++ b/web/fly.js
@@ -1,13 +1,12 @@
-// Where the six fly keys point the camera, and how far one frame of holding them moves it.
-//
-// Outside `main.js` so a node test can state the directions in longhand: the pole Q and E climb
-// is the caller's, not the camera's own vertical, and that is the part a browser cannot see.
+// Camera displacement from held keys and pivot rotation from a look drag.
 
 import * as THREE from 'three';
 
 export const FLY_SPEED_MPS = 1;
-export const FLY_FAST = 3;
 export const FLY_STALL_S = 0.1;
+
+// How near the pole the view direction may come, which is OrbitControls' own `_EPS`.
+export const LOOK_POLE_EPS = 1e-6;
 
 // Which way each key pushes. The first four are camera-space and turn with the view; the last
 // two take the pole the caller passes, so they climb the room rather than the picture.
@@ -21,6 +20,8 @@ const FLY_KEYS = new Map([
 ]);
 
 const flyAxis = new THREE.Vector3();
+const lookPole = new THREE.Vector3();
+const lookRight = new THREE.Vector3();
 
 /** Whether a key code is one of the six fly keys. */
 function isFlyKey(code) {
@@ -43,13 +44,34 @@ function flyDirection(held, quaternion, up, out) {
 }
 
 /**
- * One frame's displacement into `out`: direction x speed x the elapsed seconds, shift tripling
- * it. The cap is why a stalled tab does not teleport the camera on the frame it comes back.
+ * One frame's displacement into `out`: direction x speed x the elapsed seconds. The cap is why
+ * a stalled tab does not teleport the camera on the frame it comes back.
  */
-function flyStep(held, fast, dtSec, quaternion, up, out) {
+function flyStep(held, dtSec, quaternion, up, out) {
   flyDirection(held, quaternion, up, out);
-  const speed = FLY_SPEED_MPS * (fast ? FLY_FAST : 1);
-  return out.multiplyScalar(speed * Math.min(Math.max(dtSec, 0), FLY_STALL_S));
+  return out.multiplyScalar(FLY_SPEED_MPS * Math.min(Math.max(dtSec, 0), FLY_STALL_S));
 }
 
-export { isFlyKey, flyDirection, flyStep };
+/** Rotate `target - position` in place, at one field of view per viewport height. */
+function lookOffset(offset, up, dxPx, dyPx, fovDeg, heightPx, out) {
+  out.copy(offset);
+  const perPixel = THREE.MathUtils.degToRad(fovDeg) / Math.max(1, heightPx);
+  lookPole.copy(up).normalize();
+  out.applyAxisAngle(lookPole, -dxPx * perPixel);
+  // Off the yawed offset, so a diagonal drag pitches about where the yaw left the view.
+  lookRight.crossVectors(out, lookPole);
+  // An offset already along the pole has no right axis. The clamp below never leaves one there.
+  if (lookRight.lengthSq() < 1e-12) return out;
+  lookRight.normalize();
+  const polar = Math.acos(Math.min(1, Math.max(-1, out.dot(lookPole) / out.length())));
+  // Dragging down looks down, which is the polar angle growing. Clamped as an angle rather than
+  // by rotating and correcting, so a drag past the pole stops at it instead of flipping over it.
+  const wanted = Math.min(
+    Math.PI - LOOK_POLE_EPS, Math.max(LOOK_POLE_EPS, polar + dyPx * perPixel),
+  );
+  return out.applyAxisAngle(lookRight, polar - wanted);
+}
+
+export {
+  isFlyKey, flyDirection, flyStep, lookOffset,
+};

--- a/web/main.js
+++ b/web/main.js
@@ -17,6 +17,7 @@ import {
   handleRefusal, foldRefusal, foldFreeX, retimeSourceSecAt, retimeProgramSecAt,
 } from './curve.js';
 import { tiltQuaternion } from './world-tilt.js';
+import { isFlyKey, flyStep } from './fly.js';
 import { verticalFovForFocalLength, focalLengthForVerticalFov } from './lens.js';
 import {
   EXPORT_SIZES, DEFAULT_EXPORT_SIZE, reduceAspect, exportAspects, sizesForAspect,
@@ -4357,8 +4358,35 @@ function renderProgramFrame(t) {
 // Navigation's own clock, kept out of the seam.
 let lastNavTime = 0;
 
+// Which fly keys are down, and whether shift is with them. Written from events and read by the
+// loop, because nothing but the loop may start a redraw.
+const flyHeld = new Set();
+let flyFast = false;
+// Wall clock at the previous fly frame, or 0 when the hold has not started. The free camera is
+// interactive, so it takes real seconds where auto-orbit takes the program delta.
+let flyLastAt = 0;
+const flyMove = new THREE.Vector3();
+
+/** Whether a held fly key may move the camera. One gate for the program camera, a gizmo or
+ *  node drag, and an export - each of those is already a reason the orbit stands down. */
+const flying = () => flyHeld.size > 0 && controls.enabled && !exporting;
+
+/** One frame of flight: the camera and its pivot translate by the same vector. */
+function advanceFly() {
+  if (!flying()) { flyLastAt = 0; return; }
+  const now = performance.now();
+  const dt = flyLastAt === 0 ? 0 : (now - flyLastAt) / 1000;
+  flyLastAt = now;
+  flyStep(flyHeld, flyFast, dt, freeCamera.quaternion, freeCamera.up, flyMove);
+  freeCamera.position.add(flyMove);
+  // The pivot travels with the camera. `update()` rebuilds the position out of the target, so
+  // moving the camera alone would change the orbit's radius instead of where you are standing.
+  controls.target.add(flyMove);
+}
+
 // Auto-orbit gets the program delta, so the same orbit renders the same at any speed.
 function advanceNavigation(t) {
+  advanceFly();
   controls.update(Math.max(0, t - lastNavTime));
   lastNavTime = t;
 }
@@ -6461,12 +6489,16 @@ const SHORTCUTS = 'space play/pause · arrows step a frame, with shift a second 
   + 'home/end · i/o set in/out, with shift jump to them · option-x uses the whole clip · '
   + 'del removes the selected key · '
   + 'm marks, [/] jump to the previous and next mark · '
-  + '+/- zoom the ruler, ,/. pan it, f fits the clip, z frames in..out · '
+  + '+/- zoom the ruler, ,/. pan it, f fits the clip · '
+  + 'wasd fly, q/e down and up, shift faster · '
   + 'g moves and turns the selected clip · '
   + 'cmd-z undoes · h hides the panel';
 
 /** The editor's keyboard, and the guard that has to come with it. */
 addEventListener('keydown', (e) => {
+  // Above the typing guard: shift on its own arrives as a keydown, and releasing it as a keyup
+  // with `shiftKey` already false.
+  flyFast = e.shiftKey;
   if (isTyping(e.target)) return;
   if (e.defaultPrevented) return;
 
@@ -6477,6 +6509,13 @@ addEventListener('keydown', (e) => {
   if ((e.metaKey || e.ctrlKey) && (e.key === 'z' || e.key === 'Z')) {
     e.preventDefault();
     history.undo();
+    return;
+  }
+  // The recorder's viewport orbits the same camera, so this sits above the clip guard below.
+  // A repeat is harmless: the set already holds the code.
+  if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    e.preventDefault();
+    flyHeld.add(e.code);
     return;
   }
   if ((e.key === 'r' || e.key === 'R') && !e.metaKey && !e.ctrlKey && !e.altKey && !EDITING && ui.recGo && !ui.recGo.disabled) {
@@ -6575,14 +6614,24 @@ addEventListener('keydown', (e) => {
     case ',': case '<': e.preventDefault(); if (view.panBy(-0.25)) viewChanged(); return;
     case '.': case '>': e.preventDefault(); if (view.panBy(0.25)) viewChanged(); return;
     case 'f': case 'F': e.preventDefault(); if (view.fit()) viewChanged(); return;
-    case 'z': case 'Z':
-      e.preventDefault();
-      if (view.frame(clipIn, clipOut ?? view.duration)) viewChanged();
-      return;
     case '?': e.preventDefault(); say(SHORTCUTS); return;
     default:
   }
 });
+
+/** A key released outside the page never arrives, so losing the page releases everything. */
+function clearFlyKeys() {
+  flyHeld.clear();
+}
+
+// Not behind the typing guard: a key released after the focus moved into an input would
+// otherwise stay held for ever.
+addEventListener('keyup', (e) => {
+  flyFast = e.shiftKey;
+  flyHeld.delete(e.code);
+});
+addEventListener('blur', clearFlyKeys);
+document.addEventListener('visibilitychange', () => { if (document.hidden) clearFlyKeys(); });
 
 /** How wide the 1.00x detent is, in pixels of the control it lives on. */
 const DETENT_PX = 3;
@@ -6740,6 +6789,8 @@ let orbiting = false;
 let orbitSettling = false;
 // A flag rather than a position, since reading the transport from a control event is the loop.
 let orbitRedrawWanted = false;
+// Whether a fly key was held on the previous frame, so the release can be seen at all.
+let flyWasHeld = false;
 // Through `onNav`, because the object does not outlive a change of navigation's up.
 onNav('start', () => { orbiting = true; orbitSettling = false; });
 onNav('change', () => {
@@ -6774,9 +6825,16 @@ function pumpParkedDraft() {
     draftWanted = null;
     orbitRedrawWanted = false;
     orbitSettling = false;
+    flyWasHeld = false;
     gizmoWriteWanted = false;
     return;
   }
+  // A hold takes the same two paths a pointer orbit does: a draft-quality redraw per frame, and
+  // one accurate seek on the frame it ends.
+  const flyingNow = flying();
+  if (flyingNow) orbitRedrawWanted = true;
+  else if (flyWasHeld) orbitSettling = true;
+  flyWasHeld = flyingNow;
   // Before the drafts, because the gizmo's write is what the repaint below would be drawing.
   pumpGizmo();
   if (draftWanted !== null) {

--- a/web/main.js
+++ b/web/main.js
@@ -17,7 +17,9 @@ import {
   handleRefusal, foldRefusal, foldFreeX, retimeSourceSecAt, retimeProgramSecAt,
 } from './curve.js';
 import { tiltQuaternion } from './world-tilt.js';
-import { isFlyKey, flyDirection, flyStep } from './fly.js';
+import {
+  isFlyKey, flyDirection, flyStep, lookOffset,
+} from './fly.js';
 import { verticalFovForFocalLength, focalLengthForVerticalFov } from './lens.js';
 import {
   EXPORT_SIZES, DEFAULT_EXPORT_SIZE, reduceAspect, exportAspects, sizesForAspect,
@@ -409,6 +411,7 @@ function setDeliverableSize(text) {
 
 // Which camera the viewport draws. Navigation is off under the program camera.
 function setViewCamera(cam) {
+  stopLookDrag();
   useViewCamera(cam);
   if (gizmo) gizmo.camera = cam;
   renderPass.camera = cam;
@@ -4361,22 +4364,29 @@ let lastNavTime = 0;
 // Which fly keys are down, and whether shift is with them. Written from events and read by the
 // loop, because nothing but the loop may start a redraw.
 const flyHeld = new Set();
-let flyFast = false;
+let flyShift = false;
 // Wall clock at the previous fly frame, or 0 when the hold has not started. The free camera is
 // interactive, so it takes real seconds where auto-orbit takes the program delta.
 let flyLastAt = 0;
 const flyMove = new THREE.Vector3();
+// The look drag's live state, written by the pointer handlers far below and read here. Null
+// when no look drag is up; otherwise the last pointer position, since the turn is per-move.
+let lookDrag = null;
 
-/** Whether the held keys ask for a non-zero move. */
+/** Whether the held keys ask for a non-zero move. Shift gates the six, so it is a held key. */
 const flyInputActive = () => (
-  flyDirection(flyHeld, freeCamera.quaternion, freeCamera.up, flyMove).lengthSq() > 0
+  flyShift && flyDirection(flyHeld, freeCamera.quaternion, freeCamera.up, flyMove).lengthSq() > 0
 );
 
-/** Whether a held fly key may move the camera. One gate for the program camera, a gizmo or
- *  node drag, and an export - each of those is already a reason the orbit stands down. */
-const flying = () => flyInputActive() && controls.enabled && !exporting;
+/** Whether a held fly key may move the camera. `controls.enabled` is the program camera, a
+ *  gizmo drag, a node drag and a crop drag in one term - each already a reason the orbit stands
+ *  down. A look drag turns it off too and is the one that must not stop the flight, because
+ *  flying while you turn is what the mode is. */
+const flying = () => flyInputActive() && (controls.enabled || lookDrag !== null) && !exporting;
 
-/** Change the held keys, starting a new clock when the requested move starts or stops. */
+/** Change the held keys or the shift they need, starting a new clock when the move starts or
+ *  stops. Shift comes through here for the same reason a key does: a resumed hold that kept the
+ *  old clock takes the stall cap as its first step. */
 function changeFlyKeys(change) {
   const wasActive = flyInputActive();
   change();
@@ -4389,7 +4399,7 @@ function advanceFly() {
   const now = performance.now();
   const dt = flyLastAt === 0 ? 0 : (now - flyLastAt) / 1000;
   flyLastAt = now;
-  flyStep(flyHeld, flyFast, dt, freeCamera.quaternion, freeCamera.up, flyMove);
+  flyStep(flyHeld, dt, freeCamera.quaternion, freeCamera.up, flyMove);
   freeCamera.position.add(flyMove);
   // The pivot travels with the camera. `update()` rebuilds the position out of the target, so
   // moving the camera alone would change the orbit's radius instead of where you are standing.
@@ -6494,15 +6504,40 @@ function clearClipRange() {
   history.commit();
 }
 
-const TYPING_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
-const isTyping = (el) => el instanceof HTMLElement && (TYPING_TAGS.has(el.tagName) || el.isContentEditable);
+// An input type that is not a text field. Anything else counts as text, including a type this
+// list has never heard of, so a text-like type added later defaults to keeping its keyboard.
+const NON_TEXT_INPUT_TYPES = new Set([
+  'range', 'checkbox', 'radio', 'button', 'submit', 'reset', 'color', 'file', 'image',
+]);
+// The keys a slider, a dropdown or a checkbox uses to operate itself. Everything else reaches
+// the editor, so a focused lens slider does not swallow cmd-z and the fly keys.
+const SELF_OPERATING_KEYS = new Set([
+  'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', ' ', 'Enter', 'Home', 'End', 'PageUp', 'PageDown',
+]);
+
+/** Whether a focused control takes text, which is the case that keeps the whole keyboard. */
+function takesText(el) {
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.isContentEditable) return true;
+  if (el.tagName === 'TEXTAREA') return true;
+  if (el.tagName !== 'INPUT') return false;
+  return !NON_TEXT_INPUT_TYPES.has(el.type);
+}
+
+/** Whether the focused control has this key, so the editor must not take it off the control. */
+function controlKeeps(el, key) {
+  if (takesText(el)) return true;
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.tagName !== 'INPUT' && el.tagName !== 'SELECT') return false;
+  return SELF_OPERATING_KEYS.has(key);
+}
 
 const SHORTCUTS = 'space play/pause · arrows step a frame, with shift a second · '
   + 'home/end · i/o set in/out, with shift jump to them · option-x uses the whole clip · '
   + 'del removes the selected key · '
   + 'm marks, [/] jump to the previous and next mark · '
   + '+/- zoom the ruler, ,/. pan it, f fits the clip · '
-  + 'wasd fly, q/e down and up, shift faster · '
+  + 'shift-wasd fly, shift-q/e down and up, shift-drag turns the view, shift-wheel the lens · '
   + 'g moves and turns the selected clip · '
   + 'cmd-z undoes · h hides the panel';
 
@@ -6510,8 +6545,8 @@ const SHORTCUTS = 'space play/pause · arrows step a frame, with shift a second 
 addEventListener('keydown', (e) => {
   // Above the typing guard: shift on its own arrives as a keydown, and releasing it as a keyup
   // with `shiftKey` already false.
-  flyFast = e.shiftKey;
-  if (isTyping(e.target)) return;
+  changeFlyKeys(() => { flyShift = e.shiftKey; });
+  if (controlKeeps(e.target, e.key)) return;
   if (e.defaultPrevented) return;
 
   if (e.key === 'h' || e.key === 'H') {
@@ -6524,11 +6559,16 @@ addEventListener('keydown', (e) => {
     return;
   }
   // The recorder's viewport orbits the same camera, so this sits above the clip guard below.
-  // A repeat is harmless: the set already holds the code.
+  // A repeat is harmless: the set already holds the code. The key is recorded whether or not
+  // shift is down, so pressing shift onto a key already held starts the flight rather than
+  // waiting for the key to be pressed again; shift is what *takes* the key, so without it the
+  // key goes on to whatever else is bound to it.
   if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {
-    e.preventDefault();
     changeFlyKeys(() => flyHeld.add(e.code));
-    return;
+    if (e.shiftKey) {
+      e.preventDefault();
+      return;
+    }
   }
   if ((e.key === 'r' || e.key === 'R') && !e.metaKey && !e.ctrlKey && !e.altKey && !EDITING && ui.recGo && !ui.recGo.disabled) {
     e.preventDefault();
@@ -6634,17 +6674,20 @@ addEventListener('keydown', (e) => {
 /** A key released outside the page never arrives, so losing the page releases everything. */
 function clearFlyKeys() {
   flyHeld.clear();
-  flyFast = false;
+  flyShift = false;
   flyLastAt = 0;
 }
 
 // Not behind the typing guard: a key released after the focus moved into an input would
 // otherwise stay held for ever.
 addEventListener('keyup', (e) => {
-  flyFast = e.shiftKey;
-  changeFlyKeys(() => flyHeld.delete(e.code));
+  changeFlyKeys(() => {
+    flyShift = e.shiftKey;
+    flyHeld.delete(e.code);
+  });
 });
 addEventListener('blur', clearFlyKeys);
+document.addEventListener('focusin', (e) => { if (takesText(e.target)) clearFlyKeys(); });
 document.addEventListener('visibilitychange', () => { if (document.hidden) clearFlyKeys(); });
 
 /** How wide the 1.00x detent is, in pixels of the control it lives on. */
@@ -9823,6 +9866,61 @@ addEventListener('pointerdown', (e) => {
   setPivotDistance(hit.distance);
 }, true);
 
+// The camera turning in place, where the orbit turns it about the pivot. `lookDrag` is declared
+// with the fly state, because the fly gate has to read it.
+const lookPivot = new THREE.Vector3();
+
+// After the pick above, so `nodeDrag` and `cropDrag` are already set by the time this reads them.
+addEventListener('pointerdown', (e) => {
+  if (e.button !== 0 || !e.shiftKey || e.ctrlKey || e.metaKey
+    || e.target !== renderer.domElement) return;
+  if (lookDrag || nodeDrag || cropDrag) return;
+  if (viewCamera !== freeCamera || !controls.enabled) return;
+  const view = viewUnder(e.clientX, e.clientY);
+  if (!view || view.plan) return;
+  e.preventDefault();
+  e.stopPropagation();
+  renderer.domElement.setPointerCapture(e.pointerId);
+  controls.enabled = false;
+  // Or the damping residual turns the camera under the first frames of the drag.
+  finishOrbitDrift();
+  // Decided here and never mid-gesture: a look stays a look when shift lets go, and an orbit
+  // stays an orbit when shift arrives. Changing meaning under the pointer would jump the camera.
+  lookDrag = { pointerId: e.pointerId, x: e.clientX, y: e.clientY };
+}, true);
+
+renderer.domElement.addEventListener('pointermove', (e) => {
+  if (!lookDrag || e.pointerId !== lookDrag.pointerId) return;
+  const dx = e.clientX - lookDrag.x;
+  const dy = e.clientY - lookDrag.y;
+  lookDrag.x = e.clientX;
+  lookDrag.y = e.clientY;
+  // The pivot rides a sphere about the camera, so letting go of shift orbits whatever is now in
+  // front of you at the distance it already had.
+  lookPivot.subVectors(controls.target, freeCamera.position);
+  lookOffset(lookPivot, freeCamera.up, dx, dy, freeCamera.fov, stageSize().h, lookPivot);
+  controls.target.copy(freeCamera.position).add(lookPivot);
+  // Never a render here: `renderProgramFrame` advances navigation, so it would ask for another.
+  orbitRedrawWanted = true;
+});
+
+function stopLookDrag() {
+  if (!lookDrag) return;
+  const { pointerId } = lookDrag;
+  lookDrag = null;
+  if (renderer.domElement.hasPointerCapture(pointerId)) renderer.domElement.releasePointerCapture(pointerId);
+  controls.enabled = viewCamera === freeCamera;
+  orbitSettling = true;
+}
+
+for (const type of ['pointerup', 'pointercancel', 'lostpointercapture']) {
+  renderer.domElement.addEventListener(type, (e) => {
+    if (e.pointerId === lookDrag?.pointerId) stopLookDrag();
+  });
+}
+addEventListener('blur', stopLookDrag);
+document.addEventListener('visibilitychange', () => { if (document.hidden) stopLookDrag(); });
+
 function keyCameraHere() {
   if (!timeline) return;
   if (refuseEdit('keying the camera')) return;
@@ -9863,8 +9961,12 @@ const LENS_MAX_MM = 300;
 /** The lens row: a focal length the slider can hold, or which way it ran out of band. */
 function showLens(mm) {
   ui.camLens.value = Math.min(LENS_MAX_MM, Math.max(LENS_MIN_MM, mm)).toFixed(1);
-  if (mm < LENS_MIN_MM) ui.camLensOut.textContent = `wider than ${LENS_MIN_MM}mm`;
-  else if (mm > LENS_MAX_MM) ui.camLensOut.textContent = `longer than ${LENS_MAX_MM}mm`;
+  // The band is read at the resolution the row shows. A lens the wheel clamped to exactly 8mm
+  // comes back from `fov` as 7.99999999, and comparing the raw number called that wider than
+  // the band it had just been held inside.
+  const shown = Number(mm.toFixed(1));
+  if (shown < LENS_MIN_MM) ui.camLensOut.textContent = `wider than ${LENS_MIN_MM}mm`;
+  else if (shown > LENS_MAX_MM) ui.camLensOut.textContent = `longer than ${LENS_MAX_MM}mm`;
   else ui.camLensOut.textContent = `${mm.toFixed(1)}mm`;
 }
 
@@ -9899,6 +10001,34 @@ ui.camLens.addEventListener('input', () => {
   showLens(mm);
   requestRepaint();
 });
+
+// How much of the lens a pixel of wheel is worth. Multiplicative in millimetres, so a notch is
+// the same fraction of the lens at 8mm and at 300mm.
+const LENS_ZOOM_PER_PIXEL = 0.0015;
+
+// Captured on the window, because OrbitControls listens for the wheel on the canvas and would
+// dolly the same event.
+addEventListener('wheel', (e) => {
+  if (!e.shiftKey || e.ctrlKey || e.metaKey || e.target !== renderer.domElement) return;
+  if (viewCamera !== freeCamera || !controls.enabled) return;
+  const view = viewUnder(e.clientX, e.clientY);
+  if (!view || view.plan) return;
+  e.preventDefault();
+  e.stopPropagation();
+  // Shift and a wheel arrive with the axes swapped in some browsers, so the gesture reads
+  // whichever axis moved rather than the vertical one.
+  const delta = wheelPixels(e);
+  const pixels = Math.abs(delta.x) > Math.abs(delta.y) ? delta.x : delta.y;
+  const aspect = targetAspect();
+  const mm = focalLengthForVerticalFov(freeCamera.fov, aspect)
+    * Math.exp(-pixels * LENS_ZOOM_PER_PIXEL);
+  freeCamera.fov = verticalFovForFocalLength(
+    Math.min(LENS_MAX_MM, Math.max(LENS_MIN_MM, mm)), aspect,
+  );
+  freeCamera.updateProjectionMatrix();
+  paintLens();
+  requestRepaint();
+}, { capture: true, passive: false });
 
 // How far down the optical axis the orbit target lands.
 const SENSOR_VIEW_DISTANCE = 2.2;
@@ -10763,8 +10893,8 @@ addEventListener('keydown', (event) => {
     closeApplicationMenus({ restore: true });
     return;
   }
-  // `isTyping` stays below Escape: shutting a menu is right wherever the caret is.
-  if (isTyping(event.target) || !(event.metaKey || event.ctrlKey)) return;
+  // The guard stays below Escape: shutting a menu is right wherever the caret is.
+  if (controlKeeps(event.target, event.key) || !(event.metaKey || event.ctrlKey)) return;
   const key = event.key.toLowerCase();
   if (key === 'o' && EDITING) {
     event.preventDefault();

--- a/web/main.js
+++ b/web/main.js
@@ -17,7 +17,7 @@ import {
   handleRefusal, foldRefusal, foldFreeX, retimeSourceSecAt, retimeProgramSecAt,
 } from './curve.js';
 import { tiltQuaternion } from './world-tilt.js';
-import { isFlyKey, flyStep } from './fly.js';
+import { isFlyKey, flyDirection, flyStep } from './fly.js';
 import { verticalFovForFocalLength, focalLengthForVerticalFov } from './lens.js';
 import {
   EXPORT_SIZES, DEFAULT_EXPORT_SIZE, reduceAspect, exportAspects, sizesForAspect,
@@ -4367,9 +4367,21 @@ let flyFast = false;
 let flyLastAt = 0;
 const flyMove = new THREE.Vector3();
 
+/** Whether the held keys ask for a non-zero move. */
+const flyInputActive = () => (
+  flyDirection(flyHeld, freeCamera.quaternion, freeCamera.up, flyMove).lengthSq() > 0
+);
+
 /** Whether a held fly key may move the camera. One gate for the program camera, a gizmo or
  *  node drag, and an export - each of those is already a reason the orbit stands down. */
-const flying = () => flyHeld.size > 0 && controls.enabled && !exporting;
+const flying = () => flyInputActive() && controls.enabled && !exporting;
+
+/** Change the held keys, starting a new clock when the requested move starts or stops. */
+function changeFlyKeys(change) {
+  const wasActive = flyInputActive();
+  change();
+  if (!wasActive || !flyInputActive()) flyLastAt = 0;
+}
 
 /** One frame of flight: the camera and its pivot translate by the same vector. */
 function advanceFly() {
@@ -6515,7 +6527,7 @@ addEventListener('keydown', (e) => {
   // A repeat is harmless: the set already holds the code.
   if (isFlyKey(e.code) && !e.metaKey && !e.ctrlKey && !e.altKey) {
     e.preventDefault();
-    flyHeld.add(e.code);
+    changeFlyKeys(() => flyHeld.add(e.code));
     return;
   }
   if ((e.key === 'r' || e.key === 'R') && !e.metaKey && !e.ctrlKey && !e.altKey && !EDITING && ui.recGo && !ui.recGo.disabled) {
@@ -6622,13 +6634,15 @@ addEventListener('keydown', (e) => {
 /** A key released outside the page never arrives, so losing the page releases everything. */
 function clearFlyKeys() {
   flyHeld.clear();
+  flyFast = false;
+  flyLastAt = 0;
 }
 
 // Not behind the typing guard: a key released after the focus moved into an input would
 // otherwise stay held for ever.
 addEventListener('keyup', (e) => {
   flyFast = e.shiftKey;
-  flyHeld.delete(e.code);
+  changeFlyKeys(() => flyHeld.delete(e.code));
 });
 addEventListener('blur', clearFlyKeys);
 document.addEventListener('visibilitychange', () => { if (document.hidden) clearFlyKeys(); });

--- a/web/view-window.js
+++ b/web/view-window.js
@@ -222,11 +222,5 @@ export function makeViewWindow({ durationSec, bedRect }) {
     },
 
     fit() { return this.set(0, 1); },
-
-    /** Frames a range with a margin, so the two markers are not on the very edges. */
-    frame(fromSec, toSec) {
-      const pad = Math.max(MIN_VIEW_SEC, (toSec - fromSec) * 0.05);
-      return this.set((fromSec - pad) / this.duration, (toSec + pad) / this.duration);
-    },
   };
 }


### PR DESCRIPTION
## Problem

Keyboard flight needs a way to turn the camera in place. Orbit dragging moves the camera around its target, which makes it awkward to look around while flying.

## Solution

Use Shift as the free camera's navigation modifier:

- Shift-WASD flies along the view and across it. Shift-Q/E follows the current navigation vertical.
- Shift-left-drag turns the camera in place. The turn rate follows the field of view, so long lenses allow smaller adjustments.
- Shift-wheel changes the lens within 8–300mm. Both horizontal and vertical wheel input work.
- Plain dragging still orbits; plain wheel input still dollies. Flight has one speed.

The camera and orbit target travel together during flight. Look dragging preserves their distance. Releasing or cancelling the pointer, losing focus or capture, hiding the page, and switching cameras end the look gesture.

Text fields retain all keyboard input. Sliders and other non-text inputs retain adjustment keys while allowing navigation and editor shortcuts. Editor shortcuts take priority over dropdown letter type-ahead. The ruler's Z trim-framing shortcut is removed.

The same navigation works on the recorder. The proof tool covers both pages, drag interruptions, lens limits, keyboard focus, and deliberately broken implementations.

## Validation

- Syntax check: 99 files, no failures. Unit tests: 227 passed. Module check: 62 assertions passed.
- Full editor proof: 808 assertions passed, including a real export and saved copy.
- Focused editor/recorder checks: 65 assertions passed. All 28 mutations fired their required assertions across sequential focused sweeps; typing controls were rerun after the focus fix.
- Unit falsification detected reversed yaw, fixed turn sensitivity, and missing pitch limits.

Browser checks used `fixture-1g` and the fake grabber. Physical Kinect input was not tested. Independent Claude review was attempted but could not run because the account's session limit was reached.
