### PR TITLE
Add audio-driven effect modulation prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ output
 # settings.local.json into it, a `git add -A` takes one machine's paths and
 # permissions along for the ride.
 .claude
+
+# Imported audio assets.
+audio/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ exit code (rule 3).
 | `timeline-check.mjs` | seek equals playback | `--url`, a take of ≥12s |
 | `keyframe-check.mjs` | tracks, the retime curve, undo | `--url`, a take of ≥24s |
 | `export-check.mjs` | resolution, export, the file | `--url`, ffmpeg and ffprobe |
+| `audio-check.mjs` | audio import, EQ, mapping, undo, reload and exact exported samples | port 8196 free, ffmpeg and a GPU browser |
 | `editor-check.mjs` | the editor's controls exist, and pressing them changes something | `--url`, a take of ≥32s |
 | `library-check.mjs` | the library, the recorder, the routes | a free port span |
 | `boot-check.mjs` | after boot, every control shows the value the registry holds for the selected clip; the document door adopts a whole document or none; the undo stack is the session's and the file is the document's | port 8391 free |

--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ Drag to orbit, scroll to zoom, right-drag to pan, `H` hides the panel;
 navigation. On a canted mount,
 [level the room](docs/reference.md#levelling-a-canted-mount) first.
 
+Use **Audio** in the timeline to import a song. In the Audio panel, choose a clip, one of its
+applied effects, and a parameter. **Depth** adds the audio signal to the parameter's base value
+or keyframes. The spectrum shows the input and the signal after EQ; the readouts show the base,
+audio contribution, and resulting value. Drag the audio lane to move the song. Playback and
+video exports include the original audio. This prototype supports one audio file and one
+parameter mapping; [the reference](docs/reference.md#audio) covers its limits.
+
 ### 4. Key a camera move
 
 Park the playhead, orbit to the pose you want, and press **add key** on the panel's

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,8 @@ widen it, so widening is a decision somebody took rather than a default.
 
 **The origin rule is the second half, and it only speaks to browsers.** Mutating HTTP routes
 and the WebSocket upgrade require a same-origin `Origin` header, a matching method and a JSON
-content type — the three things a page you merely visit cannot produce together. A request
+content type, except the audio upload which requires `application/octet-stream`. Both content
+types require a browser preflight for a cross-origin request. A request
 carrying **no** `Origin` passes on purpose: every call across the capture-node link is a
 server-side `fetch`, and nothing in Node has an origin to declare.
 
@@ -60,6 +61,9 @@ Everything, to everyone who can route to the port:
   the name they left it under.
 - `PUT /projects/:name`, `/presets/:name`, `/deliverables/:name`: overwrite saved work.
 - `POST /jobs`: queue renders, without limit, on the disk your takes are being written to.
+- `POST /audio`: import an audio file through FFmpeg, limited to one concurrent upload,
+  64 MiB input, and ten minutes of decoded audio. The decoder can read its input pipe only.
+  `GET /audio/:hash` reads a stored normalized WAV after verifying its content hash.
 - The WebSocket: the live sensor feed, and the recorder's controls.
 - `GET /camera.mjpg`: **the colour camera, live, as an ordinary MJPEG stream.** This is the
   plainest thing on the list — no framing to decode and no client to write, just a URL that

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -385,6 +385,22 @@ time, so constant motion through index space is visibly variable motion through 
 
 ## Clips, and what a cut costs
 
+Audio is a separate program-time source. `web/audio-source.js` derives a 100 Hz control curve
+from normalized PCM, then answers arbitrary program positions without transport history.
+Stereo energy is measured per channel so opposite phases do not cancel. The same lookup feeds
+seeks, playback, and export. `web/audio-session.js` owns decoding and audible playback; it
+aligns the source to the transport and stops it when the transport pauses or waits for footage.
+The source lookup is also the boundary for future recorded MIDI or live-input curves; this
+build only imports audio files.
+
+The renderer applies the additive result after keyed base values, directly to the effect's
+runtime parameter. The document retains the base, source hash, conditioning, and mapping.
+`server/audio.js` imports bounded uploads through FFmpeg with only the pipe protocol allowed,
+stores normalized WAV files by content hash, and verifies those bytes before reads. The export
+server copies verified audio into its private render directory, trims by program time, and
+adds silence outside the audio clip. The export record includes the program start and source
+identity. Modulation EQ does not alter the soundtrack.
+
 A clip owns a source, a cloud, a retime curve, a `start` and a `length`. It covers
 `[start, start + length)` - half-open, so two clips abutting at a cut do not both draw on the
 frame the cut lands on, with the one exception that the instant an edit ends on belongs to

--- a/docs/proof-tools.md
+++ b/docs/proof-tools.md
@@ -43,6 +43,7 @@ node tools/registry-check.mjs --url http://localhost:8080 # step 3: one registry
 node tools/timeline-check.mjs --url http://localhost:8080 --take fixture-1g # step 4: seek equals playback
 node tools/keyframe-check.mjs --url http://localhost:8080 --take fixture-1g # step 5: tracks, retime curve, undo
 node tools/export-check.mjs --url http://localhost:8080   # step 6: resolution, export, the file
+node tools/audio-check.mjs                              # audio import, modulation, persistence and a real audio/video export
 node tools/library-check.mjs                              # step 7: library, recorder, routes
 node tools/editor-check.mjs --url http://localhost:8080 --take fixture-1g # the editor's controls: that they exist, that pressing them changes something
 node tools/boot-check.mjs                                 # the post-boot state diff: every control shows the value the registry holds for the
@@ -89,6 +90,23 @@ node tools/jobs-check.mjs                                 # step 8: the queue, t
                                                           #   entry however many rows it writes
 node tools/module-check.mjs                               # the boundaries in web/: the import graph, what an import names, what crosses it
 ```
+
+`audio-check` stages its server and every writable store in a temporary directory. It uses a
+120-frame synthetic take and a generated tone by default. `--source PATH` reuses a capture,
+`--audio PATH` imports a real audio file, and `--shots DIRECTORY` saves the panel and an MP4
+preview outside the checkout. It checks the destination list, rendered frame changes, seek
+repeatability, undo, reload, and exact stereo PCM samples from a lossless export starting after
+the audio clip begins. Its `--mutate` controls are `signal-disconnected`, `mux-ignores-start`,
+`added-effect-hidden`, `space-keeps-control-focus`, and `undo-leaves-spectrum-empty`. They must
+fail the rendered modulation, exact exported samples, newly added destination, focused Space
+shortcut, and restored spectrum checks, respectively. Read the failed assertions; exit 2 means
+the run did not finish.
+
+`audio-check --queue` also sends an audio project through the real render worker and compares
+its exported samples. `editor-check` needs four captures with distinct hashes in the server's
+library: its chosen take must have at least 32 seconds, and the additional takes keep the
+asynchronous Add Clip checks from reusing an already cached source. Its disk check expects the
+tool and server to share the same application root and `exports/` directory.
 
 The two below need no server, and `registration-check` needs no sensor either — it runs on a
 corpus of `Registration::apply` inputs dumped by `grabber --dump-corpus`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -62,9 +62,9 @@ the levelled room in the normal view and the sensor's vertical in Sensor view. F
 orbit pivot with the camera, so a drag afterwards still turns about the same subject rather than
 about where you set off from.
 
-**A focused text field keeps the whole keyboard.** Gaining text focus also stops any flight keys
+**Space always toggles playback in the editor.** A focused text field keeps the other keys. Gaining text focus also stops any flight keys
 already held. Sliders, dropdowns and other non-text inputs
-keep the arrows, space, enter, home, end and the page keys, so a focused slider still
+keep the arrows, enter, home, end and the page keys, so a focused slider still
 nudges with the arrows while `Shift-W` still flies and `cmd-z` still undoes. Editor shortcuts take
 priority over dropdown letter type-ahead.
 
@@ -536,6 +536,33 @@ handed. That snap is the pulse the look wants and it is also what makes the time
 decodes forward from the last one, the way seeking to a keyframe does — so a long refresh is a
 long dissolve *and* a long pre-roll on every scrub.
 
+## Audio
+
+The Audio panel imports one file, up to 64 MiB and ten minutes. FFmpeg converts it to stereo
+48 kHz PCM. `--audio DIRECTORY` selects the asset store; the default is `audio/` under the
+application root. Projects refer to the normalized asset by its SHA-256 hash. Moving a project
+to another machine requires that asset as well as its captures. Missing or changed audio is
+refused before the project opens.
+
+Choose **Clip**, **Effect**, then **Parameter**. The effect list includes effects explicitly added
+to that clip, effects with changed values or keyframes, and the current audio mapping. Adding
+an effect makes it available immediately, even at its defaults. Project effects have a separate **Project**
+entry. Depth is signed and uses the parameter's units. The result is the base or keyed value
+plus depth times the signal, normalized to the parameter's range and step. The base and its
+keys remain editable and are never replaced by the signal.
+
+Low, Mid, and High split at 200 Hz and 2 kHz. Gain follows the EQ. Threshold and Ceiling map
+the root mean square level to 0–1; Attack and Release smooth rises and falls. The spectrum
+shows input and EQ output at the playhead, including while paused. These controls condition
+the modulation; playback and export use the original audio. **Start** or dragging the audio
+lane moves it in program seconds, independently of capture retiming.
+
+The project saves its audio settings and mapping, and Undo restores them. MP4, MOV, and
+lossless video exports include audio trimmed to the export range, with silence outside the
+audio clip. PNG sequences are refused while audio is present. This prototype has one audio
+clip and one scalar effect mapping. MIDI files, live MIDI, and microphone input are not
+implemented.
+
 ## The edit, and what comes out of it
 
 Two menus, because there are two questions and one of them used to answer both. **File >
@@ -949,7 +976,9 @@ Rows declared `under` another parameter are hidden while that master is at its a
 Removing one resets every value and deletes every track in one undoable edit, and it asks
 nothing first: **remove** in the picker and the cross that appears on a group's own header when
 you hover it are the same edit, and undo is what takes either of them back.
-The local rack preference is panel state, not project state. The generator refuses to boot
+Explicit additions belong to the clip, or to the project for post effects, and are saved with
+that look. Selecting another clip changes its effect rack. Space toggles playback even while
+an inspector control has focus; Enter still activates buttons and selectors. The generator refuses to boot
 if the rows it emitted are not the parameters that were declared.
 
 The bounds are authoring travel, not mathematical limits. Mixes, angles and positions keep their
@@ -1043,9 +1072,11 @@ validates, so `editor-check` section 12 drives the round trip in a browser, with
 
 Documents from before the readings are version 3 and will not open, and there is nothing to
 run: the one-shot conversion this repo used to ship was deleted once every document it could
-act on had already been converted. This build reads version 7 alone — a version 6 document
+act on had already been converted. This build reads version 8 alone. Version 8 adds audio
+sources, mappings, and explicit effect additions per look. Version 7 documents are refused;
+this prototype includes no migration. A version 6 document
 carried one take at the top and one undivided look under it rather than a `clips` array, and a
 version 5 document still spelled its parameters bare (`glyphTone` rather than `glyph.tone`) and
 carried no `requires` list, so both are refused the same way a version 3 or 4 one is, and there
-is no conversion for either: every document this project holds was re-authored at 7. A file from
+is no conversion for either. A file from
 any older version is refused, naming its own version, and stays refused.

--- a/presets-builtin/blackwall.json
+++ b/presets-builtin/blackwall.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/cascade.json
+++ b/presets-builtin/cascade.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/contour.json
+++ b/presets-builtin/contour.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/depth.json
+++ b/presets-builtin/depth.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/ember.json
+++ b/presets-builtin/ember.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/ghost.json
+++ b/presets-builtin/ghost.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/grille.json
+++ b/presets-builtin/grille.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/rgb.json
+++ b/presets-builtin/rgb.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/rift.json
+++ b/presets-builtin/rift.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     {
       "id": "ghost",

--- a/presets-builtin/tearline.json
+++ b/presets-builtin/tearline.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/presets-builtin/updraft.json
+++ b/presets-builtin/updraft.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     {
       "id": "ghost",

--- a/presets-builtin/voxel.json
+++ b/presets-builtin/voxel.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "requires": [
     { "id": "ghost", "version": "1.0.0" },
     { "id": "contour", "version": "1.0.0" },

--- a/server/audio.js
+++ b/server/audio.js
@@ -1,0 +1,100 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream, constants } from 'node:fs';
+import { link, mkdir, mkdtemp, open, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { validAudioHash, AUDIO_RATE, AUDIO_SECONDS, AUDIO_UPLOAD_BYTES, readAudioWav } from '../web/audio-source.js';
+
+const FFMPEG = process.env.FFMPEG ?? '/opt/homebrew/bin/ffmpeg';
+const digest = (bytes) => `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+
+export class AudioStore {
+  constructor(root) { this.root = root; this.importing = false; this.writes = 0; }
+
+  async read(hash) {
+    if (!validAudioHash(hash)) throw new Error('invalid audio content hash');
+    const file = await open(join(this.root, `${hash.slice(7)}.wav`), constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+      const stat = await file.stat();
+      if (!stat.isFile() || stat.size > AUDIO_SECONDS * AUDIO_RATE * 4 + 4096) throw new Error('audio asset is not a bounded WAV file');
+      const bytes = await file.readFile();
+      if (digest(bytes) !== hash) throw new Error('audio asset content does not match its hash');
+      return bytes;
+    } finally { await file.close(); }
+  }
+
+  async import(stream) {
+    if (this.importing) throw new Error('another audio import is running');
+    this.importing = true;
+    let scratch = null;
+    try {
+      await mkdir(this.root, { recursive: true });
+      scratch = await mkdtemp(join(this.root, '.import-'));
+      const input = join(scratch, 'input');
+      const file = await open(input, 'wx');
+      let size = 0;
+      try {
+        for await (const chunk of stream) {
+          size += chunk.length;
+          if (size > AUDIO_UPLOAD_BYTES) throw new Error(`audio import exceeds ${AUDIO_UPLOAD_BYTES} bytes`);
+          await file.writeFile(chunk);
+        }
+      } finally { await file.close(); }
+      if (!size) throw new Error('audio file is empty');
+      const output = join(scratch, 'audio.wav');
+      await new Promise((resolve, reject) => {
+        const child = spawn(FFMPEG, [
+          '-hide_banner', '-nostdin', '-loglevel', 'error', '-protocol_whitelist', 'pipe', '-i', 'pipe:0',
+          '-map', '0:a:0', '-vn', '-t', String(AUDIO_SECONDS + 0.01), '-ac', '2', '-ar', String(AUDIO_RATE),
+          '-c:a', 'pcm_s16le', '-map_metadata', '-1', '-fflags', '+bitexact', '-flags:a', '+bitexact', output,
+        ], { stdio: ['pipe', 'ignore', 'pipe'] });
+        let error = '';
+        const timeout = setTimeout(() => { child.kill('SIGKILL'); }, 60000);
+        child.stderr.on('data', (chunk) => { error = (error + chunk).slice(-2000); });
+        child.on('error', reject);
+        child.on('close', (code) => {
+          clearTimeout(timeout);
+          if (code === 0) resolve();
+          else reject(new Error(`audio could not be decoded: ${error.trim() || 'decoder stopped or timed out'}`));
+        });
+        pipeline(createReadStream(input), child.stdin).catch(() => { /* Decoder refusal is reported on close. */ });
+      });
+      const bytes = await readFile(output);
+      const { duration } = readAudioWav(bytes);
+      const hash = digest(bytes);
+      try {
+        // Publish the complete file atomically; a failed write must not occupy its content hash.
+        await link(output, join(this.root, `${hash.slice(7)}.wav`));
+        this.writes++;
+      } catch (err) {
+        if (err.code !== 'EEXIST') throw err;
+        await this.read(hash);
+      }
+      return { hash, duration };
+    } finally {
+      if (scratch) await rm(scratch, { recursive: true, force: true });
+      this.importing = false;
+    }
+  }
+}
+
+// Silence is generated as a stream, so a clip placed hours into the edit needs no delay buffer.
+export function audioFilter(clip, from, frames, fps) {
+  const count = Math.round(frames * AUDIO_RATE / fps);
+  const outputStart = Math.round(from * AUDIO_RATE);
+  const sourceStart = Math.round(clip.start * AUDIO_RATE);
+  const sourceEnd = sourceStart + Math.round(clip.duration * AUDIO_RATE);
+  const begin = Math.max(outputStart, sourceStart);
+  const end = Math.min(outputStart + count, sourceEnd);
+  const silence = (n, name) => `anullsrc=r=${AUDIO_RATE}:cl=stereo,atrim=end_sample=${n}[${name}]`;
+  if (end <= begin) return `${silence(count, 'audio')}`;
+  const filters = [];
+  const parts = [];
+  if (begin > outputStart) { filters.push(silence(begin - outputStart, 'lead')); parts.push('[lead]'); }
+  filters.push(`[1:a]atrim=start_sample=${begin - sourceStart}:end_sample=${end - sourceStart},asetpts=PTS-STARTPTS[body]`);
+  parts.push('[body]');
+  if (end < outputStart + count) { filters.push(silence(outputStart + count - end, 'tail')); parts.push('[tail]'); }
+  filters.push(`${parts.join('')}concat=n=${parts.length}:v=0:a=1[audio]`);
+  return filters.join(';');
+}

--- a/server/export.js
+++ b/server/export.js
@@ -6,6 +6,8 @@ import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { mkdir, readdir, writeFile, stat, rm, rename } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { audioFilter } from './audio.js';
+import { AUDIO_RATE, checkAudioClip, readAudioWav } from '../web/audio-source.js';
 
 // Absolute rather than resolved off PATH: this is the encoder the export was measured against.
 const FFMPEG = process.env.FFMPEG ?? '/opt/homebrew/bin/ffmpeg';
@@ -120,13 +122,15 @@ async function artifactBytes(spec, artifact, frames) {
   return total;
 }
 
-function ffmpegArgs({ width, height, fps, codec, into }) {
+function ffmpegArgs({ width, height, fps, codec, into, audio = null }) {
   return [
     '-hide_banner', '-nostdin', '-loglevel', 'error',
     // Without it the container carries the encoder's version string and a creation time, so the
     // same frames would produce a different file every run.
     '-fflags', '+bitexact',
     '-f', 'rawvideo', '-pix_fmt', 'rgba', '-s', `${width}x${height}`, '-r', String(fps), '-i', '-',
+    ...(audio ? ['-i', audio.path, '-filter_complex', audio.filter, '-map', '0:v:0', '-map', '[audio]',
+      '-c:a', codec === 'h264' ? 'aac' : 'pcm_s16le'] : []),
     // readPixels reads the drawing buffer bottom-up, which is upside down to every video format.
     '-vf', 'vflip',
     ...CODECS[codec].args,
@@ -139,7 +143,7 @@ function ffmpegArgs({ width, height, fps, codec, into }) {
 // One export, from the begin message to the file. Everything is validated against what the
 // browser said it would send: ffmpeg's rawvideo demuxer reads a short frame as the head of
 // the next one and produces a file that plays and scrolls diagonally.
-export function handleExportSocket(ws, { outDir, log = console.log }) {
+export function handleExportSocket(ws, { outDir, audioStore = null, log = console.log }) {
   let job = null;
   let child = null;
   let received = 0;
@@ -191,6 +195,7 @@ export function handleExportSocket(ws, { outDir, log = console.log }) {
     job = {
       width, height, fps, frames, codec, frameBytes, output, outputDir, temp, scratchArtifact, href, name: msg.name, began: Date.now(),
       project: msg.project ?? null,
+      programStart: msg.programStart ?? null,
       captures: Array.isArray(msg.captures) ? msg.captures.slice() : null,
       renderer: msg.renderer ?? null,
     };
@@ -198,7 +203,24 @@ export function handleExportSocket(ws, { outDir, log = console.log }) {
     // The directory the target is in rather than the scratch directory - one level deeper for a
     // sequence, because the image2 muxer opens each frame by name and creates nothing.
     await mkdir(dirname(target), { recursive: true });
-    const args = ffmpegArgs({ width, height, fps, codec, into: target });
+    if (finished) { await rm(temp, { recursive: true, force: true }); return; }
+    const audioClip = checkAudioClip(msg.project?.audio);
+    let audio = null;
+    if (audioClip) {
+      if (codec === 'pngseq') throw new Error('PNG sequences cannot carry audio; select MP4 or MOV');
+      if (!audioStore) throw new Error('this server has no audio store');
+      if (!Number.isFinite(msg.programStart) || msg.programStart < 0 || msg.programStart > 86400
+        || frames === null) throw new Error('audio export needs a program start and frame count');
+      const wav = await audioStore.read(audioClip.hash);
+      if (finished) return;
+      const { duration } = readAudioWav(wav);
+      if (Math.abs(duration - audioClip.duration) > 0.5 / AUDIO_RATE) throw new Error('audio duration does not match its asset');
+      const audioPath = join(temp, 'audio-input.wav');
+      await writeFile(audioPath, wav, { flag: 'wx' });
+      if (finished) { await rm(temp, { recursive: true, force: true }); return; }
+      audio = { path: audioPath, filter: audioFilter(audioClip, msg.programStart, frames, fps) };
+    }
+    const args = ffmpegArgs({ width, height, fps, codec, into: target, audio });
     log(`[export] ${FFMPEG} ${args.join(' ')}`);
     child = spawn(FFMPEG, args, { stdio: ['pipe', 'ignore', 'pipe'] });
     child.stderr.on('data', (chunk) => stderr.push(chunk.toString('utf8')));
@@ -277,6 +299,7 @@ export function handleExportSocket(ws, { outDir, log = console.log }) {
     // once old jobs exist.
     const record = {
       project: job.project ?? null,
+      programStart: job.programStart,
       captures: job.captures ?? null,
       renderer: job.renderer ?? null,
       output: job.output,
@@ -295,6 +318,7 @@ export function handleExportSocket(ws, { outDir, log = console.log }) {
     // into the output.
     finished = true;
     try {
+      await rm(join(job.temp, 'audio-input.wav'), { force: true });
       await rename(job.temp, job.outputDir);
     } catch (err) {
       // And it comes back down if the rename is what failed: `fail` reads the flag as "already
@@ -336,7 +360,7 @@ export function handleExportSocket(ws, { outDir, log = console.log }) {
         throw new Error(`unknown export message ${Object.keys(msg).join(',')}`);
       }
     };
-    run().catch((err) => fail(String(err.message ?? err)));
+    return run().catch((err) => fail(String(err.message ?? err)));
   });
 
   ws.on('close', () => {

--- a/server/http-guard.js
+++ b/server/http-guard.js
@@ -1,5 +1,5 @@
-// A route that changes something requires its method, a same-origin caller and a JSON
-// content type. The three together are what a page you merely visit cannot produce.
+// A route that changes something requires its method, a same-origin caller and a declared
+// content type that requires a browser preflight. The three together are what a page you merely visit cannot produce.
 
 export function originAllowed(req) {
   const origin = req.headers.origin;
@@ -54,7 +54,7 @@ export function sameOriginBrowser(req) {
   return site === 'same-origin' || site === 'none';
 }
 
-export function requireMutation(req, res, methods) {
+export function requireMutation(req, res, methods, contentType = 'application/json') {
   // Origin first, and before the body: a refused request should not stream megabytes in.
   if (!originAllowed(req)) {
     refuse(res, 403, `${req.headers.origin} is not this server, and this route changes something`);
@@ -65,8 +65,10 @@ export function requireMutation(req, res, methods) {
     refuse(res, 405, `${req.method} is not how this route is called: it changes something, so it takes ${methods.join(' or ')}`);
     return false;
   }
-  if (!JSON_TYPE.test(req.headers['content-type'] ?? '')) {
-    refuse(res, 415, 'this route changes something, so it takes a request declaring application/json');
+  const typeRule = contentType === 'application/octet-stream'
+    ? /^application\/octet-stream\s*(?:;|$)/i : JSON_TYPE;
+  if (!typeRule.test(req.headers['content-type'] ?? '')) {
+    refuse(res, 415, `this route changes something, so it takes a request declaring ${contentType}`);
     return false;
   }
   return true;

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ import { WebSocketServer } from 'ws';
 import { MessageParser, encodeMessage, TYPE_HELLO, TYPE_FRAME, TYPE_COLOR, MAX_PAYLOAD_BYTES } from './protocol.js';
 import { openCapture, withCapture, captureIdFor, openCaptureCount, decimatePayload, cloudExtent } from './capture.js';
 import { handleExportSocket, MAX_FRAME_BYTES } from './export.js';
+import { AudioStore } from './audio.js';
 import {
   VALID_ID, DocumentStore, NodeLink, PROJECT_VERSION, appendMarks, downloadTake,
   downloadsInFlight, hashFile, markWriteCount, readMarkLog, readMarks, reconcile, remaining,
@@ -111,6 +112,7 @@ const captureAliases = new Map();
 
 // The node keeps its own preset library on disk: it may be shooting with nothing connected, where
 // a push-per-session scheme leaves a standalone node with an empty selector.
+const AUDIO = new AudioStore(resolve(flag('--audio', join(ROOT, 'audio'))));
 const PROJECTS = new DocumentStore(resolve(flag('--projects', join(ROOT, 'projects'))), 'project');
 // A second *read* root rather than files copied on first run: a builtin is always the current one,
 // a save over its name forks it, and removing the fork brings the shipped look back.
@@ -958,6 +960,7 @@ function serveRoutes(req, res) {
       // asks every one of them rather than the ones a reviewer thought of.
       live: Boolean(r.live),
       methods: r.write?.methods ?? [],
+      contentType: r.write?.contentType ?? 'application/json',
     })),
   });
 }
@@ -965,7 +968,7 @@ function serveRoutes(req, res) {
 // The route sweep read the stores either side of the drive, which a handler that writes and
 // restores inside one request defeats - a monotonic count is what a restore cannot undo.
 const serveWriteCounts = (req, res) => sendJson(res, {
-  projects: PROJECTS.writes, presets: PRESETS.writes, deliverables: DELIVERABLES.writes, marks: markWriteCount(), jobs: JOBS.writes,
+  projects: PROJECTS.writes, presets: PRESETS.writes, deliverables: DELIVERABLES.writes, marks: markWriteCount(), jobs: JOBS.writes, audio: AUDIO.writes,
 });
 
 // ---- the render queue
@@ -1130,6 +1133,15 @@ async function serveLocalTakes(req, res) {
 // changes something, and the dispatcher puts every one through `requireMutation` in one place. The
 // table is served at `/library/routes`, so a check can enumerate rather than name.
 const ROUTES = [
+  { path: '/audio', pattern: /^\/audio$/, write: { methods: ['POST'], contentType: 'application/octet-stream', run: async (req, res) => {
+    try { sendJson(res, await AUDIO.import(req)); }
+    catch (err) { sendJson(res, { error: err.message }, 400); }
+  } } },
+  { path: '/audio/:hash', pattern: /^\/audio\/([0-9a-f]{64})$/, read: async (req, res, [hash]) => {
+    const bytes = await AUDIO.read(`sha256:${hash}`);
+    res.writeHead(200, { 'Content-Type': 'audio/wav', 'Content-Length': bytes.length, 'Cache-Control': 'private, max-age=31536000, immutable' });
+    res.end(req.method === 'HEAD' ? undefined : bytes);
+  } },
   // ---- a capture, read
   { path: '/capture/:id/hello', pattern: /^\/capture\/([^/]+)\/hello$/, read: serveHello },
   { path: '/capture/:id/index', pattern: /^\/capture\/([^/]+)\/index$/, read: serveIndex },
@@ -1355,7 +1367,7 @@ async function serveRoute(req, res, urlPath, query) {
     if (!reading && r.write) {
       // The one gate, applied here rather than inside ten handlers: a `write` reaches its handler
       // only through this line.
-      if (!requireMutation(req, res, r.write.methods)) return true;
+      if (!requireMutation(req, res, r.write.methods, r.write.contentType)) return true;
       await r.write.run(req, res, args, query);
       return true;
     }
@@ -1509,7 +1521,7 @@ httpServer.on('upgrade', (req, socket, head) => {
 exportWss.on('connection', (ws) => {
   console.log('[export] client connected');
   ws.on('error', (err) => console.error('[export] socket error:', err.message));
-  handleExportSocket(ws, { outDir: EXPORTS_DIR });
+  handleExportSocket(ws, { outDir: EXPORTS_DIR, audioStore: AUDIO });
 });
 
 let helloJson = null;

--- a/test/audio-source.test.mjs
+++ b/test/audio-source.test.mjs
@@ -1,0 +1,190 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AUDIO_RATE, AUDIO_SECONDS, AUDIO_UPLOAD_BYTES, analyseAudio, checkAudioClip, defaultConditioning,
+  audioSpectrum, modulatedValue, readAudioWav, signalAt,
+} from '../web/audio-source.js';
+import { audioFilter, AudioStore } from '../server/audio.js';
+import { requireMutation } from '../server/http-guard.js';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readdir, writeFile, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { EventEmitter } from 'node:events';
+import { handleExportSocket } from '../server/export.js';
+
+const tone = (hz, amplitude = 0.2) => {
+  const samples = Float32Array.from({ length: AUDIO_RATE }, (_, i) => amplitude * Math.sin(2 * Math.PI * hz * i / AUDIO_RATE));
+  return { samples: [samples], duration: 1, rate: AUDIO_RATE };
+};
+const settings = () => {
+  const defaults = defaultConditioning();
+  return { ...defaults, gain: 0, floor: -96, ceiling: 0, attack: 0, release: 0 };
+};
+const clip = () => ({
+  kind: 'audio-file', hash: `sha256:${'0'.repeat(64)}`, name: 'tone.wav', start: 2, duration: 1,
+  conditioning: settings(), target: { clip: 'c1', param: 'glitch.amount', depth: 0.5 },
+});
+
+test('flat EQ preserves RMS and stereo analysis does not cancel opposite phases', () => {
+  const pcm = tone(100);
+  const flat = analyseAudio(pcm, settings());
+  const floor = 10 ** (-96 / 20);
+  const expected = (0.2 / Math.sqrt(2) - floor) / (1 - floor);
+  assert.ok(Math.abs(signalAt(flat, 0.5) - expected) < 1e-7);
+  const stereo = { ...pcm, samples: [pcm.samples[0], pcm.samples[0].map((v) => -v)] };
+  assert.equal(signalAt(analyseAudio(stereo, settings()), 0.5), signalAt(flat, 0.5));
+});
+
+test('the low and high EQ controls distinguish bass from treble', () => {
+  const bass = tone(50); const treble = tone(8000);
+  const lowOnly = { ...settings(), mid: -60, high: -60 };
+  const highOnly = { ...settings(), low: -60, mid: -60 };
+  assert.ok(signalAt(analyseAudio(bass, lowOnly), 0.5) > signalAt(analyseAudio(treble, lowOnly), 0.5) * 20);
+  assert.ok(signalAt(analyseAudio(treble, highOnly), 0.5) > signalAt(analyseAudio(bass, highOnly), 0.5) * 20);
+});
+
+test('frequency display distinguishes tones and shows the actual EQ response', () => {
+  const pcm = tone(1000);
+  const flat = audioSpectrum(pcm, 0.5, settings());
+  const loudest = flat.reduce((a, b) => a.input > b.input ? a : b);
+  assert.ok(loudest.hz > 800 && loudest.hz < 1200);
+  assert.ok(flat.every((bin) => Math.abs(bin.input - bin.output) < 1e-7));
+  const cut = audioSpectrum(pcm, 0.5, { ...settings(), low: -12, mid: -12, high: -12 });
+  assert.ok(cut.every((bin, i) => flat[i].input < -72 || Math.abs(bin.output - flat[i].output + 12) < 1e-7));
+  assert.ok(audioSpectrum(pcm, 2, settings()).every((bin) => bin.input === -120 && bin.output === -120));
+  assert.deepEqual(audioSpectrum(pcm, 0.5, settings()), flat);
+});
+
+test('silence, threshold, gain and ceiling bound the signal', () => {
+  const silence = analyseAudio(tone(100, 0), settings());
+  assert.ok(silence.values.every((v) => v === 0));
+  const gated = analyseAudio(tone(100, 0.01), { ...settings(), floor: -20 });
+  assert.ok(gated.values.every((v) => v === 0));
+  const hot = analyseAudio(tone(100), { ...settings(), gain: 48 });
+  assert.equal(signalAt(hot, 0.5), 1);
+});
+
+test('attack and release are computed once and random reads cannot change them', () => {
+  const pcm = tone(100);
+  pcm.samples[0].fill(0, AUDIO_RATE / 2);
+  const smooth = analyseAudio(pcm, { ...settings(), attack: 100, release: 200 });
+  const fast = analyseAudio(pcm, settings());
+  assert.ok(signalAt(smooth, 0.02) < signalAt(fast, 0.02));
+  assert.ok(signalAt(smooth, 0.6) > 0.03);
+  assert.equal(signalAt(fast, 0.6), 0);
+  const expected = signalAt(smooth, 0.35);
+  for (const at of [0.9, 0.01, 0.7, -1, 10, NaN]) signalAt(smooth, at);
+  assert.equal(signalAt(smooth, 0.35), expected);
+  assert.equal(signalAt(smooth, -0.01), 0);
+  assert.equal(signalAt(smooth, 1), 0);
+});
+
+test('modulation adds signed depth to the base and clamps to the parameter range', () => {
+  assert.equal(modulatedValue(0.3, 0.4, 0.5, 0, 1), 0.5);
+  assert.equal(modulatedValue(0.3, -0.4, 0.5, 0, 1), 0.09999999999999998);
+  assert.equal(modulatedValue(0.8, 1, 1, 0, 1), 1);
+  assert.equal(modulatedValue(0.2, -1, 1, 0, 1), 0);
+});
+
+test('audio document validation rejects malformed and unsupported sources before adoption', () => {
+  const good = clip();
+  assert.deepEqual(checkAudioClip(good), good);
+  assert.equal(checkAudioClip(null), null);
+  for (const patch of [
+    { kind: 'live-midi' }, { hash: '../outside' }, { start: NaN }, { duration: 0 },
+    { duration: AUDIO_SECONDS + 1 }, { target: {} }, { target: { ...good.target, depth: Infinity } },
+    { conditioning: { ...good.conditioning, floor: -6, ceiling: -12 } },
+    { conditioning: { ...good.conditioning, attack: -1 } },
+  ]) assert.throws(() => checkAudioClip({ ...good, ...patch }));
+});
+
+function wav() {
+  const b = Buffer.alloc(48);
+  b.write('RIFF'); b.writeUInt32LE(40, 4); b.write('WAVEfmt ', 8); b.writeUInt32LE(16, 16);
+  b.writeUInt16LE(1, 20); b.writeUInt16LE(1, 22); b.writeUInt32LE(AUDIO_RATE, 24);
+  b.writeUInt32LE(AUDIO_RATE * 2, 28); b.writeUInt16LE(2, 32); b.writeUInt16LE(16, 34);
+  b.write('data', 36); b.writeUInt32LE(4, 40); b.writeInt16LE(-32768, 44); b.writeInt16LE(16384, 46);
+  return b;
+}
+
+test('WAV reader checks chunk bounds, sample format and complete PCM frames', () => {
+  const bytes = wav();
+  assert.deepEqual([...readAudioWav(bytes).samples[0]], [-1, 0.5]);
+  for (const [at, value] of [[4, 200], [16, 100], [24, 44100], [40, 3]]) {
+    const broken = Buffer.from(bytes); broken.writeUInt32LE(value, at);
+    assert.throws(() => readAudioWav(broken));
+  }
+  assert.throws(() => readAudioWav(Buffer.alloc(0)));
+});
+
+test('audio store refuses missing, changed and symlinked assets without leaving imports behind', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'audio-store-'));
+  try {
+    const store = new AudioStore(root);
+    const bytes = wav();
+    const hash = 'sha256:' + createHash('sha256').update(bytes).digest('hex');
+    const path = join(root, `${hash.slice(7)}.wav`);
+    await assert.rejects(store.read(hash));
+    await writeFile(path, bytes);
+    assert.deepEqual(await store.read(hash), bytes);
+    await writeFile(path, Buffer.alloc(48));
+    await assert.rejects(store.read(hash), /hash/);
+    await rm(path);
+    await writeFile(join(root, 'outside'), bytes);
+    await symlink(join(root, 'outside'), path);
+    await assert.rejects(store.read(hash));
+    await assert.rejects(store.import(Readable.from([])), /empty/);
+    const chunk = Buffer.alloc(1024 * 1024);
+    const chunks = [...Array(AUDIO_UPLOAD_BYTES / chunk.length).fill(chunk), Buffer.alloc(1)];
+    await assert.rejects(store.import(Readable.from(chunks)), /exceeds/);
+    assert.equal(store.importing, false);
+    assert.equal(store.writes, 0);
+    assert.ok((await readdir(root)).every((name) => !name.startsWith('.import-')));
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test('audio mux derives a trimmed source and silence from program positions', () => {
+  const source = { start: 2, duration: 1 };
+  const filter = audioFilter(source, 1, 90, 30);
+  assert.match(filter, /atrim=end_sample=48000\[lead\]/);
+  assert.match(filter, /start_sample=0:end_sample=48000/);
+  assert.match(filter, /atrim=end_sample=48000\[tail\]/);
+  assert.match(audioFilter(source, 2.5, 15, 30), /start_sample=24000:end_sample=48000/);
+  assert.match(audioFilter(source, 1000, 30, 30), /anullsrc.*end_sample=48000\[audio\]/);
+});
+
+test('binary uploads retain method, origin and non-simple content-type gates', () => {
+  const run = (patch = {}, contentType = 'application/octet-stream') => {
+    let status = 200;
+    const req = { method: 'POST', headers: { host: '127.0.0.1:8176', 'content-type': contentType }, ...patch };
+    const res = { setHeader() {}, writeHead(n) { status = n; }, end() {} };
+    return { ok: requireMutation(req, res, ['POST'], 'application/octet-stream'), status };
+  };
+  assert.deepEqual(run(), { ok: true, status: 200 });
+  assert.equal(run({ method: 'GET' }).status, 405);
+  for (const type of ['text/plain', 'multipart/form-data', 'application/x-www-form-urlencoded', 'application/json']) {
+    assert.equal(run({}, type).status, 415);
+  }
+  assert.equal(run({ headers: { host: '127.0.0.1:8176', origin: 'http://evil.invalid', 'content-type': 'application/octet-stream' } }).status, 403);
+});
+
+test('closing an export during setup stops it before the audio asset is read', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'audio-export-cancel-'));
+  let reads = 0;
+  let closed;
+  const close = new Promise((resolve) => { closed = resolve; });
+  const ws = new EventEmitter();
+  Object.assign(ws, { OPEN: 1, readyState: 1, send() {}, close: closed });
+  handleExportSocket(ws, { outDir: root, log() {}, audioStore: { async read() { reads++; throw new Error('read after close'); } } });
+  const message = ws.listeners('message')[0];
+  const pending = message(Buffer.from(JSON.stringify({ begin: {
+    name: 'canceled', width: 320, height: 180, fps: 30, frames: 1, codec: 'lossless',
+    programStart: 0, project: { audio: clip() },
+  } })), false);
+  ws.readyState = 3;
+  ws.emit('close');
+  try { await Promise.all([pending, close]); assert.equal(reads, 0); }
+  finally { await rm(root, { recursive: true, force: true }); }
+});

--- a/tools/audio-check.mjs
+++ b/tools/audio-check.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+// Drives audio import, conditioning, mapping, persistence and a real mux in an isolated editor.
+import { spawn, spawnSync } from 'node:child_process';
+import { createServer } from 'node:net';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const flag = (name, fallback = null) => { const i = process.argv.indexOf(name); return i < 0 ? fallback : process.argv[i + 1]; };
+const PORT = Number(flag('--port', '8196'));
+const AUDIO = flag('--audio');
+const SOURCE = flag('--source');
+const SHOTS = flag('--shots');
+const MUTATE = flag('--mutate');
+const FFMPEG = process.env.FFMPEG ?? '/opt/homebrew/bin/ffmpeg';
+const MUTATIONS = {
+  'signal-disconnected': {
+    file: 'web/main.js', edits: [['    applyAudio(t);', '    /* audio deliberately disconnected */']],
+    fails: 'the rendered frame and the displayed result no longer change with modulation depth',
+  },
+  'mux-ignores-start': {
+    file: 'server/export.js', edits: [['audioFilter(audioClip, msg.programStart, frames, fps)', 'audioFilter(audioClip, 0, frames, fps)']],
+    fails: 'the exported PCM does not match the source samples at the requested program position',
+  },
+  'added-effect-hidden': {
+    file: 'web/main.js', edits: [['return look.effects.has(effect) || effectParamNames(effect)', 'return effectParamNames(effect)']],
+    fails: 'an effect added at its defaults is absent from the audio destination list',
+  },
+  'space-keeps-control-focus': {
+    file: 'web/main.js', edits: [['  if (e.repeat) return;\n  ui.play.click();', '  if (e.repeat || controlKeeps(e.target, e.key)) return;\n  ui.play.click();']],
+    fails: 'Space cannot start the transport while a slider, selector, or numeric field holds focus',
+  },
+  'undo-leaves-spectrum-empty': {
+    file: 'web/audio-session.js', edits: [['if (!inspection && inspectionFailure !== clip.hash)', 'if (false && !inspection && inspectionFailure !== clip.hash)']],
+    fails: 'undoing a replacement cannot restore the earlier audio spectrum while paused',
+  },
+};
+let count = 0; let failed = 0; let browser; let server; let work;
+const check = (ok, label, detail = '') => {
+  count++; if (!ok) failed++;
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${label}${detail ? `: ${detail}` : ''}`);
+};
+const command = (bin, args) => {
+  const out = spawnSync(bin, args, { maxBuffer: 64 * 1024 * 1024 });
+  if (out.status !== 0) throw new Error(`${bin}: ${out.error?.message ?? out.stderr.toString()}`);
+  return out.stdout;
+};
+async function main() {
+  if (MUTATE && !MUTATIONS[MUTATE]) throw new Error(`unknown mutation; have ${Object.keys(MUTATIONS).join(', ')}`);
+  const reservation = createServer();
+  await new Promise((yes, no) => { reservation.once('error', no); reservation.listen(PORT, '127.0.0.1', yes); });
+  await new Promise((yes) => reservation.close(yes));
+  work = mkdtempSync(join(tmpdir(), 'audio-check-'));
+  const app = join(work, 'app'); mkdirSync(app);
+  for (const name of ['web', 'server', 'effects-builtin', 'presets-builtin', 'package.json']) cpSync(join(ROOT, name), join(app, name), { recursive: true });
+  symlinkSync(join(ROOT, 'node_modules'), join(app, 'node_modules'));
+  if (MUTATE) {
+    const m = MUTATIONS[MUTATE]; const file = join(app, m.file); let text = readFileSync(file, 'utf8');
+    for (const [from, to] of m.edits) {
+      if (text.split(from).length !== 2) throw new Error(`mutation anchor must match once: ${from}`);
+      text = text.replace(from, to);
+    }
+    writeFileSync(file, text); console.log(`MUTATION ${MUTATE}: ${m.fails}`);
+  }
+  const captures = join(work, 'captures'); mkdirSync(captures);
+  if (SOURCE) symlinkSync(resolve(SOURCE), join(captures, 'audioprobe.knct'));
+  else command(process.execPath, [join(ROOT, 'tools/make-sample.mjs'), join(captures, 'audioprobe.knct'), '--frames', '120']);
+  const tone = join(work, 'tone.wav');
+  command(FFMPEG, ['-v', 'error', '-f', 'lavfi', '-i', 'sine=frequency=125:sample_rate=48000:duration=4', '-ac', '2', tone]);
+  const replacement = join(work, 'replacement.wav');
+  command(FFMPEG, ['-v', 'error', '-f', 'lavfi', '-i', 'sine=frequency=8000:sample_rate=48000:duration=2', '-ac', '2', replacement]);
+  const origin = `http://127.0.0.1:${PORT}`;
+  server = spawn(process.execPath, [join(app, 'server/index.js'), '--port', String(PORT), '--captures', captures,
+    '--grabber', join(work, 'no-grabber')], { cwd: app, stdio: ['ignore', 'pipe', 'pipe'] });
+  let log = ''; for (const stream of [server.stdout, server.stderr]) stream.on('data', (data) => { log = (log + data).slice(-8000); });
+  for (let i = 0; ; i++) {
+    if (server.exitCode !== null || i > 100) throw new Error(`server did not start: ${log}`);
+    try { if ((await fetch(`${origin}/library`)).ok) break; } catch { /* Wait for this server's listener. */ }
+    await new Promise((yes) => setTimeout(yes, 100));
+  }
+  for (const [body, headers, status, label] of [
+    ['', { 'Content-Type': 'application/octet-stream' }, 400, 'empty upload refused'],
+    ['bad audio', { 'Content-Type': 'application/octet-stream' }, 400, 'malformed upload refused'],
+    ['x', { 'Content-Type': 'text/plain' }, 415, 'simple content type refused'],
+    ['x', { 'Content-Type': 'application/octet-stream', Origin: 'http://evil.invalid' }, 403, 'foreign origin refused'],
+  ]) { const r = await fetch(`${origin}/audio`, { method: 'POST', headers, body }); check(r.status === status, label, String(r.status)); }
+  browser = await chromium.launch({ headless: !process.argv.includes('--headed'), args: ['--autoplay-policy=no-user-gesture-required'] });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1050 } });
+  page.setDefaultTimeout(45000);
+  const errors = []; page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto(`${origin}/edit?new=audioprobe`);
+  await page.waitForFunction(() => globalThis.__kinect?.timeline.transport()?.duration > 1);
+  await page.evaluate(async () => {
+    const k = __kinect;
+    k.params.set('glitch.amount', 0.05); k.params.set('fade', 0); k.params.set('trails', 0);
+    k.keyframes.undo.commit(); await k.timeline.settled();
+  });
+  await page.locator('#panelTabLook').click();
+  await page.locator('#effectRackOpen').click();
+  await page.locator('[data-effect-add="noise"]').click();
+  await page.locator('#effectRackClose').click();
+  await page.locator('#panelTabAudio').click();
+  const [chooser] = await Promise.all([page.waitForEvent('filechooser'), page.locator('#tAddAudio').click()]);
+  const upload = async (path) => {
+    await page.locator('#audioFile').setInputFiles(path);
+    await page.waitForFunction(() => !document.getElementById('audioImport').disabled && __kinect.audio.clip());
+    const note = await page.locator('#audioNote').textContent(); if (note) throw new Error(note);
+  };
+  await chooser.setFiles(AUDIO ? resolve(AUDIO) : tone);
+  await page.waitForFunction(() => !document.getElementById('audioImport').disabled && __kinect.audio.clip());
+  const imported = await page.evaluate(() => __kinect.audio.clip());
+  check(imported.kind === 'audio-file' && imported.hash.startsWith('sha256:'), 'real file chooser imported an audio asset', imported.name);
+  const change = async (selector, value) => {
+    await page.locator(selector).fill(String(value));
+    await page.locator(selector).dispatchEvent('change');
+    await page.waitForFunction(() => !document.getElementById('audioImport').disabled);
+    const note = await page.locator('#audioNote').textContent(); if (note) throw new Error(note);
+  };
+  await page.locator('#audioMappingTitle').click();
+  await page.locator('#audioEffect').selectOption('glitch');
+  await page.waitForFunction(() => !document.getElementById('audioImport').disabled);
+  await page.locator('#audioTarget').selectOption('glitch.amount');
+  await page.waitForFunction(() => !document.getElementById('audioImport').disabled);
+  const effects = await page.locator('#audioEffect option').evaluateAll((items) => items.map((o) => o.value));
+  check(effects.includes('noise'), 'effect added at defaults immediately appears as an audio destination');
+  check(effects.every((id) => !id || ['noise', 'glitch'].includes(id)), 'destination excludes unapplied effects');
+  const single = await page.evaluate(() => {
+    const k = __kinect; const original = k.library.serialiseProjectBody(); const two = structuredClone(original);
+    const other = structuredClone(two.clips[0]); other.id = 'c2'; other.effects = []; other.tracks = {};
+    for (const name of Object.keys(other.params)) other.params[name] = k.params.spec(name).default;
+    two.clips.push(other); k.library.restoreProject(two); return original;
+  });
+  await page.locator('#audioOwner').selectOption(JSON.stringify('c2'));
+  await page.waitForFunction(() => !document.getElementById('audioImport').disabled);
+  check(await page.locator('#audioEffect').isDisabled(), 'another clip does not inherit the first clip\'s added effect');
+  await page.evaluate((original) => { __kinect.library.restoreProject(original); __kinect.keyframes.undo.begin(); document.getElementById('panelTabAudio').click(); }, single);
+  await change('#audioDepth', 0.7);
+  const frame = () => page.evaluate(async () => {
+    const k = __kinect; const t = k.timeline.transport(); await t.seek(1);
+    const bytes = k.drive.readPixels();
+    const hash = [...new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))].map((v) => v.toString(16).padStart(2, '0')).join('');
+    return { hash, base: k.params.get('glitch.amount'), value: k.audio.value('glitch.amount', 1, 'c1'), signal: k.audio.signal(1),
+      shown: document.getElementById('audioResult').value, spectrum: document.querySelector('[data-spectrum=output]').getAttribute('points') };
+  });
+  const driven = await frame();
+  check(driven.base === 0.05 && driven.value > driven.base, 'audio adds to the base without changing the registry', `base=${driven.base}, result=${driven.value}, signal=${driven.signal}`);
+  check(Math.abs(Number(driven.shown) - driven.value) < 0.001 && driven.spectrum?.split(' ').length === 64, 'visible spectrum and result read the current signal');
+  await change('#audioDepth', 0);
+  const flat = await frame();
+  check(flat.hash !== driven.hash, 'modulation depth changes the rendered frame');
+  await change('#audioDepth', 0.7);
+  const again = await frame();
+  check(again.hash === driven.hash, 'random seeks reproduce the modulated frame');
+  const playedHash = await page.evaluate(async () => {
+    const k = __kinect; const t = k.timeline.transport(); await t.seek(0.5); await t.runTo(30);
+    return [...new Uint8Array(await crypto.subtle.digest('SHA-256', k.drive.readPixels()))].map((v) => v.toString(16).padStart(2, '0')).join('');
+  });
+  check(playedHash === driven.hash, 'stepped playback and a seek produce the same modulated frame');
+  await page.locator('.audio-advanced summary').click();
+  const conditioning = { low: -9, mid: -15, high: -21, gain: 3, floor: -60, ceiling: -3, attack: 40, release: 250 };
+  for (const [name, value] of Object.entries(conditioning)) await change(`#audio-${name}`, value);
+  check(await page.evaluate((expected) => Object.entries(expected).every(([name, value]) => __kinect.audio.clip().conditioning[name] === value), conditioning), 'every conditioning control reaches the saved audio settings');
+  const defaults = { low: 0, mid: 0, high: 0, gain: 0, floor: -48, ceiling: -6, attack: 10, release: 180 };
+  for (const [name, value] of Object.entries(defaults)) await change(`#audio-${name}`, value);
+  await page.locator('.audio-advanced summary').click();
+  await change('#audio-gain', -24);
+  const quiet = await frame();
+  check(quiet.signal < driven.signal && quiet.spectrum !== driven.spectrum, 'EQ gain changes both the control signal and the displayed spectrum');
+  await change('#audio-gain', 0);
+  await page.locator('#tPlay').click();
+  await page.waitForFunction(() => __kinect.timeline.transport().programSec > 1.3);
+  await page.locator('#tPlay').click();
+  check(await page.evaluate(() => !__kinect.timeline.transport().playing), 'real transport starts and pauses with audio loaded');
+  for (const selector of ['#audio-low', '#audioEffect', '#audioDepth', '#audioImport']) {
+    await page.locator(selector).focus();
+    await page.keyboard.press('Space');
+    const playing = await page.waitForFunction(() => __kinect.timeline.transport().playing, null, { timeout: 3000 }).then(() => true, () => false);
+    check(playing, `Space starts playback with ${selector} focused`);
+    if (playing) {
+      await page.keyboard.press('Space');
+      check(await page.evaluate(() => !__kinect.timeline.transport().playing), `Space pauses playback with ${selector} focused`);
+    }
+  }
+  if (SHOTS) {
+    await change('#audio-mid', -12); await change('#audio-high', -24);
+    await page.evaluate(async () => { await __kinect.timeline.transport().seek(1); document.getElementById('panelBody').scrollTop = 0; });
+    mkdirSync(SHOTS, { recursive: true }); await page.screenshot({ path: join(SHOTS, 'audio-panel.png') });
+    await change('#audio-mid', 0); await change('#audio-high', 0);
+  }
+  await change('#audioStart', 0.5);
+  await page.keyboard.press('Meta+z');
+  await page.waitForFunction(() => __kinect.audio.clip().start === 0);
+  check(await page.locator('#audioStart').inputValue() === '0', 'undo restores audio placement and the control');
+  await change('#audioStart', 0.25);
+  const expected = await page.evaluate(() => __kinect.audio.clip());
+  await page.waitForFunction(async () => {
+    const name = new URL(location.href).searchParams.get('project'); if (!name) return false;
+    const saved = await (await fetch(`/projects/${name}`)).json();
+    return saved.body.audio?.start === 0.25;
+  });
+  await page.reload();
+  await page.waitForFunction(() => globalThis.__kinect?.audio.clip()?.start === 0.25);
+  check(JSON.stringify(await page.evaluate(() => __kinect.audio.clip())) === JSON.stringify(expected), 'reload preserves the asset, EQ, mapping and placement');
+  check(await page.evaluate(() => __kinect.library.serialiseProjectBody().clips[0].effects.includes('noise')), 'an effect added at defaults survives project reload');
+  const missing = await page.evaluate(async () => {
+    const before = __kinect.library.serialiseProjectBody(); const broken = structuredClone(before);
+    broken.audio.hash = 'sha256:' + '0'.repeat(64);
+    const put = await fetch('/projects/missing-audio?rev=absent', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(broken) });
+    if (!put.ok) throw new Error(`could not stage missing audio: ${put.status}`);
+    let error = ''; try { await __kinect.library.loadProject('missing-audio'); } catch (e) { error = e.message; }
+    return { error, same: JSON.stringify(before) === JSON.stringify(__kinect.library.serialiseProjectBody()) };
+  });
+  check(missing.error.includes('unavailable') && missing.same, 'missing audio refuses the whole project before changing the open edit');
+  await page.locator('#panelTabAudio').click();
+  const exportOptions = { width: 320, height: 180, fps: 30, from: 15, to: 29, name: 'audio-proof', codec: 'lossless' };
+  const done = await page.evaluate((options) => __kinect.export.run(options), exportOptions);
+  const actual = command(FFMPEG, ['-v', 'error', '-i', done.output, '-map', '0:a:0', '-f', 's16le', '-c:a', 'pcm_s16le', '-']);
+  const asset = join(app, 'audio', `${expected.hash.slice(7)}.wav`);
+  const source = command(FFMPEG, ['-v', 'error', '-i', asset, '-af', 'atrim=start_sample=12000:end_sample=36000,asetpts=PTS-STARTPTS', '-f', 's16le', '-c:a', 'pcm_s16le', '-']);
+  check(actual.equals(source) && actual.length === 96000, 'mux carries the exact source PCM at the exported program position', `${actual.length} bytes; 24000 stereo samples`);
+  const record = JSON.parse(readFileSync(`${done.output}.job.json`, 'utf8'));
+  check(record.programStart === 0.5 && record.project.audio.hash === expected.hash, 'export record retains audio identity and program start');
+  const lead = await page.evaluate((options) => __kinect.export.run({ ...options, from: 0, to: 14, name: 'audio-leading-silence' }), exportOptions);
+  const leadPcm = command(FFMPEG, ['-v', 'error', '-i', lead.output, '-map', '0:a:0', '-f', 's16le', '-c:a', 'pcm_s16le', '-']);
+  const firstPcm = command(FFMPEG, ['-v', 'error', '-i', asset, '-af', 'atrim=end_sample=12000', '-f', 's16le', '-c:a', 'pcm_s16le', '-']);
+  check(leadPcm.equals(Buffer.concat([Buffer.alloc(48000), firstPcm])), 'mux inserts silence before an audio clip starts');
+  if (process.argv.includes('--queue')) {
+    const queued = await page.evaluate(async () => {
+      const project = __kinect.library.serialiseProjectBody();
+      const response = await fetch('/jobs', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({
+        project, captures: project.clips.map((clip) => clip.take.hash), output: 'queued-audio', width: 320, height: 180, fps: 30, codec: 'lossless',
+        deliverable: { version: 2, in: 0.5, out: 29 / 30, outputSize: '320x180', codec: 'lossless', name: 'queued-audio' },
+      }) });
+      const job = await response.json(); if (!response.ok) throw new Error(job.error); return job;
+    });
+    command(process.execPath, [join(ROOT, 'tools/render-worker.mjs'), '--url', origin, '--once', '--name', 'audio-proof']);
+    const job = await (await fetch(`${origin}/jobs/${queued.id}`)).json();
+    const queuedPcm = job.state === 'done' ? command(FFMPEG, ['-v', 'error', '-i', job.artifactPath, '-map', '0:a:0', '-f', 's16le', '-c:a', 'pcm_s16le', '-']) : Buffer.alloc(0);
+    check(job.state === 'done' && queuedPcm.equals(source), 'the real render worker preserves the same source audio and offset', job.error ?? job.state);
+  }
+  const png = await page.evaluate(async () => { try { await __kinect.export.run({ width: 320, height: 180, fps: 30, from: 0, to: 1, name: 'audio-png', codec: 'pngseq' }); return ''; } catch (e) { return e.message; } });
+  check(png.includes('cannot carry audio'), 'PNG export refuses silent loss of the audio');
+  if (SHOTS) {
+    const video = await page.evaluate((options) => __kinect.export.run({ ...options, name: 'audio-preview', codec: 'h264' }), { ...exportOptions, from: 0, to: 89 });
+    cpSync(video.output, join(SHOTS, 'audio-preview.mp4'));
+  }
+  await page.locator('#audioRemove').click();
+  check(await page.evaluate(() => __kinect.audio.clip() === null && !document.querySelector('.taudio')), 'Remove clears the audio source and lane');
+  await page.keyboard.press('Meta+z');
+  await page.waitForFunction(() => __kinect.audio.clip());
+  check(await page.evaluate((hash) => __kinect.audio.clip().hash === hash, expected.hash), 'Undo restores removed audio');
+  await page.evaluate(async () => { await __kinect.timeline.transport().seek(1); });
+  const priorSpectrum = await page.locator('[data-spectrum=output]').getAttribute('points');
+  await upload(replacement);
+  await page.keyboard.press('Meta+z');
+  await page.waitForFunction((hash) => __kinect.audio.clip()?.hash === hash, expected.hash);
+  await page.evaluate(async () => { await __kinect.timeline.transport().seek(1); });
+  const restoredSpectrum = await page.waitForFunction((points) => document.querySelector('[data-spectrum=output]').getAttribute('points') === points,
+    priorSpectrum, { timeout: 5000 }).then(() => true, () => false);
+  check(restoredSpectrum, 'Undo after replacing the audio restores its paused frequency display');
+  check(errors.length === 0, 'browser has no uncaught errors', errors.join('; '));
+}
+try { await main(); }
+catch (error) { console.error(`DID NOT FINISH: ${error.stack}`); process.exitCode = 2; }
+finally {
+  await browser?.close();
+  if (server && server.exitCode === null) { server.kill('SIGTERM'); await new Promise((yes) => server.once('exit', yes)); }
+  if (work) rmSync(work, { recursive: true, force: true });
+  console.log(`[audio] ${count} assertions, ${failed} failed`);
+  if (MUTATE) console.log(failed ? 'mutation caught; read the failed assertions above' : 'NOT CAUGHT');
+  if (!process.exitCode) process.exitCode = failed ? 1 : 0;
+}

--- a/tools/editor-check.mjs
+++ b/tools/editor-check.mjs
@@ -2140,9 +2140,8 @@ const MUTATIONS = {
   'space-unbound': {
     file: 'web/main.js',
     edits: [[
-      '      if (timeline.playing || timeline.pendingPlay) pauseTransport();\n'
-      + '      else timeline.play().catch(showTimelineError);\n      return;',
-      '      return;',
+      '  if (e.repeat) return;\n  ui.play.click();',
+      '  if (e.repeat) return;',
     ]],
   },
 
@@ -2492,6 +2491,12 @@ const DRIVER_RULES = [
     what: 'a control in the effect rack sidebar',
     by: 'section 1 opens the effect rack, searches, adds every effect, and removes one',
     match: (row) => inGroup(row, '#effectRackPanel'),
+  },
+  {
+    key: 'audio',
+    what: 'an audio import, conditioning, or mapping control',
+    by: 'audio-check drives the file chooser, every conditioning setting, mapping, depth, placement, removal, and undo',
+    match: (row) => inGroup(row, '#audioGroup') || row.id === 'tAddAudio',
   },
   {
     key: 'paneltabs',
@@ -3102,8 +3107,8 @@ try {
   await page.waitForTimeout(50);
   const halationAdded = await page.evaluate(`(() => {
     const row = document.getElementById('halation.amount')?.closest('.row, .checkrow');
-    let stored = [];
-    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    const doc = globalThis.__kinect.library.serialiseProjectBody();
+    const stored = [...new Set([...(doc.look.effects ?? []), ...doc.clips.flatMap((clip) => clip.effects ?? [])])];
     return {
       hidden: row?.hidden ?? null,
       stored,
@@ -3151,8 +3156,8 @@ try {
     const k = globalThis.__kinect;
     const row = document.getElementById('halation.amount')?.closest('.row, .checkrow');
     const spec = k.params.spec('halation.amount');
-    let stored = [];
-    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    const doc = globalThis.__kinect.library.serialiseProjectBody();
+    const stored = [...new Set([...(doc.look.effects ?? []), ...doc.clips.flatMap((clip) => clip.effects ?? [])])];
     return {
       atDefault: k.params.get('halation.amount') === k.params.normalise('halation.amount', spec.default),
       keyed: k.keyframes.names().includes('halation.amount'),
@@ -3196,8 +3201,8 @@ try {
     const k = globalThis.__kinect;
     const row = document.getElementById('halation.amount')?.closest('.row, .checkrow');
     const spec = k.params.spec('halation.amount');
-    let stored = [];
-    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    const doc = globalThis.__kinect.library.serialiseProjectBody();
+    const stored = [...new Set([...(doc.look.effects ?? []), ...doc.clips.flatMap((clip) => clip.effects ?? [])])];
     return {
       atDefault: k.params.get('halation.amount') === k.params.normalise('halation.amount', spec.default),
       hidden: row?.hidden ?? null,
@@ -3236,8 +3241,8 @@ try {
   }
   const rackComplete = await page.evaluate(`(() => {
     const k = globalThis.__kinect;
-    let stored = [];
-    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    const doc = globalThis.__kinect.library.serialiseProjectBody();
+    const stored = [...new Set([...(doc.look.effects ?? []), ...doc.clips.flatMap((clip) => clip.effects ?? [])])];
     const unavailable = k.effectIds().filter((id) => k.effectParamNames(id).every((name) => {
       const row = document.getElementById(name)?.closest('.row, .checkrow');
       return !row || row.hidden;
@@ -3265,8 +3270,8 @@ try {
   if (headRemoveCount === 1) await headRemove.click();
   await settle();
   const headRemoved = await page.evaluate(`(() => {
-    let stored = [];
-    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    const doc = globalThis.__kinect.library.serialiseProjectBody();
+    const stored = [...new Set([...(doc.look.effects ?? []), ...doc.clips.flatMap((clip) => clip.effects ?? [])])];
     const row = document.getElementById('halation.amount')?.closest('.row, .checkrow');
     return { stored, hidden: row?.hidden ?? null };
   })()`);
@@ -3325,7 +3330,7 @@ try {
       // menu from a button that merely shares the nav row with one.
       groups: ['#appBar', '#panel', '#panelTabs', '#lookPresetGroup', '#cameraGroup', '#navRow',
         '#recordGroup', '#recLookGroup', '#sensorGroup', '#monitorGroup',
-        '#programOutGroup', '#presetPick', '#projectDialog', '#exportDialog', '#obsDialog',
+        '#programOutGroup', '#audioGroup', '#presetPick', '#projectDialog', '#exportDialog', '#obsDialog',
         '#renameDialog',
         '#effectRackPanel', '#panelDock', '.appmenu']
         .filter((g) => el.closest(g)),
@@ -3393,7 +3398,7 @@ try {
     'the strip is among what was swept', `${sweep.filter((r) => r.inTbar).map((r) => r.id).filter(Boolean).slice(0, 6).join(', ')}...`);
 
   // The census racks every installed effect so its generated controls exist for the sweep. That
-  // is local panel state, not project state, and leaving it behind changes every later claim about
+  // is explicit document state, and leaving it behind changes every later claim about
   // a fresh inspector. Remove through the real controls so the cleanup also proves that an idle
   // effect needs no destructive confirmation.
   let rackRemoves = 0;
@@ -3402,8 +3407,8 @@ try {
     rackRemoves++;
   }
   const rackClean = await page.evaluate(`(() => {
-    let stored = [];
-    try { stored = JSON.parse(localStorage.getItem('kinect.rackedEffects') ?? '[]'); } catch {}
+    const doc = globalThis.__kinect.library.serialiseProjectBody();
+    const stored = [...new Set([...(doc.look.effects ?? []), ...doc.clips.flatMap((clip) => clip.effects ?? [])])];
     return {
       stored,
       visible: globalThis.__kinect.effectIds().filter((id) =>
@@ -12393,6 +12398,7 @@ try {
       await page.locator('#tPreset').click();
       await page.waitForFunction("document.getElementById('tPresetList').hidden === false");
       await page.locator(`#tPresetList .pickeroption[data-name=${JSON.stringify(name)}]`).click();
+      await page.waitForFunction(() => !globalThis.__kinect.library.presetGestureRunning());
       await settle();
     };
     await page.evaluate(`(() => {

--- a/tools/export-check.mjs
+++ b/tools/export-check.mjs
@@ -2,7 +2,7 @@
 // is the frame the editor showed, that no wall clock reaches the render, and that
 // the file ffmpeg produced is the one that was asked for.
 
-import { readFileSync, readdirSync, existsSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, mkdtempSync, writeFileSync, rmSync, cpSync, mkdirSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { execFileSync } from 'node:child_process';
@@ -937,7 +937,8 @@ async function onFreshPage(what, work, attempts = 3) {
  * goes with the viewport, because the editor is letterboxed to the export aspect.
  */
 async function setStage(page, size) {
-  for (let attempt = 1; attempt <= 4; attempt++) {
+  // The timeline takes a proportion of the viewport, so its height must converge after resizing.
+  for (let attempt = 1; attempt <= 12; attempt++) {
     // Settled before the strip is measured, and the buffer read again after it lands: the lane
     // stack is built after the transport exists, so a strip measured before it has its rows grows
     // under the viewport that was just sized to it. That left the editor reading pixels at one
@@ -957,24 +958,18 @@ async function setStage(page, size) {
     });
     await page.evaluate(`globalThis.__kinect.setOutputSize?.(${JSON.stringify(`${size.width}x${size.height}`)})`);
     try {
-      await page.waitForFunction(
-        `(() => {
-          const gl = globalThis.__kinect.renderer.getContext();
-          return gl.drawingBufferWidth === ${size.width} && gl.drawingBufferHeight === ${size.height};
-        })()`,
-        null, { timeout: attempt === 1 ? 5000 : 10000 },
-      );
+      await page.evaluate('new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))');
       await page.evaluate('globalThis.__kinect.timeline.settled()').catch(() => {});
       const held = await page.evaluate(`(() => {
         const gl = globalThis.__kinect.renderer.getContext();
         return [gl.drawingBufferWidth, gl.drawingBufferHeight];
       })()`);
       if (held[0] === size.width && held[1] === size.height) return;
-      if (attempt === 4) {
+      if (attempt === 12) {
         throw new Error(`the stage settled at ${held.join('x')} rather than ${size.width}x${size.height}`);
       }
     } catch (err) {
-      if (attempt === 4) throw err;
+      if (attempt === 12) throw err;
     }
   }
 }
@@ -1673,6 +1668,7 @@ console.log('\n[7] a failed export leaves the previous file and its record exact
 // different module. So this imports it into a server of its own on an ephemeral port.
 {
   const outDir = join(REPO, 'exports');
+  mkdirSync(outDir, { recursive: true });
   const NAME = 'check-atomic';
   for (const f of readdirSync(outDir).filter((f) => f.startsWith(NAME))) {
     rmSync(join(outDir, f), { recursive: true, force: true });
@@ -1684,12 +1680,14 @@ console.log('\n[7] a failed export leaves the previous file and its record exact
   const frameOf = (n) => Buffer.alloc(FRAME_BYTES, 24 + n * 96);
 
   const scratch = mkdtempSync(join(tmpdir(), 'export-check-'));
+  for (const name of ['server', 'web']) cpSync(join(REPO, name), join(scratch, name), { recursive: true });
+  cpSync(join(REPO, 'package.json'), join(scratch, 'package.json'));
   const serverSource = mutation?.find((m) => m.file === 'server/export.js')?.body
     ?? readFileSync(join(REPO, 'server/export.js'), 'utf8');
   let copies = 0;
 
   const exportServer = async (ffmpeg) => {
-    const modPath = join(scratch, `export-${++copies}.mjs`);
+    const modPath = join(scratch, 'server', `export-${++copies}.mjs`);
     writeFileSync(modPath, serverSource);
     const had = Object.hasOwn(process.env, 'FFMPEG') ? process.env.FFMPEG : null;
     process.env.FFMPEG = ffmpeg;

--- a/tools/library-check.mjs
+++ b/tools/library-check.mjs
@@ -269,7 +269,7 @@ const MUTATIONS = {
   // link does not have.
   'writes-take-any-method': { file: 'server/index.js', edits: [
     ['    if (!reading && r.write) {', '    if (r.write) {'],
-    ['      if (!requireMutation(req, res, r.write.methods)) return true;',
+    ['      if (!requireMutation(req, res, r.write.methods, r.write.contentType)) return true;',
       '      /* mutation: whatever method arrived is fine */'],
   ] },
   'origin-unchecked': { file: 'server/http-guard.js', edits: [[
@@ -4347,6 +4347,7 @@ async function runChecks() {
       const built = path
         .replace(':id', id)
         .replace(':name', name)
+        .replace(':hash', '0'.repeat(64))
         .replace(':a-:b', '0-1')
         .replace(':n', '0');
       return built.includes(':') ? null : built;
@@ -4362,17 +4363,18 @@ async function runChecks() {
     for (const r of mutating) {
       swept.add(r.path);
       const method = r.methods[0];
+      const contentType = r.contentType;
       // Method: a GET that is otherwise perfectly formed.
-      if (!r.read && await status(r.path, { headers: { 'Content-Type': 'application/json' } }) !== 405) wrongMethod.push(r.path);
+      if (!r.read && await status(r.path, { headers: { 'Content-Type': contentType } }) !== 405) wrongMethod.push(r.path);
       // Content type: the right method, declaring text/plain.
       if (await status(r.path, { method, headers: { 'Content-Type': 'text/plain' }, body: '{}' }) !== 415) wrongType.push(r.path);
       // Origin: everything right except the page it claims to come from.
       if (await status(r.path, {
         method,
-        headers: { 'Content-Type': 'application/json', Origin: 'http://evil.invalid' },
+        headers: { 'Content-Type': contentType, Origin: 'http://evil.invalid' },
         body: '{}',
       }) !== 403) wrongOrigin.push(r.path);
-      if (GUARDED.has(await status(r.path, { method, headers: { 'Content-Type': 'application/json' }, body: '{}' }))) {
+      if (GUARDED.has(await status(r.path, { method, headers: { 'Content-Type': contentType }, body: '{}' }))) {
         refusedOutright.push(r.path);
       }
     }
@@ -4380,11 +4382,11 @@ async function runChecks() {
       `every route that only changes things refuses a GET (${writeOnly.length} of ${mutating.length} mutating routes)`,
       wrongMethod.join(' ') || 'all 405');
     check(wrongType.length === 0,
-      'every mutating route refuses a body that does not declare JSON', wrongType.join(' ') || 'all 415');
+      'every mutating route refuses a body with a simple content type', wrongType.join(' ') || 'all 415');
     check(wrongOrigin.length === 0,
       'every mutating route refuses a cross-origin caller', wrongOrigin.join(' ') || 'all 403');
     check(refusedOutright.length === 0,
-      'and the shape the node link uses - right method, JSON, no Origin header - is let through, which is what stops this being a guard that refuses everything',
+      'and the shape the node link uses - right method, declared content type, no Origin header - is let through, which is what stops this being a guard that refuses everything',
       refusedOutright.join(' ') || `${mutating.length} routes reached their handler`);
 
     // A refusal has to mean the route did not act, which a status code does not say on its own.

--- a/tools/module-check.mjs
+++ b/tools/module-check.mjs
@@ -73,7 +73,7 @@ const MUTATIONS = {
 
   'export-form-nothing-claims': {
     file: 'web/format.js',
-    edits: [['export const PROJECT_VERSION = 7;', 'export const PROJECT_VERSION = 7;\nexport const { major, minor } = { major: 1, minor: 0 };']],
+    edits: [['export const PROJECT_VERSION = 8;', 'export const PROJECT_VERSION = 8;\nexport const { major, minor } = { major: 1, minor: 0 };']],
   },
 
   'a-barrel-re-export': {

--- a/web/audio-panel.js
+++ b/web/audio-panel.js
@@ -1,0 +1,141 @@
+import { AUDIO_UPLOAD_BYTES } from './audio-source.js';
+
+export function createAudioPanel({ getClip, targets, owners, selectedOwner, change, importFile, remove, open }) {
+  const root = document.getElementById('audioGroup');
+  const file = document.getElementById('audioFile');
+  const name = document.getElementById('audioName');
+  const controls = document.getElementById('audioControls');
+  const note = document.getElementById('audioNote');
+  const target = document.getElementById('audioTarget');
+  const owner = document.getElementById('audioOwner');
+  const effect = document.getElementById('audioEffect');
+  const start = document.getElementById('audioStart');
+  const depth = document.getElementById('audioDepth');
+  const meter = document.getElementById('audioMeter');
+  const readout = document.getElementById('audioValue');
+  const spectrum = document.getElementById('audioSpectrum');
+  const baseOut = document.getElementById('audioBase');
+  const addedOut = document.getElementById('audioAdded');
+  const resultOut = document.getElementById('audioResult');
+  const resultMeter = document.getElementById('audioResultMeter');
+  const inputs = new Map();
+  let busy = false;
+  let chosenOwner;
+  const settingRows = [
+    ['low', 'Low', -60, 24, 1, 'dB'],
+    ['mid', 'Mid', -60, 24, 1, 'dB'],
+    ['high', 'High', -60, 24, 1, 'dB'],
+    ['gain', 'Gain', -24, 48, 1, 'dB'],
+    ['floor', 'Threshold', -96, -1, 1, 'dB'],
+    ['ceiling', 'Ceiling', -95, 0, 1, 'dB'],
+    ['attack', 'Attack', 0, 2000, 1, 'ms'],
+    ['release', 'Release', 0, 2000, 1, 'ms'],
+  ];
+  const run = async (work) => {
+    if (busy) return;
+    busy = true;
+    root.querySelectorAll('button, input, select').forEach((el) => { el.disabled = true; });
+    note.textContent = 'Analyzing audio…';
+    try { await work(); note.textContent = ''; }
+    catch (err) { note.textContent = err.message; }
+    finally { busy = false; paint(); }
+  };
+  for (const [key, label, min, max, step, unit] of settingRows) {
+    const row = document.createElement('label');
+    row.className = 'audio-setting';
+    const text = document.createElement('span');
+    text.textContent = label;
+    const input = document.createElement('input');
+    input.type = 'range'; input.id = `audio-${key}`;
+    input.min = min; input.max = max; input.step = step;
+    const out = document.createElement('output');
+    const show = () => { out.value = `${input.value} ${unit}`; };
+    input.addEventListener('input', show);
+    input.addEventListener('change', () => run(() => change({ conditioning: { ...getClip().conditioning, [key]: Number(input.value) } })));
+    inputs.set(key, { input, show });
+    row.append(text, input, out);
+    const group = ['low', 'mid', 'high'].includes(key) ? 'audioEqBands'
+      : ['floor', 'ceiling', 'attack', 'release'].includes(key) ? 'audioAdvancedSettings' : 'audioSettings';
+    document.getElementById(group).append(row);
+  }
+  document.getElementById('audioImport').addEventListener('click', () => file.click());
+  file.addEventListener('change', () => {
+    const picked = file.files[0];
+    file.value = '';
+    if (!picked) return;
+    run(async () => {
+      if (!picked.size) throw new Error('Audio file is empty');
+      if (picked.size > AUDIO_UPLOAD_BYTES) throw new Error('Audio files must be 64 MiB or smaller');
+      await importFile(picked);
+    });
+  });
+  document.getElementById('audioRemove').addEventListener('click', () => run(remove));
+  start.addEventListener('change', () => run(() => {
+    if (start.value === '') throw new Error('Audio start needs a number');
+    return change({ start: Number(start.value) });
+  }));
+  const selectTarget = (next) => run(() => {
+    return change({ target: next ? { clip: next.clip, param: next.param, depth: (next.max - next.min) / 2 } : null });
+  });
+  owner.addEventListener('change', () => {
+    chosenOwner = JSON.parse(owner.value);
+    selectTarget(null);
+  });
+  effect.addEventListener('change', () => selectTarget(targets().find((t) => t.clip === chosenOwner && t.effect === effect.value)));
+  target.addEventListener('change', () => selectTarget(targets().find((t) => t.clip === chosenOwner && t.param === target.value)));
+  depth.addEventListener('change', () => run(() => {
+    if (depth.value === '') throw new Error('Modulation depth needs a number');
+    return change({ target: { ...getClip().target, depth: Number(depth.value) } });
+  }));
+  function paint() {
+    if (busy) return;
+    const clip = getClip();
+    root.querySelectorAll('button, input, select').forEach((el) => { el.disabled = false; });
+    document.getElementById('audioRemove').disabled = !clip;
+    name.textContent = clip?.name ?? 'No audio';
+    controls.hidden = !clip;
+    if (!clip) return;
+    start.value = clip.start;
+    const options = targets();
+    chosenOwner = clip.target ? clip.target.clip : chosenOwner === undefined ? selectedOwner() : chosenOwner;
+    const availableOwners = owners();
+    if (!availableOwners.some((item) => item.id === chosenOwner)) chosenOwner = selectedOwner();
+    owner.replaceChildren(...availableOwners.map((item) => new Option(item.label, JSON.stringify(item.id))));
+    owner.value = JSON.stringify(chosenOwner);
+    const scoped = options.filter((item) => item.clip === chosenOwner);
+    const effects = [...new Map(scoped.map((item) => [item.effect, item.effectLabel])).entries()];
+    effect.replaceChildren(new Option(effects.length ? 'None' : 'No applied effects', ''), ...effects.map(([id, label]) => new Option(label, id)));
+    effect.disabled = !effects.length;
+    const selected = scoped.find((item) => item.param === clip.target?.param);
+    effect.value = selected?.effect ?? '';
+    document.getElementById('audioMappingTitle').textContent = selected ? `${chosenOwner ?? 'Project'} · ${selected.effectLabel} · ${selected.label}` : 'Choose effect';
+    target.replaceChildren(...scoped.filter((item) => item.effect === selected?.effect).map((item) => new Option(item.label, item.param)));
+    target.value = selected?.param ?? '';
+    target.disabled = !selected;
+    const spec = options.find((t) => t.clip === clip.target?.clip && t.param === clip.target?.param);
+    depth.disabled = !spec;
+    depth.value = clip.target?.depth ?? 0;
+    depth.min = spec ? -(spec.max - spec.min) : -1e6;
+    depth.max = spec ? spec.max - spec.min : 1e6;
+    depth.step = spec?.step ?? 0.01;
+    for (const [key, { input, show }] of inputs) { input.value = clip.conditioning[key]; show(); }
+  }
+  return {
+    paint,
+    visible: () => !root.hidden,
+    open: () => { open(); paint(); },
+    chooseFile: () => { open(); file.click(); },
+    meter: ({ signal, base = null, result = null, min = 0, max = 1, bins = [] }) => {
+      if (root.hidden) return;
+      meter.value = signal; readout.value = signal.toFixed(3);
+      const number = (n) => n === null ? '—' : Number(n.toFixed(4)).toString();
+      baseOut.value = number(base);
+      addedOut.value = number(result === null ? null : result - base);
+      resultOut.value = number(result);
+      resultMeter.value = result === null ? 0 : (result - min) / Math.max(1e-9, max - min);
+      const points = (field) => bins.map((b, i) => `${i * 300 / 63},${Math.max(0, Math.min(100, -b[field] / 72 * 100))}`).join(' ');
+      spectrum.querySelector('[data-spectrum=input]').setAttribute('points', points('input'));
+      spectrum.querySelector('[data-spectrum=output]').setAttribute('points', points('output'));
+    },
+  };
+}

--- a/web/audio-session.js
+++ b/web/audio-session.js
@@ -1,0 +1,85 @@
+import { AUDIO_RATE, analyseAudio, audioSpectrum, readAudioWav, signalAt } from './audio-source.js';
+
+export function createAudioSession({ changed = () => {}, failed = () => {} } = {}) {
+  const curves = new Map();
+  let decoded = null;
+  let context = null;
+  let buffer = null;
+  let playing = null;
+  let spectrum = null;
+  let inspection = null;
+  let inspectionFailure = null;
+  const key = (clip) => JSON.stringify([clip.hash, clip.duration, clip.conditioning]);
+  const stop = () => {
+    if (playing) { playing.node.stop(); playing.node.disconnect(); playing = null; }
+  };
+  const pcmFor = async (clip) => {
+    if (decoded?.hash === clip.hash) {
+      if (Math.abs(decoded.pcm.duration - clip.duration) > 0.5 / AUDIO_RATE) throw new Error('audio duration does not match its saved asset');
+      return decoded.pcm;
+    }
+    const response = await fetch(`/audio/${clip.hash.slice(7)}`);
+    if (!response.ok) throw new Error(`audio ${clip.name} is unavailable (${response.status})`);
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const hash = 'sha256:' + [...new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))]
+      .map((b) => b.toString(16).padStart(2, '0')).join('');
+    if (hash !== clip.hash) throw new Error(`audio ${clip.name} does not match its saved content hash`);
+    const pcm = readAudioWav(bytes);
+    if (Math.abs(pcm.duration - clip.duration) > 0.5 / AUDIO_RATE) throw new Error('audio duration does not match its saved asset');
+    decoded = { hash, pcm };
+    return pcm;
+  };
+  const prepare = async (clip) => {
+    if (!clip) return;
+    inspectionFailure = null;
+    const pcm = await pcmFor(clip);
+    if (curves.has(key(clip))) return;
+    // Let the import status paint before the bounded offline analysis.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    curves.set(key(clip), analyseAudio(pcm, clip.conditioning));
+  };
+  const ready = (clip) => !clip || curves.has(key(clip));
+  const value = (clip, t) => clip ? signalAt(curves.get(key(clip)), t - clip.start) : 0;
+  const inspect = (clip, t) => {
+    if (!clip) return [];
+    if (decoded?.hash !== clip.hash) {
+      if (!inspection && inspectionFailure !== clip.hash) {
+        inspection = pcmFor(clip).then(changed).catch((error) => { inspectionFailure = clip.hash; failed(error); })
+          .finally(() => { inspection = null; });
+      }
+      return [];
+    }
+    const second = t - clip.start;
+    const stamp = `${key(clip)}:${Math.floor(second * 30)}`;
+    if (spectrum?.stamp !== stamp) spectrum = { stamp, bins: audioSpectrum(decoded.pcm, second, clip.conditioning) };
+    return spectrum.bins;
+  };
+  const unlock = () => {
+    context ??= new AudioContext({ sampleRate: AUDIO_RATE });
+    return context.resume();
+  };
+  const arm = async (clip) => {
+    if (!clip) return;
+    await unlock();
+    const pcm = await pcmFor(clip);
+    if (buffer?.hash !== clip.hash) {
+      const audio = context.createBuffer(pcm.samples.length, pcm.samples[0].length, AUDIO_RATE);
+      pcm.samples.forEach((channel, i) => audio.copyToChannel(channel, i));
+      buffer = { hash: clip.hash, audio };
+    }
+  };
+  const sync = (clip, program, running) => {
+    const offset = clip ? program - clip.start : -1;
+    if (!running || !clip || buffer?.hash !== clip.hash || context?.state !== 'running'
+      || offset < 0 || offset >= clip.duration) { stop(); return; }
+    const now = context.currentTime;
+    if (playing && playing.hash === clip.hash && Math.abs(playing.offset + now - playing.when - offset) <= 0.08) return;
+    stop();
+    const node = context.createBufferSource();
+    node.buffer = buffer.audio;
+    node.connect(context.destination);
+    node.start(now, offset);
+    playing = { node, hash: clip.hash, offset, when: now };
+  };
+  return { prepare, ready, value, inspect, arm, stop, sync };
+}

--- a/web/audio-source.js
+++ b/web/audio-source.js
@@ -1,0 +1,187 @@
+// Audio becomes a sampled control signal before the renderer asks for any program time.
+export const AUDIO_RATE = 48000;
+export const AUDIO_SECONDS = 600;
+export const AUDIO_UPLOAD_BYTES = 64 * 1024 * 1024;
+export const validAudioHash = (value) => typeof value === 'string' && /^sha256:[0-9a-f]{64}$/.test(value);
+const FEATURE_RATE = 100;
+
+export function defaultConditioning() {
+  return { low: 0, mid: 0, high: 0, gain: 0, floor: -48, ceiling: -6, attack: 10, release: 180 };
+}
+
+function bounded(value, lo, hi, name) {
+  if (!Number.isFinite(value) || value < lo || value > hi) {
+    throw new Error(`audio ${name} must be a number from ${lo} to ${hi}`);
+  }
+  return value;
+}
+
+function checkConditioning(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('audio needs conditioning settings');
+  const result = {};
+  for (const name of ['low', 'mid', 'high']) result[name] = bounded(value[name], -60, 24, name);
+  result.gain = bounded(value.gain, -24, 48, 'gain');
+  result.floor = bounded(value.floor, -96, -1, 'floor');
+  result.ceiling = bounded(value.ceiling, -95, 0, 'ceiling');
+  if (result.ceiling <= result.floor) throw new Error('audio ceiling must be above its threshold');
+  for (const name of ['attack', 'release']) result[name] = bounded(value[name], 0, 2000, name);
+  return result;
+}
+
+export function checkAudioClip(value) {
+  if (value === null || value === undefined) return null;
+  if (!value || typeof value !== 'object' || Array.isArray(value) || value.kind !== 'audio-file') {
+    throw new Error('this build reads an audio-file source');
+  }
+  if (!validAudioHash(value.hash)) throw new Error('audio needs a SHA-256 content hash');
+  if (typeof value.name !== 'string' || !value.name.trim() || value.name.length > 255) throw new Error('audio needs a name of 1 to 255 characters');
+  const start = bounded(value.start, 0, 86400, 'start');
+  const duration = bounded(value.duration, 1 / AUDIO_RATE, AUDIO_SECONDS, 'duration');
+  let target = null;
+  if (value.target !== null) {
+    const t = value.target;
+    if (!t || typeof t !== 'object' || typeof t.param !== 'string' || !/^[a-z][a-z0-9]*\.[A-Za-z][A-Za-z0-9]*$/.test(t.param)
+      || (t.clip !== null && (typeof t.clip !== 'string' || !t.clip))) {
+      throw new Error('audio target must name an effect parameter and its clip, or null for a project effect');
+    }
+    target = { param: t.param, clip: t.clip, depth: bounded(t.depth, -1e6, 1e6, 'depth') };
+  }
+  return { kind: 'audio-file', hash: value.hash, name: value.name, start, duration, conditioning: checkConditioning(value.conditioning), target };
+}
+
+// Only the server's bounded PCM WAV is read here; compressed files go through the import door.
+export function readAudioWav(bytes) {
+  const v = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const text = (at, n) => String.fromCharCode(...bytes.subarray(at, at + n));
+  if (bytes.length < 44 || text(0, 4) !== 'RIFF' || text(8, 4) !== 'WAVE'
+    || v.getUint32(4, true) + 8 !== bytes.length) throw new Error('audio is not a complete PCM WAV');
+  let channels = 0;
+  let data = null;
+  for (let at = 12; at + 8 <= bytes.length;) {
+    const n = v.getUint32(at + 4, true);
+    if (at + 8 + n > bytes.length) throw new Error('audio WAV has a truncated chunk');
+    if (text(at, 4) === 'fmt ') {
+      if (n < 16 || v.getUint16(at + 8, true) !== 1 || v.getUint32(at + 12, true) !== AUDIO_RATE
+        || v.getUint16(at + 22, true) !== 16) throw new Error('audio must be 48 kHz, 16-bit PCM');
+      channels = v.getUint16(at + 10, true);
+      if (![1, 2].includes(channels) || v.getUint16(at + 20, true) !== channels * 2) throw new Error('audio must be mono or stereo');
+    }
+    if (text(at, 4) === 'data') data = { at: at + 8, n };
+    at += 8 + n + (n % 2);
+  }
+  if (!channels || !data || !data.n || data.n % (channels * 2)) throw new Error('audio WAV has no complete samples');
+  const frames = data.n / (channels * 2);
+  if (frames > AUDIO_SECONDS * AUDIO_RATE) throw new Error(`audio is longer than ${AUDIO_SECONDS} seconds`);
+  const samples = Array.from({ length: channels }, () => new Float32Array(frames));
+  for (let i = 0; i < frames; i++) {
+    for (let c = 0; c < channels; c++) samples[c][i] = v.getInt16(data.at + (i * channels + c) * 2, true) / 32768;
+  }
+  return { samples, duration: frames / AUDIO_RATE, rate: AUDIO_RATE };
+}
+
+// Two complementary low-pass splits keep unity EQ equal to the input, including phase.
+export function analyseAudio(pcm, settings) {
+  const s = checkConditioning(settings);
+  const frames = pcm.samples[0].length;
+  const hop = AUDIO_RATE / FEATURE_RATE;
+  const count = Math.ceil(frames / hop);
+  const energy = new Float64Array(count);
+  const lowK = 1 - Math.exp(-2 * Math.PI * 200 / AUDIO_RATE);
+  const midK = 1 - Math.exp(-2 * Math.PI * 2000 / AUDIO_RATE);
+  const gains = [s.low, s.mid, s.high].map((db) => 10 ** (db / 20));
+  for (const channel of pcm.samples) {
+    let low = 0;
+    let belowHigh = 0;
+    for (let i = 0; i < frames; i++) {
+      const sample = channel[i];
+      low += lowK * (sample - low);
+      belowHigh += midK * (sample - belowHigh);
+      const filtered = low * gains[0] + (belowHigh - low) * gains[1] + (sample - belowHigh) * gains[2];
+      energy[Math.floor(i / hop)] += filtered * filtered;
+    }
+  }
+  const values = new Float32Array(count + 1);
+  const floor = 10 ** (s.floor / 20);
+  const ceiling = 10 ** (s.ceiling / 20);
+  const gain = 10 ** (s.gain / 20);
+  let envelope = 0;
+  for (let i = 0; i < count; i++) {
+    const samples = Math.min(hop, frames - i * hop);
+    const rms = Math.sqrt(energy[i] / (samples * pcm.samples.length)) * gain;
+    const level = Math.min(1, Math.max(0, (rms - floor) / (ceiling - floor)));
+    const ms = level > envelope ? s.attack : s.release;
+    const keep = ms === 0 ? 0 : Math.exp(-samples / AUDIO_RATE / (ms / 1000));
+    envelope = level + keep * (envelope - level);
+    values[i + 1] = envelope;
+  }
+  return { rate: FEATURE_RATE, duration: pcm.duration, values };
+}
+
+// A file, a recorded MIDI curve, and a captured live signal can all answer this same question.
+export function signalAt(source, second) {
+  if (!source || !Number.isFinite(second) || second < 0 || second >= source.duration) return 0;
+  const at = second * source.rate;
+  const i = Math.floor(at);
+  const a = source.values[i] ?? 0;
+  return a + ((source.values[i + 1] ?? a) - a) * (at - i);
+}
+
+export function modulatedValue(base, depth, signal, min, max) {
+  return Math.min(max, Math.max(min, base + depth * signal));
+}
+
+// The display windows the input and filtered samples at the playhead, including while paused.
+export function audioSpectrum(pcm, second, settings) {
+  const n = 2048;
+  const powers = [new Float64Array(n / 2), new Float64Array(n / 2)];
+  const end = Math.floor(second * AUDIO_RATE);
+  const lowK = 1 - Math.exp(-2 * Math.PI * 200 / AUDIO_RATE);
+  const midK = 1 - Math.exp(-2 * Math.PI * 2000 / AUDIO_RATE);
+  const gains = [settings.low, settings.mid, settings.high].map((db) => 10 ** (db / 20));
+  const gain = 10 ** (settings.gain / 20);
+  for (const channel of pcm.samples) {
+    const windows = [new Float64Array(n), new Float64Array(n)];
+    let low = 0; let belowHigh = 0;
+    // This lead-in settles the slowest filter below floating-point precision.
+    for (let i = -n; i < n; i++) {
+      const sample = second < 0 || second >= pcm.duration ? 0 : (channel[end - n + i] ?? 0);
+      low += lowK * (sample - low);
+      belowHigh += midK * (sample - belowHigh);
+      if (i < 0) continue;
+      const window = 0.5 - 0.5 * Math.cos(2 * Math.PI * i / n);
+      windows[0][i] = sample * window;
+      windows[1][i] = (low * gains[0] + (belowHigh - low) * gains[1] + (sample - belowHigh) * gains[2]) * gain * window;
+    }
+    for (const [band, re] of windows.entries()) {
+      const im = new Float64Array(n);
+      for (let i = 1, j = 0; i < n; i++) {
+        let bit = n >> 1;
+        for (; j & bit; bit >>= 1) j ^= bit;
+        j ^= bit;
+        if (i < j) [re[i], re[j]] = [re[j], re[i]];
+      }
+      for (let size = 2; size <= n; size *= 2) {
+        for (let at = 0; at < n; at += size) {
+          for (let j = 0; j < size / 2; j++) {
+            const angle = -2 * Math.PI * j / size;
+            const x = at + j; const y = x + size / 2;
+            const a = re[y] * Math.cos(angle) - im[y] * Math.sin(angle);
+            const b = re[y] * Math.sin(angle) + im[y] * Math.cos(angle);
+            re[y] = re[x] - a; im[y] = im[x] - b;
+            re[x] += a; im[x] += b;
+          }
+        }
+      }
+      for (let i = 1; i < powers[band].length; i++) powers[band][i] += (re[i] ** 2 + im[i] ** 2) * (4 / n) ** 2 / pcm.samples.length;
+    }
+  }
+  return Array.from({ length: 64 }, (_, i) => {
+    const lo = 20 * 1000 ** (i / 64); const hi = 20 * 1000 ** ((i + 1) / 64);
+    const levels = powers.map((bins) => {
+      let power = 0;
+      for (let k = Math.max(1, Math.floor(lo * n / AUDIO_RATE)); k <= Math.min(bins.length - 1, Math.ceil(hi * n / AUDIO_RATE)); k++) power = Math.max(power, bins[k]);
+      return Math.max(-120, 10 * Math.log10(Math.max(1e-12, power)));
+    });
+    return { hz: Math.sqrt(lo * hi), input: levels[0], output: levels[1] };
+  });
+}

--- a/web/format.js
+++ b/web/format.js
@@ -1,14 +1,5 @@
-/**
- * The document format's version, stamped by the page as it saves and by the server as it
- * writes, so there is one number rather than two that agree.
- *
- * A document from any other version is refused, naming the version it found, rather than
- * opened on a best guess: this build ships no conversion and no reader of a second shape.
- * Version 7 carries a `clips` array - each clip its own take, placement, retime curve and the
- * look values that write the cloud - beside the `look` block holding the ones that write the
- * post chain. Version 6 carried one take at the top and one undivided look under it.
- */
-export const PROJECT_VERSION = 7;
+// Version 8 adds a content-addressed audio clip and its modulation settings.
+export const PROJECT_VERSION = 8;
 
 /**
  * How many clips this build composites.

--- a/web/index.html
+++ b/web/index.html
@@ -450,6 +450,8 @@
      surface they are always visible - the hidden attribute is not set. */
   body.editing #panelTabs { display: none; }
   body.editing #panelTabs:not([hidden]) { display: grid; }
+  body.editing #panelTabs { grid-template-columns: repeat(5, 1fr); }
+  body:not(.editing) #panelTabAudio { display: none; }
   .paneltab {
     min-width: 0;
     border: 0;
@@ -1248,6 +1250,40 @@
     border-radius: 50%; background: var(--paper-1); border: 1px solid var(--accent);
     cursor: grab; z-index: 5;
   }
+  .audio-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-bottom: 10px; color: var(--ink); }
+  .audio-field { display: flex; align-items: center; gap: 8px; margin: 10px 0; flex-wrap: wrap; }
+  .audio-field input, .audio-field select { min-width: 0; width: 100%; background: var(--paper-1); color: var(--ink); border: 1px solid var(--line); padding: 5px; font: inherit; }
+  .audio-section { margin: 16px 0 10px; color: var(--ink); }
+  .audio-setting { display: grid; grid-template-columns: 1fr 60px; gap: 3px 8px; margin: 9px 0; }
+  .audio-setting input { grid-column: 1 / -1; grid-row: 2; width: 100%; }
+  .audio-setting output { text-align: right; }
+  .audio-note { color: var(--accent); overflow-wrap: anywhere; }
+  #audioMeter { flex: 1; min-width: 70px; }
+  .audio-spectrum { margin: 14px 0 10px; }
+  .audio-spectrum svg { width: 100%; height: 100px; display: block; background: var(--paper-1); border: 1px solid var(--line); }
+  .audio-spectrum polyline { fill: none; stroke-width: 1.5; vector-effect: non-scaling-stroke; }
+  .audio-spectrum [data-spectrum=input] { stroke: var(--dim); opacity: .65; }
+  .audio-spectrum [data-spectrum=output] { stroke: var(--accent); }
+  .audio-spectrum-labels { display: flex; justify-content: space-between; font-size: 10px; margin: 4px 0; }
+  .audio-spectrum-labels .conditioned { color: var(--accent); }
+  .audio-result { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 5px; padding: 10px 0; border-block: 1px solid var(--line); }
+  .audio-result label { display: flex; flex-direction: column; gap: 4px; font-size: 10px; }
+  .audio-result output { font-size: 14px; color: var(--ink); font-variant-numeric: tabular-nums; }
+  .audio-result meter { grid-column: 1 / -1; width: 100%; }
+  .audio-advanced { margin: 14px 0; }
+  .audio-advanced summary { cursor: pointer; }
+  .audio-spectrum + #audioSettings { margin-top: 0; }
+  #audioEqBands { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+  #audioEqBands .audio-setting { grid-template-columns: 1fr; gap: 4px; }
+  #audioEqBands .audio-setting output { grid-row: 3; text-align: left; }
+  #audioGroup meter::-webkit-meter-bar { background: var(--paper-1); border: 1px solid var(--line); }
+  #audioGroup meter::-webkit-meter-optimum-value { background: var(--accent); }
+  .audio-mapping summary { cursor: pointer; color: var(--ink); padding: 10px 0; }
+  .taudio { position: absolute; top: 2px; bottom: 2px; min-width: 2px; border: 1px solid var(--accent); background: var(--paper-2); color: var(--ink); overflow: hidden; cursor: grab; text-align: left; font: inherit; }
+  .taudio:focus-visible { outline: 2px solid var(--accent); }
+  .taudio svg { position: absolute; inset: 0; width: 100%; height: 100%; opacity: .4; pointer-events: none; }
+  .taudio span { position: relative; padding: 0 5px; pointer-events: none; }
+  #tAddAudio { font-size: 10px; padding: 0 4px; }
 </style>
 </head>
 <body>
@@ -1375,12 +1411,47 @@
       <button class="paneltab" id="panelTabFraming" type="button" role="tab" data-panel-tab="framing" aria-selected="false">Framing</button>
       <button class="paneltab" id="panelTabLook" type="button" role="tab" data-panel-tab="look" aria-selected="false">Effects</button>
       <button class="paneltab" id="panelTabRegion" type="button" role="tab" data-panel-tab="region" aria-selected="false">Region</button>
+      <button class="paneltab" id="panelTabAudio" type="button" role="tab" data-panel-tab="audio" aria-selected="false">Audio</button>
     </div>
 
   <!-- Everything below scrolls. Left at its old indentation on purpose: this is a box
        drawn around a block that did not otherwise change, and re-indenting a hundred
        and eighty lines to say so would bury the change that was actually made. -->
   <div id="panelBody">
+    <div class="group" id="audioGroup" data-panel-tab="audio" hidden>
+      <div class="audio-name" id="audioName">No audio</div>
+      <div class="btnrow">
+        <button type="button" id="audioImport">Import audio</button>
+        <button type="button" id="audioRemove" disabled>Remove</button>
+      </div>
+      <input type="file" id="audioFile" accept="audio/*,.wav,.mp3,.flac,.aiff,.m4a,.ogg" hidden>
+      <div id="audioControls" hidden>
+        <div class="audio-spectrum">
+          <div class="audio-spectrum-labels"><span>Input</span><span class="conditioned">After EQ</span></div>
+          <svg id="audioSpectrum" viewBox="0 0 300 100" preserveAspectRatio="none" role="img" aria-label="Audio frequency spectrum before and after modulation EQ">
+            <polyline data-spectrum="input"></polyline><polyline data-spectrum="output"></polyline>
+          </svg>
+          <div class="audio-spectrum-labels"><span>20 Hz</span><span>200</span><span>2k</span><span>20k</span></div>
+        </div>
+        <div id="audioSettings" aria-label="Modulation EQ"><div id="audioEqBands"></div></div>
+        <details class="audio-advanced"><summary>Signal response</summary><div id="audioAdvancedSettings"></div></details>
+        <label class="audio-field">Signal<meter id="audioMeter" min="0" max="1" value="0"></meter><output id="audioValue">0.000</output></label>
+        <div class="audio-result">
+          <label>Base<output id="audioBase">—</output></label>
+          <label>+ Audio<output id="audioAdded">—</output></label>
+          <label>Result<output id="audioResult">—</output></label>
+          <meter id="audioResultMeter" min="0" max="1" value="0" aria-label="Result within parameter range"></meter>
+        </div>
+        <label class="audio-field">Depth<input id="audioDepth" type="number" step="0.01"></label>
+        <details class="audio-mapping" id="audioMapping"><summary id="audioMappingTitle">Choose effect</summary>
+          <label class="audio-field">Clip<select id="audioOwner" aria-label="Audio destination clip"></select></label>
+          <label class="audio-field">Effect<select id="audioEffect" aria-label="Audio destination effect"></select></label>
+          <label class="audio-field">Parameter<select id="audioTarget" aria-label="Effect parameter"></select></label>
+        </details>
+        <label class="audio-field">Start (s)<input id="audioStart" type="number" min="0" max="86400" step="0.01"></label>
+      </div>
+      <div class="audio-note" id="audioNote" role="status"></div>
+    </div>
     <div class="group" id="lookPresetGroup" data-panel-tab="look" hidden>
       <label>Preset</label>
       <!-- The picker the design draws, and the reason it is not a `<select>` any more is

--- a/web/main.js
+++ b/web/main.js
@@ -5,6 +5,14 @@ import {
   versionRefusal, captureFormatRefusal, requiresEntryRefusal, requiresListRefusal,
 } from './format.js';
 import { pollRecordState } from './record-poll.js';
+import { checkAudioClip, defaultConditioning, modulatedValue } from './audio-source.js';
+import { createAudioSession } from './audio-session.js';
+import { createAudioPanel } from './audio-panel.js';
+
+let audioClip = null;
+let audioPanel = null;
+let audioEditGeneration = 0;
+const audioSession = createAudioSession({ changed: () => requestRepaint(), failed: (error) => showTimelineError(error) });
 import { pickTakes } from './take-picker.js';
 // The renderer, imported first: its body appends the canvas, so import order is boot order.
 import {
@@ -210,6 +218,7 @@ const clipGestureLive = () => !EDITING || clipRow !== null;
 const createLook = () => ({
   values: new Map(),
   tracks: new Map(),
+  effects: new Set(),
   parked: { params: {}, tracks: {} },
 });
 
@@ -1848,13 +1857,14 @@ function hideOffTab() {
 }
 
 function setPanelTab(tab) {
-  if (!['record', 'camera', 'framing', 'look', 'region'].includes(tab)) return false;
+  if (!['record', 'camera', 'framing', 'look', 'region', 'audio'].includes(tab)) return false;
   activePanelTab = tab;
   for (const button of panelTabButtons) {
     button.setAttribute('aria-selected', String(button.dataset.panelTab === tab));
   }
   hideOffTab();
   document.getElementById('panelBody').scrollTop = 0;
+  if (tab === 'audio' && audioPanel) { audioPanel.paint(); requestRepaint(); }
   return true;
 }
 
@@ -2119,34 +2129,16 @@ function storeGroupOverride() {
   }
 }
 
-// Which installed effects are kept in the inspector. Panel state, not project state.
-const EFFECT_RACKED = 'kinect.rackedEffects';
-const rackedEffects = new Set();
-try {
-  const saved = localStorage.getItem(EFFECT_RACKED);
-  if (saved !== null && saved.trim() !== '') {
-    const parsed = JSON.parse(saved);
-    if (Array.isArray(parsed)) {
-      for (const id of parsed) if (typeof id === 'string' && id) rackedEffects.add(id);
-    }
-  }
-} catch {
-  // The values and tracks stay authoritative when storage is unavailable or damaged.
-}
-
-function storeRackedEffects() {
-  try {
-    localStorage.setItem(EFFECT_RACKED, JSON.stringify([...rackedEffects].sort()));
-  } catch {
-    // The rack still works for this page. Only the preference is lost on reload.
-  }
-}
+// The inspector reads explicit additions from the selected clip and the project.
+const rackedEffects = {
+  has: (id) => lookOf().effects.has(id) || projectLook.effects.has(id),
+  add(id) { for (const name of effectParamNames(id)) homeOf(PARAMS[name]).effects.add(id); },
+  delete(id) { for (const look of [...clips.map((clip) => clip.look), projectLook, bootLook]) look.effects.delete(id); },
+};
 
 function retainEffectFor(name) {
   const id = effectOf(name);
-  if (!id || rackedEffects.has(id)) return;
-  rackedEffects.add(id);
-  storeRackedEffects();
+  if (id) homeOf(PARAMS[name]).effects.add(id);
 }
 
 function effectTouched(id) {
@@ -2215,14 +2207,15 @@ function refreshUnderRows() {
 
 function addEffectToRack(id) {
   if (!effectInstalled(id)) return false;
+  if (refuseEdit('adding ' + id)) return false;
   rackedEffects.add(id);
-  storeRackedEffects();
   for (const group of effectGroups(id)) {
     if (!group.collapses) continue;
     groupOverride.set(group.key, true);
     groupOverrideDirty = true;
   }
   refreshPanel();
+  history.commit();
   paintEffectRackDialog();
   document.getElementById('effectRackSearch')?.focus();
   return true;
@@ -2232,8 +2225,8 @@ function removeEffectFromRack(id) {
   if (!effectInstalled(id)) return false;
   if (refuseEdit('taking ' + id + ' out of the rack')) return false;
   const { names } = effectRackEntry(id);
+  if (names.includes(audioClip?.target?.param)) replaceAudio({ ...audioClip, target: null });
   rackedEffects.delete(id);
-  storeRackedEffects();
 
   // Values and tracks leave as one document edit, from every clip: an effect taken out of the
   // rack that kept its values in the clips nobody was looking at would be written back out.
@@ -2253,6 +2246,7 @@ function removeEffectFromRack(id) {
   lanesChanged();
   requestRepaint();
   history.commit();
+  audioPanel?.paint();
   paintEffectRackDialog();
   document.getElementById('effectRackSearch')?.focus();
   return true;
@@ -2463,13 +2457,112 @@ function valueAtProgram(name, t, clip = null) {
   const on = spec.scope === 'clip' ? (clip ?? clipOfLook()) : null;
   const look = on ? on.look : homeOf(spec);
   const track = look.tracks.get(name);
-  if (!track || track.keys.length === 0) {
-    const held = look.values.get(name);
-    // Copied rather than handed out, because a caller writing into a pose would move the value.
-    return WORLD_KINDS.has(spec.kind)
+  const held = look.values.get(name);
+  const base = track?.keys.length
+    ? params.normalise(name, track.valueAt(t - trackEpoch(name, on)))
+    : WORLD_KINDS.has(spec.kind)
       ? { ...held, position: [...held.position], quaternion: [...held.quaternion] } : held;
+  const target = audioClip?.target;
+  if (target?.param === name && target.clip === (on?.id ?? null)) {
+    return params.normalise(name, modulatedValue(base, target.depth, audioSession.value(audioClip, t), spec.min, spec.max));
   }
-  return params.normalise(name, track.valueAt(t - trackEpoch(name, on)));
+  return base;
+}
+
+function checkAudioTarget(target) {
+  if (!target) return;
+  const spec = specOf(target.param);
+  if (!effectOf(target.param) || spec.kind !== 'scalar' || spec.tag !== 'look'
+    || (spec.scope === 'project') !== (target.clip === null)) {
+    throw new Error('audio can drive a scalar effect parameter at its declared scope');
+  }
+  if (Math.abs(target.depth) > spec.max - spec.min) throw new Error('audio depth exceeds the parameter range');
+}
+
+function replaceAudio(next) {
+  audioSession.stop();
+  const target = audioClip?.target;
+  if (target && Object.hasOwn(PARAMS, target.param)) {
+    const clip = target.clip === null ? null : clips.find((c) => c.id === target.clip);
+    if (target.clip === null || clip) {
+      const reset = () => specOf(target.param).apply(params.get(target.param));
+      if (clip) withClip(clip, reset); else reset();
+    }
+  }
+  audioClip = next;
+}
+
+function applyAudio(t) {
+  const signal = audioSession.value(audioClip, t);
+  const target = audioClip?.target;
+  const display = { signal, bins: audioPanel?.visible() ? audioSession.inspect(audioClip, t) : [] };
+  if (!target || !Object.hasOwn(PARAMS, target.param)) { audioPanel?.meter(display); return; }
+  const clip = target.clip === null ? null : clips.find((c) => c.id === target.clip);
+  if (target.clip !== null && !clip) { audioPanel?.meter(display); return; }
+  const spec = specOf(target.param);
+  const look = clip ? clip.look : projectLook;
+  const track = look.tracks.get(target.param);
+  const base = track?.keys.length ? params.normalise(target.param, track.valueAt(t - trackEpoch(target.param, clip))) : look.values.get(target.param);
+  const result = borrowed?.has(target.param) ? base : valueAtProgram(target.param, t, clip);
+  audioPanel?.meter({ ...display, base, result, min: spec.min, max: spec.max });
+  if (borrowed?.has(target.param)) return;
+  const write = () => spec.apply(result);
+  if (clip) withClip(clip, write); else write();
+}
+
+async function changeAudio(patch, imported = null) {
+  if (refuseEdit('changing audio')) return;
+  const generation = documentGeneration;
+  const edit = ++audioEditGeneration;
+  const prior = audioClip;
+  const next = checkAudioClip(imported ?? { ...audioClip, ...patch });
+  checkAudioTarget(next?.target);
+  if (next?.target?.clip !== null && next?.target && !clips.some((c) => c.id === next.target.clip)) {
+    throw new Error('audio target clip is no longer in this project');
+  }
+  pauseTransport();
+  await audioSession.prepare(next);
+  if (edit !== audioEditGeneration || generation !== documentGeneration || prior !== audioClip || refuseEdit('changing audio')) return;
+  replaceAudio(next);
+  if (next?.target) {
+    const targetClip = clips.find((clip) => clip.id === next.target.clip);
+    if (targetClip) withClip(targetClip, () => retainEffectFor(next.target.param));
+    else retainEffectFor(next.target.param);
+  }
+  timingChanged();
+  requestRepaint();
+  history.commit();
+  audioPanel?.paint();
+}
+
+async function importAudio(file) {
+  if (refuseEdit('importing audio')) return;
+  const generation = documentGeneration;
+  const edit = ++audioEditGeneration;
+  const prior = audioClip;
+  pauseTransport();
+  const targetClip = selectedClip.id;
+  const response = await fetch('/audio', { method: 'POST', headers: { 'Content-Type': 'application/octet-stream' }, body: file });
+  const result = await response.json();
+  if (!response.ok || result.error) throw new Error(result.error ?? 'audio import failed');
+  if (edit !== audioEditGeneration || generation !== documentGeneration || prior !== audioClip) return;
+  const first = audioTargets().find((entry) => entry.clip === targetClip);
+  await changeAudio(null, {
+    kind: 'audio-file', ...result, name: file.name.slice(0, 255), start: 0,
+    conditioning: defaultConditioning(),
+    target: first ? { clip: targetClip, param: first.param, depth: (first.max - first.min) / 2 } : null,
+  });
+}
+
+function removeAudio() {
+  if (refuseEdit('removing audio')) return;
+  audioEditGeneration++;
+  pauseTransport();
+  replaceAudio(null);
+  timingChanged();
+  requestRepaint();
+  history.commit();
+  audioPanel?.paint();
 }
 
 // How near an existing key has to be to count as the same key: half an output frame.
@@ -2560,13 +2653,16 @@ function serialiseLookBlock(scope, parked, look) {
     if (mine.some((n) => PARAMS[n].reading)) continue;
     const keyed = mine.some((n) => look.tracks.get(n)?.keys.length);
     const moved = mine.some((n) => values[n] !== PARAMS[n].def);
-    if (keyed || moved) continue;
+    const modulated = audioClip?.target && effectOf(audioClip.target.param) === id
+      && (audioClip.target.clip === null ? look === projectLook : clips.find((c) => c.id === audioClip.target.clip)?.look === look);
+    if (keyed || moved || modulated || look.effects.has(id)) continue;
     for (const n of mine) delete values[n];
   }
   const kept = Object.keys(values);
   return {
     kept,
     block: {
+      ...(look.effects.size ? { effects: [...look.effects].sort() } : {}),
       // Look parameters only, so a snapshot or a render job carries no camera and no scale.
       params: { ...values, ...parked.params },
       tracks: {
@@ -2595,6 +2691,7 @@ function serialiseProjectBody({ suppressed = null } = {}) {
   ];
   return {
     version: PROJECT_VERSION,
+    audio: audioClip ? structuredClone(audioClip) : null,
     ...(requires.length ? { requires } : {}),
     ...(suppressed ? { suppressed } : {}),
     // The terms that write the post chain, which is the project's however many clips draw into it.
@@ -2615,6 +2712,7 @@ function serialiseProjectBody({ suppressed = null } = {}) {
       // these and they are allowed to disagree, which is what makes a clip's look its own.
       params: perClip[at].block.params,
       tracks: perClip[at].block.tracks,
+      ...(perClip[at].block.effects ? { effects: perClip[at].block.effects } : {}),
     })),
     // The framing the clip was composed for, as the shape rather than as a size.
     aspect: [...projectAspect],
@@ -2694,6 +2792,11 @@ function checkLookBlock(what, block, scope) {
   }
   // Where the missing-effect split happens, as one predicate rather than a special case.
   const names = [...Object.keys(block.params), ...Object.keys(block.tracks)];
+  const effects = block.effects ?? [];
+  if (!Array.isArray(effects) || new Set(effects).size !== effects.length
+    || effects.some((id) => typeof id !== 'string' || !/^[a-z][a-z0-9]*$/.test(id) || !names.some((name) => effectOf(name) === id))) {
+    throw new Error(`${what} carries an effects list whose entries must also have parameters in this block`);
+  }
   const parkedNames = new Set(names.filter(isParkedName));
 
   // A parked name's scope is unknowable here by construction - the manifest declaring where it
@@ -2760,7 +2863,7 @@ function checkLookBlock(what, block, scope) {
     // clip's - so a value refused there leaves the editor holding parts of two documents.
     applied[name] = params.normalise(name, value);
   }
-  return { names, applied, tracks: restored, parked };
+  return { names, applied, tracks: restored, parked, effects: [...effects] };
 }
 
 /**
@@ -2971,7 +3074,17 @@ function checkProject(project) {
     }
   }
 
+  const audio = checkAudioClip(project.audio);
+  if (audio?.target) {
+    const target = audio.target;
+    const clip = target.clip === null ? null : plannedClips.find((c) => c.id === target.clip);
+    if (target.clip !== null && !clip) throw new Error('audio targets a clip this project does not contain');
+    const block = clip ? project.clips.find((c) => c.id === target.clip) : project.look;
+    if (!Object.hasOwn(block.params, target.param)) throw new Error('audio target must be carried in its look block');
+    if (!isParkedName(target.param)) checkAudioTarget(target);
+  }
   return {
+    audio,
     project,
     clips: plannedClips,
     // The project's own half, and the only half that is not per clip.
@@ -3008,6 +3121,8 @@ function fitClipCount(want) {
 }
 
 function applyProject(plan, sources = null) {
+  if (!audioSession.ready(plan.audio)) throw new Error('audio is not prepared; open this document through the project loader');
+  replaceAudio(null);
   documentGeneration++;
   const project = plan.project;
   // Read before the refit, because the refit is what can take the selected clip away.
@@ -3040,6 +3155,7 @@ function applyProject(plan, sources = null) {
   params.apply(plan.projectLook.applied);
   for (const [name, keys] of plan.projectLook.tracks) trackFor(name).keys = keys;
   projectLook.parked = plan.parked.project;
+  projectLook.effects = new Set(plan.projectLook.effects);
   trackFor('camera').keys = plan.camera;
 
   parkedRequires = plan.parked.requires;
@@ -3060,6 +3176,7 @@ function applyProject(plan, sources = null) {
       for (const [name, keys] of planned.look.tracks) trackFor(name).keys = keys;
     });
     clip.look.parked = planned.look.parked;
+    clip.look.effects = new Set(planned.look.effects);
     // Only clips whose footage or route label changed are repointed, and the id they come back holding is
     // the one the hash resolved to: a document names its take by hash and carries the id as a
     // label, so adopting the document's copy would put a name the take has been renamed out of
@@ -3089,6 +3206,8 @@ function applyProject(plan, sources = null) {
   if (clipRow) selectClip(clipRow);
   paintClipPanel();
   paintGizmo();
+  audioClip = plan.audio;
+  audioPanel?.paint();
 
   timingChanged();
 }
@@ -4311,6 +4430,7 @@ function renderProgramFrame(t) {
 
     // Every track, look and camera alike, through the registry rather than onto the uniforms.
     evaluateTracks(t);
+    applyAudio(t);
 
     // Source history stays valid while the camera is still. A changed camera is
     // a new projection.
@@ -4843,6 +4963,7 @@ class TimelineTransport {
   get duration() {
     let end = 0;
     for (const clip of clips) if (Number.isFinite(clip.end)) end = Math.max(end, clip.end);
+    if (audioClip) end = Math.max(end, audioClip.start + audioClip.duration);
     return end;
   }
 
@@ -5024,6 +5145,7 @@ class TimelineTransport {
    * far enough back.
    */
   seek(programSec, options = {}) {
+    audioSession.stop();
     return this.exclusive(() => this.seekNow(programSec, options));
   }
 
@@ -5250,14 +5372,16 @@ class TimelineTransport {
       this.tickNow(nowMs);
     } catch (err) {
       this.playing = false;
+      audioSession.stop();
       this.paint();
       showTimelineError(err);
     }
   }
 
   tickNow(nowMs) {
-    if (!this.playing) return;
+    if (!this.playing) { audioSession.stop(); return; }
     if (this.working) {
+      audioSession.stop();
       this.prefetch();
       return;
     }
@@ -5274,6 +5398,7 @@ class TimelineTransport {
       else this.pause();
     }
     this.behindMs = Math.max(0, nowMs - this.nextDueMs);
+    audioSession.sync(audioClip, this.programSec, this.playing && !exporting && (rendered > 0 || nowMs < this.nextDueMs));
     this.prefetch();
   }
 
@@ -5375,6 +5500,7 @@ class TimelineTransport {
     const gen = this.playGen;
     this.pendingPlay = true;
     try {
+      await audioSession.arm(audioClip);
       // A draft is not what playback would have produced, so it cannot seed the afterimage.
       if (this.drafted) await this.seek(this.programSec);
       // Keep playback inside the clip's in/out points.
@@ -5396,6 +5522,7 @@ class TimelineTransport {
   pause() {
     this.playGen += 1;
     this.playing = false;
+    audioSession.stop();
     this.paint();
   }
 
@@ -5562,6 +5689,7 @@ async function exportClip(options = {}) {
   }
   const fps = options.fps ?? timeline.outputFps;
   const codec = options.codec ?? d.codec ?? 'h264';
+  if (audioClip && codec === 'pngseq') throw new Error('PNG sequences cannot carry audio; select MP4 or MOV');
 
   const restore = {
     outputFps: timeline.outputFps,
@@ -5619,6 +5747,7 @@ async function exportClip(options = {}) {
       height,
       fps,
       frames: to - from + 1,
+      programStart: from / fps,
       codec,
       project: serialiseProjectBody(suppressed.length ? { suppressed } : {}),
       captures: clips.map((clip) => clip.source.index.hash),
@@ -5750,6 +5879,35 @@ const stripCommand = (id, text, title) => {
 ui.addClip = stripCommand('tAddClip', '+', 'Add clips from Media library');
 ui.addClip.classList.add('tclipadd');
 ui.addClip.setAttribute('aria-label', 'Add clips');
+ui.addAudio = stripCommand('tAddAudio', 'Audio', 'Import audio');
+ui.addAudio.addEventListener('click', () => audioPanel.chooseFile());
+function audioTargets() {
+  return Object.entries(PARAMS).flatMap(([param, spec]) => {
+    const effect = effectOf(param);
+    if (!effect || spec.kind !== 'scalar' || spec.tag !== 'look') return [];
+    const owners = spec.scope === 'clip' ? clips : [null];
+    return owners.filter((clip) => {
+      const look = clip?.look ?? projectLook;
+      return look.effects.has(effect) || effectParamNames(effect).some((name) => look.values.has(name)
+        && (look.values.get(name) !== groupDefaults.get(name) || look.tracks.get(name)?.keys.length))
+        || (audioClip?.target?.clip === (clip?.id ?? null) && effectOf(audioClip.target.param) === effect);
+    }).map((clip) => ({
+      clip: clip?.id ?? null, param, min: spec.min, max: spec.max, step: spec.step,
+      effect, effectLabel: effectPackages.find((entry) => entry.id === effect)?.manifest.title ?? effect,
+      label: spec.label ?? param,
+    }));
+  });
+}
+audioPanel = createAudioPanel({
+  getClip: () => audioClip,
+  targets: audioTargets,
+  owners: () => [...clips.map((clip) => ({ id: clip.id, label: `${clip.id} · ${clip.take?.id ?? 'clip'}` })), { id: null, label: 'Project' }],
+  selectedOwner: () => selectedClip.id,
+  change: changeAudio,
+  importFile: importAudio,
+  remove: removeAudio,
+  open: () => { setPanelTab('audio'); setPanelCollapsed(false); },
+});
 ui.deleteClip = stripCommand('tDeleteClip', 'delete clip', 'Delete the selected clip (Del)');
 ui.moveClip = stripCommand('tMoveClip', 'move', 'Move the selected clip in the room (g)');
 ui.rotateClip = stripCommand('tRotateClip', 'rotate', 'Turn the selected clip in the room (g)');
@@ -6541,6 +6699,15 @@ const SHORTCUTS = 'space play/pause · arrows step a frame, with shift a second 
   + 'g moves and turns the selected clip · '
   + 'cmd-z undoes · h hides the panel';
 
+// Space belongs to the transport even when a control still holds focus.
+addEventListener('keydown', (e) => {
+  if (e.code !== 'Space' || e.metaKey || e.ctrlKey || e.altKey || !EDITING || !timeline) return;
+  e.preventDefault();
+  e.stopImmediatePropagation();
+  if (e.repeat) return;
+  ui.play.click();
+}, true);
+
 /** The editor's keyboard, and the guard that has to come with it. */
 addEventListener('keydown', (e) => {
   // Above the typing guard: shift on its own arrives as a keydown, and releasing it as a keyup
@@ -6610,16 +6777,6 @@ addEventListener('keydown', (e) => {
   };
 
   switch (e.key) {
-    case ' ':
-      // A focused button owns the space bar: that is how a button is pressed without a mouse.
-      if (e.target instanceof HTMLElement && e.target.closest('button, [role=button]')) return;
-      // Or the page scrolls under the strip.
-      e.preventDefault();
-      // `pendingPlay` beside `playing`, because a play warming up from a draft is one
-      // this press stops.
-      if (timeline.playing || timeline.pendingPlay) pauseTransport();
-      else timeline.play().catch(showTimelineError);
-      return;
     case 'ArrowRight': e.preventDefault(); step(e.shiftKey ? timeline.outputFps : 1); return;
     case 'ArrowLeft': e.preventDefault(); step(e.shiftKey ? -timeline.outputFps : -1); return;
     case 'Home': e.preventDefault(); goTo(timeline.clipInSec); return;
@@ -7056,6 +7213,7 @@ function laneRows() {
       });
     }
   }
+  if (audioClip) rows.push({ owner: 'audio', label: 'Audio', kind: 'audio', height: 32 });
   rows.push({ owner: 'clip-add', label: '', kind: 'clip-add', height: CLIP_ADD_H });
   if (retime.keys.length > 0) {
     rows.push({ owner: 'retime', label: 'retime', kind: 'scalar', height: RETIME_LANE_H });
@@ -7109,7 +7267,7 @@ const withLaneClip = (owner, write) => {
 
 // A clip row and the bar above it own no keys, so a lane's key list is empty rather than absent.
 const keysOf = (owner) => {
-  if (owner === 'clip-add' || isClipRow(owner)) return [];
+  if (owner === 'clip-add' || owner === 'audio' || isClipRow(owner)) return [];
   return owner === 'retime' ? retime.keys : (trackOf(owner)?.keys ?? []);
 };
 
@@ -7118,6 +7276,7 @@ const clipOf = (owner) => (isClipRow(owner) ? laneClip(owner) : null);
 
 function laneReadout(owner) {
   if (owner === 'clip-add') return '';
+  if (owner === 'audio') return audioClip ? `${audioClip.duration.toFixed(2)}s` : '';
   const clip = clipOf(owner);
   // The length rather than the placement: where a clip sits is what its box already says, and
   // the rail is 96px wide, which fits one number and not two.
@@ -7162,7 +7321,7 @@ function rebuildLanes() {
     }
     if (row.kind === 'clip-add') {
       rail.classList.add('clip-add-row');
-      rail.append(ui.addClip);
+      rail.append(ui.addClip, ui.addAudio);
     } else {
       rail.append(label, value);
     }
@@ -7191,6 +7350,12 @@ function repositionLanes() {
   for (const lane of ui.lanes.querySelectorAll('.tlane')) {
     const row = lane.__row;
     if (!row) return false;
+    if (row.kind === 'audio') {
+      const box = lane.querySelector('.taudio');
+      if (!box || !audioClip) return false;
+      placeClipBox(box, { start: audioClip.start, end: audioClip.start + audioClip.duration });
+      continue;
+    }
     if (row.kind === 'clip') {
       const box = lane.querySelector('.tclip');
       if (!box || box.__clip !== row.clip) return false;
@@ -7260,8 +7425,57 @@ function placeClipBox(box, clip) {
   box.hidden = to < -5 || from > 105;
 }
 
+function beginAudioDrag(e) {
+  if (e.button !== 0 || !audioClip || refuseEdit('moving audio')) return;
+  e.preventDefault();
+  e.stopPropagation();
+  const box = e.currentTarget;
+  const held = audioClip;
+  const generation = documentGeneration;
+  const from = view.timeAt(e.clientX);
+  let start = held.start;
+  box.setPointerCapture(e.pointerId);
+  const move = (event) => {
+    start = Math.max(0, Math.min(86400, held.start + view.timeAt(event.clientX) - from));
+    start = Math.round(start * timeline.outputFps) / timeline.outputFps;
+    placeClipBox(box, { start, end: start + held.duration });
+  };
+  const finish = (event) => {
+    box.removeEventListener('pointermove', move);
+    box.removeEventListener('pointerup', finish);
+    box.removeEventListener('pointercancel', finish);
+    if (box.hasPointerCapture(event.pointerId)) box.releasePointerCapture(event.pointerId);
+    if (event.type === 'pointerup' && held === audioClip && generation === documentGeneration && start !== held.start) {
+      changeAudio({ start }).catch(showTimelineError);
+    } else if (held === audioClip) {
+      placeClipBox(box, { start: held.start, end: held.start + held.duration });
+    }
+  };
+  box.addEventListener('pointermove', move);
+  box.addEventListener('pointerup', finish);
+  box.addEventListener('pointercancel', finish);
+}
+
 function drawLane(lane, row) {
   if (row.kind === 'clip-add') return;
+  if (row.kind === 'audio') {
+    const box = document.createElement('button');
+    box.type = 'button'; box.className = 'taudio';
+    box.setAttribute('aria-label', `Audio clip: ${audioClip.name}`);
+    const label = document.createElement('span'); label.textContent = audioClip.name;
+    const graph = svg('svg', { viewBox: '0 0 1000 100', preserveAspectRatio: 'none' });
+    const points = Array.from({ length: 501 }, (_, i) => {
+      const second = audioClip.start + i / 500 * audioClip.duration;
+      return `${i * 2},${95 - audioSession.value(audioClip, second) * 90}`;
+    });
+    graph.append(svg('polyline', { points: points.join(' '), fill: 'none', stroke: 'var(--accent)', 'stroke-width': 2 }));
+    box.append(graph, label);
+    placeClipBox(box, { start: audioClip.start, end: audioClip.start + audioClip.duration });
+    box.addEventListener('click', () => audioPanel.open());
+    box.addEventListener('pointerdown', beginAudioDrag);
+    lane.append(box);
+    return;
+  }
   if (row.kind === 'clip') {
     // A positive box, unlike the trim chrome on the ruler, which draws the region the export
     // leaves out. `#tMiniRange` is the precedent: a clip is a thing that is there.
@@ -8358,6 +8572,7 @@ const laneProgramAt = (clientX) => view.timeAt(clientX);
 
 // Known gap: an undo between this pointerdown and its pointerup rebuilds every track.
 ui.beds.addEventListener('pointerdown', (e) => {
+  if (e.target.closest('.taudio')) return;
   const box = e.target.closest('.tclip');
   if (box && timeline) {
     e.preventDefault();
@@ -8632,6 +8847,7 @@ async function addClipFromTake(id, start) {
     return null;
   }
   const from = withClip(initiating, () => params.values(scopeNames('clip')));
+  const addedEffects = new Set(initiating.look.effects);
   const generation = documentGeneration;
   pendingClipAdds++;
   paintClipCommands();
@@ -8657,6 +8873,7 @@ async function addClipFromTake(id, start) {
   adoptSource(clip, opened);
   clip.start = start;
   withClip(clip, () => params.apply(from));
+  clip.look.effects = addedEffects;
   orderClips();
   selectClipRow(clip);
   history.commit();
@@ -8733,6 +8950,7 @@ function deleteSelectedClip() {
   timeline.pause();
   const at = clips.indexOf(clip);
   clips.splice(at, 1);
+  if (audioClip?.target?.clip === clip.id) { audioClip.target = null; audioPanel?.paint(); }
   clipLanesShut.delete(clip.id);
   // Onto whatever took its place rather than onto nothing: the panel's clip half greys when the
   // strip holds no clip, and an edit that still has clips has one under the panel.
@@ -10960,6 +11178,7 @@ async function loadProjectNamed(name, offered = null) {
   // the shape checks, the fold refusals and the requires check all run over the document before
   // this page opens a take on its say-so.
   const plan = checkProject(doc.body);
+  await audioSession.prepare(plan.audio);
   const sources = await sourcesFor(plan);
   if (refuseEdit(`opening ${name}`)) return null;
   refuseResolvedDurations(plan, sources);
@@ -11664,6 +11883,11 @@ globalThis.__kinect = {
   viewCamera: () => viewCamera,
 
   // The timeline, and the counters read instead of taking the transport's word for it.
+  audio: {
+    clip: () => audioClip ? structuredClone(audioClip) : null,
+    signal: (t) => audioSession.value(audioClip, t),
+    value: (name, t, clipId = null) => valueAtProgram(name, t, clips.find((c) => c.id === clipId) ?? null),
+  },
   timeline: {
     open: openTake,
     transport: () => timeline,


### PR DESCRIPTION
Import a song into the timeline and use its conditioned signal to drive a scalar effect parameter. The result adds `depth × signal` to the base or keyed value, without rewriting either. The Audio panel overlays input and post-EQ spectra and shows the signal, base, audio contribution, and final value.

Destinations are grouped by Clip → Effect → Parameter and include effects applied to that clip. Effects added at their defaults appear immediately and survive saving. Space toggles playback while inspector controls have focus.

Audio placement, EQ, response settings, and mapping support undo and project reload. Playback and direct/queued video exports include the original soundtrack, trimmed to the export range with silence outside the audio clip. Imports are bounded and normalized through FFmpeg; stored assets are verified by content hash. The proof tools cover import, rendered modulation, persistence, keyboard behavior, and exact exported audio samples.

**Prototype limits:** one audio file, one scalar parameter mapping, 64 MiB uploads, and ten minutes of audio. MIDI and live input are not implemented. Modulation EQ does not alter the soundtrack. PNG sequences are refused while audio is present. **Project format 8 refuses version 7 documents; no migration is included.**

### Integration pending

This branch is based on `194ae97`. Current `main` (`dd8a70f`) replaces retime curves with clip speed and source in-points and also declares project format 8. The two format-8 schemas differ. Reconcile the clip timing and choose a distinct combined document version before merging, then rerun the affected proofs.

The merge preview reports conflicts in `docs/architecture.md`, `docs/reference.md`, `tools/export-check.mjs`, `web/format.js`, and `web/main.js`. The validation below covers this prototype commit before integration with those newer changes.

### Validation

Verified on `765901c` with a 1024-frame synthetic capture at 30 fps and an MP3 imported through the real file chooser. The demo and regression runtime files match the committed files. No physical Kinect was used.

| Check | Result |
| --- | --- |
| Syntax | 105 files, 0 failed |
| Unit | 239 passed |
| Module | 62 assertions, 0 failed |
| Audio, including real queued render | 37 assertions, 0 failed |
| Editor | 808 assertions, 0 failed |
| Timeline | 171 assertions, 0 failed |
| Boot | 62 assertions, 0 failed |
| Guard | 24 assertions, 0 failed |
| Library | 527 assertions, 0 failed |
| Export | 75/85 passed; 10 synthetic-image failures |

All ten export failures reproduced on the unchanged `194ae97` baseline with identical reported measurements. They are the synthetic-capture limits documented in `docs/proof-tools.md`. Frame accuracy, repeatability, codecs, timing, failed-export cleanup, and protection against edits during a render passed.

All five audio mutation controls were caught: disconnected modulation, ignored export offset, hidden newly added effects, focused controls blocking Space, and an empty spectrum after undo. Unit controls also caught ignored EQ/additive math, reading audio after export cancellation, resetting the upload byte count per chunk, and leaving import scratch files behind.

Independent Claude review did not complete: the CLI returned a session-limit error. This is not independent review approval.
